### PR TITLE
ResourcePicker API

### DIFF
--- a/packages/admin-ui-extensions-react/src/components/DatePicker/DatePicker.ts
+++ b/packages/admin-ui-extensions-react/src/components/DatePicker/DatePicker.ts
@@ -1,0 +1,4 @@
+import {DatePicker as BaseDatePicker} from '@shopify/admin-ui-extensions';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const DatePicker = createRemoteReactComponent(BaseDatePicker);

--- a/packages/admin-ui-extensions-react/src/components/DatePicker/examples/DatePicker.example.jsx
+++ b/packages/admin-ui-extensions-react/src/components/DatePicker/examples/DatePicker.example.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { extend, render, Badge } from '@shopify/admin-ui-extensions-react';
+
+function App() {
+  return <Badge message="Example message" status="success" />;
+}
+
+extend(
+  'Playground',
+  render(() => <App />),
+);

--- a/packages/admin-ui-extensions-react/src/components/DatePicker/index.ts
+++ b/packages/admin-ui-extensions-react/src/components/DatePicker/index.ts
@@ -1,0 +1,2 @@
+export {DatePicker} from './DatePicker';
+export type {DatePickerProps} from '@shopify/admin-ui-extensions';

--- a/packages/admin-ui-extensions-react/src/components/List/List.ts
+++ b/packages/admin-ui-extensions-react/src/components/List/List.ts
@@ -1,0 +1,4 @@
+import {List as BaseList} from '@shopify/admin-ui-extensions';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const List = createRemoteReactComponent(BaseList);

--- a/packages/admin-ui-extensions-react/src/components/List/ListItem.ts
+++ b/packages/admin-ui-extensions-react/src/components/List/ListItem.ts
@@ -1,0 +1,4 @@
+import {ListItem as BaseListItem} from '@shopify/admin-ui-extensions';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const ListItem = createRemoteReactComponent(BaseListItem);

--- a/packages/admin-ui-extensions-react/src/components/List/examples/List.example.jsx
+++ b/packages/admin-ui-extensions-react/src/components/List/examples/List.example.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { extend, render, Badge } from '@shopify/admin-ui-extensions-react';
+
+function App() {
+  return <Badge message="Example message" status="success" />;
+}
+
+extend(
+  'Playground',
+  render(() => <App />),
+);

--- a/packages/admin-ui-extensions-react/src/components/List/examples/List.example.jsx
+++ b/packages/admin-ui-extensions-react/src/components/List/examples/List.example.jsx
@@ -1,8 +1,14 @@
 import React from 'react';
