### PR TITLE
Fixed dependency things

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "^4.5.0",
-    "@shopify/retail-ui-extensions": "^0.1.0",
+    "@shopify/retail-ui-extensions": "^0.2.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/.npmignore
+++ b/packages/retail-ui-extensions/.npmignore
@@ -1,3 +1,0 @@
-.*
-node_modules
-tsconfig.json

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "index.js",
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/retail-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/retail-ui-extensions/src/extension-points/extension-points.ts
@@ -4,13 +4,10 @@ import {RenderExtension} from './render-extension';
 type Components = typeof import('../components');
 type AllComponents = Components[keyof Components];
 
-type Tile = typeof import('../components/Tile');
-type TileComponent = Tile[keyof Tile];
-
 export interface ExtensionPoints {
   'Retail::SmartGrid::Tile': RenderExtension<
     StandardApi<'Retail::SmartGrid::Tile'>,
-    TileComponent
+    AllComponents
   >;
   'Retail::SmartGrid::Modal': RenderExtension<
     StandardApi<'Retail::SmartGrid::Modal'>,

--- a/packages/retail-ui-extensions/tsconfig.json
+++ b/packages/retail-ui-extensions/tsconfig.json
@@ -1,10 +1,21 @@
 {
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "build/ts",
+    "baseUrl": "src",
     "rootDir": "src",
-    "outDir": "build/ts"
+    "isolatedModules": true,
+    "lib": [
+      "WebWorker",
+      "es2015",
+      "es2016",
+      "es2017",
+      "es2018",
+      "esnext",
+      "esnext.asynciterable"
+    ]
   },
-  "references": [],
-  "include": ["./src/**/*.ts"],
-  "exclude": ["./src/**/*.example.*"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.example.ts"],
+  "references": []
 }


### PR DESCRIPTION
### Background

We're having compiler issues when running extensions on a third party app. Specifically with the `checkout-ui-extension-run` library. Hopefully this fixes some issues. Either way the tsconfig.json being ignored is causing complains in the retail-ui-extensions-react package.

### Solution

Delete the `npmignore` file, as well as fix the tsconfig.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
