### PR TITLE
chore: temporary change the deploy script to publish from git tags only

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "version-bump": "lerna version --no-push --include-merged-tags",
     "version-bump:checkout": "lerna version --no-push --ignore-changes 'packages/admin-ui-extensions*/**' --include-merged-tags",
     "version-bump:admin": "lerna version --no-push --ignore-changes 'packages/!(admin-ui-extensions*)/**' --include-merged-tags",
-    "deploy": "lerna publish from-package --yes",
+    "deploy": "lerna publish from-git --yes",
     "nuke": "lerna clean --yes && rm -rf node_modules && yarn cache clean",
     "build-consumer": "yarnpkg build && ./scripts/build-consumer.sh",
     "build-consumer-spin": "yarnpkg build && ./scripts/build-consumer-spin.sh",


### PR DESCRIPTION
### Background

We are currently unable to publish packages because shipit keeps thinking the latest version of `@shopify/ui-extension` hasn't been published and tries to publish it again.
```
$ lerna publish from-package --yes --dist-tag=latest
lerna notice cli v3.22.1
lerna info versioning independent
lerna WARN Yarn's registry proxy is broken, replacing with public npm registry
lerna WARN If you don't have an npm token, you should exit and run `npm login`
Found 2 packages to publish:
 - @shopify/checkout-ui-extensions-run => 0.5.1
 - @shopify/ui-extensions => 0.2.0

lerna ERR! E403 You cannot publish over the previously published versions: 0.2.0.
```

I'm guessing this is related to us publishing this package as a private package previously. I'm still looking into a real fix.

### Solution

Temporary change the deploy script to deploy from git tags only until we can figure out why it keeps thinking it has to publish a new version of `@shopify/ui-extension` .

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
