### PR TITLE
Create InlineStack in Argo client and hosts

### DIFF
--- a/packages/admin-ui-extensions-react/src/components/InlineStack/InlineStack.ts
+++ b/packages/admin-ui-extensions-react/src/components/InlineStack/InlineStack.ts
@@ -1,0 +1,4 @@
+import {InlineStack as BaseInlineStack} from '@shopify/admin-ui-extensions';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const InlineStack = createRemoteReactComponent(BaseInlineStack);

--- a/packages/admin-ui-extensions-react/src/components/InlineStack/examples/InlineStack.example.tsx
+++ b/packages/admin-ui-extensions-react/src/components/InlineStack/examples/InlineStack.example.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {extend, render, InlineStack, Text} from '@shopify/admin-ui-extensions-react';
+
+function App() {
+  return (
+    <InlineStack inlineAlignment="center" spacing="loose">
+      <Text>Items to stack</Text>
+      <Text>Items to stack</Text>
+      <Text>Items to stack</Text>
+    </InlineStack>
+  );
+}
+
+extend(
+  'Playground',
+  render(() => <App />),
+);

--- a/packages/admin-ui-extensions-react/src/components/InlineStack/index.ts
+++ b/packages/admin-ui-extensions-react/src/components/InlineStack/index.ts
@@ -1,0 +1,2 @@
+export {InlineStack} from './InlineStack';
+export type {InlineStackProps} from '@shopify/admin-ui-extensions';

--- a/packages/admin-ui-extensions-react/src/components/index.ts
+++ b/packages/admin-ui-extensions-react/src/components/index.ts
@@ -7,6 +7,7 @@ export * from './CardSection';
 export * from './Checkbox';
 export * from './Pressable';
 export * from './Icon';
+export * from './InlineStack';
 export * from './Heading';
 export * from './Link';
 export * from './Modal';

--- a/packages/admin-ui-extensions/src/component-sets/Basic.ts
+++ b/packages/admin-ui-extensions/src/component-sets/Basic.ts
@@ -1,4 +1,5 @@
 import {
+  InlineStack,
   Heading,
   Pressable,
   Stack,
@@ -9,6 +10,7 @@ import {
 } from '../components';
 
 export type BasicComponents =
+  | typeof InlineStack
   | typeof Heading
   | typeof Pressable
   | typeof Stack

--- a/packages/admin-ui-extensions/src/components/InlineStack/InlineStack.ts
+++ b/packages/admin-ui-extensions/src/components/InlineStack/InlineStack.ts
@@ -1,0 +1,15 @@
+import {createRemoteComponent} from '@remote-ui/core';
+import type {BaseInlineStackProps} from '@shopify/ui-extensions';
+
+export type {BaseInlineStackProps as InlineStackProps} from '@shopify/ui-extensions';
+
+/**
+ * Use to lay out a horizontal row of components.
+ *
+ * A stack is made of flexible items that wrap each of the stack’s children. Options provide control of the alignment and spacing of the items in the stack.
+ * Use `StackItem` to group multiple elements inside a `InlineStack` together.
+ */
+export const InlineStack = createRemoteComponent<
+  'InlineStack',
+  BaseInlineStackProps
+>('InlineStack');

--- a/packages/admin-ui-extensions/src/components/InlineStack/content/guidelines.md
+++ b/packages/admin-ui-extensions/src/components/InlineStack/content/guidelines.md
@@ -1,0 +1,10 @@
+## Guidelines
+
+- 📱 All children of `InlineStack` are placed in a single view object, which makes recycling the views expensive and results in poorer performance when scrolling. Consider keeping your Stacks simple.
+- By default, `InlineStack` alignment is `'leading’`.
+
+| ✅ Do                                                                         | 🛑 Don't                              |
+| ----------------------------------------------------------------------------- | ------------------------------------- |
+| 📱 Keep Inline Stacks shallow. Complex hierarchies have performance penalties | 📱 Use complex and deep Stack layouts |
+
+For more guidelines, refer to Polaris' [Stack best practices](https://polaris.shopify.com/components/structure/stack#section-best-practices).

--- a/packages/admin-ui-extensions/src/components/InlineStack/examples/InlineStack.example.tsx
+++ b/packages/admin-ui-extensions/src/components/InlineStack/examples/InlineStack.example.tsx
@@ -1,0 +1,22 @@
+import {extend, InlineStack, Text} from '@shopify/admin-ui-extensions';
+
+function buildStackText(root) {
+  const text = root.createComponent(Text);
+  text.appendChild('Items to stack');
+  return text;
+}
+
+extend('Playground', (root) => {
+  const inlineStack = root.createComponent(InlineStack, {
+    inlineAlignment: 'center',
+    spacing: 'loose',
+  });
+
+  inlineStack.appendChild(buildStackText(root));
+  inlineStack.appendChild(buildStackText(root));
+  inlineStack.appendChild(buildStackText(root));
+
+  root.appendChild(inlineStack);
+
+  root.mount();
+});

--- a/packages/admin-ui-extensions/src/components/InlineStack/index.ts
+++ b/packages/admin-ui-extensions/src/components/InlineStack/index.ts
@@ -1,0 +1,2 @@
+export {InlineStack} from './InlineStack';
+export type {InlineStackProps} from './InlineStack';

--- a/packages/admin-ui-extensions/src/components/index.ts
+++ b/packages/admin-ui-extensions/src/components/index.ts
@@ -16,6 +16,8 @@ export {Heading} from './Heading';
 export type {HeadingProps} from './Heading';
 export {Icon} from './Icon';
 export type {IconProps} from './Icon';
+export {InlineStack} from './InlineStack';
+export type {InlineStackProps} from './InlineStack';
 export {Modal} from './Modal';
 export type {ModalProps} from './Modal';
 export {Link} from './Link';

--- a/packages/admin-ui-extensions/src/index.ts
+++ b/packages/admin-ui-extensions/src/index.ts
@@ -12,6 +12,7 @@ export type {
   CheckboxProps,
   PressableProps,
   IconProps,
+  InlineStackProps,
   ModalProps,
   LinkProps,
   RadioProps,


### PR DESCRIPTION
### Background

As part of the [Argo API Alignment project](https://docs.google.com/document/d/1LeZmHDT1Tr-XT5Xj-uwjRFlwis-asmM5zwp2VTj-oOw/edit#heading=h.vkiyv6kr3azd) we need update and/or add the following components to the library.

### Solution

This PR adds the `InlineStack` component to the `admin-ui-extensions` and to the `admin-ui-extensions-react` packages.

### 🎩

- Checkout the `feat/ui-extensions/1493/block-stack-web` branch on [shopify/ui-extensions](https://github.com/Shopify/ui-extensions), [shopify/admin-ui-extensions](https://github.com/Shopify/admin-ui-extensions) and [shopify/web](https://github.com/Shopify/web)
- In `ui-extensions`, run `yarn build-consumer web` and `yarn build-consumer admin-ui-extensions/packages/admin-ui-extensions-playground`. This will make the local changes available in both projects.
- In `admin-ui-extensions`, run `dev s`. This will make the changes to the playground project available to the web project.
- On the `web` project, run `dev playground:argo`  and visit to http://localhost:8080/#/playground/3p-components-list.worker.js

### Related PRs

- [Shopify/web](https://github.com/Shopify/web/pull/48439)
- [Shopify/admin-ui-extensions](https://github.com/Shopify/admin-ui-extensions/pull/123)

### Checklist

- [x] I have :tophat:'d these changes
