### PR TITLE
Renames PostPurchaseCrossSell to PostPurchase

### DIFF
--- a/packages/argo-checkout-testing/README.md
+++ b/packages/argo-checkout-testing/README.md
@@ -8,7 +8,7 @@ The first thing to understand is that nothing in this library is strictly requir
 
 ```js
 self.shopify.extend(
-  'Checkout::PostPurchaseCrossSell::Render',
+  'Checkout::PostPurchase::Render',
   (root, input) => {
     const button = root.createComponent('Button', {
       onPress() {
@@ -32,7 +32,7 @@ The main function this library exports is called `extend`. It’s actually just 
 ```ts
 import {extend} from '@shopify/argo-checkout';
 
-extend('Checkout::PostPurchaseCrossSell::Render', (input) => {
+extend('Checkout::PostPurchase::Render', (input) => {
   /* your extension goes here */
 });
 ```
@@ -42,7 +42,7 @@ Most extensions render UI. These extensions are called with a remote "root" to w
 ```ts
 import {extend, Button} from '@shopify/argo-checkout';
 
-extend('Checkout::PostPurchaseCrossSell::Render', (root, {done}) => {
+extend('Checkout::PostPurchase::Render', (root, {done}) => {
   const button = root.createComponent(Button, {
     // If I had misspelled (like calling this `onpress()`), my editor
     // would warn me of the invalid property.

--- a/packages/argo-checkout-testing/src/extension-points/extension-points.ts
+++ b/packages/argo-checkout-testing/src/extension-points/extension-points.ts
@@ -1,16 +1,16 @@
 import {RenderExtension} from './render-extension';
-import type {StandardApi, PostPurchaseCrossSellApi} from './input';
+import type {StandardApi, PostPurchaseApi} from './input';
 
 type Components = typeof import('../components');
 type AllComponents = Components[keyof Components];
 
 export interface ExtensionPoints {
   'Checkout::KitchenSink': RenderExtension<StandardApi, AllComponents>;
-  'Checkout::PostPurchaseCrossSell::Render': RenderExtension<
-    PostPurchaseCrossSellApi,
+  'Checkout::PostPurchase::Render': RenderExtension<
+    PostPurchaseApi,
     AllComponents
   >;
-  'Checkout::PostPurchaseCrossSell::Inquiry': () => boolean;
+  'Checkout::PostPurchase::Inquiry': () => boolean;
 }
 
 export type ExtensionPoint = keyof ExtensionPoints;

--- a/packages/argo-checkout-testing/src/extension-points/input/index.ts
+++ b/packages/argo-checkout-testing/src/extension-points/input/index.ts
@@ -1,2 +1,2 @@
-export type {PostPurchaseCrossSellApi} from './post-purchase-cross-sell-render';
+export type {PostPurchaseApi} from './post-purchase-render';
 export type {StandardApi, Version} from './standard';

--- a/packages/argo-checkout-testing/src/extension-points/input/post-purchase-render.ts
+++ b/packages/argo-checkout-testing/src/extension-points/input/post-purchase-render.ts
@@ -1,6 +1,6 @@
 import type {StandardApi} from './standard';
 
-export interface PostPurchaseCrossSellApi extends StandardApi {
+export interface PostPurchaseApi extends StandardApi {
   orderId: number;
   shopId: number;
   token: string;


### PR DESCRIPTION
The purpose of this PR is to update the extension point name so that it aligns with other repos.  `Checkout::PostPurchaseCrossSell::Render'` --> `Checkout::PostPurchase::Render'`