### PR TITLE
Update links to Storefront API metafields tutorial

### DIFF
--- a/packages/post-purchase-ui-extensions/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/post-purchase-ui-extensions/src/extension-points/api/post-purchase/post-purchase.ts
@@ -85,7 +85,7 @@ interface Shop {
   /** The primary domain of the shop (ending with “.myshopify.com”). */
   domain: string;
   /**
-   * Only [public listed](/custom-storefronts/products/metafields#step-1-expose-metafields) metafields are available.
+   * Only [public listed](/api/examples/metafields#step-1-expose-metafields) metafields are available.
    */
   metafields: Metafield[];
 }
@@ -109,7 +109,7 @@ interface Product {
   /** Variant being purchased. */
   variant: Variant;
   /**
-   * Only [public listed](/custom-storefronts/products/metafields#step-1-expose-metafields) metafields are available.
+   * Only [public listed](/api/examples/metafields#step-1-expose-metafields) metafields are available.
    */
   metafields: Metafield[];
 }
@@ -120,7 +120,7 @@ interface Variant {
   /** The variant title. */
   title: string;
   /**
-   * Only [public listed](/custom-storefronts/products/metafields#step-1-expose-metafields) metafields are available.
+   * Only [public listed](/api/examples/metafields#step-1-expose-metafields) metafields are available.
    */
   metafields: Metafield[];
 }


### PR DESCRIPTION
## This PR: 
- Updates a few links to the docs that were recently changed
- Relates to https://github.com/Shopify/shopify-dev/pull/15856