### PR TITLE
Swapped self for globalThis

### DIFF
--- a/packages/retail-ui-extensions/src/extend.ts
+++ b/packages/retail-ui-extensions/src/extend.ts
@@ -8,4 +8,4 @@ import type {ShopifyGlobal} from './globals';
  * is ready to run the extension point.
  */
 export const extend: ShopifyGlobal['extend'] = (...args) =>
-  ((self as any) as {shopify: ShopifyGlobal}).shopify.extend(...args);
+  ((globalThis as any) as WorkerGlobalScope).shopify.extend(...args);


### PR DESCRIPTION
### Background

We're having issues working with self on POS. Our yarn type-check is complaining with the usage of self. Instead I'm swapping it for the widely adopted globalThis. This seems to resolve the complains.

### Solution

Swapping to `globalThis`. Is this correct? It seems weird to have to do this, but the type definition of self is `GlobalWorkScope & typeof globalThis`. 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
