### PR TITLE
checkout feature: target line item

### DIFF
--- a/packages/argo-checkout-react/src/hooks/index.ts
+++ b/packages/argo-checkout-react/src/hooks/index.ts
@@ -14,6 +14,7 @@ export {
   useApplyPrivateMetafieldsChange,
 } from './private-metafields';
 export {useLineItems, useApplyLineItemsChange} from './line-items';
+export {useTargetLineItem} from './target-line-item';
 export {useApplySignedChange} from './signed';
 export {useAppMetafields} from './app-metafields';
 export {useShop} from './shop';

--- a/packages/argo-checkout-react/src/hooks/target-line-item.ts
+++ b/packages/argo-checkout-react/src/hooks/target-line-item.ts
@@ -1,0 +1,23 @@
+import {ExtensionPoint} from '@shopify/argo-checkout';
+
+import {useExtensionApi} from './api';
+import {useSubscription} from './subscription';
+
+class ExtensionHasNoTargetError extends Error {
+  constructor(extensionPoint: ExtensionPoint) {
+    super(
+      `Cannot call 'useTargetLineItem()' on extensionPoint '${extensionPoint}'. Property 'target' is not found on api.`,
+    );
+  }
+}
+
+/**
+ * Returns the target line item.
+ */
+export function useTargetLineItem() {
+  const api = useExtensionApi<'Checkout::LineItem::RenderAfter'>();
+  if (!api.target) {
+    throw new ExtensionHasNoTargetError(api.extensionPoint);
+  }
+  return useSubscription(api.target);
+}

--- a/packages/argo-checkout/src/extension-points/api/index.ts
+++ b/packages/argo-checkout/src/extension-points/api/index.ts
@@ -29,3 +29,4 @@ export type {
   SignedChange,
 } from './standard';
 export type {CurrencyCode, CountryCode} from './shared';
+export type {LineItemRenderAfterApi} from './line-item-render-after';

--- a/packages/argo-checkout/src/extension-points/api/line-item-render-after.ts
+++ b/packages/argo-checkout/src/extension-points/api/line-item-render-after.ts
@@ -1,0 +1,11 @@
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+
+import {LineItem, StandardApi} from './standard';
+
+export interface LineItemRenderAfterApi
+  extends StandardApi<'Checkout::LineItem::RenderAfter'> {
+  /**
+   * The line item this extension is attached to.
+   */
+  target: StatefulRemoteSubscribable<LineItem>;
+}

--- a/packages/argo-checkout/src/extension-points/extension-points.ts
+++ b/packages/argo-checkout/src/extension-points/extension-points.ts
@@ -1,5 +1,5 @@
 import {RenderExtension} from './render-extension';
-import type {StandardApi} from './api';
+import type {LineItemRenderAfterApi, StandardApi} from './api';
 
 type Components = typeof import('../components');
 
@@ -25,6 +25,10 @@ export interface ExtensionPoints {
   >;
   'Checkout::KitchenSink': RenderExtension<
     StandardApi<'Checkout::KitchenSink'>,
+    AllComponents
+  >;
+  'Checkout::LineItem::RenderAfter': RenderExtension<
+    LineItemRenderAfterApi,
     AllComponents
   >;
 }


### PR DESCRIPTION
Updates from this ticket: https://github.com/Shopify/checkout-web/pull/5148

<img width="743" alt="Screen Shot 2021-05-19 at 4 39 48 PM" src="https://user-images.githubusercontent.com/1744278/118882011-afa5a700-b8c1-11eb-889b-2cece1c8632a.png">

<img width="660" alt="Screen Shot 2021-05-19 at 4 40 04 PM" src="https://user-images.githubusercontent.com/1744278/118882031-b59b8800-b8c1-11eb-8b24-c8e512d34a81.png">

### 🎩

- checkout this branch and yarn link into these packages. `cd packages/argo-checkout-react; yarn link`
- In a dev extension link the package. `yarn link @shopify/argo-checkout-react`
- Check the extension is able to use `useTargetLineItem`. Also checkout `api.target` is working.

### Checklist

- [x] I have :tophat:'d these changes
