### PR TITLE
Fix constructor type: a conf object is required

### DIFF
--- a/packages/ui-extensions-webpack-hot-client/src/index.ts
+++ b/packages/ui-extensions-webpack-hot-client/src/index.ts
@@ -8,7 +8,7 @@ const ParserHelpers = require('webpack/lib/ParserHelpers');
 
 // @see https://github.com/webpack-contrib/webpack-hot-client/blob/1b7f221918217be0db7a6089fb77fffde9a973f6/lib/compiler.js#L63
 export class UIExtensionsHotClient {
-  constructor(private readonly options?: Options) {}
+  constructor(private readonly options: Options) {}
 
   apply(compiler: Compiler) {
     const {options} = this;


### PR DESCRIPTION
### Background

The constructor of `UIExtensionsHotClient` requires configuration otherwise the call to [`new WebSocket(...)`](https://github.com/Shopify/ui-extensions/blob/38e3adacc084152591126acf89e1094db94be568/packages/ui-extensions-webpack-hot-client/src/worker.ts#L60-L62) will throw a `SyntaxError` for the invalid connection string.

### Solution

This corrects the types to match the implementation.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
