### PR TITLE
Extract title variable

### DIFF
--- a/scripts/generate-docs-checkout.ts
+++ b/scripts/generate-docs-checkout.ts
@@ -50,11 +50,14 @@ components(checkout, componentsPageContent(checkout.shopifyDevUrl), {
 gettingStarted(checkout);
 
 // Post-purchase docs
-extensionPoints(postPurchase, {visibility: 'postUnite'});
+extensionPoints(postPurchase, {
+  title: 'Post-purchase',
+  visibility: 'postUnite',
+});
 components(postPurchase, componentsPageContent(postPurchase.shopifyDevUrl), {
   subcomponentMap: {ChoiceList: ['Choice'], FormLayout: ['FormLayoutGroup']},
   componentsToSkip: ['FormLayoutGroup', 'ListItem', 'Choice'],
   generateReadmes: true,
   visibility: 'postUnite',
 });
-gettingStarted(postPurchase, {visibility: 'postUnite'});
+gettingStarted(postPurchase, {title: 'Post-purchase', visibility: 'postUnite'});

--- a/scripts/generate-docs-checkout.ts
+++ b/scripts/generate-docs-checkout.ts
@@ -26,9 +26,9 @@ const postPurchase = {
   shopifyDevAssets: '../shopify-dev/app/assets/images/api/checkout-extensions',
 };
 
-const componentsPageContent = (url: string) => ({
-  title: 'Components for Post-purchase extensions',
-  frontMatterDescription: 'A list of components for Post-purchase extensions.',
+const componentsPageContent = (url: string, title = 'Checkout') => ({
+  title: `Components for ${title} extensions`,
+  frontMatterDescription: `A list of components for ${title} extensions.`,
   description: `Checkout UI Extensions provide many powerful UI components that a
   [rendering extension](${url}/extension-points#rendering) can
   use to build an interface. This UI is rendered natively by Shopify, so you
@@ -54,10 +54,14 @@ extensionPoints(postPurchase, {
   title: 'Post-purchase',
   visibility: 'postUnite',
 });
-components(postPurchase, componentsPageContent(postPurchase.shopifyDevUrl), {
-  subcomponentMap: {ChoiceList: ['Choice'], FormLayout: ['FormLayoutGroup']},
-  componentsToSkip: ['FormLayoutGroup', 'ListItem', 'Choice'],
-  generateReadmes: true,
-  visibility: 'postUnite',
-});
+components(
+  postPurchase,
+  componentsPageContent(postPurchase.shopifyDevUrl, 'Post-purchase'),
+  {
+    subcomponentMap: {ChoiceList: ['Choice'], FormLayout: ['FormLayoutGroup']},
+    componentsToSkip: ['FormLayoutGroup', 'ListItem', 'Choice'],
+    generateReadmes: true,
+    visibility: 'postUnite',
+  },
+);
 gettingStarted(postPurchase, {title: 'Post-purchase', visibility: 'postUnite'});

--- a/scripts/typedoc/shopify-dev-renderer/extension-points.ts
+++ b/scripts/typedoc/shopify-dev-renderer/extension-points.ts
@@ -20,11 +20,12 @@ const additionalPropsTables: string[] = [];
 
 interface Options {
   visibility?: Visibility;
+  title?: string;
 }
 
 export async function extensionPoints(paths: Paths, options: Options = {}) {
   const extensionsIndex = resolve(`${paths.inputRoot}/src/index.ts`);
-  const {visibility = 'hidden'} = options;
+  const {visibility = 'hidden', title = 'Checkout'} = options;
   const visibilityFrontMatter = visibilityToFrontMatterMap.get(visibility);
 
   const graph = await createDependencyGraph(extensionsIndex);
@@ -62,9 +63,8 @@ export async function extensionPoints(paths: Paths, options: Options = {}) {
   let markdown = renderYamlFrontMatter({
     gid: findUuid(apiFile),
     url: `${paths.shopifyDevUrl}/extension-points/api`,
-    title: 'Post-purchase extension points API',
-    description:
-      'An API reference for Post-purchase extension points and their respective types.',
+    title: `${title} extension points API`,
+    description: `An API reference for ${title} extension points and their respective types.`,
     ...visibilityFrontMatter,
   });
 

--- a/scripts/typedoc/shopify-dev-renderer/getting-started.ts
+++ b/scripts/typedoc/shopify-dev-renderer/getting-started.ts
@@ -12,6 +12,7 @@ import type {Visibility} from './shared';
 
 interface Options {
   visibility?: Visibility;
+  title?: string;
 }
 
 export function gettingStarted(paths: Paths, options: Options = {}) {
@@ -19,7 +20,7 @@ export function gettingStarted(paths: Paths, options: Options = {}) {
   const extensionPointsDocsPath = resolve(
     `${paths.outputRoot}/extension-points`,
   );
-  const {visibility = 'hidden'} = options;
+  const {visibility = 'hidden', title = 'Checkout'} = options;
   const visibilityFrontMatter = visibilityToFrontMatterMap.get(visibility);
 
   if (!fs.existsSync(outputRoot)) {
@@ -35,9 +36,8 @@ export function gettingStarted(paths: Paths, options: Options = {}) {
   let markdown = renderYamlFrontMatter({
     gid: findUuid(indexFile),
     url: `${paths.shopifyDevUrl}/extension-points/index`,
-    title: 'Post-purchase extensions API reference',
-    description:
-      'API reference for Post-purchase extension points. Learn about global objects, rendering, components, and how you’ll interact with them.',
+    title: `${title} extensions API reference`,
+    description: `API reference for ${title} extension points. Learn about global objects, rendering, components, and how you’ll interact with them.`,
     ...visibilityFrontMatter,
   });
 


### PR DESCRIPTION
### Background

The docs generation for Post-purchase extensions docs and `beta` Checkout extensions docs are using the same template, so there's no way to show different heading depending on the docs subject.

### Solution

Use a `title` variable instead of the hardcoded title and pass it as an argument to the docs generator function.
