### PR TITLE
Update shopify CLI instructions for shopify 2.x

### DIFF
--- a/packages/checkout-ui-extensions-run/src/dev.ts
+++ b/packages/checkout-ui-extensions-run/src/dev.ts
@@ -148,7 +148,7 @@ export async function dev(...args: string[]) {
             `Create a checkout and append <code>?dev=${origin}/query</code> to the URL to start developing your extension.`,
           );
         } else {
-          renderIndexPage(`Make sure you have a secure URL for your local development server by running <code>shopify tunnel start --port=${port}</code>,
+          renderIndexPage(`Make sure you have a secure URL for your local development server by running <code>shopify extension tunnel start --port=${port}</code>,
             create a checkout, and append <code>?dev=https://TUNNEL_URL/query</code> to the URL, where <code>TUNNEL_URL</code> is
             replaced with your own ngrok URL.`);
         }
@@ -293,7 +293,9 @@ function printNextSteps({
       );
     }
   } else {
-    log(`next, run \`shopify tunnel start --port=${port}\` in a new terminal.`);
+    log(
+      `next, run \`shopify extension tunnel start --port=${port}\` in a new terminal.`,
+    );
     log(
       `you’ll then need to create a checkout on your development shop, and append this query string to the first page of checkout,`,
     );


### PR DESCRIPTION
### Background

In certain situations, `checkout-ui-extensions-run serve` will explain how to start a tunnel. The command was for pre-2.0 `shopify` CLIs so it is now outdated.

### Solution

I updated the command.

### 🎩

Run `checkout-ui-extensions-run serve`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
