### PR TITLE
Rename post purchase endpoints

### DIFF
--- a/packages/argo-checkout/documentation/extension-points.md
+++ b/packages/argo-checkout/documentation/extension-points.md
@@ -4,4 +4,4 @@ An Argo extension will register for one or more extension points using [`shopify
 
 The current extension points are available for Checkout:
 
-- [`Checkout::PostPurchase::Inquiry` and `Checkout::PostPurchase::Render`](../src/extension-points/api/post-purchase), used to build post-purchase interstitials for cross sell applications.
+- [`Checkout::PostPurchase::ShouldRender` and `Checkout::PostPurchase::Render`](../src/extension-points/api/post-purchase), used to build post-purchase interstitials for cross sell applications.

--- a/packages/argo-checkout/documentation/globals.md
+++ b/packages/argo-checkout/documentation/globals.md
@@ -5,8 +5,8 @@
 The most important API to an Argo extension is `shopify`, an object that is globally available. This object has a single method, `extend`. `extend` takes two arguments: the name of an [available extension point](./extension-points.md), and a function to call when Shopify is ready to run the extension point. The function you pass is called with at least one input argument, depending on the extension point — please refer to the documentation for the extension point you are targeting to see what you have access to.
 
 ```ts
-shopify.extend('Checkout::PostPurchase::Inquiry', (...args) => {
-  // Implement your Checkout::PostPurchase::Inquiry extension point logic here
+shopify.extend('Checkout::PostPurchase::ShouldRender', (...args) => {
+  // Implement your Checkout::PostPurchase::ShouldRender extension point logic here
 });
 ```
 
@@ -15,8 +15,8 @@ This library provides an alias for `shopify.extend` in the form of the `extend()
 ```ts
 import {extend} from '@shopify/argo-checkout';
 
-extend('Checkout::PostPurchase::Inquiry', (api) => {
-  // Implement your Checkout::PostPurchase::Inquiry extension point logic here
+extend('Checkout::PostPurchase::ShouldRender', (api) => {
+  // Implement your Checkout::PostPurchase::ShouldRender extension point logic here
   // If you hover over `api` in an editor that supports TypeScript, you’ll see
   // the properties and methods available for this extension point, even if you
   // are writing your extension in "vanilla" JavaScript.

--- a/packages/argo-checkout/documentation/testing.md
+++ b/packages/argo-checkout/documentation/testing.md
@@ -4,7 +4,7 @@ Argo extensions can be tested with any test runner that supports JavaScript. At 
 
 ## Non-rendering extension points
 
-A non-rendering extension point, like `Checkout::PostPurchase::Inquiry`, is really just a function that takes input, and returns output. To test these functions, we recommend you export (instead of writing them as inline callback functions to `shopify.extend`), and call them directly in your tests. If you are using TypeScript, you can use the `ArgumentsForExtension` helper type to get access to the expected types for the inputs to your function, which can be useful to create API-compatible mock data.
+A non-rendering extension point, like `Checkout::PostPurchase::ShouldRender`, is really just a function that takes input, and returns output. To test these functions, we recommend you export (instead of writing them as inline callback functions to `shopify.extend`), and call them directly in your tests. If you are using TypeScript, you can use the `ArgumentsForExtension` helper type to get access to the expected types for the inputs to your function, which can be useful to create API-compatible mock data.
 
 Assuming we had an extension like this one:
 
@@ -13,9 +13,9 @@ Assuming we had an extension like this one:
 
 import {extend} from '@shopify/argo-checkout';
 
-extend('Checkout::PostPurchase::Inquiry', handleInquiryExtension);
+extend('Checkout::PostPurchase::ShouldRender', handleShouldRenderExtension);
 
-export function handleInquiryExtension({storage}) {
+export function handleShouldRenderExtension({storage}) {
   storage.update({myExtensionData: {}});
   return {render: true};
 }
@@ -26,16 +26,16 @@ You could write a test with Jest by importing the extension callback and running
 ```ts
 // In extension.test.js
 
-import {handleInquiryExtension} from './extension';
+import {handleShouldRenderExtension} from './extension';
 
-describe('inquiry', () => {
+describe('shouldRender', () => {
   it('stores some data', () => {
     const storage = {update: jest.fn()};
 
     // To be a little more future-proof, you may want to supply mock values
     // for all the fields this extension receives. For now, we’re just mocking
     // what we know our extension point callback uses.
-    handleInquiryExtension({storage});
+    handleShouldRenderExtension({storage});
 
     expect(storage.update).toHaveBeenCalledWith(expect.any(Object));
   });

--- a/packages/argo-checkout/src/extension-points/api/index.ts
+++ b/packages/argo-checkout/src/extension-points/api/index.ts
@@ -1,6 +1,6 @@
 export type {
   PostPurchaseRenderApi,
-  PostPurchaseInquiryApi,
-  PostPurchaseInquiryResult,
+  PostPurchaseShouldRenderApi,
+  PostPurchaseShouldRenderResult,
 } from './post-purchase';
 export type {StandardApi, Version} from './standard';

--- a/packages/argo-checkout/src/extension-points/api/post-purchase/README.md
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/README.md
@@ -1,6 +1,6 @@
 # Post purchase extension points
 
-## Inquiry (`Checkout::PostPurchase::Inquiry`)
+## ShouldRender (`Checkout::PostPurchase::ShouldRender`)
 
 This extension provides the [standard extension API](../standard).
 

--- a/packages/argo-checkout/src/extension-points/api/post-purchase/index.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/index.ts
@@ -1,5 +1,5 @@
 export type {
   PostPurchaseRenderApi,
-  PostPurchaseInquiryApi,
-  PostPurchaseInquiryResult,
+  PostPurchaseShouldRenderApi,
+  PostPurchaseShouldRenderResult,
 } from './post-purchase';

--- a/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
@@ -1,9 +1,9 @@
 import type {StandardApi} from '../standard';
 import type {ValueOrPromise} from '../shared';
 
-/** input given to the inquiry extension point (Checkout::PostPurchase::Inquiry) */
-export interface PostPurchaseInquiryApi
-  extends StandardApi<'Checkout::PostPurchase::Inquiry'> {
+/** input given to the ShouldRender extension point (Checkout::PostPurchase::ShouldRender) */
+export interface PostPurchaseShouldRenderApi
+  extends StandardApi<'Checkout::PostPurchase::ShouldRender'> {
   /** current cart being checked out */
   checkout: Checkout;
 
@@ -17,11 +17,11 @@ export interface PostPurchaseInquiryApi
 }
 
 /**
- * output expected from the inquiry extension point (Checkout::PostPurchase::Inquiry)
+ * output expected from the ShouldRender extension point (Checkout::PostPurchase::ShouldRender)
  * if the result sets requestPostPurchasePage to be true, the post purchase page might be shown after payment
  *
  */
-export type PostPurchaseInquiryResult = ValueOrPromise<{
+export type PostPurchaseShouldRenderResult = ValueOrPromise<{
   render: boolean;
 }>;
 

--- a/packages/argo-checkout/src/extension-points/api/standard/README.md
+++ b/packages/argo-checkout/src/extension-points/api/standard/README.md
@@ -1,6 +1,6 @@
 # Standard extension point API
 
-This document outlines the API that is provided to every extension point. When the extension point renders UI (like `Checkout::PostPurchase::Render`), these properties are part of the second argument to an extension point. When the extension point does not render UI (like `Checkout::PostPurchase::Inquiry`), these properties are part of the first argument.
+This document outlines the API that is provided to every extension point. When the extension point renders UI (like `Checkout::PostPurchase::Render`), these properties are part of the second argument to an extension point. When the extension point does not render UI (like `Checkout::PostPurchase::ShouldRender`), these properties are part of the first argument.
 
 ## `locale`
 

--- a/packages/argo-checkout/src/extension-points/extension-points.ts
+++ b/packages/argo-checkout/src/extension-points/extension-points.ts
@@ -1,8 +1,8 @@
 import {RenderExtension} from './render-extension';
 import type {
   StandardApi,
-  PostPurchaseInquiryApi,
-  PostPurchaseInquiryResult,
+  PostPurchaseShouldRenderApi,
+  PostPurchaseShouldRenderResult,
   PostPurchaseRenderApi,
 } from './api';
 
@@ -19,9 +19,9 @@ export interface ExtensionPoints {
     PostPurchaseRenderApi,
     AllComponents
   >;
-  'Checkout::PostPurchase::Inquiry': (
-    api: PostPurchaseInquiryApi,
-  ) => PostPurchaseInquiryResult;
+  'Checkout::PostPurchase::ShouldRender': (
+    api: PostPurchaseShouldRenderApi,
+  ) => PostPurchaseShouldRenderResult;
 }
 
 export type ExtensionPoint = keyof ExtensionPoints;

--- a/packages/argo-run/README.md
+++ b/packages/argo-run/README.md
@@ -44,13 +44,13 @@ This command will open your default browser to the `open` URL, with an `extensio
 The most complex example might look something like this:
 
 ```bash
-$ yarn argo-run dev --open https://argogogo.dev --extension-point Checkout::PostPurchase::Inquiry
+$ yarn argo-run dev --open https://argogogo.dev --extension-point Checkout::PostPurchase::ShouldRender
 ```
 
 Which would open your default browser to a the following URL, assuming the default asset server port is available:
 
 ```
-https://argogogo.dev?extension=%2522http%253A%252F%252Flocalhost%253A8910%252Fassets%252Fextension.js%2522&extension-point=Checkout::PostPurchase::Inquiry
+https://argogogo.dev?extension=%2522http%253A%252F%252Flocalhost%253A8910%252Fassets%252Fextension.js%2522&extension-point=Checkout::PostPurchase::ShouldRender
 ```
 
 ### `argo-run build`


### PR DESCRIPTION
https://github.com/Shopify/cross-sell-app/issues/123
`Checkout::PostPurchase::Inquiry` -> `Checkout::PostPurchase::ShouldRender`

Order of changes for the entire rename:

- this repo (+publish)
-  `checkout-web` (depends on `argo-checkout` for types)
- `shopify` (update manifest and ids)
- `argo-checkout-template` / `post-purchase-reference-extension`  
