### PR TITLE
Parse union of TSTypeLiteral

### DIFF
--- a/packages/checkout-ui-extensions/src/components/Text/README.md
+++ b/packages/checkout-ui-extensions/src/components/Text/README.md
@@ -11,6 +11,37 @@ optional = ?
 | size? | <code>"extraSmall" &#124; "small" &#124; "base" &#124; "large" &#124; "extraLarge"</code> | Size of the text  |
 | emphasized? | <code>boolean</code> |  |
 | subdued? | <code>boolean</code> |  |
-| role? | <code>"address" &#124; "deletion" &#124; UndocumentedType &#124; UndocumentedType &#124; UndocumentedType</code> | Assign semantic value  |
+| role? | <code>"address" &#124; "deletion" &#124; <a href="#abbreviationroletype">AbbreviationRoleType</a> &#124; <a href="#directionaloverrideroletype">DirectionalOverrideRoleType</a> &#124; <a href="#datetimeroletype">DatetimeRoleType</a></code> | Assign semantic value  |
 | id? | <code>string</code> | Unique identifier. Typically used as a target for another component’s controls to associate an accessible label with an action.  |
-| appearance? | <code>"critical" &#124; "warning" &#124; "success" &#124; "accent"</code> | Changes the visual appearance  |
+| appearance? | <code>"critical" &#124; "warning" &#124; "success" &#124; "accent"</code> | Changes the visual appearance  |<a name="DatetimeRoleType"></a>
+
+### DatetimeRoleType
+
+Indicate the text is a date, a time or a duration. Use the &#34;machineReadable&#34; option
+to help browsers, tools or software understand the human-readable date. Valid format
+for &#34;machineReadable&#34; can be found here:
+https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#Valid_datetime_Values
+
+| Name | Type | Description |
+| --- | --- | --- |
+| type | <code>"datetime"</code> |  |
+| machineReadable? | <code>string</code> |  |<a name="DirectionalOverrideRoleType"></a>
+
+### DirectionalOverrideRoleType
+
+Override the text directionality. Typically used for email and phone numbers.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| type | <code>"directional-override"</code> |  |
+| direction | <code>"ltr" &#124; "rtl"</code> |  |<a name="AbbreviationRoleType"></a>
+
+### AbbreviationRoleType
+
+Indicate the text is an abbreviation or acronym. Use the &#34;for&#34; option to
+provide a description of the abbreviation.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| type | <code>"abbreviation"</code> |  |
+| for? | <code>string</code> |  |

--- a/packages/checkout-ui-extensions/src/components/Text/Text.ts
+++ b/packages/checkout-ui-extensions/src/components/Text/Text.ts
@@ -6,20 +6,35 @@ type Role =
   | 'address'
   /** Indicate the text has been deleted. Typically used for discounted prices. */
   | 'deletion'
