### PR TITLE
[Docs script] Resolve imported types

### DIFF
--- a/packages/ui-extensions/src/index.ts
+++ b/packages/ui-extensions/src/index.ts
@@ -1,1 +1,1 @@
-export * from './types';
+export type {BaseBannerProps, BaseButtonProps, BaseHeadingProps} from './types';

--- a/packages/ui-extensions/src/types/index.ts
+++ b/packages/ui-extensions/src/types/index.ts
@@ -1,5 +1,5 @@
-export * from './Banner';
-export * from './BlockStack';
-export * from './Button';
-export * from './Heading';
-export * from './InlineStack';
+export type {BaseBannerProps} from './Banner';
+export type {BaseBlockStackProps} from './BlockStack';
+export type {BaseButtonProps} from './Button';
+export type {BaseHeadingProps} from './Heading';
+export type {BaseInlineStackProps} from './InlineStack';

--- a/scripts/typedoc/types.ts
+++ b/scripts/typedoc/types.ts
@@ -39,6 +39,7 @@ export interface ImportedReference {
 export interface InterfaceType extends Documentable {
   kind: 'InterfaceType';
   name: string;
+  remoteExtends?: string;
   properties: PropertySignature[];
 }
 


### PR DESCRIPTION
### Background

Closes https://github.com/Shopify/ui-extensions/issues/132

:warning: based on https://github.com/Shopify/ui-extensions/pull/166

We’re starting to store types in a shared package (`ui-extensions`) and extend them to produce our public interfaces. The doc generation script isn’t capable of following those imports, therefore the generated docs are missing information.

[`Banner`](https://github.com/Shopify/ui-extensions/blob/main/packages/admin-ui-extensions/src/components/Banner/Banner.ts#L12) is the only component consuming a remotely imported type at the time of this PR.

[`PostPurchaseShouldRenderApi`](https://github.com/Shopify/ui-extensions/blob/38e3adacc084152591126acf89e1094db94be568/packages/post-purchase-ui-extensions/src/extension-points/api/post-purchase/post-purchase.ts#L5-L11) and [`PostPurchaseRenderApi`](https://github.com/Shopify/ui-extensions/blob/38e3adacc084152591126acf89e1094db94be568/packages/post-purchase-ui-extensions/src/extension-points/api/post-purchase/post-purchase.ts#L20-L37) extend an imported type from the same package, and are also missing properties in the generated docs.

### Solution

The dependency graph now processes imports from sibling libraries in this monorepo, flags remote `extends` (instead of ignoring them) and does a final pass over the entire graph to resolve remote extends.

<table>
<tr><th colspan="2"><code>BannerProps extends BaseBannerProps</code></th></tr>
<tr>
<th>before</th>
<th>after</th>
</tr>
<tr>
<td><img width="938" alt="Screen Shot 2021-07-13 at 5 41 02 PM" src="https://user-images.githubusercontent.com/3248903/125528991-ccc6b5d9-5ee3-4f1d-80a0-dd7d6a96f12c.png"></td>
<td><img width="918" alt="Screen Shot 2021-07-13 at 5 41 56 PM" src="https://user-images.githubusercontent.com/3248903/125529078-54de82db-22ae-4142-aaca-034479ac5ab1.png"></td>
</tr>
</table>


### 🎩

On branch `admin-api-doc-extraction`, run `yarn docs:admin`. Commit the changes in a temporary branch in shopify-dev repo.

Check out this branch, then run `yarn docs:admin` again. Note the changes.

Repeat the same process, but run `yarn docs:checkout`.

### Checklist

- [x] I have :tophat:'d these changes
