### PR TITLE
chore: add reminder to PR template to update docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,4 @@
 ### Checklist
 
 - [ ] I have :tophat:'d these changes
+- [ ] I have updated relevant documentation


### PR DESCRIPTION
### Background

In an effort to keep documentation up-to-date, we want to add more reminders for ourselves.

### Solution

Add a reminder to the PR template. 

### 🎩

N/A

### Checklist

- [ ] I have :tophat:'d these changes