-  /**
-   * Indicate the text is an abbreviation or acronym. Use the "for" option to
-   * provide a description of the abbreviation.
-   */
-  | {type: 'abbreviation'; for?: string}
-  /** Override the text directionality. Typically used for email and phone numbers. */
-  | {type: 'directional-override'; direction: 'ltr' | 'rtl'}
-  /**
-   * Indicate the text is a date, a time or a duration. Use the "machineReadable" option
-   * to help browsers, tools or software understand the human-readable date. Valid format
-   * for "machineReadable" can be found here:
-   * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#Valid_datetime_Values
-   */
-  | {type: 'datetime'; machineReadable?: string};
+  | AbbreviationRoleType
+  | DirectionalOverrideRoleType
+  | DatetimeRoleType;
+
+/**
+ * Indicate the text is an abbreviation or acronym. Use the "for" option to
+ * provide a description of the abbreviation.
+ */
+interface AbbreviationRoleType {
+  type: 'abbreviation';
+  for?: string;
+}
+
+/** Override the text directionality. Typically used for email and phone numbers. */
+interface DirectionalOverrideRoleType {
+  type: 'directional-override';
+  direction: 'ltr' | 'rtl';
+}
+
+/**
+ * Indicate the text is a date, a time or a duration. Use the "machineReadable" option
+ * to help browsers, tools or software understand the human-readable date. Valid format
+ * for "machineReadable" can be found here:
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#Valid_datetime_Values
+ */
+interface DatetimeRoleType {
+  type: 'datetime';
+  machineReadable?: string;
+}
 
 export interface TextProps {
   /** Size of the text */

--- a/packages/post-purchase-ui-extensions/src/components/Text/README.md
+++ b/packages/post-purchase-ui-extensions/src/components/Text/README.md
@@ -11,6 +11,37 @@ optional = ?
 | size? | <code>"auto" &#124; "fill" &#124; number</code> | Size of the text  |
 | emphasized? | <code>boolean</code> |  |
 | subdued? | <code>boolean</code> |  |
-| role? | <code>"address" &#124; "deletion" &#124; UndocumentedType &#124; UndocumentedType &#124; UndocumentedType</code> | Assign semantic value  |
+| role? | <code>"address" &#124; "deletion" &#124; <a href="#abbreviationroletype">AbbreviationRoleType</a> &#124; <a href="#directionaloverrideroletype">DirectionalOverrideRoleType</a> &#124; <a href="#datetimeroletype">DatetimeRoleType</a></code> | Assign semantic value  |
 | id? | <code>string</code> | Unique identifier. Typically used as a target for another component’s controls to associate an accessible label with an action.  |
-| appearance? | <code>"critical" &#124; "warning" &#124; "success"</code> | Changes the visual appearance  |
+| appearance? | <code>"critical" &#124; "warning" &#124; "success"</code> | Changes the visual appearance  |<a name="DatetimeRoleType"></a>
+
+### DatetimeRoleType
+
+Indicate the text is a date, a time or a duration. Use the &#34;machineReadable&#34; option
+to help browsers, tools or software understand the human-readable date. Valid format
+for &#34;machineReadable&#34; can be found here:
+https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#Valid_datetime_Values
+
+| Name | Type | Description |
+| --- | --- | --- |
+| type | <code>"datetime"</code> |  |
+| machineReadable? | <code>string</code> |  |<a name="DirectionalOverrideRoleType"></a>
+
+### DirectionalOverrideRoleType
+
+Override the text directionality. Typically used for email and phone numbers.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| type | <code>"directional-override"</code> |  |
+| direction | <code>"ltr" &#124; "rtl"</code> |  |<a name="AbbreviationRoleType"></a>
+
+### AbbreviationRoleType
+
+Indicate the text is an abbreviation or acronym. Use the &#34;for&#34; option to
+provide a description of the abbreviation.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| type | <code>"abbreviation"</code> |  |
+| for? | <code>string</code> |  |

--- a/packages/post-purchase-ui-extensions/src/components/Text/Text.ts
+++ b/packages/post-purchase-ui-extensions/src/components/Text/Text.ts
@@ -6,20 +6,35 @@ type Role =
   | 'address'
   /** Indicate the text has been deleted. Typically used for discounted prices. */
   | 'deletion'
-  /**
-   * Indicate the text is an abbreviation or acronym. Use the "for" option to
-   * provide a description of the abbreviation.
-   */
-  | {type: 'abbreviation'; for?: string}
-  /** Override the text directionality. Typically used for email and phone numbers. */
-  | {type: 'directional-override'; direction: 'ltr' | 'rtl'}
-  /**
-   * Indicate the text is a date, a time or a duration. Use the "machineReadable" option
-   * to help browsers, tools or software understand the human-readable date. Valid format
-   * for "machineReadable" can be found here:
-   * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#Valid_datetime_Values
-   */
-  | {type: 'datetime'; machineReadable?: string};
+  | AbbreviationRoleType
+  | DirectionalOverrideRoleType
+  | DatetimeRoleType;
+
+/**
+ * Indicate the text is an abbreviation or acronym. Use the "for" option to
+ * provide a description of the abbreviation.
+ */
+interface AbbreviationRoleType {
+  type: 'abbreviation';
+  for?: string;
+}
+
+/** Override the text directionality. Typically used for email and phone numbers. */
+interface DirectionalOverrideRoleType {
+  type: 'directional-override';
+  direction: 'ltr' | 'rtl';
+}
+
+/**
+ * Indicate the text is a date, a time or a duration. Use the "machineReadable" option
+ * to help browsers, tools or software understand the human-readable date. Valid format
+ * for "machineReadable" can be found here:
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#Valid_datetime_Values
+ */
+interface DatetimeRoleType {
+  type: 'datetime';
+  machineReadable?: string;
+}
 
 export interface TextProps {
   /** Size of the text */

--- a/scripts/typedoc/types.ts
+++ b/scripts/typedoc/types.ts
@@ -50,6 +50,11 @@ export interface PropertySignature extends Documentable {
   parameters?: ParameterType[];
 }
 
+export interface TypeLiteral extends Documentable {
+  kind: 'TypeLiteral';
+  properties: PropertySignature[];
+}
+
 export interface StringType {
   kind: 'StringType';
 }
@@ -130,6 +135,10 @@ export interface MappedType {
   mapping: string;
 }
 
+export interface NeverKeyword {
+  kind: 'NeverKeyword';
+}
+
 export interface TypeParameter {
   kind: 'TypeParameter';
   constraint?: string;
@@ -160,6 +169,8 @@ export type Type =
   | ArrayType
   | UnknownType
   | AnyType
+  | TypeLiteral
+  | NeverKeyword
   | UndocumentedType
   | LocalReference;
 


### PR DESCRIPTION
### Background

Union of TSTypeLiteral is not parsed correctly.

```ts
type CalculateChangesetResult =
  | {
      errors: ChangesetError[];
      status: 'unprocessed';
      calculatedPurchase?: never;
    }
  | {
      errors: ChangesetError[];
      status: 'processed';
      calculatedPurchase: CalculatedPurchase;
    };
```

is rendered like this

<img width="526" alt="Screen Shot 2021-06-25 at 5 56 34 PM" src="https://user-images.githubusercontent.com/1244342/123488823-af927880-d5de-11eb-8dd5-8f363ebcb543.png">

A similar issue is encountered in the `Text` component docs:

<img width="482" alt="Screen Shot 2021-06-25 at 5 59 26 PM" src="https://user-images.githubusercontent.com/1244342/123488999-16179680-d5df-11eb-8e5a-a9d4fb58ae37.png">

### Solution

The solution if a combination of approaches:
1. Add a special treatment for the union of only `TSTypeLiteral`s that covers the `CalculateChangesetResult`
2. Extract `TSTypeLiteral`s from `Role` into separate types.

Worth noting that this is by far not the best solution but it does the job and can be iterated upon. The script must be improved anyway to support more of the possible type declarations. The current version just covers whatever we have so far.

### Checklist

- [x] I have :tophat:'d these changes
