### PR TITLE
Checkout UI ext react hooks docs

### DIFF
--- a/scripts/typedoc/shopify-dev-renderer/components/components.ts
+++ b/scripts/typedoc/shopify-dev-renderer/components/components.ts
@@ -153,6 +153,7 @@ export async function components(
       face.value.kind === 'InterfaceType' &&
       face.value.properties.length > 0
     ) {
+      
       propsTableMd += '## Props\noptional = ?\n';
       propsTableMd += propsTable(
         name,

--- a/scripts/typedoc/shopify-dev-renderer/extension-points.ts
+++ b/scripts/typedoc/shopify-dev-renderer/extension-points.ts
@@ -2,7 +2,7 @@ import {resolve} from 'path';
 import * as fs from 'fs';
 import {createDependencyGraph, filterGraph} from '@shopify/docs-tools';
 
-import type {Paths, InterfaceType} from '../types';
+import type {Paths, InterfaceType, PropertySignature} from '../types';
 
 import {
   renderYamlFrontMatter,
@@ -70,6 +70,7 @@ export async function extensionPoints(paths: Paths, options: Options = {}) {
   });
   
   interfaces.forEach(({name, docs, properties}) => {
+    
     markdown += propsTable(
       name,
       docs,
@@ -85,16 +86,20 @@ export async function extensionPoints(paths: Paths, options: Options = {}) {
   markdown += dedupe(additionalPropsTables).reverse().join('');
 
   
-  reactGraph.hooks.forEach(({value: {name, docs, props}}: any) => {
+  reactGraph.hooks.forEach(({value}: any) => {
     
-    const face = reactGraph.nodes.find(({value}: any) => {
-      return value.name === props.params[0].constraint
-    });
-   debugger;
+    const property: PropertySignature = {
+      kind: 'PropertySignature',
+      optional: false,
+      name: value.name,
+      value: value
+    }
+    
+   
     markdown += propsTable(
-      name,
-      docs,
-      face?.value?.properties ?? [],
+      value.name,
+      value.docs,
+      [property],
       reactGraph.nodes,
       reactIndex,
       additionalPropsTables,
@@ -153,7 +158,7 @@ async function buildHooksGraph(hooksIndex: string) {
       }
     });
   });
-  debugger;
+  
   const hooks = [
     ...new Set(nodes.filter(({value}: any) => value.kind === 'Hook')),
   ];

--- a/scripts/typedoc/shopify-dev-renderer/shared/index.ts
+++ b/scripts/typedoc/shopify-dev-renderer/shared/index.ts
@@ -335,6 +335,8 @@ function propType(
         '🚨 A type could not be resolved and is being used in documentation showing as `UndocumentedType`. Check the output for the affected docs.',
       );
       return value.kind;
+    case 'Hook': 
+      return `() => ${value.returnType ? propType(value.returnType, exports, dir, additionalPropsTables) : 'Unknown'}`;
     default:
       return value.kind;
   }


### PR DESCRIPTION
### Background

This patch along with https://github.com/Shopify/docs-tools/pull/21 will solve https://github.com/Shopify/docs-tools/issues/20.

### Solution

- Use some sort of identifier such as "Hook" to filter functions declarations that are React Hooks
- Loop through each React Hook and output a table row - one row per React Hook which shows its `name`, `function signature/type` and `description`. 
- The `function signature/type` should show the parameters for the function (and their types) along with the return type
- If the parameter or return is a mapped type it should link to the type via #{typeName} so a user can navigate to it within the document

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
