### PR TITLE
Added retail-ui-extensions package

### DIFF
--- a/packages/retail-ui-extensions/.gitignore
+++ b/packages/retail-ui-extensions/.gitignore
@@ -1,0 +1,7 @@
+*.js
+*.map
+*.d.ts
+
+/components-schemas
+/components
+/extension-api

--- a/packages/retail-ui-extensions/.npmignore
+++ b/packages/retail-ui-extensions/.npmignore
@@ -1,0 +1,3 @@
+.*
+node_modules
+tsconfig.json

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@shopify/retail-ui-extensions",
+  "version": "0.0.1",
+  "main": "index.js",
+  "module": "index.mjs",
+  "esnext": "index.esnext",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "esnext": "./index.esnext",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./": "./"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "dependencies": {
+    "@remote-ui/core": "^2.1.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/retail-ui-extensions/sewing-kit.config.ts
+++ b/packages/retail-ui-extensions/sewing-kit.config.ts
@@ -1,0 +1,7 @@
+import {createPackage} from '@sewing-kit/config';
+import {uiExtensionsPackage} from '../../config/sewing-kit';
+
+export default createPackage((pkg) => {
+  pkg.entry({root: './src/index'});
+  pkg.use(uiExtensionsPackage());
+});

--- a/packages/retail-ui-extensions/tsconfig.json
+++ b/packages/retail-ui-extensions/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../config/typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/ts"
+  },
+  "references": [],
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./src/**/*.example.*"]
+}


### PR DESCRIPTION
### Background

We're starting to move our UI components from our private repo to this one. This PR is to start setting up the project, however we don't want to publish anything just yet.

### Solution

I've copied the layout for admin-ui-extensions as the way we've set it up in our private repo has been heavily inspired by this.
