### PR TITLE
allow to set static port

### DIFF
--- a/packages/argogogo-run/src/serve.ts
+++ b/packages/argogogo-run/src/serve.ts
@@ -4,11 +4,11 @@ import webpack from 'webpack';
 import Koa from 'koa';
 import koaWebpack from 'koa-webpack';
 
-import {log} from './utilities';
+import {log, namedArgument} from './utilities';
 import {createWebpackConfiguration} from './webpack-config';
 
-export async function serve(..._args: string[]) {
-  const port = await getPort({port: 8910});
+export async function serve(...args: string[]) {
+  const port = namedArgument('port', args) ?? (await getPort({port: 8910}));
   const url = `http://localhost:${port}`;
   const publicPath = `${url}/assets/`;
   const filename = 'extension.js';


### PR DESCRIPTION
Random ports are great to avoid collisions, however in order to be able to reuse and bookmark URLs (and automate processes) it would be great to be able set a static port even if starting will fail when this port is already taken.

## 🎩

There might be easier ways, but I created a new repo using `argogo` and linked `argogo-run` to test the built artifact.

```
yarn build
cd packages/argogogo-run
yarn link
```

Go to a different folder

```
npx argogogo@latest argo-app
cd argo-app
yarn link "argogogo-run"
yarn argogogo-run --port 9999
```

Open http://localhost:9999/assets/extension.js and ensure it serves js

```
yarn argogogo-run
```

and ensure it picked a random port.