### PR TITLE
Support for Checkout One Deeplinks

### DIFF
--- a/packages/checkout-ui-extensions-run/package.json
+++ b/packages/checkout-ui-extensions-run/package.json
@@ -44,7 +44,6 @@
     "camelcase-keys": "^6.0.0",
     "chalk": "^4.0.0",
     "core-js": "^3.0.0",
-    "get-port": "^5.1.1",
     "glob": "^7.0.0",
     "gzip-size": "^6.0.0",
     "js-yaml": "^3.14.0",

--- a/packages/checkout-ui-extensions-run/src/utilities.test.ts
+++ b/packages/checkout-ui-extensions-run/src/utilities.test.ts
@@ -8,22 +8,22 @@ describe('argumentParserFor', () => {
   });
 
   test('creates a function for accessing individual arguments', () => {
-    const fetch = argumentParserFor(['--shop=shop1.myshopify.io']);
-    expect(fetch('shop')).toBe('shop1.myshopify.io');
+    const fetch = argumentParserFor(['--store=shop1.myshopify.io']);
+    expect(fetch('store')).toBe('shop1.myshopify.io');
   });
 });
 
 describe('parseDevelopmentServerConfig', () => {
   const args = [
-    '--shop=shop1.myshopify.io',
+    '--store=shop1.myshopify.io',
     '--resourceUrl=/cart/1:1',
     '--publicUrl=https://example.com',
     '--port=5678',
   ];
 
-  test('includes shop', () => {
+  test('includes store', () => {
     expect(parseDevelopmentServerConfig(args)).toMatchObject({
-      shop: 'shop1.myshopify.io',
+      store: 'shop1.myshopify.io',
     });
   });
 
@@ -85,17 +85,17 @@ describe('parseDevelopmentServerConfig', () => {
   });
 
   describe('permalinkUrl', () => {
-    test('returns undefined if resourceUrl, publicUrl or shop are missing', () => {
+    test('returns undefined if resourceUrl, publicUrl or store are missing', () => {
       const argsWithoutShop = [
         '--resourceUrl=/cart/1:1',
         '--publicUrl=https://example.com',
       ];
       const argsWithoutResourceUrl = [
         '--publicUrl=https://example.com',
-        '--shop=shop1.myshopify.io',
+        '--store=shop1.myshopify.io',
       ];
       const argsWithoutPublicUrl = [
-        '--shop=shop1.myshopify.io',
+        '--store=shop1.myshopify.io',
         '--resourceUrl=/cart/1:1',
       ];
       const configWithoutPermalinkUrl = {permalinkUrl: undefined};
@@ -123,14 +123,14 @@ describe('parseDevelopmentServerConfig', () => {
           ...args,
           '--resourceUrl=/cart/1:1',
           '--publicUrl=https://example.com',
-          '--shop=shop1.myshopify.com',
+          '--store=shop1.myshopify.com',
         ]),
       ).toMatchObject(configWithPermalink);
     });
   });
 
   describe('passwordPageUrl', () => {
-    test('returns undefined if shop flag is missing', () => {
+    test('returns undefined if store flag is missing', () => {
       const configWithoutPasswordPageUrl = {
         passwordPageUrl: undefined,
       };
@@ -139,12 +139,12 @@ describe('parseDevelopmentServerConfig', () => {
       );
     });
 
-    test('returns https://<shop>/password if shop flag is present', () => {
+    test('returns https://<store>/password if store flag is present', () => {
       const configWithPasswordPageUrl = {
         passwordPageUrl: 'https://shop1.myshopify.io/password',
       };
       expect(
-        parseDevelopmentServerConfig([...args, '--shop=shop1.myshopify.io']),
+        parseDevelopmentServerConfig([...args, '--store=shop1.myshopify.io']),
       ).toMatchObject(configWithPasswordPageUrl);
     });
   });

--- a/packages/checkout-ui-extensions-run/src/utilities.test.ts
+++ b/packages/checkout-ui-extensions-run/src/utilities.test.ts
@@ -1,0 +1,262 @@
+import {URL} from 'url';
+import {argumentParserFor, parseDevelopmentServerConfig} from './utilities';
+
+describe('argumentParserFor', () => {
+  test('creates a function', () => {
+    expect(argumentParserFor([])).toBeInstanceOf(Function);
+  });
+
+  test('creates a function for accessing individual arguments', () => {
+    const fetch = argumentParserFor(['--shop=shop1.myshopify.io']);
+    expect(fetch('shop')).toBe('shop1.myshopify.io');
+  });
+});
+
+describe('parseDevelopmentServerConfig', () => {
+  const args = [
+    '--shop=shop1.myshopify.io',
+    '--resourceUrl=/cart/1:1',
+    '--publicUrl=https://example.com',
+    '--port=5678',
+  ];
+  const fetchArgument = argumentParserFor(args);
+  const createWebpackConfiguration = () => ({});
+
+  test('includes shop', () => {
+    expect(
+      parseDevelopmentServerConfig({fetchArgument, createWebpackConfiguration}),
+    ).toMatchObject({
+      shop: 'shop1.myshopify.io',
+    });
+  });
+
+  test('includes resource URL', () => {
+    expect(
+      parseDevelopmentServerConfig({fetchArgument, createWebpackConfiguration}),
+    ).toMatchObject({
+      resourceUrl: '/cart/1:1',
+    });
+  });
+
+  test('includes public URL', () => {
+    expect(
+      parseDevelopmentServerConfig({fetchArgument, createWebpackConfiguration}),
+    ).toMatchObject({
+      publicUrl: 'https://example.com',
+    });
+  });
+
+  test('includes port', () => {
+    expect(
+      parseDevelopmentServerConfig({fetchArgument, createWebpackConfiguration}),
+    ).toMatchObject({
+      port: '5678',
+    });
+  });
+
+  test('includes filename', () => {
+    expect(
+      parseDevelopmentServerConfig({fetchArgument, createWebpackConfiguration}),
+    ).toMatchObject({
+      filename: 'extension.js',
+    });
+  });
+
+  test('includes extensionPoint', () => {
+    const fetchArgument = argumentParserFor(['--extension-point=test']);
+    expect(
+      parseDevelopmentServerConfig({fetchArgument, createWebpackConfiguration}),
+    ).toMatchObject({
+      extensionPoint: 'test',
+    });
+  });
+
+  describe('scriptUrl', () => {
+    test('points to localhost:8910 when no public url and port is provided', () => {
+      const fetchArgument = argumentParserFor([]);
+      expect(
+        parseDevelopmentServerConfig({
+          fetchArgument,
+          createWebpackConfiguration,
+        }),
+      ).toMatchObject({
+        scriptUrl: 'http://localhost:8910/assets/extension.js',
+      });
+    });
+
+    test('supports custom port', () => {
+      const fetchArgument = argumentParserFor(['--port=1234']);
+      expect(
+        parseDevelopmentServerConfig({
+          fetchArgument,
+          createWebpackConfiguration,
+        }),
+      ).toMatchObject({
+        scriptUrl: 'http://localhost:1234/assets/extension.js',
+      });
+    });
+
+    test('points to public URL if one was provided and ignores port', () => {
+      const fetchArgument = argumentParserFor([
+        '--port=1234',
+        '--publicUrl=https://example.com',
+      ]);
+      expect(
+        parseDevelopmentServerConfig({
+          fetchArgument,
+          createWebpackConfiguration,
+        }),
+      ).toMatchObject({
+        scriptUrl: 'https://example.com/assets/extension.js',
+      });
+    });
+  });
+
+  describe('permalinkUrl', () => {
+    test('returns undefined if resourceUrl, publicUrl or shop are missing', () => {
+      const argsWithoutShop = [
+        '--resourceUrl=/cart/1:1',
+        '--publicUrl=https://example.com',
+      ];
+      const argsWithoutResourceUrl = [
+        '--publicUrl=https://example.com',
+        '--shop=shop1.myshopify.io',
+      ];
+      const argsWithoutPublicUrl = [
+        '--shop=shop1.myshopify.io',
+        '--resourceUrl=/cart/1:1',
+      ];
+      const configWithoutPermalinkUrl = {permalinkUrl: undefined};
+
+      expect(
+        parseDevelopmentServerConfig({
+          fetchArgument: argumentParserFor(argsWithoutShop),
+          createWebpackConfiguration,
+        }),
+      ).toMatchObject(configWithoutPermalinkUrl);
+
+      expect(
+        parseDevelopmentServerConfig({
+          fetchArgument: argumentParserFor(argsWithoutResourceUrl),
+          createWebpackConfiguration,
+        }),
+      ).toMatchObject(configWithoutPermalinkUrl);
+
+      expect(
+        parseDevelopmentServerConfig({
+          fetchArgument: argumentParserFor(argsWithoutPublicUrl),
+          createWebpackConfiguration,
+        }),
+      ).toMatchObject(configWithoutPermalinkUrl);
+    });
+
+    test('returns a permalinkUrl if all necessary command line flags are present', () => {
+      const args = [
+        '--resourceUrl=/cart/1:1',
+        '--publicUrl=https://example.com',
+        '--shop=shop1.myshopify.com',
+      ];
+
+      const permalink = new URL('https://shop1.myshopify.com/cart/1:1');
+      permalink.searchParams.append('dev', 'https://example.com/query');
+      const configWithPermalink = {permalinkUrl: permalink.toString()};
+
+      expect(
+        parseDevelopmentServerConfig({
+          fetchArgument: argumentParserFor(args),
+          createWebpackConfiguration,
+        }),
+      ).toMatchObject(configWithPermalink);
+    });
+  });
+
+  describe('passwordPageUrl', () => {
+    test('returns undefined if shop flag is missing', () => {
+      const configWithoutPasswordPageUrl = {
+        passwordPageUrl: undefined,
+      };
+      expect(
+        parseDevelopmentServerConfig({
+          fetchArgument: argumentParserFor([]),
+          createWebpackConfiguration,
+        }),
+      ).toMatchObject(configWithoutPasswordPageUrl);
+    });
+
+    test('returns https://<shop>/password if shop flag is present', () => {
+      const configWithPasswordPageUrl = {
+        passwordPageUrl: 'https://shop1.myshopify.io/password',
+      };
+      expect(
+        parseDevelopmentServerConfig({
+          fetchArgument: argumentParserFor(['--shop=shop1.myshopify.io']),
+          createWebpackConfiguration,
+        }),
+      ).toMatchObject(configWithPasswordPageUrl);
+    });
+  });
+
+  describe('webpackConfiguration', () => {
+    test('runs in development mode', () => {
+      const createWebpackConfiguration = jest.fn();
+      parseDevelopmentServerConfig({fetchArgument, createWebpackConfiguration});
+      expect(createWebpackConfiguration).toBeCalledWith(
+        settingsContaining({development: true}),
+      );
+    });
+
+    test('correct output settings', () => {
+      const createWebpackConfiguration = jest.fn();
+      parseDevelopmentServerConfig({fetchArgument, createWebpackConfiguration});
+      expect(createWebpackConfiguration).toBeCalledWith(
+        settingsContaining({
+          output: {
+            filename: 'extension.js',
+            publicPath: '/assets/',
+          },
+        }),
+      );
+    });
+
+    test('websocket points to localhost:8910 by default', () => {
+      const fetchArgument = argumentParserFor([]);
+      const createWebpackConfiguration = jest.fn();
+      parseDevelopmentServerConfig({fetchArgument, createWebpackConfiguration});
+      expect(createWebpackConfiguration).toBeCalledWith(
+        settingsContaining({
+          hotOptions: {
+            https: false,
+            webSocket: {
+              host: 'localhost',
+              port: 8910,
+              path: '/build',
+            },
+          },
+        }),
+      );
+    });
+
+    test('websocket points to the public endpoint if --publicUrl was provided', () => {
+      const fetchArgument = argumentParserFor([
+        '--publicUrl=https://example.com/',
+      ]);
+      const createWebpackConfiguration = jest.fn();
+      parseDevelopmentServerConfig({fetchArgument, createWebpackConfiguration});
+      expect(createWebpackConfiguration).toBeCalledWith(
+        settingsContaining({
+          hotOptions: {
+            https: true,
+            webSocket: {
+              host: 'example.com',
+              port: 443,
+              path: '/build',
+            },
+          },
+        }),
+      );
+    });
+
+    const settingsContaining = (settings: Record<string, any>) =>
+      expect.objectContaining(settings);
+  });
+});

--- a/packages/checkout-ui-extensions-run/src/utilities.ts
+++ b/packages/checkout-ui-extensions-run/src/utilities.ts
@@ -64,7 +64,7 @@ export interface DevelopmentServerConfiguration {
   port: string;
   scriptUrl: string;
   filename: string;
-  shop?: string;
+  store?: string;
   resourceUrl?: string;
   publicUrl?: string;
   passwordPageUrl?: string;
@@ -160,7 +160,7 @@ export function convertLegacyPostPurchaseDataToQueryString(data: Data) {
 export function parseDevelopmentServerConfig(args: string[]) {
   const fetchArgument = argumentParserFor(args);
   const port = fetchArgument('port') || '8910';
-  const shop = fetchArgument('shop');
+  const store = fetchArgument('store');
   const resourceUrl = fetchArgument('resourceUrl');
   const publicUrl = fetchArgument('publicUrl');
   const generatePublicUrl = urlGeneratorFor(publicUrl);
@@ -168,14 +168,14 @@ export function parseDevelopmentServerConfig(args: string[]) {
   const filename = 'extension.js';
   const path = `/assets/${filename}`;
   const scriptUrl = (generatePublicUrl(path) || generateLocalUrl(path))!;
-  const generateShopUrl = urlGeneratorFor(`https://${shop}`);
+  const generateShopUrl = urlGeneratorFor(`https://${store}`);
   const permalinkUrl =
-    resourceUrl && publicUrl && shop
+    resourceUrl && publicUrl && store
       ? generateShopUrl(resourceUrl, {
           dev: generatePublicUrl('query')!.toString(),
         })
       : undefined;
-  const passwordPageUrl = shop && generateShopUrl('/password');
+  const passwordPageUrl = store && generateShopUrl('/password');
   const extensionPoint = fetchArgument('extension-point');
   const useSSL = scriptUrl.protocol === 'https:';
   const webpackConfiguration = createWebpackConfiguration({
@@ -195,7 +195,7 @@ export function parseDevelopmentServerConfig(args: string[]) {
   });
 
   return {
-    shop,
+    store,
     resourceUrl,
     publicUrl,
     scriptUrl: scriptUrl.toString(),

--- a/packages/checkout-ui-extensions-run/src/webpack-config.ts
+++ b/packages/checkout-ui-extensions-run/src/webpack-config.ts
@@ -5,7 +5,26 @@ import {DefinePlugin} from 'webpack';
 import type {Configuration} from 'webpack';
 import {UIExtensionsHotClient} from '@shopify/ui-extensions-webpack-hot-client';
 
-import {shouldUseReact} from './utilities';
+const REACT_UI_EXTENSIONS_PACKAGES = [
+  '@shopify/checkout-ui-extensions-react',
+  '@shopify/post-purchase-ui-extensions-react',
+];
+
+export function shouldUseReact(): boolean | 'mini' {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const packageJson = require(path.resolve('package.json'));
+    const dependencies = new Set(Object.keys(packageJson.dependencies));
+
+    if (!REACT_UI_EXTENSIONS_PACKAGES.some((pkg) => dependencies.has(pkg))) {
+      return false;
+    }
+
+    return dependencies.has('@remote-ui/mini-react') ? 'mini' : true;
+  } catch {
+    return false;
+  }
+}
 
 const PRODUCTION_TARGETS = undefined;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6164,11 +6164,6 @@ get-port@^4.2.0:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.2.0.tgz#e37368b1e863b7629c43c5a323625f95cf24b119"
   integrity sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==
 
-get-port@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
-  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
-
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"


### PR DESCRIPTION
### Background

Today's checkout extension developer experience isn't ideal because developers have to manually assemble checkout links to test their extension.

### Solution

To improve this experience, Shopify CLI will pass `--resourceUrl` and `--store` in future, which can be used to assemble a cart permalink as follows:

```
https://<store>/<resourceUrl>?dev=<publicUrl>/query
```

Outputting this link instead of just the query parameters will enable developers to create a new checkout with just one click.

### 🎩
**Setup**
1. Create a new Checkout or Post Purchase extension using the CLI
2. In this repo, run after `yarn build-consumer <relative-path-to-checkout-extension> checkout-ui-extensions-run`

Running 

```
❯ yarn start --port=39351 --publicUrl=https://809671a3c94f.ngrok.io --store=t6d-dev.myshopify.io --resourceUrl=/cart/1:1
```


```
yarn run v1.22.10
$ checkout-ui-extensions-run serve --port=39351 --publicUrl=https://809671a3c94f.ngrok.io --store=t6d-dev.myshopify.io --resourceUrl=/cart/1:1
🔭 > Starting dev server on port 39351
🔭 > Your extension is available at https://809671a3c94f.ngrok.io/assets/extension.js
🔭 > 
🔭 > If this is first time you are testing the extension, 
🔭 > please login to your development store first by visiting
🔭 > https://t6d-dev.myshopify.io/password
🔭 > 
🔭 > To create a checkout and test your extension please visit the following URL:
🔭 > https://t6d-dev.myshopify.io/cart/1:1?dev=https%3A%2F%2F809671a3c94f.ngrok.io%2Fquery
```

omitting `--store` and `--resourceUrl` results in

```
yarn run v1.22.10
$ checkout-ui-extensions-run serve --port=39351 --publicUrl=https://809671a3c94f.ngrok.io
🔭 > Starting dev server on port 39351
🔭 > Your extension is available at https://809671a3c94f.ngrok.io/assets/extension.js
🔭 > Next, you’ll need to create a checkout on your development shop and
🔭 > append this query string to the first page of checkout: `?dev=https://809671a3c94f.ngrok.io/query`
```

as expected.

### Checklist

- [x] I have :tophat:'d these changes