-import { extend, render, Badge } from '@shopify/admin-ui-extensions-react';
+import { extend, render, List, ListItem } from '@shopify/admin-ui-extensions-react';
 
 function App() {
-  return <Badge message="Example message" status="success" />;
+  return (
+    <List type="bullet">
+      <ListItem>Yellow shirt</ListItem>
+      <ListItem>Red shirt</ListItem>
+      <ListItem>Green shirt</ListItem>
+    </List>
+  );
 }
 
 extend(

--- a/packages/admin-ui-extensions-react/src/components/List/index.ts
+++ b/packages/admin-ui-extensions-react/src/components/List/index.ts
@@ -1,0 +1,5 @@
+export {List} from './List';
+export type {ListProps} from '@shopify/admin-ui-extensions';
+
+export {ListItem} from './ListItem';
+export type {ListItemProps} from '@shopify/admin-ui-extensions';

--- a/packages/admin-ui-extensions-react/src/components/ResourcePicker/ResourcePicker.ts
+++ b/packages/admin-ui-extensions-react/src/components/ResourcePicker/ResourcePicker.ts
@@ -1,0 +1,4 @@
+import {ResourcePicker as BaseResourcePicker} from '@shopify/admin-ui-extensions';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const ResourcePicker = createRemoteReactComponent(BaseResourcePicker);

--- a/packages/admin-ui-extensions-react/src/components/ResourcePicker/examples/ResourcePicker.example.tsx
+++ b/packages/admin-ui-extensions-react/src/components/ResourcePicker/examples/ResourcePicker.example.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import {extend, render, Item, ResourcePicker} from '@shopify/admin-ui-extensions-react';
+
+const mockData: Item[] = [
+  {
+    accessibilityLabel: 'item 1 a11y',
+    badges: [
+      {
+        id: 'badge1',
+        content: 'done',
+        progress: 'incomplete',
+        status: 'success',
+      },
+      {
+        id: 'badge2',
+        content: 'warning',
+        progress: 'complete',
+        status: 'attention',
+      },
+    ],
+    id: '3',
+    media: {
+      kind: 'Thumbnail',
+      source: 'https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg',
+      alt: 'Black choker necklace',
+    },
+    onPress: () => console.log('onPress'),
+    name: 'item 1',
+    options: [
+      {
+        accessibilityLabel: 'inner item 1',
+        badges: [
+          {
+            id: 'badge1',
+            content: 'done',
+            progress: 'incomplete',
+            status: 'success',
+          },
+          {
+            id: 'badge2',
+            content: 'warning',
+            progress: 'complete',
+            status: 'attention',
+          },
+        ],
+        id: '31',
+        onPress: () => console.log('onPress'),
+        name: 'inner item 1',
+        media: {
+          kind: 'Thumbnail',
+          source: 'https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg',
+          alt: 'Black choker necklace',
+        },
+      },
+      {
+        accessibilityLabel: 'inner item 2',
+        id: '32',
+        onPress: () => console.log('onPress'),
+        name: 'inner item 2',
+        media: {
+          kind: 'Thumbnail',
+          source: 'https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg',
+          alt: 'Black choker necklace',
+        },
+      },
+    ],
+  },
+  {
+    accessibilityLabel: 'item 2 a11y',
+    id: '4',
+    media: {
+      kind: 'Thumbnail',
+      source: 'https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg',
+      alt: 'Black choker necklace',
+    },
+    onPress: () => console.log('onPress'),
+    name: 'item 2',
+    options: [
+      {
+        accessibilityLabel: 'inner item 2 a11y',
+        id: '41',
+        onPress: () => console.log('onPress'),
+        name: 'inner item 2',
+        media: {
+          kind: 'Thumbnail',
+          source: 'https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg',
+          alt: 'Black choker necklace',
+        },
+      },
+    ],
+  },
+];
+
+function App() {
+  return (
+    <ResourcePicker
+      items={mockData}
+      maxSelectable={1}
+      onChange = {() => 'onChange'}
+      onClose={() => 'onClose'}
+      primaryAction={{
+        content: 'Add',
+        onAction: () => console.log('primary action'),
+      }}
+      selectedItems={[
+        {
+          id: 'item1',
+          options: [{id: 'option1a'}],
+        },
+      ]}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: () => 'onClose', 
+        },
+      ]}
+      title="Resource Picker"
+      visible={true}
+    />
+  );
+}
+
+extend(
+  'Playground',
+  render(() => <App />),
+);

--- a/packages/admin-ui-extensions-react/src/components/ResourcePicker/index.ts
+++ b/packages/admin-ui-extensions-react/src/components/ResourcePicker/index.ts
@@ -1,0 +1,5 @@
+import type {PropsWithChildren} from 'react';
+import type {ResourcePickerProps as BaseResourcePickerProps} from '@shopify/admin-ui-extensions';
+
+export type ResourcePickerProps = PropsWithChildren<BaseResourcePickerProps>;
+export {ResourcePicker} from './ResourcePicker';

--- a/packages/admin-ui-extensions-react/src/components/TimePicker/TimePicker.ts
+++ b/packages/admin-ui-extensions-react/src/components/TimePicker/TimePicker.ts
@@ -1,0 +1,4 @@
+import {TimePicker as BaseTimePicker} from '@shopify/admin-ui-extensions';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const TimePicker = createRemoteReactComponent(BaseTimePicker);

--- a/packages/admin-ui-extensions-react/src/components/TimePicker/examples/TimePicker.example.jsx
+++ b/packages/admin-ui-extensions-react/src/components/TimePicker/examples/TimePicker.example.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import {extend, render, Badge} from '@shopify/admin-ui-extensions-react';
+
+function App() {
+  return <Badge message="Example message" status="success" />;
+}
+
+extend(
+  'Playground',
+  render(() => <App />),
+);

--- a/packages/admin-ui-extensions-react/src/components/TimePicker/index.ts
+++ b/packages/admin-ui-extensions-react/src/components/TimePicker/index.ts
@@ -1,0 +1,2 @@
+export {TimePicker} from './TimePicker';
+export type {TimePickerProps} from '@shopify/admin-ui-extensions';

--- a/packages/admin-ui-extensions-react/src/components/index.ts
+++ b/packages/admin-ui-extensions-react/src/components/index.ts
@@ -22,3 +22,7 @@ export * from './Text';
 export * from './TextBlock';
 export * from './TextField';
 export * from './Thumbnail';
