### PR TITLE
Publish

### DIFF
--- a/packages/post-purchase-ui-extensions-react/package.json
+++ b/packages/post-purchase-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/post-purchase-ui-extensions-react",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "React bindings for @shopify/post-purchase-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "^4.1.3",
-    "@shopify/post-purchase-ui-extensions": "^0.12.0",
+    "@shopify/post-purchase-ui-extensions": "^0.12.1",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/post-purchase-ui-extensions/package.json
+++ b/packages/post-purchase-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/post-purchase-ui-extensions",
   "description": "The API for UI Extensions that run in the post-purchase step of Shopify’s Checkout",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Bump post-purchase packages to include the new applyChangeset options. Packages are now: 
 - @shopify/post-purchase-ui-extensions-react@0.12.1
 - @shopify/post-purchase-ui-extensions@0.12.1

