### PR TITLE
[WIP] Add purchase options extension point

### DIFF
--- a/packages/admin-ui-extensions/src/extension-points/identifiers/purchase_options.ts
+++ b/packages/admin-ui-extensions/src/extension-points/identifiers/purchase_options.ts
@@ -1,0 +1,37 @@
+import {RemoteRoot} from '@remote-ui/core';
+
+import {AllComponentsSchema} from '../../containers';
+
+import {RenderableExtensionCallback, StandardApi, ToastApi} from '../types';
+
+// Add the unique extension point(s) as a union string
+// This example only contains a single extension point
+
+export type PurchaseOptionsExtensionPoint = 'Admin::ProductDetails::PurchaseOptions';
+
+// Declare the Container API if needed
+export interface PurchaseOptionsExtensionContainerApi {
+  container: unknown;
+}
+
+// Declare the Data API if needed
+export interface PurchaseOptionsExtensionDataApi {
+  data: unknown;
+}
+
+// Update APIs for your needs
+// All Extension APIs should include the StandardApi by default
+export interface PurchaseOptionsExtensionApi {
+  'Admin::ProductDetails::PurchaseOptions': StandardApi<PurchaseOptionsExtensionPoint> &
+    ToastApi &
+    PurchaseOptionsExtensionContainerApi &
+    PurchaseOptionsExtensionDataApi;
+}
+
+// Replace AllComponentsSchema with a schema for your needs
+export interface PurchaseOptionsExtensionPointCallback {
+  'Admin::ProductDetails::PurchaseOptions': RenderableExtensionCallback<
+    PurchaseOptionsExtensionApi['Admin::ProductDetails::PurchaseOptions'],
+    RemoteRoot<AllComponentsSchema>
+  >;
+}

--- a/packages/admin-ui-extensions/src/extension-points/index.ts
+++ b/packages/admin-ui-extensions/src/extension-points/index.ts
@@ -11,6 +11,13 @@ import {
 
 export type {PlaygroundExtensionPoint, ProductSubscriptionExtensionPoint};
 
+import {
+  PurchaseOptionsExtensionPoint,
+  PurchaseOptionsExtensionApi,
+  PurchaseOptionsExtensionPointCallback,
+} from './identifiers/purchase_options';
+export {PurchaseOptionsExtensionPoint};
+
 /*
 Placeholder for new imports
 */
@@ -23,10 +30,13 @@ export type {
 
 export type ExtensionPoint =
   | PlaygroundExtensionPoint
-  | ProductSubscriptionExtensionPoint;
+  | ProductSubscriptionExtensionPoint
+  | PurchaseOptionsExtensionPoint;
 
 export type ExtensionApi = PlaygroundExtensionApi &
-  ProductSubscriptionExtensionApi;
+  ProductSubscriptionExtensionApi &
+  PurchaseOptionsExtensionApi;
 
 export type ExtensionPointCallback = PlaygroundExtensionPointCallback &
-  ProductSubscriptionExtensionPointCallback;
+  ProductSubscriptionExtensionPointCallback &
+  PurchaseOptionsExtensionPointCallback;


### PR DESCRIPTION
### Background

Relates to https://github.com/Shopify/shopify/issues/306904

### Solution

Add the `purchase_options` extension point that has the same functionality as the `product_subscription` point on the admin product details page

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
