### PR TITLE
Fix checkout-ui-extensions-run /data endpoint to reflect the latest values in the config file

### DIFF
--- a/packages/checkout-ui-extensions-run/src/dev.ts
+++ b/packages/checkout-ui-extensions-run/src/dev.ts
@@ -187,6 +187,10 @@ export async function dev(...args: string[]) {
       // post-purchase extension:
       // https://github.com/Shopify/post-purchase-devtools/blob/master/src/background/background.ts#L16-L35
       app.get(LEGACY_POST_PURCHASE_DATA_PATH, (_, res) => {
+        // The browser extension allows for the user to update his extension configuration
+        // without having to restart the server.
+        // In order to do so, we have to read the file every time the endpoint is called.
+        const extension = loadExtension();
         res.set('Access-Control-Allow-Origin', '*');
         res.json(getLegacyPostPurchaseData(scriptUrl.toString(), extension));
       });


### PR DESCRIPTION
### Background

The post-purchase browser extension has a feature where partners can update their `extension.config.yml` file and every 30 seconds or when partners click a `Refresh` button, the browser extension will query the `/data` endpoint and collect the metafields information.

<img width="1033" alt="Screen Shot 2022-01-07 at 1 29 41 PM" src="https://user-images.githubusercontent.com/17585917/148590331-cfd35af5-f108-4f66-a334-bba64cc34b52.png">

At the moment, this is broken since the `extension.config.yml` file is read once on startup and we reuse the value for every subsequent requests.

### Solution

Instead of using the value queried when the server starts, read the file every time for the post-purchase endpoint only.

### 🎩

I've tophatted this with both the refresh button and the 30 second delay succesfully.

The simples way to tophat is to edit the file in the node_modules of the reference extension to add the new line :

`node_modules/@shopify/checkout-ui-extensions-run/build/node/dev.js` (Line 197)

```
 app.get(LEGACY_POST_PURCHASE_DATA_PATH, (_, res) => {
        const extension = (0, _utilities.loadExtension)() // <- this here
        console.log({metafields: extension.config.metafields})
        res.set('Access-Control-Allow-Origin', '*');
        res.json((0, _utilities.getLegacyPostPurchaseData)(scriptUrl.toString(), extension));
      });
```

You'll need the reference extension running and the browser extension installed on your Chrome browser.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] ~I have updated relevant documentation~
