### PR TITLE
Bump retail-ui-extensions to 0.4.0

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "^4.5.0",
-    "@shopify/retail-ui-extensions": "^0.3.0",
+    "@shopify/retail-ui-extensions": "^0.4.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/retail-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify Point of Sale",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
 - @shopify/retail-ui-extensions-react@0.4.0
 - @shopify/retail-ui-extensions@0.4.0

### Background

We're resolving some build issues with retail ui extensions. Hopefully this new version will fix the problems.

### Solution

The fixes involved changes to tsconfig files as well as fixing export and import issues.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