+
+export * from './List';
+export * from './DatePicker';
+export * from './TimePicker';

--- a/packages/admin-ui-extensions-react/src/components/index.ts
+++ b/packages/admin-ui-extensions-react/src/components/index.ts
@@ -15,6 +15,7 @@ export * from './OptionList';
 export * from './Radio';
 export * from './ResourceItem';
 export * from './ResourceList';
+export * from './ResourcePicker';
 export * from './Select';
 export * from './Spinner';
 export * from './StackItem';

--- a/packages/admin-ui-extensions/src/component-sets/List.ts
+++ b/packages/admin-ui-extensions/src/component-sets/List.ts
@@ -1,14 +1,16 @@
 import {
-  ResourceList,
-  ResourceItem,
-  OptionList,
   List,
   ListItem,
+  OptionList,
+  ResourceItem,
+  ResourceList,
+  ResourcePicker,
 } from '../components';
 
 export type ListComponents =
   | typeof List
   | typeof ListItem
-  | typeof ResourceList
+  | typeof OptionList
   | typeof ResourceItem
-  | typeof OptionList;
+  | typeof ResourceList
+  | typeof ResourcePicker;

--- a/packages/admin-ui-extensions/src/component-sets/List.ts
+++ b/packages/admin-ui-extensions/src/component-sets/List.ts
@@ -1,6 +1,14 @@
-import {ResourceList, ResourceItem, OptionList} from '../components';
+import {
+  ResourceList,
+  ResourceItem,
+  OptionList,
+  List,
+  ListItem,
+} from '../components';
 
 export type ListComponents =
+  | typeof List
+  | typeof ListItem
   | typeof ResourceList
   | typeof ResourceItem
   | typeof OptionList;

--- a/packages/admin-ui-extensions/src/components/DatePicker/DatePicker.ts
+++ b/packages/admin-ui-extensions/src/components/DatePicker/DatePicker.ts
@@ -1,0 +1,22 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+export interface DatePickerProps {
+  /** ID for the Element. */
+  id: string;
+
+  /** The month to show, from 0 to 11. 0 is January, 1 is February ... 11 is December. */
+  month?: number;
+
+  /** The year to show. */
+  year?: number;
+
+  /** Callback when a date is selected. */
+  onChange?(value: Date): void | Promise<void>;
+}
+
+/**
+ * DatePickers let merchants choose dates from a visual calendar that’s consistently applied wherever dates need to be selected across Shopify.
+ */
+export const DatePicker = createRemoteComponent<'DatePicker', DatePickerProps>(
+  'DatePicker',
+);

--- a/packages/admin-ui-extensions/src/components/DatePicker/index.ts
+++ b/packages/admin-ui-extensions/src/components/DatePicker/index.ts
@@ -1,0 +1,2 @@
+export {DatePicker} from './DatePicker';
+export type {DatePickerProps} from './DatePicker';

--- a/packages/admin-ui-extensions/src/components/Icon/Icon.ts
+++ b/packages/admin-ui-extensions/src/components/Icon/Icon.ts
@@ -5,7 +5,8 @@ type Source =
   | 'searchMinor'
   | 'starHollow'
   | 'starFilled'
