### PR TITLE
Fix relative links on NPM for @shopify/argo-checkout

### DIFF
--- a/packages/argo-checkout/package.json
+++ b/packages/argo-checkout/package.json
@@ -2,6 +2,11 @@
   "name": "@shopify/argo-checkout",
   "description": "The API for Argo extensions that run in Shopify’s Checkout",
   "version": "0.7.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shopify/argo-checkout.git",
+    "directory": "packages/argo-checkout"
+  },
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
### Problem

For package [`@shopify/argo-checkout`](https://www.npmjs.com/package/@shopify/argo-checkout), when viewing on NPM, any relative links to supplementary documentation does not work (broken link). This does not impact GitHub's rendering of markdown links.

### Example

On the landing page (README), under the "API" heading, the content "Details about the globals available to Argo extensions" currently links to `https://www.npmjs.com/package/@shopify/documentation/globals.md`. The expected path would be `https://github.com/Shopify/argo-checkout/blob/HEAD/packages/argo-checkout/documentation/globals.md`.

### Hypothesis

This problem seems more specific to scoped packages (`@shopify` package name prefix), and loses the package name. Changes made were based on recommendation based on [relative links in npm README markdown not functional](https://npm.community/t/relative-links-in-npm-readme-markdown-not-functional/1525/8) bug report.

By setting the [`repository` property of package.json](https://docs.npmjs.com/files/package.json.html#repository), the belief is that NPM will then know how to build absolute URLs from relative paths.