### PR TITLE
Remove `hidden` property from post-purchase components' docs

### DIFF
--- a/scripts/generate-docs-checkout.ts
+++ b/scripts/generate-docs-checkout.ts
@@ -52,7 +52,7 @@ gettingStarted(checkout);
 // Post-purchase docs
 extensionPoints(postPurchase, {
   title: 'Post-purchase',
-  visibility: 'postUnite',
+  visibility: 'visible',
 });
 components(
   postPurchase,
@@ -61,6 +61,7 @@ components(
     subcomponentMap: {ChoiceList: ['Choice'], FormLayout: ['FormLayoutGroup']},
     componentsToSkip: ['FormLayoutGroup', 'ListItem', 'Choice'],
     generateReadmes: true,
+    visibility: 'visible',
   },
 );
-gettingStarted(postPurchase, {title: 'Post-purchase', visibility: 'postUnite'});
+gettingStarted(postPurchase, {title: 'Post-purchase', visibility: 'visible'});


### PR DESCRIPTION
### Background

The sidebar in the post-purchase extensions components docs doesn't work because the components docs page have a `hidden: true` property.

### Solution

Edit the docs generating script not add `hidden: true`.
