### PR TITLE
Remove deprecated exports path mapping

### DIFF
--- a/packages/admin-ui-extensions-react/package.json
+++ b/packages/admin-ui-extensions-react/package.json
@@ -10,8 +10,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "license": "MIT",
   "sideEffects": false,

--- a/packages/admin-ui-extensions/package.json
+++ b/packages/admin-ui-extensions/package.json
@@ -10,8 +10,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "license": "MIT",
   "sideEffects": false,

--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -17,8 +17,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.7",

--- a/packages/checkout-ui-extensions-run/package.json
+++ b/packages/checkout-ui-extensions-run/package.json
@@ -20,8 +20,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "devDependencies": {
     "@types/glob": "^7.1.1",

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -17,8 +17,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.7",

--- a/packages/post-purchase-ui-extensions-react/package.json
+++ b/packages/post-purchase-ui-extensions-react/package.json
@@ -17,8 +17,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "dependencies": {
     "@remote-ui/react": "^4.1.3",

--- a/packages/post-purchase-ui-extensions/package.json
+++ b/packages/post-purchase-ui-extensions/package.json
@@ -17,8 +17,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "dependencies": {
     "@remote-ui/core": "^2.1.3"

--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -17,8 +17,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "dependencies": {
     "@remote-ui/react": "^4.5.0",

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -17,8 +17,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "dependencies": {
     "@remote-ui/core": "^2.1.6"

--- a/packages/ui-extensions-webpack-hot-client/package.json
+++ b/packages/ui-extensions-webpack-hot-client/package.json
@@ -18,7 +18,6 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./": "./",
     "./worker": {
       "esnext": "./worker.esnext",
       "import": "./worker.mjs",

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -10,8 +10,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "license": "MIT",
   "sideEffects": false,


### PR DESCRIPTION
### Background

Node versions prior to 16.x often used `"./"` to allow deep package imports during the introduction of the `exports` field. Starting with node 16.x [folder mappings are deprecated](https://nodejs.org/api/deprecations.html#DEP0148) and should not be used.

Related: https://github.com/preactjs/preact/issues/3299

### Solution

Drop the field, since it's deprecated and not necessary. Instead every package entry point should be explicitely declared via `exports`.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation

