### PR TITLE
Exposes PostPurchaseRenderApi type from post-purchase-ui-extensions

### DIFF
--- a/packages/post-purchase-ui-extensions-react/src/index.ts
+++ b/packages/post-purchase-ui-extensions-react/src/index.ts
@@ -6,6 +6,7 @@ export type {
   ArgumentsForExtension,
   InputForRenderExtension,
   RenderExtension,
+  PostPurchaseRenderApi,
   RenderExtensions,
   ReturnTypeForExtension,
   ShopifyGlobal,

--- a/packages/post-purchase-ui-extensions/src/extension-points/index.ts
+++ b/packages/post-purchase-ui-extensions/src/extension-points/index.ts
@@ -1,5 +1,5 @@
 export type {ExtensionPoints, ExtensionPoint} from './extension-points';
-export type {StandardApi, Version} from './api';
+export type {PostPurchaseRenderApi, StandardApi, Version} from './api';
 export type {RenderExtension} from './render-extension';
 export type {
   RenderExtensions,

--- a/packages/post-purchase-ui-extensions/src/index.ts
+++ b/packages/post-purchase-ui-extensions/src/index.ts
@@ -8,6 +8,7 @@ export type {
   ArgumentsForExtension,
   InputForRenderExtension,
   ReturnTypeForExtension,
+  PostPurchaseRenderApi,
   StandardApi,
   Version,
 } from './extension-points';


### PR DESCRIPTION
### Background

Currently, any code using post-purchase-ui-extensions and post-purchase-ui-extensions-react have to do a verbose filepath import in order to access the `PostPurchaseRenderApi` type , rather than a cleaner top-level export:

```ts
import {PostPurchaseRenderApi} from '@shopify/post-purchase-ui-extensions/src/extension-points/api';
```

This also was an issue before the Argo rename:

```ts
import {PostPurchaseRenderApi} from '@shopify/argo-post-purchase/src/extension-points/api';
```

Ideally, the import could be just be succinct like this, similar to all other type and member imports from ui-extensions:

```ts
import {PostPurchaseRenderApi} from '@shopify/post-purchase-ui-extensions';
// OR
import {PostPurchaseRenderApi} from '@shopify/post-purchase-ui-extensions-react';
```

### Solution

I simply had to add `PostPurchaseRenderApi` to some `export` statements in Barrel Files.

### 🎩

I'm not personally sure how to view the build output after this change, I would like some pointers on this from reviewers. After we determine that, I would inspect the `.d.ts` output from a build to ensure that `PostPurchaseRenderApi` is present as a top-level export.

### Checklist

- [ ] I have :tophat:'d these changes
