### PR TITLE
Update prettier to 2.6.2 and fix formatting

### DIFF
--- a/packages/admin-ui-extensions-react/package.json
+++ b/packages/admin-ui-extensions-react/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@remote-ui/react": "^4.1.5",
+    "@remote-ui/react": "^4.5.0",
     "@shopify/admin-ui-extensions": "^1.0.1",
     "@types/react": ">=17.0.0 <18.0.0"
   },

--- a/packages/admin-ui-extensions-react/src/test/api.test.tsx
+++ b/packages/admin-ui-extensions-react/src/test/api.test.tsx
@@ -26,7 +26,7 @@ describe('api', () => {
   it('render calls remote render with generated element', () => {
     const element = <div />;
 
-    const root = ({mount: jest.fn()} as unknown) as RemoteRoot;
+    const root = {mount: jest.fn()} as unknown as RemoteRoot;
     const api = {locale: 'en'} as any;
 
     const createdElement = <p />;

--- a/packages/admin-ui-extensions/package.json
+++ b/packages/admin-ui-extensions/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@remote-ui/core": "^2.1.3",
+    "@remote-ui/core": "^2.1.9",
     "@shopify/ui-extensions": "^1.0.1"
   },
   "publishConfig": {

--- a/packages/admin-ui-extensions/src/api.ts
+++ b/packages/admin-ui-extensions/src/api.ts
@@ -19,7 +19,7 @@ export function extend<T extends ExtensionPoint>(
   extensionPoint: T,
   callback: ExtensionPointCallback[T],
 ) {
-  return ((self as any) as ShopifyGlobal).shopify.extend(
+  return (self as any as ShopifyGlobal).shopify.extend(
     extensionPoint,
     callback,
   );

--- a/packages/admin-ui-extensions/src/extension-api/ContainerApi/index.ts
+++ b/packages/admin-ui-extensions/src/extension-api/ContainerApi/index.ts
@@ -1,8 +1,7 @@
 import {ExtensionPoint, ExtensionApi} from '../../extension-points';
 
-export type ExtensionContainer<
-  T extends ExtensionPoint
-> = ExtensionApi[T]['container'];
+export type ExtensionContainer<T extends ExtensionPoint> =
+  ExtensionApi[T]['container'];
 
 /**
  * Each extension point provides a container API with methods the extension can use to communicate with Shopify Admin.

--- a/packages/admin-ui-extensions/src/extension-points/identifiers/product_subscription.ts
+++ b/packages/admin-ui-extensions/src/extension-points/identifiers/product_subscription.ts
@@ -25,53 +25,49 @@ export interface ProductSubscriptionModalContainerApi {
 }
 
 export type ProductSubscriptionStandardApi<
-  T extends ProductSubscriptionExtensionPoint
+  T extends ProductSubscriptionExtensionPoint,
 > = StandardApi<T> & ToastApi;
 
-export type ProductSubscriptionCreateApi = ProductSubscriptionStandardApi<
-  'Admin::Product::SubscriptionPlan::Create'
-> & {
-  container: ProductSubscriptionContainerApi;
-  data: {
-    productId: string;
-    variantId?: string;
+export type ProductSubscriptionCreateApi =
+  ProductSubscriptionStandardApi<'Admin::Product::SubscriptionPlan::Create'> & {
+    container: ProductSubscriptionContainerApi;
+    data: {
+      productId: string;
+      variantId?: string;
+    };
   };
-};
 
-export type ProductSubscriptionAddApi = ProductSubscriptionStandardApi<
-  'Admin::Product::SubscriptionPlan::Add'
-> & {
-  container: ProductSubscriptionContainerApi &
-    ProductSubscriptionModalContainerApi;
-  data: {
-    productId: string;
-    variantId?: string;
+export type ProductSubscriptionAddApi =
+  ProductSubscriptionStandardApi<'Admin::Product::SubscriptionPlan::Add'> & {
+    container: ProductSubscriptionContainerApi &
+      ProductSubscriptionModalContainerApi;
+    data: {
+      productId: string;
+      variantId?: string;
+    };
   };
-};
 
-export type ProductSubscriptionEditApi = ProductSubscriptionStandardApi<
-  'Admin::Product::SubscriptionPlan::Edit'
-> & {
-  container: ProductSubscriptionContainerApi;
-  data: {
-    sellingPlanGroupId: string;
-    productId: string;
-    variantId?: string;
+export type ProductSubscriptionEditApi =
+  ProductSubscriptionStandardApi<'Admin::Product::SubscriptionPlan::Edit'> & {
+    container: ProductSubscriptionContainerApi;
+    data: {
+      sellingPlanGroupId: string;
+      productId: string;
+      variantId?: string;
+    };
   };
-};
 
-export type ProductSubscriptionRemoveApi = ProductSubscriptionStandardApi<
-  'Admin::Product::SubscriptionPlan::Remove'
-> & {
-  container: ProductSubscriptionContainerApi &
-    ProductSubscriptionModalContainerApi;
-  data: {
-    sellingPlanGroupId: string;
-    productId: string;
-    variantId?: string;
-    variantIds: string[];
+export type ProductSubscriptionRemoveApi =
+  ProductSubscriptionStandardApi<'Admin::Product::SubscriptionPlan::Remove'> & {
+    container: ProductSubscriptionContainerApi &
+      ProductSubscriptionModalContainerApi;
+    data: {
+      sellingPlanGroupId: string;
+      productId: string;
+      variantId?: string;
+      variantIds: string[];
+    };
   };
-};
 
 export interface ProductSubscriptionExtensionApi {
   'Admin::Product::SubscriptionPlan::Create': ProductSubscriptionCreateApi;

--- a/packages/admin-ui-extensions/src/extension-points/types.ts
+++ b/packages/admin-ui-extensions/src/extension-points/types.ts
@@ -9,7 +9,7 @@ export type ExtensionResult = Record<string, never> | void;
 
 export interface RenderExtension<
   Api,
-  AllowedComponents extends RemoteComponentType<string, any, any>
+  AllowedComponents extends RemoteComponentType<string, any, any>,
 > {
   (root: RemoteRoot<AllowedComponents, true>, api: Api): ExtensionResult;
 }

--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -21,8 +21,8 @@
     "./": "./"
   },
   "dependencies": {
-    "@remote-ui/async-subscription": "^2.1.7",
-    "@remote-ui/react": "^4.3.0",
+    "@remote-ui/async-subscription": "^2.1.9",
+    "@remote-ui/react": "^4.5.0",
     "@shopify/checkout-ui-extensions": "^0.15.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },

--- a/packages/checkout-ui-extensions-react/src/context.ts
+++ b/packages/checkout-ui-extensions-react/src/context.ts
@@ -4,6 +4,5 @@ import {
   RenderExtensionPoint,
 } from '@shopify/checkout-ui-extensions';
 
-export const ExtensionApiContext = createContext<ApiForRenderExtension<
-  RenderExtensionPoint
-> | null>(null);
+export const ExtensionApiContext =
+  createContext<ApiForRenderExtension<RenderExtensionPoint> | null>(null);

--- a/packages/checkout-ui-extensions-react/src/hooks/api.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/api.ts
@@ -12,7 +12,7 @@ import {ExtensionApiContext} from '../context';
  * extension when it was created.
  */
 export function useExtensionApi<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >(): ApiForRenderExtension<ID> {
   const api = useContext(ExtensionApiContext);
 

--- a/packages/checkout-ui-extensions-react/src/hooks/app-metafields.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/app-metafields.ts
@@ -24,7 +24,7 @@ type AppMetafieldFilterKeys = keyof AppMetafieldFilters;
  * @arg {AppMetafieldFilters} - filter the list of returned metafields
  */
 export function useAppMetafields<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >(filters: AppMetafieldFilters = {}) {
   const appMetafields = useSubscription(useExtensionApi<ID>().appMetafields);
 

--- a/packages/checkout-ui-extensions-react/src/hooks/billing-address.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/billing-address.ts
@@ -7,7 +7,7 @@ import {useSubscription} from './subscription';
  * Returns the proposed `billingAddress` applied to the checkout.
  */
 export function useBillingAddress<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useSubscription(useExtensionApi<ID>().billingAddress);
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/buyer-journey.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/buyer-journey.ts
@@ -10,7 +10,7 @@ import {useExtensionApi} from './api';
  * Returns the `buyerJourney` details on buyer progression in checkout
  */
 export function useBuyerJourney<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useExtensionApi<ID>().buyerJourney;
 }
@@ -22,7 +22,7 @@ export function useBuyerJourney<
  * the reason why navigation was blocked.
  */
 export function useBuyerJourneyIntercept<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >(interceptor: Interceptor) {
   const buyerJourney = useBuyerJourney<ID>();
   const interceptorRef = useRef(interceptor);

--- a/packages/checkout-ui-extensions-react/src/hooks/configuration.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/configuration.ts
@@ -26,9 +26,7 @@ import {useSubscription} from './subscription';
  * ```
  */
 export function useConfiguration<
-  ConfigType extends ApiForRenderExtension<
-    RenderExtensionPoint
-  >['configuration']['current']
+  ConfigType extends ApiForRenderExtension<RenderExtensionPoint>['configuration']['current'],
 >(): ConfigType {
   const {configuration} = useExtensionApi();
 

--- a/packages/checkout-ui-extensions-react/src/hooks/custom-attributes.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/custom-attributes.ts
@@ -7,7 +7,7 @@ import {useSubscription} from './subscription';
  * Returns the proposed `custom attributes` applied to the checkout.
  */
 export function useCustomAttributes<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useSubscription(useExtensionApi<ID>().customAttributes);
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/customer-account.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/customer-account.ts
@@ -7,7 +7,7 @@ import {useSubscription} from './subscription';
  * Returns the customer account associated to the buyer.
  */
 export function useCustomerAccount<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useSubscription(useExtensionApi<ID>().customerAccount);
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/extension-data.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/extension-data.ts
@@ -6,7 +6,7 @@ import {useExtensionApi} from './api';
  * Returns the metadata about the extension.
  */
 export function useExtensionData<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useExtensionApi<ID>().extension;
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/extension-locale.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/extension-locale.ts
@@ -7,7 +7,7 @@ import {useExtensionApi} from './api';
 import {useSubscription} from './subscription';
 
 export function useExtensionLocale<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >(): ApiForRenderExtension<ID>['i18n']['extensionLocale']['current'] {
   const {i18n} = useExtensionApi<ID>();
 

--- a/packages/checkout-ui-extensions-react/src/hooks/line-items.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/line-items.ts
@@ -11,7 +11,7 @@ import {useSubscription} from './subscription';
  * your component if line items are added, removed, or updated.
  */
 export function useLineItems<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >(): LineItem[] {
   const {lineItems} = useExtensionApi<ID>();
 
@@ -19,7 +19,7 @@ export function useLineItems<
 }
 
 export function useApplyLineItemsChange<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useExtensionApi<ID>().applyLineItemsChange;
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/locale.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/locale.ts
@@ -11,7 +11,7 @@ import {useSubscription} from './subscription';
  * your component if the locale changes.
  */
 export function useLocale<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >(): ApiForRenderExtension<ID>['i18n']['locale']['current'] {
   const {i18n} = useExtensionApi<ID>();
 

--- a/packages/checkout-ui-extensions-react/src/hooks/metafields.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/metafields.ts
@@ -16,7 +16,7 @@ interface MetafieldsFilters {
  * @arg {MetafieldsFilters} - filter the list of returned metafields
  */
 export function useMetafields<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >(filters?: MetafieldsFilters) {
   const metaFields = useSubscription(useExtensionApi<ID>().metafields);
 
@@ -46,7 +46,7 @@ export function useMetafields<
  * Returns a function to mutate the `metafields` property of the checkout.
  */
 export function useApplyMetafieldsChange<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useExtensionApi<ID>().applyMetafieldChange;
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/note.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/note.ts
@@ -7,7 +7,7 @@ import {useSubscription} from './subscription';
  * Returns the proposed `note` applied to the checkout.
  */
 export function useNote<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useSubscription(useExtensionApi<ID>().note);
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/primary-address.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/primary-address.ts
@@ -8,7 +8,7 @@ import {useSubscription} from './subscription';
  * the proposed `billingAddress` applied to the checkout.
  */
 export function usePrimaryAddress<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useSubscription(useExtensionApi<ID>().primaryAddress);
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/running-total.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/running-total.ts
@@ -7,7 +7,7 @@ import {useSubscription} from './subscription';
  * Returns the running total calculated at the current step.
  */
 export function useRunningTotal<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useSubscription(useExtensionApi<ID>().runningTotal);
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/shipping-address.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/shipping-address.ts
@@ -7,7 +7,7 @@ import {useSubscription} from './subscription';
  * Returns the proposed `shippingAddress` applied to the checkout.
  */
 export function useShippingAddress<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useSubscription(useExtensionApi<ID>().shippingAddress);
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/shop.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/shop.ts
@@ -6,7 +6,7 @@ import {useExtensionApi} from './api';
  * Returns the shop where the checkout is taking place.
  */
 export function useShop<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useExtensionApi<ID>().shop;
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/signed.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/signed.ts
@@ -3,7 +3,7 @@ import type {RenderExtensionPoint} from '@shopify/checkout-ui-extensions';
 import {useExtensionApi} from './api';
 
 export function useApplySignedChange<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useExtensionApi<ID>().applySignedChange;
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/storage.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/storage.ts
@@ -6,7 +6,7 @@ import {useExtensionApi} from './api';
  * Returns the interface for the key / value storage for this extension point.
  */
 export function useStorage<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   return useExtensionApi<ID>().storage;
 }

--- a/packages/checkout-ui-extensions-react/src/hooks/tests/extension-locale.test.tsx
+++ b/packages/checkout-ui-extensions-react/src/hooks/tests/extension-locale.test.tsx
@@ -9,9 +9,8 @@ describe('useExtensionLocale', () => {
     const {value} = mount.hook(() => useExtensionLocale(), {
       extensionApi: {
         i18n: {
-          extensionLocale: createMockStatefulRemoteSubscribable(
-            extensionLocale,
-          ),
+          extensionLocale:
+            createMockStatefulRemoteSubscribable(extensionLocale),
         },
       },
     });

--- a/packages/checkout-ui-extensions-react/src/hooks/tests/metafield.test.tsx
+++ b/packages/checkout-ui-extensions-react/src/hooks/tests/metafield.test.tsx
@@ -89,7 +89,7 @@ describe('useMetafields', () => {
       metafields: createMockStatefulRemoteSubscribable(createMetafields()),
     };
 
-    const key = (undefined as unknown) as string;
+    const key = undefined as unknown as string;
 
     expect(() =>
       mount.hook(() => useMetafield({namespace: 'test_namespace', key}), {

--- a/packages/checkout-ui-extensions-react/src/hooks/tests/metafields.test.tsx
+++ b/packages/checkout-ui-extensions-react/src/hooks/tests/metafields.test.tsx
@@ -110,7 +110,7 @@ describe('useMetafields', () => {
       metafields: createMockStatefulRemoteSubscribable(createMetafields()),
     };
 
-    const namespace = (undefined as unknown) as string;
+    const namespace = undefined as unknown as string;
 
     expect(() =>
       mount.hook(() => useMetafields({namespace, key: 'test_key'}), {

--- a/packages/checkout-ui-extensions-react/src/hooks/translate.tsx
+++ b/packages/checkout-ui-extensions-react/src/hooks/translate.tsx
@@ -8,7 +8,7 @@ import type {RemoteComponentType} from '@remote-ui/types';
 import {useExtensionApi} from './api';
 
 export function useTranslate<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >() {
   const {i18n} = useExtensionApi<ID>();
 

--- a/packages/checkout-ui-extensions-run/src/dev.ts
+++ b/packages/checkout-ui-extensions-run/src/dev.ts
@@ -22,13 +22,8 @@ const PUBLIC_PATH = '/assets/';
 export async function dev(...args: string[]) {
   const extension = loadExtension();
   const config = await parseDevelopmentServerConfig(args);
-  const {
-    extensionPoint,
-    filename,
-    port,
-    scriptUrl,
-    webpackConfiguration,
-  } = config;
+  const {extensionPoint, filename, port, scriptUrl, webpackConfiguration} =
+    config;
   const compiler = webpack(webpackConfiguration);
 
   const firstCompilePromise = new Promise<void>((resolve) => {

--- a/packages/checkout-ui-extensions-run/src/utilities.ts
+++ b/packages/checkout-ui-extensions-run/src/utilities.ts
@@ -208,17 +208,16 @@ export function parseDevelopmentServerConfig(args: string[]) {
   };
 }
 
-export const urlGeneratorFor = (baseUrl?: string) => (
-  path?: string,
-  query: Record<string, string> = {},
-): URL | undefined => {
-  if (!baseUrl) return undefined;
-  if (!path) return undefined;
+export const urlGeneratorFor =
+  (baseUrl?: string) =>
+  (path?: string, query: Record<string, string> = {}): URL | undefined => {
+    if (!baseUrl) return undefined;
+    if (!path) return undefined;
 
-  const url = new URL(path, baseUrl);
-  Object.keys(query).forEach((parameter) => {
-    url.searchParams.append(parameter, query[parameter]);
-  });
+    const url = new URL(path, baseUrl);
+    Object.keys(query).forEach((parameter) => {
+      url.searchParams.append(parameter, query[parameter]);
+    });
 
-  return url;
-};
+    return url;
+  };

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -21,7 +21,7 @@
     "./": "./"
   },
   "dependencies": {
-    "@remote-ui/async-subscription": "^2.1.7",
-    "@remote-ui/core": "^2.1.6"
+    "@remote-ui/async-subscription": "^2.1.9",
+    "@remote-ui/core": "^2.1.9"
   }
 }

--- a/packages/checkout-ui-extensions/src/components/shared.ts
+++ b/packages/checkout-ui-extensions/src/components/shared.ts
@@ -211,7 +211,4 @@ export type AccessibilityRole =
   | 'alert';
 
 export type UnitSuffix = 'fr' | '%' | 'px';
-/* eslint-disable eslint-comments/no-unlimited-disable */
-// eslint-disable-next-line
 export type Unit<Suffix extends UnitSuffix> = `${number}${Suffix}`;
-/* eslint-enable eslint-comments/no-unlimited-disable */

--- a/packages/checkout-ui-extensions/src/extend.ts
+++ b/packages/checkout-ui-extensions/src/extend.ts
@@ -7,4 +7,4 @@ import type {ShopifyGlobal} from './globals';
  * is ready to run the extension point.
  */
 export const extend: ShopifyGlobal['extend'] = (...args) =>
-  ((self as any) as {shopify: ShopifyGlobal}).shopify.extend(...args);
+  (self as any as {shopify: ShopifyGlobal}).shopify.extend(...args);

--- a/packages/checkout-ui-extensions/src/extension-points/api/standard/index.ts
+++ b/packages/checkout-ui-extensions/src/extension-points/api/standard/index.ts
@@ -305,7 +305,7 @@ export interface Buyer {
  * The following APIs are provided to all extension points.
  */
 export interface StandardApi<
-  ExtensionPoint extends import('../../extension-points').ExtensionPoint
+  ExtensionPoint extends import('../../extension-points').ExtensionPoint,
 > {
   /**
    * Merchant configuration for this extension.

--- a/packages/checkout-ui-extensions/src/extension-points/render-extension.ts
+++ b/packages/checkout-ui-extensions/src/extension-points/render-extension.ts
@@ -10,9 +10,10 @@ import {RemoteRoot, RemoteComponentType} from '@remote-ui/core';
  */
 export interface RenderExtension<
   Input,
-  AllowedComponents extends RemoteComponentType<string, any, any>
+  AllowedComponents extends RemoteComponentType<string, any, any>,
 > {
-  (root: RemoteRoot<AllowedComponents, true>, input: Input): void | Promise<
-    void
-  >;
+  (
+    root: RemoteRoot<AllowedComponents, true>,
+    input: Input,
+  ): void | Promise<void>;
 }

--- a/packages/checkout-ui-extensions/src/extension-points/types.ts
+++ b/packages/checkout-ui-extensions/src/extension-points/types.ts
@@ -5,17 +5,15 @@ import {RenderExtension} from './render-extension';
  * For a given extension point, returns the value that is expected to be
  * returned by that extension point’s callback type.
  */
-export type ReturnTypeForExtension<
-  ID extends keyof ExtensionPoints
-> = ReturnType<ExtensionPoints[ID]>;
+export type ReturnTypeForExtension<ID extends keyof ExtensionPoints> =
+  ReturnType<ExtensionPoints[ID]>;
 
 /**
  * For a given extension point, returns the tuple of arguments that would
  * be provided to that extension point’s callback type.
  */
-export type ArgumentsForExtension<
-  ID extends keyof ExtensionPoints
-> = Parameters<ExtensionPoints[ID]>;
+export type ArgumentsForExtension<ID extends keyof ExtensionPoints> =
+  Parameters<ExtensionPoints[ID]>;
 
 /**
  * A union type containing all extension points that follow the pattern of
@@ -46,9 +44,8 @@ type ExtractedApiFromRenderExtension<T> = T extends RenderExtension<
   ? Api
   : never;
 
-type ExtractedAllowedComponentsFromRenderExtension<
-  T
-> = T extends RenderExtension<any, infer Components> ? Components : never;
+type ExtractedAllowedComponentsFromRenderExtension<T> =
+  T extends RenderExtension<any, infer Components> ? Components : never;
 
 /**
  * For a given rendering extension point, returns the type of the API that the
@@ -56,14 +53,13 @@ type ExtractedAllowedComponentsFromRenderExtension<
  * the callback for that extension point (the first callback for all rendering
  * extension points is the same — they all receive a `RemoteRoot` object)
  */
-export type ApiForRenderExtension<
-  ID extends keyof RenderExtensions
-> = ExtractedApiFromRenderExtension<RenderExtensions[ID]>;
+export type ApiForRenderExtension<ID extends keyof RenderExtensions> =
+  ExtractedApiFromRenderExtension<RenderExtensions[ID]>;
 
 /**
  * For a given rendering extension point, returns the UI components that the
  * extension point supports.
  */
 export type AllowedComponentsForRenderExtension<
-  ID extends keyof RenderExtensions
+  ID extends keyof RenderExtensions,
 > = ExtractedAllowedComponentsFromRenderExtension<RenderExtensions[ID]>;

--- a/packages/checkout-ui-extensions/src/utilities.ts
+++ b/packages/checkout-ui-extensions/src/utilities.ts
@@ -5,9 +5,9 @@ import type {
 } from '@remote-ui/core';
 
 export type ReactPropsFromRemoteComponentType<
-  Type extends RemoteComponentType<any, any, any>
+  Type extends RemoteComponentType<any, any, any>,
 > = PropsForRemoteComponent<Type> & {children?: ReactNode};
 
 export type ReactComponentTypeFromRemoteComponentType<
-  Type extends RemoteComponentType<any, any, any>
+  Type extends RemoteComponentType<any, any, any>,
 > = FunctionComponent<ReactPropsFromRemoteComponentType<Type>>;

--- a/packages/post-purchase-ui-extensions-react/package.json
+++ b/packages/post-purchase-ui-extensions-react/package.json
@@ -21,7 +21,7 @@
     "./": "./"
   },
   "dependencies": {
-    "@remote-ui/react": "^4.1.3",
+    "@remote-ui/react": "^4.5.0",
     "@shopify/post-purchase-ui-extensions": "^0.13.3",
     "@types/react": ">=17.0.0 <18.0.0"
   },

--- a/packages/post-purchase-ui-extensions-react/src/context.ts
+++ b/packages/post-purchase-ui-extensions-react/src/context.ts
@@ -5,6 +5,5 @@ import {
   RenderExtensionPoint,
 } from '@shopify/post-purchase-ui-extensions';
 
-export const ExtensionInputContext = createContext<InputForRenderExtension<
-  RenderExtensionPoint
-> | null>(null);
+export const ExtensionInputContext =
+  createContext<InputForRenderExtension<RenderExtensionPoint> | null>(null);

--- a/packages/post-purchase-ui-extensions-react/src/hooks/input.ts
+++ b/packages/post-purchase-ui-extensions-react/src/hooks/input.ts
@@ -7,7 +7,7 @@ import {
 import {ExtensionInputContext} from '../context';
 
 export function useExtensionInput<
-  ID extends RenderExtensionPoint = RenderExtensionPoint
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
 >(): InputForRenderExtension<ID> {
   const input = useContext(ExtensionInputContext);
 

--- a/packages/post-purchase-ui-extensions/package.json
+++ b/packages/post-purchase-ui-extensions/package.json
@@ -21,6 +21,6 @@
     "./": "./"
   },
   "dependencies": {
-    "@remote-ui/core": "^2.1.3"
+    "@remote-ui/core": "^2.1.9"
   }
 }

--- a/packages/post-purchase-ui-extensions/src/extension-points/api/standard/index.ts
+++ b/packages/post-purchase-ui-extensions/src/extension-points/api/standard/index.ts
@@ -1,7 +1,7 @@
 export type Version = 'unstable';
 
 export interface StandardApi<
-  ExtensionPoint extends import('../../extension-points').ExtensionPoint
+  ExtensionPoint extends import('../../extension-points').ExtensionPoint,
 > {
   version: Version;
   locale: string;

--- a/packages/post-purchase-ui-extensions/src/extension-points/render-extension.ts
+++ b/packages/post-purchase-ui-extensions/src/extension-points/render-extension.ts
@@ -19,12 +19,13 @@ interface RenderResult<Input> {
  */
 export interface RenderExtension<
   Input,
-  AllowedComponents extends RemoteComponentType<string, any, any>
+  AllowedComponents extends RemoteComponentType<string, any, any>,
 > {
   /**
    * Input type for RenderExtension.
    */
-  (root: RemoteRoot<AllowedComponents, true>, input: Input): RenderResult<
-    Input
-  > | void;
+  (
+    root: RemoteRoot<AllowedComponents, true>,
+    input: Input,
+  ): RenderResult<Input> | void;
 }

--- a/packages/post-purchase-ui-extensions/src/extension-points/types.ts
+++ b/packages/post-purchase-ui-extensions/src/extension-points/types.ts
@@ -5,17 +5,15 @@ import {RenderExtension} from './render-extension';
  * For a given extension point, returns the value that is expected to be
  * returned by that extension point’s callback type.
  */
-export type ReturnTypeForExtension<
-  ID extends keyof ExtensionPoints
-> = ReturnType<ExtensionPoints[ID]>;
+export type ReturnTypeForExtension<ID extends keyof ExtensionPoints> =
+  ReturnType<ExtensionPoints[ID]>;
 
 /**
  * For a given extension point, returns the tuple of arguments that would
  * be provided to that extension point’s callback type.
  */
-export type ArgumentsForExtension<
-  ID extends keyof ExtensionPoints
-> = Parameters<ExtensionPoints[ID]>;
+export type ArgumentsForExtension<ID extends keyof ExtensionPoints> =
+  Parameters<ExtensionPoints[ID]>;
 
 /**
  * A union type containing all extension points that follow the pattern of
@@ -46,9 +44,8 @@ type ExtractedInputFromRenderExtension<T> = T extends RenderExtension<
   ? Input
   : never;
 
-type ExtractedAllowedComponentsFromRenderExtension<
-  T
-> = T extends RenderExtension<any, infer Components> ? Components : never;
+type ExtractedAllowedComponentsFromRenderExtension<T> =
+  T extends RenderExtension<any, infer Components> ? Components : never;
 
 /**
  * For a given rendering extension point, returns the input type that the
@@ -56,14 +53,13 @@ type ExtractedAllowedComponentsFromRenderExtension<
  * the callback for that extension point (the first callback for all rendering
  * extension points is the same — they all receive a `RemoteRoot` object)
  */
-export type InputForRenderExtension<
-  ID extends keyof RenderExtensions
-> = ExtractedInputFromRenderExtension<RenderExtensions[ID]>;
+export type InputForRenderExtension<ID extends keyof RenderExtensions> =
+  ExtractedInputFromRenderExtension<RenderExtensions[ID]>;
 
 /**
  * For a given rendering extension point, returns the UI extension components that the
  * extension point supports.
  */
 export type AllowedComponentsForRenderExtension<
-  ID extends keyof RenderExtensions
+  ID extends keyof RenderExtensions,
 > = ExtractedAllowedComponentsFromRenderExtension<RenderExtensions[ID]>;

--- a/packages/post-purchase-ui-extensions/src/utilities.ts
+++ b/packages/post-purchase-ui-extensions/src/utilities.ts
@@ -5,9 +5,9 @@ import type {
 } from '@remote-ui/core';
 
 export type ReactPropsFromRemoteComponentType<
-  Type extends RemoteComponentType<any, any, any>
+  Type extends RemoteComponentType<any, any, any>,
 > = PropsForRemoteComponent<Type> & {children?: ReactNode};
 
 export type ReactComponentTypeFromRemoteComponentType<
-  Type extends RemoteComponentType<any, any, any>
+  Type extends RemoteComponentType<any, any, any>,
 > = FunctionComponent<ReactPropsFromRemoteComponentType<Type>>;

--- a/packages/retail-ui-extensions-react/src/components/SegmentedControl/SegmentedControl.ts
+++ b/packages/retail-ui-extensions-react/src/components/SegmentedControl/SegmentedControl.ts
@@ -1,6 +1,5 @@
 import {createRemoteReactComponent} from '@remote-ui/react';
 import {SegmentedControl as BaseSegmentedControl} from '@shopify/retail-ui-extensions';
 
-export const SegmentedControl = createRemoteReactComponent(
-  BaseSegmentedControl,
-);
+export const SegmentedControl =
+  createRemoteReactComponent(BaseSegmentedControl);

--- a/packages/retail-ui-extensions-react/src/context.ts
+++ b/packages/retail-ui-extensions-react/src/context.ts
@@ -4,6 +4,5 @@ import {
   RenderExtensionPoint,
 } from '@shopify/retail-ui-extensions/src';
 
-export const ExtensionApiContext = createContext<ApiForRenderExtension<
-  RenderExtensionPoint
-> | null>(null);
+export const ExtensionApiContext =
+  createContext<ApiForRenderExtension<RenderExtensionPoint> | null>(null);

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@remote-ui/core": "^2.1.3"
+    "@remote-ui/core": "^2.1.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/retail-ui-extensions/src/extend.ts
+++ b/packages/retail-ui-extensions/src/extend.ts
@@ -8,4 +8,4 @@ import type {ShopifyGlobal} from './globals';
  * is ready to run the extension point.
  */
 export const extend: ShopifyGlobal['extend'] = (...args) =>
-  ((self as any) as {shopify: ShopifyGlobal}).shopify.extend(...args);
+  (self as any as {shopify: ShopifyGlobal}).shopify.extend(...args);

--- a/packages/retail-ui-extensions/src/extension-points/render-extension.ts
+++ b/packages/retail-ui-extensions/src/extension-points/render-extension.ts
@@ -10,9 +10,10 @@ import {RemoteRoot, RemoteComponentType} from '@remote-ui/core';
  */
 export interface RenderExtension<
   Input,
-  AllowedComponents extends RemoteComponentType<string, any, any>
+  AllowedComponents extends RemoteComponentType<string, any, any>,
 > {
-  (root: RemoteRoot<AllowedComponents, true>, input: Input): void | Promise<
-    void
-  >;
+  (
+    root: RemoteRoot<AllowedComponents, true>,
+    input: Input,
+  ): void | Promise<void>;
 }

--- a/packages/retail-ui-extensions/src/extension-points/types.ts
+++ b/packages/retail-ui-extensions/src/extension-points/types.ts
@@ -5,17 +5,15 @@ import {RenderExtension} from './render-extension';
  * For a given extension point, returns the value that is expected to be
  * returned by that extension point’s callback type.
  */
-export type ReturnTypeForExtension<
-  ID extends keyof ExtensionPoints
-> = ReturnType<ExtensionPoints[ID]>;
+export type ReturnTypeForExtension<ID extends keyof ExtensionPoints> =
+  ReturnType<ExtensionPoints[ID]>;
 
 /**
  * For a given extension point, returns the tuple of arguments that would
  * be provided to that extension point’s callback type.
  */
-export type ArgumentsForExtension<
-  ID extends keyof ExtensionPoints
-> = Parameters<ExtensionPoints[ID]>;
+export type ArgumentsForExtension<ID extends keyof ExtensionPoints> =
+  Parameters<ExtensionPoints[ID]>;
 
 /**
  * A union type containing all extension points that follow the pattern of
@@ -46,9 +44,8 @@ type ExtractedApiFromRenderExtension<T> = T extends RenderExtension<
   ? Api
   : never;
 
-type ExtractedAllowedComponentsFromRenderExtension<
-  T
-> = T extends RenderExtension<any, infer Components> ? Components : never;
+type ExtractedAllowedComponentsFromRenderExtension<T> =
+  T extends RenderExtension<any, infer Components> ? Components : never;
 
 /**
  * For a given rendering extension point, returns the type of the API that the
@@ -56,14 +53,13 @@ type ExtractedAllowedComponentsFromRenderExtension<
  * the callback for that extension point (the first callback for all rendering
  * extension points is the same — they all receive a `RemoteRoot` object)
  */
-export type ApiForRenderExtension<
-  ID extends keyof RenderExtensions
-> = ExtractedApiFromRenderExtension<RenderExtensions[ID]>;
+export type ApiForRenderExtension<ID extends keyof RenderExtensions> =
+  ExtractedApiFromRenderExtension<RenderExtensions[ID]>;
 
 /**
  * For a given rendering extension point, returns the UI components that the
  * extension point supports.
  */
 export type AllowedComponentsForRenderExtension<
-  ID extends keyof RenderExtensions
+  ID extends keyof RenderExtensions,
 > = ExtractedAllowedComponentsFromRenderExtension<RenderExtensions[ID]>;

--- a/packages/ui-extensions-webpack-hot-client/src/worker.ts
+++ b/packages/ui-extensions-webpack-hot-client/src/worker.ts
@@ -16,7 +16,7 @@ const MAX_RETRIES = 10;
 
 interface DevServerMessage<
   Type extends string,
-  Data extends Record<string, unknown> = Record<string, unknown>
+  Data extends Record<string, unknown> = Record<string, unknown>,
 > {
   type: Type;
   data: Data;

--- a/scripts/typedoc/shopify-dev-renderer/components/utilities/skypack-url-resolve.ts
+++ b/scripts/typedoc/shopify-dev-renderer/components/utilities/skypack-url-resolve.ts
@@ -8,9 +8,8 @@ export function skypackUrlResolve() {
   return {
     async resolveId(source: string) {
       const convertedSource = await convertToSkypackSource(source);
-      const maybeAbsoluteUrl = convertSkypackPathsToAbsoluteUrls(
-        convertedSource,
-      );
+      const maybeAbsoluteUrl =
+        convertSkypackPathsToAbsoluteUrls(convertedSource);
       const url = parseURL(maybeAbsoluteUrl);
       return url && isValidURL(url) ? url.href : null;
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,37 +2169,37 @@
     react-reconciler "^0.26.0"
     react-test-renderer "^17.0.0"
 
-"@remote-ui/async-subscription@^2.1.7", "@remote-ui/async-subscription@^2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.8.tgz#c5852180ec5a909ca74eb4d064c995cfa516d40a"
-  integrity sha512-prrHLURIqJQKDMDHn404u4uywYXBm4oz7ke43OLQx5e/dvM0Io72KHJUx3ZwoYNCTS9q9M+wICHS6g9S2d8d3g==
+"@remote-ui/async-subscription@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.9.tgz#84f413e40a8136ba28ee6ee0f946e4c1f85832d7"
+  integrity sha512-+5UmqyjQJXLJLOVbEBvfzc/Yt4mV/9J36IGJhCJdpdEmIBde7DjkWBt91eSFxa3+Zx6Enq1unkBl4rqosYgpgw==
   dependencies:
-    "@remote-ui/rpc" "^1.2.6"
+    "@remote-ui/rpc" "^1.3.0"
 
-"@remote-ui/core@^2.1.3", "@remote-ui/core@^2.1.6", "@remote-ui/core@^2.1.7":
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.1.7.tgz#5936810a18225f6cef586ec8baf3b1bd00459006"
-  integrity sha512-urcIKnhGLwTn/fE0RyKqvYAxxDDBj46ANHT0zNooIHLeOMxKafAvrWZcdItxYKH6k51lR1/wmbOPKwG0lzm7Qg==
+"@remote-ui/core@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.1.9.tgz#dd3c8eee304b5660189c520f5848b9562ec6f7dc"
+  integrity sha512-a8HbfrZ1fq7u8/mmlFnmfl3LlQsFA9kkuvBtSnRf82dbUsspCT/y0yU6cN6/3Ek+tsPvuAd06lrlhd5L+VCMNg==
   dependencies:
-    "@remote-ui/rpc" "^1.2.6"
+    "@remote-ui/rpc" "^1.3.0"
     "@remote-ui/types" "^1.1.2"
 
-"@remote-ui/react@^4.1.3", "@remote-ui/react@^4.1.5", "@remote-ui/react@^4.3.0":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-4.4.2.tgz#ad5c39beb023150a2eb792936b21c0070e9bae51"
-  integrity sha512-jQXsg9LwdfLJ0Sr31C/WtO/SwKolWvlJhhc8YGbYlWknUAnjTDrI682Mmv6Zh5VVRh+8fMjeuThJA7Bfhx8vXg==
+"@remote-ui/react@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-4.5.0.tgz#359969a80b9ad1abfde1404048a3f23783e0672c"
+  integrity sha512-NE9cvNu4i91/ymVp72x/jvtv6gfOatlq8ZWQBMt3MP0i93EBscqWs0932SestJUDLIdr6JgiceBgzLPD0qRblA==
   dependencies:
-    "@remote-ui/async-subscription" "^2.1.8"
-    "@remote-ui/core" "^2.1.7"
-    "@remote-ui/rpc" "^1.2.6"
+    "@remote-ui/async-subscription" "^2.1.9"
+    "@remote-ui/core" "^2.1.9"
+    "@remote-ui/rpc" "^1.3.0"
     "@types/react" ">=17.0.0 <18.0.0"
     "@types/react-reconciler" "^0.26.0"
-    react-reconciler ">=0.26.0 <1.0.0"
+    react-reconciler ">=0.26.0 <0.27.0"
 
-"@remote-ui/rpc@^1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.2.6.tgz#33ebfd97f5d5ab16b000bacbe392d96738b3d693"
-  integrity sha512-KdfDEnQEJmlNh8gbcPMG5Ldae94rsRytDqeuFUVsviQQ2CDui3RygN64iZlw8bVqbKiRpJ66hlVfpHkY6NbEDg==
+"@remote-ui/rpc@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.3.0.tgz#e9469803e8024707f096bd52041fdfe61154dac8"
+  integrity sha512-tO0nYON8IhErx/DYxufo7ccwnSh1Vo5mS41HAjUQ+fCctNmRABug0tjvCdOq1E6R6JAq1EbxN0U5w+7pYMcaFg==
 
 "@remote-ui/types@^1.1.2":
   version "1.1.2"
@@ -9827,9 +9827,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^2.0.4:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
-  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"
@@ -10116,16 +10116,7 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
-"react-reconciler@>=0.26.0 <1.0.0":
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.1.tgz#860952dd359fd870f94895c254271e3a9de3b2d6"
-  integrity sha512-6E/CvH9zcDmHjhiNJlP0qJ8+3ufnY2b5RWs774Uy8XKWN0l6qfnlkz0XnDacxqj2rbJdq76w9dlFXjPPOQrmqA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.1"
-
-react-reconciler@^0.26.0:
+"react-reconciler@>=0.26.0 <0.27.0", react-reconciler@^0.26.0:
   version "0.26.2"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
   integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==
@@ -10720,14 +10711,6 @@ saxes@^5.0.0:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
-
-scheduler@^0.20.1:
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
-  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
### Background
Update to @remote-ui/core@^2.1.9, @remote-ui/react@^4.5.0 and @remote-ui/async-subscription@^2.1.9

### Solution

Update our prettier to latest so it understands TS template literals. Also bump our shared `@remote-ui` dependencies so all packages are consistent and we can clean up the yarn.lock.

### 🎩

I'm not sure we need to top hat as all of these bumps are minor/patch versions

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
