### PR TITLE
Publish 0.15.0 checkout-ui-extensions/react

### DIFF
--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/checkout-ui-extensions-react",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "React bindings for @shopify/checkout-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.7",
     "@remote-ui/react": "^4.3.0",
-    "@shopify/checkout-ui-extensions": "^0.14.0",
+    "@shopify/checkout-ui-extensions": "^0.15.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify’s Checkout",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
 - @shopify/checkout-ui-extensions-react@0.15.0
 - @shopify/checkout-ui-extensions@0.15.0

### Background

This publishes the latest cut from this #284  (already merged).

### Solution

Ran `yarn version-bump:checkout` to create the git tags for the release

### 🎩
Tophatting instructions can be found in the [previous PR that brought the changes](https://github.com/Shopify/ui-extensions/pull/284) in.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
