### PR TITLE
Reduce noise when running ui-extension in Shopify's Spin

### DIFF
--- a/.spin/Procfile
+++ b/.spin/Procfile
@@ -1,0 +1,3 @@
+# This is an empty Procfile so that ui-extensions does not appear as a failed service in Spin.
+# See https://github.com/Shopify/spin/issues/3928
+# ui-extensions is a library, not a service.


### PR DESCRIPTION
### Background

When running `ui-extensions` in Shopify's internal Spin development tool, the repo is marked as a "failed service"

### Solution

Adding an empty `Procfile` is the suggested workaround until this is resolved: https://github.com/Shopify/spin/issues/3928

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have updated relevant documentation
