### PR TITLE
Update applyChangeset type signature to allow buyer consent to be passed

### DIFF
--- a/packages/post-purchase-ui-extensions/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/post-purchase-ui-extensions/src/extension-points/api/post-purchase/post-purchase.ts
@@ -16,6 +16,10 @@ export type PostPurchaseShouldRenderResult = ValueOrPromise<{
   render: boolean;
 }>;
 
+export interface ApplyChangesetOptions {
+  buyerConsentToSubscriptions?: boolean;
+}
+
 /** Input given to the render extension point (Checkout::PostPurchase::Render). */
 export interface PostPurchaseRenderApi
   extends StandardApi<'Checkout::PostPurchase::Render'> {
@@ -28,7 +32,10 @@ export interface PostPurchaseRenderApi
     changeset: Readonly<Changeset> | string,
   ): Promise<CalculateChangesetResult>;
   /**  Requests a changeset to be applied to the initial purchase, and to charge the buyer with the difference in total price, if any. */
-  applyChangeset(changeset: string): Promise<ApplyChangesetResult>;
+  applyChangeset(
+    changeset: string,
+    options?: ApplyChangesetOptions,
+  ): Promise<ApplyChangesetResult>;
   /**
    * Indicates that the extension has finished running.
    * Currently, effectively redirects buyers to the thank you page.


### PR DESCRIPTION
### Background

While updating our reference extension with the new version of the post-purchase package, I noticed that the option to passed the buyer consent to the apply changeset method was not updated.

### Solution

Add the new type ➕ 
