### PR TITLE
Expose shared breakpoint and responsive types on post-purchase-ui-extensions

### DIFF
--- a/packages/post-purchase-ui-extensions/src/components/index.ts
+++ b/packages/post-purchase-ui-extensions/src/components/index.ts
@@ -52,3 +52,10 @@ export {View} from './View';
 export type {ViewProps} from './View';
 export {VisuallyHidden} from './VisuallyHidden';
 export type {VisuallyHiddenProps} from './VisuallyHidden';
+export type {
+  Autocomplete,
+  AutocompleteField,
+  AutocompleteGroup,
+  Breakpoint,
+  Responsive,
+} from './shared';

--- a/packages/post-purchase-ui-extensions/src/components/shared.ts
+++ b/packages/post-purchase-ui-extensions/src/components/shared.ts
@@ -123,3 +123,7 @@ export type AutocompleteField =
   | 'pager telephone-extension'
   | 'pager email'
   | 'pager instant-message';
+
+export type Breakpoint = 'base' | 'small' | 'medium' | 'large';
+
+export type Responsive<T> = {[key in Breakpoint]?: T};


### PR DESCRIPTION
### Background

Post-purchase was previously importing from checkout-ui-extensions the `Responsive` and `Breakpoint` types.

### Solution

Expose those types in `post-purchase-ui-extensions` instead, which will let us remove the dependency from `checkout-web-ui-post-purchase` to checkout-ui-extensions. See https://github.com/Shopify/checkout-web/pull/5846 for reference.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
