### PR TITLE
chore: change rebase to merge into admin-rc

### DIFF
--- a/.github/workflows/admin-rc.yml
+++ b/.github/workflows/admin-rc.yml
@@ -21,5 +21,5 @@ jobs:
 
       - name: Rebase and push
         run: |
-             git pull --rebase origin main
+             git pull origin main
              git push --force


### PR DESCRIPTION
### Background

Rebasing was causing conflicts. It'll be cleaner (less error prone) to merge on top of the admin-rc branch.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
