### PR TITLE
add admin-rc.yml

### DIFF
--- a/.github/workflows/admin-rc.yml
+++ b/.github/workflows/admin-rc.yml
@@ -1,0 +1,25 @@
+name: Rebase admin-rc from main
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  rebase-from-main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout admin-rc
+        with:
+          ref: admin-rc
+
+      - name: Set up
+        run: |
+             git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
+             git config --global user.name "admin-rc merge bot"
+
+      - name: Rebase and push
+        run: |
+             git pull --rebase origin main
+             git push --force


### PR DESCRIPTION
### Background

Ticket https://github.com/Shopify/ui-extensions-private/issues/1635

### Solution

This is a GitHub Action task to rebase admin-rc everytime something merges into main. There is no error handling until we get permissions to add environment variables.

### 🎩

- Check out `rebase-test-main`. This will have the auto-rebase from `rebase-test-main` to `rebase-test-admin-rc`
- Create a new branch off it called `rebase-test-admin-rc` and push it up.
- Make a change on `rebase-test-main` and push force push it up (or do a PR merge if that doesn't work).
- Go to the [github workflows](https://github.com/Shopify/ui-extensions/actions/workflows/admin-rc.yml) and make sure it  pushes up the task. If it green-lights then it means rebase is complete.
- Pull latest `rebase-test-admin-rc` and see the rebase works.
- Clean up: delete `rebase-test-admin-rc`.

### Checklist

- [x] I have :tophat:'d these changes
