### PR TITLE
Support mulitple extension points for checkout

### DIFF
--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -179,30 +179,18 @@ export async function dev(...args: string[]) {
         res.set('Access-Control-Allow-Origin', '*');
         res.set('Cache-Control', 'no-cache');
 
-        const defaultExtension = {
-          scriptUrl: `${origin}${PUBLIC_PATH}${filename}`,
-          socketUrl: `${origin.replace(/^http/, 'ws')}${WEBSOCKET_PATH}`,
-        };
-        let extensions;
-        if (extension.type === 'checkout') {
-          extensions = extension.config.extensionPoints.map(
-            (extensionPoint) => ({
-              ...defaultExtension,
-              extensionPoint,
-            }),
-          );
-        } else {
-          extensions = [
-            {
-              ...defaultExtension,
-              extensionPoint: 'Checkout::PostPurchase::Render',
-            },
-          ];
-        }
-
         res.json({
           queryUrl: `${origin}${req.path}`,
-          extensions,
+          extensions: [
+            {
+              scriptUrl: `${origin}${PUBLIC_PATH}${filename}`,
+              socketUrl: `${origin.replace(/^http/, 'ws')}${WEBSOCKET_PATH}`,
+              extensionPoints:
+                extension.type === 'checkout'
+                  ? extension.config.extensionPoints
+                  : ['Checkout::PostPurchase::Render'],
+            },
+          ],
         });
       });
 


### PR DESCRIPTION
### Background

Current `/query` endpoint doesn't returns all extension points. This PR fixes it. 

Resolves https://github.com/Shopify/checkout-web/issues/4573

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- In https://github.com/Shopify/argo-checkout-template, run `yarn && yarn generate --type=CHECKOUT_ARGO_EXTENSION --template=react-typescript`
- In this PR, run `yarn && yarn build && cp -R packages/* ../argo-checkout-template/node_modules/@shopify/`
- Back to argo-checkout-template repo:
  + Update `extension.config.yml` 
  ```
  ---
  extension_points:
    - Checkout::Feature::Render
    - Checkout::KitchenSink
  ```
  + Run `yarn server`
- Open http://localhost:39351/query, verify that extensions field returns an array of two.

### Checklist

- [x] I have :tophat:'d these changes
