### PR TITLE
Fix for `yarn docs:checkout` returning an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rollup": "^2.52.2",
     "rollup-plugin-jsx": "^1.0.3",
     "uuid": "^8.3.2",
-    "@shopify/docs-tools": "^0.0.11"
+    "@shopify/docs-tools": "^0.0.12"
   },
   "resolutions": {
     "@typescript-eslint/eslint-plugin": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,12 +2176,27 @@
   dependencies:
     "@remote-ui/rpc" "^1.2.6"
 
+"@remote-ui/async-subscription@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.9.tgz#84f413e40a8136ba28ee6ee0f946e4c1f85832d7"
+  integrity sha512-+5UmqyjQJXLJLOVbEBvfzc/Yt4mV/9J36IGJhCJdpdEmIBde7DjkWBt91eSFxa3+Zx6Enq1unkBl4rqosYgpgw==
+  dependencies:
+    "@remote-ui/rpc" "^1.3.0"
+
 "@remote-ui/core@^2.1.3", "@remote-ui/core@^2.1.6", "@remote-ui/core@^2.1.7":
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.1.7.tgz#5936810a18225f6cef586ec8baf3b1bd00459006"
   integrity sha512-urcIKnhGLwTn/fE0RyKqvYAxxDDBj46ANHT0zNooIHLeOMxKafAvrWZcdItxYKH6k51lR1/wmbOPKwG0lzm7Qg==
   dependencies:
     "@remote-ui/rpc" "^1.2.6"
+    "@remote-ui/types" "^1.1.2"
+
+"@remote-ui/core@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.1.9.tgz#dd3c8eee304b5660189c520f5848b9562ec6f7dc"
+  integrity sha512-a8HbfrZ1fq7u8/mmlFnmfl3LlQsFA9kkuvBtSnRf82dbUsspCT/y0yU6cN6/3Ek+tsPvuAd06lrlhd5L+VCMNg==
+  dependencies:
+    "@remote-ui/rpc" "^1.3.0"
     "@remote-ui/types" "^1.1.2"
 
 "@remote-ui/react@^4.1.3", "@remote-ui/react@^4.1.5", "@remote-ui/react@^4.3.0":
@@ -2196,10 +2211,27 @@
     "@types/react-reconciler" "^0.26.0"
     react-reconciler ">=0.26.0 <1.0.0"
 
+"@remote-ui/react@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-4.5.0.tgz#359969a80b9ad1abfde1404048a3f23783e0672c"
+  integrity sha512-NE9cvNu4i91/ymVp72x/jvtv6gfOatlq8ZWQBMt3MP0i93EBscqWs0932SestJUDLIdr6JgiceBgzLPD0qRblA==
+  dependencies:
+    "@remote-ui/async-subscription" "^2.1.9"
+    "@remote-ui/core" "^2.1.9"
+    "@remote-ui/rpc" "^1.3.0"
+    "@types/react" ">=17.0.0 <18.0.0"
+    "@types/react-reconciler" "^0.26.0"
+    react-reconciler ">=0.26.0 <0.27.0"
+
 "@remote-ui/rpc@^1.2.6":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.2.6.tgz#33ebfd97f5d5ab16b000bacbe392d96738b3d693"
   integrity sha512-KdfDEnQEJmlNh8gbcPMG5Ldae94rsRytDqeuFUVsviQQ2CDui3RygN64iZlw8bVqbKiRpJ66hlVfpHkY6NbEDg==
+
+"@remote-ui/rpc@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.3.0.tgz#e9469803e8024707f096bd52041fdfe61154dac8"
+  integrity sha512-tO0nYON8IhErx/DYxufo7ccwnSh1Vo5mS41HAjUQ+fCctNmRABug0tjvCdOq1E6R6JAq1EbxN0U5w+7pYMcaFg==
 
 "@remote-ui/types@^1.1.2":
   version "1.1.2"
@@ -2516,10 +2548,10 @@
   resolved "https://registry.yarnpkg.com/@sewing-kit/webpack-plugin-hash-output/-/webpack-plugin-hash-output-0.0.2.tgz#a41ddef000619ac20e64513edbbfc6f28afe7905"
   integrity sha512-BF3gmC9YZf4VY5RLAc5qUbxft16O614jnTtGr8gPRbJF4y3Qz3AVSxSB8dJDldzk4AH9lTQvH0e1Wkbgp5tR8g==
 
-"@shopify/docs-tools@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@shopify/docs-tools/-/docs-tools-0.0.11.tgz#bba6d39967654f168101a6a2ad5894903a7f4c0a"
-  integrity sha512-zLSQuZSDui6dxjYO31tQlhBYFw6WsMuNvck/RCkHIcKhN7igea14SZevKBjnmeDfi23Uq3IW9+psomcq6BtjSA==
+"@shopify/docs-tools@^0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@shopify/docs-tools/-/docs-tools-0.0.12.tgz#cd383f2e2b89bbb8db4adea327e505155e86d6de"
+  integrity sha512-IZN913Zx9gucp7gYuV++vU4ZnPs5Q7Gj0UvP3wvPBmNwjiKRxsCjqHMtV5npLsvl8quxFUw1RGF+8bY+WmJlKQ==
   dependencies:
     "@babel/parser" "^7.16.4"
     "@microsoft/tsdoc" "^0.13.2"
@@ -10116,6 +10148,15 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
+"react-reconciler@>=0.26.0 <0.27.0", react-reconciler@^0.26.0:
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
+  integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
 "react-reconciler@>=0.26.0 <1.0.0":
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.1.tgz#860952dd359fd870f94895c254271e3a9de3b2d6"
@@ -10124,15 +10165,6 @@ react-is@^17.0.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.1"
-
-react-reconciler@^0.26.0:
-  version "0.26.2"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
-  integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
 
 react-refresh@^0.8.2:
   version "0.8.3"


### PR DESCRIPTION
### Background
Closes https://github.com/Shopify/docs-tools/issues/7. 

This patch allows you to run `yarn docs:checkout` without a critical error. 

> Note: There are still outstanding issues with `Undocumented` being outputted in numerous doc files due to unsupported TS types. See https://github.com/Shopify/docs-tools/issues/6 for details.

### Solution

Use the latest version of @shopify/docs-tools `0.0.12`.

### 🎩

Run `yarn docs:checkout` and you should be able to generate the documentation now.

### Checklist

- [X] I have :tophat:'d these changes
