### PR TITLE
Add changesetApplicationsRemaining to post-purchase types

### DIFF
--- a/packages/post-purchase-ui-extensions/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/post-purchase-ui-extensions/src/extension-points/api/post-purchase/post-purchase.ts
@@ -269,6 +269,8 @@ interface ApplyChangesetResult {
   errors: ChangesetError[];
   /** An enum representing the result of attempting to apply or calculate a changeset. */
   status: ChangesetProcessingStatus;
+  /** How many changesets can still be applied to the initial purchase. */
+  changesetApplicationsRemaining: number;
 }
 
 export type ChangesetProcessingStatus =


### PR DESCRIPTION
### Background

Following the implementation in core (see https://github.com/Shopify/shopify/pull/298195), we're now updating the post-purchase types to include the `changesetApplicationsRemaining` attribute.

You can see more information on the PR liked above, but in summary, it returns how many changesets a partner can still apply to an initial purchase. This is important for payment gateways that only support one changeset per initial purchase, like PayPal express.

### Solution

Just adding the type, along with a brief description.

### Checklist

- [x] I have :tophat:'d these changes
