### PR TITLE
Added command to bump retail packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "type-check": "sk type-check",
     "version-bump:admin": "lerna version --no-push --ignore-changes 'packages/!(admin*|ui-extensions)/**' --include-merged-tags",
     "version-bump:checkout": "lerna version --no-push --ignore-changes 'packages/!(checkout*)/**' --include-merged-tags",
-    "version-bump:post-purchase": "lerna version --no-push --ignore-changes 'packages/!(post-purchase*)/**' --include-merged-tags"
+    "version-bump:post-purchase": "lerna version --no-push --ignore-changes 'packages/!(post-purchase*)/**' --include-merged-tags",
+    "version-bump:retail": "lerna version --no-push --ignore-changes 'packages/!(retail*)/**' --include-merged-tags"
   },
   "devDependencies": {
     "@babel/node": "^7.8.7",


### PR DESCRIPTION
### Background

Adds a new command to bump the retail package versions so we can release new versions.

### Solution

Same command as for the other packages, except for the retail packages.

### 🎩

Try out the new command!

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
