### PR TITLE
Publish version 0.3.0 of retail packages

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "^4.5.0",
-    "@shopify/retail-ui-extensions": "^0.2.0",
+    "@shopify/retail-ui-extensions": "^0.3.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.js",
   "module": "index.mjs",
   "esnext": "index.esnext",


### PR DESCRIPTION
 - @shopify/retail-ui-extensions-react@0.3.0
 - @shopify/retail-ui-extensions@0.3.0

### Background

Creates a new version 0.3.0. This should resolve some of the dependency issues between the react and vanilla package.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
