### PR TITLE
Update link anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ extend('Checkout::Feature::Render', (root) => {
 });
 ```
 
-Your UI Extension will receive different arguments depending on the extension point you’ve selected. The extension API you receive may also be affected by other factors, like your app’s permissions. For full details on what arguments are passed for each extension point, please refer to the documentation for the [Admin and Checkout surface area you want to extend](#i-just-want-to-build-an-ui-extension-not-learn-about-them).
+Your UI Extension will receive different arguments depending on the extension point you’ve selected. The extension API you receive may also be affected by other factors, like your app’s permissions. For full details on what arguments are passed for each extension point, please refer to the documentation for the [Admin and Checkout surface area you want to extend](#i-just-want-to-build-a-ui-extension-not-learn-about-them).
 
 ## Contributing
 

--- a/packages/admin-ui-extensions-react/README.md
+++ b/packages/admin-ui-extensions-react/README.md
@@ -27,4 +27,4 @@ extend(
 );
 ```
 
-You can find more component usage examples alongside each component in [packages/admin-ui-extensions-react/src/components](packages/admin-ui-extensions-react/src/components)
+You can find more component usage examples alongside each component in [packages/admin-ui-extensions-react/src/components](/packages/admin-ui-extensions-react/src/components)


### PR DESCRIPTION
### Background

There is a small typo in the `README.md` when linking back to the "I want to build an extension" section, as well as in `packages/admin-ui-extensions-react/README.md` when clicking into the components directory.

### Solution

Fix the anchor.

### 🎩

- [Render the `README.md` change as Markdown and click the link](https://github.com/Shopify/ui-extensions/blob/update-link-anchor-in-readme/README.md). It should take you to the appropriate heading.
- [Render the `admin-ui-extensions-react/README.md` change as Markdown and click the link](https://github.com/Shopify/ui-extensions/blob/update-link-anchor-in-readme/packages/admin-ui-extensions-react/README.md)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
