### PR TITLE
chore: update build-consumer and restore-consumer for spin to work with short form workspace name

### DIFF
--- a/scripts/build-consumer-spin.sh
+++ b/scripts/build-consumer-spin.sh
@@ -7,7 +7,7 @@ Usage: $(basename "$0") <workspace short name> [<package_name>]
 
 Build UI Extensions packages into a project
 
- <workspace short name>  Target spin workspace, i.e. only enter \`web\` if your workspace is \`web.test.trish-ta.us.spin.dev\`
+ <workspace short name>  Target spin workspace short name, i.e. only enter \`web\` if your workspace is \`web.test.trish-ta.us.spin.dev\`
  <package_name>    Space separated package names
                    default: ${AVAILABLE_PACKAGES[@]}
 

--- a/scripts/build-consumer-spin.sh
+++ b/scripts/build-consumer-spin.sh
@@ -3,11 +3,11 @@
 . "$PWD/scripts/consumer-helper.sh"
 
 usage="
-Usage: $(basename "$0") <workspace> [<package_name>]
+Usage: $(basename "$0") <workspace short name> [<package_name>]
 
 Build UI Extensions packages into a project
 
- <workspace>  Target spin workspace, i.e. \`web.test.trish-ta.us.spin.dev\`
+ <workspace short name>  Target spin workspace, i.e. only enter \`web\` if your workspace is \`web.test.trish-ta.us.spin.dev\`
  <package_name>    Space separated package names
                    default: ${AVAILABLE_PACKAGES[@]}
 

--- a/scripts/consumer-helper.sh
+++ b/scripts/consumer-helper.sh
@@ -38,7 +38,7 @@ function run_command {
   if [[ -z $spin ]]; then
     $command
   else
-    ssh -o LogLevel=ERROR $projectDirectoryOrWorkspace $command
+    ssh -o LogLevel=ERROR `spin show | grep Shopify/$projectName | awk '{print $1}'` $command
   fi
 }
 
@@ -214,7 +214,7 @@ function build_consumer {
 
   done
 
-  echo "💃 ${GREEN}Build copied to ${BOLD}$projectDirectory${NORMAL}.${NONE} Run the project to see your changes from UI Extensions packages."
+  echo "💃 ${GREEN}Build copied to ${BOLD}$projectDirectoryOrWorkspace${NORMAL}.${NONE} Run the project to see your changes from UI Extensions packages."
 
   exit 0
 }

--- a/scripts/consumer-helper.sh
+++ b/scripts/consumer-helper.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-AVAILABLE_PACKAGES=('admin-ui-extensions' 'admin-ui-extensions-react' 'checkout-ui-extensions', 'checkout-ui-extensions-react', 'post-purchase-ui-extensions', 'post-purchase-ui-extensions-react', 'checkout-ui-extensions-run')
+AVAILABLE_PACKAGES=('admin-ui-extensions' 'admin-ui-extensions-react' 'checkout-ui-extensions' 'checkout-ui-extensions-react' 'post-purchase-ui-extensions' 'post-purchase-ui-extensions-react' 'checkout-ui-extensions-run')
 ROOT=$(pwd)
 
 # Font color

--- a/scripts/restore-consumer-spin.sh
+++ b/scripts/restore-consumer-spin.sh
@@ -3,11 +3,11 @@
 . "$PWD/scripts/consumer-helper.sh"
 
 usage="
-Usage: $(basename "$0") <workspace>
+Usage: $(basename "$0") <workspace short name>
 
 Restore a project by removing UI Extension packages and running \`yarn install\`
 
- <workspace>  Target spin workspace, i.e. \`web.test.trish-ta.us.spin.dev\`
+ <workspace short name>  Target spin workspace short name, i.e. only enter \`web\` if your workspace is \`web.test.trish-ta.us.spin.dev\`
 
  Options:
   -h, --help       Show this help text


### PR DESCRIPTION
### Background

Improve build-consumer and restore-consumer scripts for Spin so you don't have to type out the full workspace names

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- Create a spin instance for Web
- Run `yarn build-consumer-spin web admin-ui-extensions`
- Open the Web spin instance and inspect the node modules to ensure the package content was copied over

### Checklist

- [ ] I have :tophat:'d these changes
