### PR TITLE
[DO NOT MERGE] Breaking: Update Button API

### DIFF
--- a/packages/admin-ui-extensions-react/src/components/Button/examples/Button.example.jsx
+++ b/packages/admin-ui-extensions-react/src/components/Button/examples/Button.example.jsx
@@ -3,7 +3,18 @@ import {extend, render, Button} from '@shopify/admin-ui-extensions-react';
 
 function App() {
   return (
-    <Button title="Press Me" primary onPress={() => console.log('Pressed')} disabled={false} />
+    <Button
+      to="/settings"
+      kind="secondary"
+      appearance="monochrome"
+      size="large"
+      inlineSize="fill"
+      accessibilityLabel="open settings"
+      disabled={false}
+      onPress={() => console.log('Pressed')}
+    >
+      Settings
+    </Button>
   );
 }
 

--- a/packages/admin-ui-extensions/src/components/Button/Button.ts
+++ b/packages/admin-ui-extensions/src/components/Button/Button.ts
@@ -1,33 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {BaseButtonProps} from '@shopify/ui-extensions';
 
-import {IconProps} from '../Icon';
-
-type RequiredTitleOrIcon =
-  | {
-      /** Button label text */
-      title: string;
-
-      icon?: IconProps;
-    }
-  | {
-      /** Button label text */
-      title?: string;
-      icon: IconProps;
-    };
-
-export type ButtonProps = RequiredTitleOrIcon & {
-  /**
-   * Provides extra visual weight and identifies the primary action in a set of buttons.
-   * @defaultValue `false`
-   */
-  primary?: boolean;
-
-  /** Callback when button is pressed */
-  onPress?(): void;
-
-  /** Disables the button, preventing interaction. */
-  disabled?: boolean;
-};
+export interface ButtonProps extends BaseButtonProps {}
 
 /**
  * Buttons are used primarily for actions, such as “Add”, “Close”, “Cancel”, or “Save”.

--- a/packages/admin-ui-extensions/src/components/Button/examples/Button.example.ts
+++ b/packages/admin-ui-extensions/src/components/Button/examples/Button.example.ts
@@ -2,11 +2,18 @@ import {extend, Button} from '@shopify/admin-ui-extensions';
 
 extend('Playground', (root) => {
   const button = root.createComponent(Button, {
-    title: 'Press Me',
-    primary: true,
-    onPress: () => console.log('Pressed'),
+    to: '/settings',
+    kind: 'secondary',
+    appearance: 'monochrome',
+    size: 'large',
+    inlineSize: 'fill',
+    accessibilityLabel: 'open settings',
     disabled: false,
+    onPress: () => console.log('Pressed'),
   });
+
+
+  button.appendChild('Settings');
 
   root.appendChild(button);
   root.mount();

--- a/packages/ui-extensions/src/types/Button.ts
+++ b/packages/ui-extensions/src/types/Button.ts
@@ -9,6 +9,7 @@ export interface BaseButtonProps {
    * `primary`: button used for main actions or green-path. Ex: Continue to next step, Discount field
    * `secondary`: button used for secondary actions not blocking user progress. Ex: Download Shop app
    * `plain`: Renders a button that visually looks like a Link
+   *  @default 'primary'
    */
   kind?: 'primary' | 'secondary' | 'plain';
   /**


### PR DESCRIPTION
### Background

Related to https://github.com/Shopify/ui-extensions-private/issues/1490

This is a breaking change for the new Button API (to be merged AFTER cutting major version 0)

### Solution

The new `ButtonProps` extends `BaseButtonProps`

### 🎩

Not ready to tophat yet.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
