### PR TITLE
Add missing page to Shopify.dev

### DIFF
--- a/scripts/typedoc/shopify-dev-renderer/getting-started.ts
+++ b/scripts/typedoc/shopify-dev-renderer/getting-started.ts
@@ -43,7 +43,7 @@ export function gettingStarted(paths: Paths, options: Options = {}) {
 
   const docsInputPath = resolve(`${paths.inputRoot}/documentation`);
 
-  const files = ['extension-points.md'];
+  const files = ['extension-points.md', 'globals.md'];
 
   if (fs.existsSync(docsInputPath)) {
     files.forEach((file) => {


### PR DESCRIPTION
### Background

A broken anchor linking to missing content causes build failures on `shopify-dev` when generating the `beta/checkout-extension` docs. The problem is twofold:

- Failing build check on `shopify-dev` means the link has to be manually removed, to ship updates for either post-purchase or beta checkout extensions content

- Partners are missing information that they need

### Solution

Add `globals.md` to the array

### 🎩
![globals](https://user-images.githubusercontent.com/63201605/162053609-5566e9d2-d184-40df-8063-c2e80f034b6a.gif)


### Checklist

- [X ] I have :tophat:'d these changes
- [X ] I have updated relevant documentation
