### PR TITLE
Add new changeset post purchase error code

### DIFF
--- a/packages/post-purchase-ui-extensions/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/post-purchase-ui-extensions/src/extension-points/api/post-purchase/post-purchase.ts
@@ -292,6 +292,7 @@ interface CalculatedPurchase {
  * - `subscription_contract_creation_error` - Indicates that an error occurred during the contract creation phase of the application of an `add_subscription` change. The subscription could not be created.
  * - `subscription_no_shipping_address_error` - Indicates that the order is missing the required customer shipping address for an `add_subscription` change.
  * - `subscription_limit_error` - Indicates that no more subscriptions can be added to this order via the post-purchase API.
+ * - `order_released_error` - Indicates that the checkout was already completed and the order has been released to fulfillment.
  */
 type ChangesetErrorCode =
   | 'payment_required'
@@ -304,7 +305,8 @@ type ChangesetErrorCode =
   | 'subscription_vaulting_error'
   | 'subscription_contract_creation_error'
   | 'subscription_no_shipping_address_error'
-  | 'subscription_limit_error';
+  | 'subscription_limit_error'
+  | 'order_released_error';
 
 /** Represents an error occurred while calculating or applying a changeset.
  */


### PR DESCRIPTION
### Background

_(Draft until https://github.com/Shopify/shopify/pull/339101 is shipped)_

I introduced a new error code on this PR: https://github.com/Shopify/shopify/pull/339101

### Solution

Add new error code to post purchase `ChangesetErrorCode` type.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
