### PR TITLE
Publish 0.15.1

### DIFF
--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/checkout-ui-extensions-react",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "React bindings for @shopify/checkout-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.9",
     "@remote-ui/react": "^4.5.0",
-    "@shopify/checkout-ui-extensions": "^0.15.0",
+    "@shopify/checkout-ui-extensions": "^0.15.1",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify’s Checkout",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
- @shopify/checkout-ui-extensions-react@0.15.1
- @shopify/checkout-ui-extensions@0.15.1
### Background

This is a package bump PR prior to publishing public packages. For details on what has changed in this new version see this PR https://github.com/Shopify/ui-extensions/pull/322.

### Solution

Followed the [publishing packages instructions](https://checkout.docs.shopify.io/docs/referencedocs/web/extensions/libraries).

### 🎩
 Instructions can be found in the original PR that brought over the changes: https://github.com/Shopify/ui-extensions/pull/322

### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
