### PR TITLE
Add line in build-consumer to echo spin instance

### DIFF
--- a/scripts/consumer-helper.sh
+++ b/scripts/consumer-helper.sh
@@ -52,6 +52,7 @@ function copy_to_target {
     targetDir=$(resolve "$ROOT/../$projectDirectoryOrWorkspace/node_modules/@shopify/$package")
   else
     targetDir="$shopifyNodeModulesDir/$package"
+    echo "🌀 spin instance: `spin show | grep Shopify/$projectName | awk '{print $1}'` "
   fi
 
   if (run_command "[ -d $targetDir ]"); then


### PR DESCRIPTION
### Background

This is a tiny thing, but I feel more confident seeing where `build-consumer-spin` is copying the build.

### Solution

I added a line to echo the spin instance.

![echo spin](https://user-images.githubusercontent.com/7654369/145452012-5f2f690b-37bd-48e7-89aa-686b16f54f26.png)


### 🎩

Run `yarn build-consumer-spin web` and confirm that the output is your current spin instance.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
