### PR TITLE
remove role prop from Heading

### DIFF
--- a/packages/ui-extensions/src/types/Heading.ts
+++ b/packages/ui-extensions/src/types/Heading.ts
@@ -11,9 +11,4 @@ export interface BaseHeadingProps {
    * The visual level of the heading.
    */
   level?: Level;
-  /**
-   * A custom accessibility role for this heading.
-   * `presentation` will strip the semantic meaning of the heading, but leave the visual styling intact.
-   */
-  role?: 'presentation';
 }


### PR DESCRIPTION
### Background

Polaris `Heading` and `DisplayText` do not support a `role` prop. We are going to remove it until Polaris adds support.

Discussion [here](https://github.com/Shopify/web/pull/46630#discussion_r679218931).

### Solution

Remove `role` prop from `Heading` API.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