-  | 'sortMinor';
+  | 'sortMinor'
+  | 'plusMinor';
 
 export interface IconProps {
   /** Pre-defined glyph content to display. */

--- a/packages/admin-ui-extensions/src/components/List/List.ts
+++ b/packages/admin-ui-extensions/src/components/List/List.ts
@@ -1,0 +1,11 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+export interface ListProps {
+  /** Type of list to display. */
+  type: 'bullet' | 'number';
+}
+
+/**
+ * Lists display a set of related text-only content. Each list item begins with a bullet or a number.
+ */
+export const List = createRemoteComponent<'List', ListProps>('List');

--- a/packages/admin-ui-extensions/src/components/List/ListItem.ts
+++ b/packages/admin-ui-extensions/src/components/List/ListItem.ts
@@ -1,0 +1,10 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+export interface ListItemProps {}
+
+/**
+ * ListItems are child items of the List component.
+ */
+export const ListItem = createRemoteComponent<'ListItem', ListItemProps>(
+  'ListItem',
+);

--- a/packages/admin-ui-extensions/src/components/List/content/guidelines.md
+++ b/packages/admin-ui-extensions/src/components/List/content/guidelines.md
@@ -1,0 +1,12 @@
+## Guidelines
+
+- Lists display a set of related text-only content. Each list item begins with a bullet or a number.
+
+### List Items
+
+| ✅ Do                     | 🛑 Don't                                              |
+| ------------------------- | ---------------------------------------------------- |
+| Start with capital letter | Not use commas or semicolons at the end of each line |
+|                           | Be written in sentence case |
+
+For more guidelines, refer to Polaris' [List best practices](https://polaris.shopify.com/components/structure/stack#section-best-practices).

--- a/packages/admin-ui-extensions/src/components/List/examples/List.example.tsx
+++ b/packages/admin-ui-extensions/src/components/List/examples/List.example.tsx
@@ -1,0 +1,19 @@
+import {extend, List, ListItem} from '@shopify/admin-ui-extensions';
+
+function buildListItem(root) {
+  const listItem = root.createComponent(ListItem);
+  listItem.appendChild('Item in list');
+  return listItem;
+}
+
+extend('Playground', (root) => {
+  const list = root.createComponent(List);
+
+  list.appendChild(buildListItem(root));
+  list.appendChild(buildListItem(root));
+  list.appendChild(buildListItem(root)); 
+
+  root.appendChild(list);
+
+  root.mount();
+});

--- a/packages/admin-ui-extensions/src/components/List/index.ts
+++ b/packages/admin-ui-extensions/src/components/List/index.ts
@@ -1,0 +1,5 @@
+export {List} from './List';
+export type {ListProps} from './List';
+
+export {ListItem} from './ListItem';
+export type {ListItemProps} from './ListItem';

--- a/packages/admin-ui-extensions/src/components/ResourceItem/ResourceItem.ts
+++ b/packages/admin-ui-extensions/src/components/ResourceItem/ResourceItem.ts
@@ -1,15 +1,13 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 export interface ResourceItemProps {
-  /** Unique ID for the resource item. */
   id: string;
-
-  /** Callback when the resource item is pressed. */
-  onPress(): void;
+  onPress?: any;
 }
 
 /**
- * Resource items represent specific objects within a collection, such as products or orders. They provide contextual information on the resource type and link to the object’s detail page.
+ * Resource items represent specific objects within a collection, such as products or orders.
+ * They provide contextual information on the resource type and link to the object’s detail page.
  *
  * A `ResourceItem` should be rendered within a `ResourceList`.
  */

--- a/packages/admin-ui-extensions/src/components/ResourcePicker/ResourcePicker.ts
+++ b/packages/admin-ui-extensions/src/components/ResourcePicker/ResourcePicker.ts
@@ -1,0 +1,145 @@
+import {createRemoteComponent} from '@remote-ui/core';
+import {DestructableAction} from '../types';
+
+type Alignment = 'leading' | 'trailing' | 'center';
+
+interface AvatarProps {
+  kind: 'Avatar';
+  accessibilityLabel: string;
+  name: string;
+  initials: string;
+  source: string;
+}
+
+interface ThumbnailProps {
+  kind: 'Thumbnail';
+  source: string;
+  alt: string;
+}
+
+interface FilterControl {
+  /** Search query value */
+  queryValue?: string;
+
+  /** Placeholder for search query field */
+  queryPlaceholder: string;
+
+  /** Callback when search query changes */
+  onQueryChange?(queryValue: string): void;
+
+  /** Callback when the search field is cleared */
+  onQueryClear?(): void;
+}
+
+export interface Item {
+  /** Visually hidden text for screen readers used for item link*/
+  accessibilityLabel?: string;
+
+  /** Id of the element the item onClick controls */
+  ariaControls?: string;
+
+  /** Tells screen reader the controlled element is expanded */
+  ariaExpanded?: boolean;
+
+  /** Indicators to display info in list item */
+  badges?: {
+    id: string;
+    content: string;
+    progress: 'incomplete' | 'partiallyComplete' | 'complete';
+    status: 'success' | 'info' | 'attention' | 'critical' | 'warning' | 'new';
+  }[];
+
+  /** Wether the checkbox on a selectable item is disabled */
+  disabled?: boolean;
+
+  /** Allows url to open in a new tab */
+  external?: boolean;
+
+  /** Unique identifier for the item */
+  id: string;
+
+  /** Content for the media area at the left of the item */
+  media?: AvatarProps | ThumbnailProps;
+
+  /** Individual item name used by various text labels */
+  name: string;
+
+  /** Items nested beneath top level item. Single level of nesting supported. */
+  options?: NestedItem[];
+
+  /** Callback when clicked (required if url is omitted) */
+  onPress?(id?: string): void;
+
+  /** Makes the shortcut actions always visible */
+  persistActions?: boolean;
+
+  /** Display checkboxes next to items */
+  /** @default true */
+  selectable?: boolean;
+
+  /** 1 or 2 shortcut actions; must be available on the page linked to by url */
+  // eslint-disable-next-line line-comment-position
+  shortcutActions?: any[]; // DisableableAction[];
+
+  /** URL for the resource’s details page (required unless onClick is provided) */
+  url?: string;
+
+  /** Prefetched url attribute to bind to the main element being returned */
+  dataHref?: string;
+}
+
+export type NestedItem = Omit<Item, 'nestedItem'>;
+
+export interface SelectedItem {
+  id: string;
+  options?: {id: string}[];
+}
+
+export interface ResourcePickerProps {
+  /** A set of handlers to pass into the Filter component */
+  filterControl?: FilterControl;
+
+  /** An array of list items to display in the ResourceList component */
+  items: Item[];
+
+  /** Overlays item list with a spinner while a background action is being performed */
+  loading?: boolean;
+
+  /** The maximum number of items that may be selected at once */
+  maxSelectable?: number;
+
+  /** Callback when ResourcePicker is closed */
+  onClose: () => void;
+
+  /** Callback when selection changes */
+  onChange: (selected: any[]) => void;
+
+  /** Primary action to display at bottom of ResourcePicker modal */
+  primaryAction?: DestructableAction;
+
+  /** An array of secondary actions to display to the right of the primary action */
+  secondaryActions?: DestructableAction[];
+
+  /** Currently selected items */
+  selectedItems?: SelectedItem[];
+
+  /** Heading to display at top of ResourcePicker */
+  title?: string;
+
+  /** Adjust vertical alignment of elements */
+  /** @default 'center' */
+  verticalAlignment?: Alignment;
+
+  /** Whether the ResourcePicker modal is open */
+  visible: boolean;
+}
+
+/**
+ * `ResourcePicker` displays a ResourceList in a modal
+ *
+ * `ResourcePicker` provide a generic UI to display any type of data in an interactive list.
+ */
+export const ResourcePicker = createRemoteComponent<
+  'ResourcePicker',
+  ResourcePickerProps
+>('ResourcePicker');

--- a/packages/admin-ui-extensions/src/components/ResourcePicker/content/guidelines.md
+++ b/packages/admin-ui-extensions/src/components/ResourcePicker/content/guidelines.md
@@ -1,0 +1,7 @@
+## Guidelines
+
+A ResourcePicker displays a resource list within a modal. It accepts a nested list of resource items. It supports optional media and badge elements.
+
+| ✅ Do                                                       | 🛑 Don't                                                                   |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Use ResourcePicker to show an interactive list of resources | ResourcePicker data should not contain more than one level of nested items |

--- a/packages/admin-ui-extensions/src/components/ResourcePicker/examples/ResourcePicker.example.ts
+++ b/packages/admin-ui-extensions/src/components/ResourcePicker/examples/ResourcePicker.example.ts
@@ -1,0 +1,120 @@
+import {extend, Item, ResourcePicker} from '@shopify/admin-ui-extensions';
+
+const mockData: Item[] = [
+  {
+    accessibilityLabel: 'item 1 a11y',
+    badges: [
+      {
+        id: 'badge1',
+        content: 'done',
+        progress: 'incomplete',
+        status: 'success',
+      },
+      {
+        id: 'badge2',
+        content: 'warning',
+        progress: 'complete',
+        status: 'attention',
+      },
+    ],
+    id: '3',
+    media: {
+      kind: 'Thumbnail',
+      source: 'https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg',
+      alt: 'Black choker necklace',
+    },
+    onPress: () => console.log('onPress'),
+    name: 'item 1',
+    options: [
+      {
+        accessibilityLabel: 'inner item 1',
+        badges: [
+          {
+            id: 'badge1',
+            content: 'done',
+            progress: 'incomplete',
+            status: 'success',
+          },
+          {
+            id: 'badge2',
+            content: 'warning',
+            progress: 'complete',
+            status: 'attention',
+          },
+        ],
+        id: '31',
+        onPress: () => console.log('onPress'),
+        name: 'inner item 1',
+        media: {
+          kind: 'Thumbnail',
+          source: 'https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg',
+          alt: 'Black choker necklace',
+        },
+      },
+      {
+        accessibilityLabel: 'inner item 2',
+        id: '32',
+        onPress: () => console.log('onPress'),
+        name: 'inner item 2',
+        media: {
+          kind: 'Thumbnail',
+          source: 'https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg',
+          alt: 'Black choker necklace',
+        },
+      },
+    ],
+  },
+  {
+    accessibilityLabel: 'item 2 a11y',
+    id: '4',
+    media: {
+      kind: 'Thumbnail',
+      source: 'https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg',
+      alt: 'Black choker necklace',
+    },
+    onPress: () => console.log('onPress'),
+    name: 'item 2',
+    options: [
+      {
+        accessibilityLabel: 'inner item 2 a11y',
+        id: '41',
+        onPress: () => console.log('onPress'),
+        name: 'inner item 2',
+        media: {
+          kind: 'Thumbnail',
+          source: 'https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg',
+          alt: 'Black choker necklace',
+        },
+      },
+    ],
+  },
+];
+
+extend('Playground', (root) => {
+  root.createComponent(ResourcePicker, {
+    items: mockData,
+    maxSelectable: 1,
+    onChange: () => 'onChange',
+    onClose: () => 'onClose',
+    primaryAction: {
+      content: 'Add',
+      onAction: () => console.log('primary action'),
+    },
+    selectedItems: [
+      {
+        id: 'item1',
+        options: [{id: 'option1a'}],
+      },
+    ],
+    secondaryActions: [
+      {
+        content: 'Cancel',
+        onAction: () => 'onClose', 
+      },
+    ],
+    title: "Resource Picker",
+    visible: true,
+  });
+
+  root.mount();
+});

--- a/packages/admin-ui-extensions/src/components/ResourcePicker/index.ts
+++ b/packages/admin-ui-extensions/src/components/ResourcePicker/index.ts
@@ -1,0 +1,7 @@
+export {ResourcePicker} from './ResourcePicker';
+export type {
+  Item,
+  NestedItem,
+  ResourcePickerProps,
+  SelectedItem,
+} from './ResourcePicker';

--- a/packages/admin-ui-extensions/src/components/TimePicker/TimePicker.ts
+++ b/packages/admin-ui-extensions/src/components/TimePicker/TimePicker.ts
@@ -1,0 +1,19 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+export interface TimePickerProps {
+  /** ID for the Element. */
+  id: string;
+
+  /** Text to display when no time is selected */
+  placeholder?: string;
+
+  /** Callback when a time is selected. */
+  onChange?(value: string): void | Promise<void>;
+}
+
+/**
+ * TimePickers let merchants choose dates from a visual calendar that’s consistently applied wherever dates need to be selected across Shopify.
+ */
+export const TimePicker = createRemoteComponent<'TimePicker', TimePickerProps>(
+  'TimePicker',
+);

--- a/packages/admin-ui-extensions/src/components/TimePicker/index.ts
+++ b/packages/admin-ui-extensions/src/components/TimePicker/index.ts
@@ -1,0 +1,2 @@
+export {TimePicker} from './TimePicker';
+export type {TimePickerProps} from './TimePicker';

--- a/packages/admin-ui-extensions/src/components/index.ts
+++ b/packages/admin-ui-extensions/src/components/index.ts
@@ -32,6 +32,13 @@ export {ResourceItem} from './ResourceItem';
 export type {ResourceItemProps} from './ResourceItem';
 export {ResourceList} from './ResourceList';
 export type {ResourceListProps} from './ResourceList';
+export {ResourcePicker} from './ResourcePicker';
+export type {
+  Item,
+  NestedItem,
+  ResourcePickerProps,
+  SelectedItem,
+} from './ResourcePicker';
 export {Select} from './Select';
 export type {SelectProps} from './Select';
 export {Spinner} from './Spinner';

--- a/packages/admin-ui-extensions/src/components/index.ts
+++ b/packages/admin-ui-extensions/src/components/index.ts
@@ -47,4 +47,13 @@ export type {TextFieldProps} from './TextField';
 export {Thumbnail} from './Thumbnail';
 export type {ThumbnailProps} from './Thumbnail';
 
+export {DatePicker} from './DatePicker';
+export type {DatePickerProps} from './DatePicker';
+export {List} from './List';
+export type {ListProps} from './List';
+export {ListItem} from './List';
+export type {ListItemProps} from './List';
+export {TimePicker} from './TimePicker';
+export type {TimePickerProps} from './TimePicker';
+
 export type {DestructableAction, DisableableAction} from './types';

--- a/packages/admin-ui-extensions/src/extension-api/ContextualSaveBarApi/examples/contextualSaveBar.example.ts
+++ b/packages/admin-ui-extensions/src/extension-api/ContextualSaveBarApi/examples/contextualSaveBar.example.ts
@@ -1,0 +1,29 @@
+import {extend, Button} from '@shopify/admin-ui-extensions';
+
+extend('Admin::Discounts::Create', (root, api) => {
+  const {
+    contextualSaveBar: {
+      setVisible,
+      setSaveAction,
+      setDiscardAction
+    },
+  } = api;
+
+  setSaveAction(() => console.log("Save content"));
+  setDiscardAction(() => console.log("Discard content"));
+
+  const button = root.createComponent(Button, {
+    title: 'Show contextual save bar',
+    primary: true,
+    onPress: () => setVisible(true),
+  });
+  root.appendChild(button);
+
+  const hideButton = root.createComponent(Button, {
+    title: 'Hide contextual save bar',
+    onPress: () => setVisible(false),
+  });
+  root.appendChild(hideButton);
+
+  root.mount();
+});

--- a/packages/admin-ui-extensions/src/extension-api/ContextualSaveBarApi/index.ts
+++ b/packages/admin-ui-extensions/src/extension-api/ContextualSaveBarApi/index.ts
@@ -1,0 +1,12 @@
+export interface ContextualSaveBarApi {
+  contextualSaveBar: {
+    visible: boolean;
+    setVisible: (visible: boolean) => void;
+    setSaveAction(action: () => void): void;
+    setDiscardAction(action: () => void): void;
+  };
+}
+
+export function isContextualSaveBarApi(api: any): api is ContextualSaveBarApi {
+  return 'contextualSaveBar' in api;
+}

--- a/packages/admin-ui-extensions/src/extension-api/index.ts
+++ b/packages/admin-ui-extensions/src/extension-api/index.ts
@@ -15,3 +15,6 @@ export {isSessionTokenApi} from './SessionTokenApi';
 
 export type {ToastApi} from './ToastApi';
 export {isToastApi} from './ToastApi';
+
+export type {ContextualSaveBarApi} from './ContextualSaveBarApi';
+export {isContextualSaveBarApi} from './ContextualSaveBarApi';

--- a/packages/admin-ui-extensions/src/extension-points/identifiers/discounts.ts
+++ b/packages/admin-ui-extensions/src/extension-points/identifiers/discounts.ts
@@ -1,0 +1,62 @@
+import {RemoteRoot} from '@remote-ui/core';
+
+import {AllComponentsSchema} from '../../containers';
+
+import {
+  RenderableExtensionCallback,
+  StandardApi,
+  ToastApi,
+  ContextualSaveBarApi,
+} from '../types';
+
+// Add the unique extension point(s) as a union string
+// This example only contains a single extension point
+
+export type DiscountsExtensionPoint =
+  | 'Admin::Discounts::Create'
+  | 'Admin::Discounts::Edit';
+
+export interface DiscountsExtensionContainerApi {
+  container: {
+    save: () => void;
+    discard: () => void;
+  };
+}
+
+export type DiscountsStandardApi<
+  T extends DiscountsExtensionPoint
+> = StandardApi<T> & ToastApi & ContextualSaveBarApi;
+
+export type DiscountsCreateApi = DiscountsStandardApi<
+  'Admin::Discounts::Create'
+> & {
+  container: DiscountsExtensionContainerApi;
+};
+
+export type DiscountsEditApi = DiscountsStandardApi<
+  'Admin::Discounts::Edit'
+> & {
+  container: DiscountsExtensionContainerApi;
+  data: {
+    discountId: string;
+  };
+};
+
+// Update APIs for your needs
+// All Extension APIs should include the StandardApi by default
+export interface DiscountsExtensionApi {
+  'Admin::Discounts::Create': DiscountsCreateApi;
+  'Admin::Discounts::Edit': DiscountsEditApi;
+}
+
+// Replace AllComponentsSchema with a schema for your needs
+export interface DiscountsExtensionPointCallback {
+  'Admin::Discounts::Create': RenderableExtensionCallback<
+    DiscountsExtensionApi['Admin::Discounts::Create'],
+    RemoteRoot<AllComponentsSchema>
+  >;
+  'Admin::Discounts::Edit': RenderableExtensionCallback<
+    DiscountsExtensionApi['Admin::Discounts::Edit'],
+    RemoteRoot<AllComponentsSchema>
+  >;
+}

--- a/packages/admin-ui-extensions/src/extension-points/index.ts
+++ b/packages/admin-ui-extensions/src/extension-points/index.ts
@@ -10,7 +10,15 @@ import {
   ProductSubscriptionExtensionPointCallback,
 } from './identifiers/product_subscription';
 
+import {
+  DiscountsExtensionPoint,
+  DiscountsExtensionApi,
+  DiscountsExtensionPointCallback,
+} from './identifiers/discounts';
+
 export type {PlaygroundExtensionPoint, ProductSubscriptionExtensionPoint};
+
+export {DiscountsExtensionPoint};
 
 /*
 Placeholder for new imports
@@ -24,10 +32,13 @@ export type {
 
 export type ExtensionPoint =
   | PlaygroundExtensionPoint
-  | ProductSubscriptionExtensionPoint;
+  | ProductSubscriptionExtensionPoint
+  | DiscountsExtensionPoint;
 
 export type ExtensionApi = PlaygroundExtensionApi &
-  ProductSubscriptionExtensionApi;
+  ProductSubscriptionExtensionApi &
+  DiscountsExtensionApi;
 
 export type ExtensionPointCallback = PlaygroundExtensionPointCallback &
-  ProductSubscriptionExtensionPointCallback;
+  ProductSubscriptionExtensionPointCallback &
+  DiscountsExtensionPointCallback;

--- a/packages/admin-ui-extensions/src/extension-points/types.ts
+++ b/packages/admin-ui-extensions/src/extension-points/types.ts
@@ -4,6 +4,7 @@ import type {LayoutApi} from '../extension-api/LayoutApi';
 import type {LocaleApi} from '../extension-api/LocaleApi';
 import type {ToastApi} from '../extension-api/ToastApi';
 import type {SessionTokenApi} from '../extension-api/SessionTokenApi';
+import type {ContextualSaveBarApi} from '../extension-api/ContextualSaveBarApi';
 
 export type ExtensionResult = Record<string, never> | void;
 
@@ -25,7 +26,13 @@ export type StandardApi<T> = {[key: string]: any} & {
   LocaleApi &
   SessionTokenApi;
 
-export type {LayoutApi, LocaleApi, SessionTokenApi, ToastApi};
+export type {
+  LayoutApi,
+  LocaleApi,
+  SessionTokenApi,
+  ToastApi,
+  ContextualSaveBarApi,
+};
 
 export interface ContainerAction {
   content: string;

--- a/packages/admin-ui-extensions/src/index.ts
+++ b/packages/admin-ui-extensions/src/index.ts
@@ -41,11 +41,13 @@ export type {
   ExtensionData,
   SessionTokenApi,
   ToastApi,
+  ContextualSaveBarApi,
 } from './extension-api';
 
 export type {
   PlaygroundExtensionPoint,
   ProductSubscriptionExtensionPoint,
+  DiscountsExtensionPoint,
   ContainerAction,
   ExtensionResult,
   RenderableExtensionCallback,

--- a/packages/admin-ui-extensions/src/index.ts
+++ b/packages/admin-ui-extensions/src/index.ts
@@ -18,6 +18,7 @@ export type {
   RadioProps,
   ResourceItemProps,
   ResourceListProps,
+  ResourcePickerProps,
   SelectProps,
   SpinnerProps,
   StackItemProps,

--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/checkout-ui-extensions-react",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "React bindings for @shopify/checkout-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.3",
     "@remote-ui/react": "^4.1.3",
-    "@shopify/checkout-ui-extensions": "^0.12.0",
+    "@shopify/checkout-ui-extensions": "^0.13.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify’s Checkout",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
### Background

Closes Shopify/ui-extensions-private#1448

This PR introduces a UI Extensions `ResourcePicker` API.

### Solution

Introduce new APIs for `ResourcePicker`:

- `ResourcePickerProps` 
-  `Item` (`ResourcePickerProps` requires an array of Items)
- `FilterControl` (different from `FilterControl` in `ResourceList` because `onQueryChange` and `onQueryClear` are optional)
- `AvatarProps` and `ThumbnailProps` to make media type in `Item` more explicit

![Screen Shot 2021-08-27 at 2 08 47 PM](https://user-images.githubusercontent.com/7654369/131183284-ad4c1930-a3b5-48a2-a3ab-8a9e8e027358.png)


### 🎩

See 🎩  instructions [here](https://github.com/Shopify/web/pull/47118)

### Checklist

- [x] I have :tophat:'d these changes
