### PR TITLE
Checkout: give subcomponents their own docs page

### DIFF
--- a/packages/checkout-ui-extensions/documentation/components.md
+++ b/packages/checkout-ui-extensions/documentation/components.md
@@ -22,8 +22,7 @@ Checkout components are designed to be flexible, enabling you to layer and mix t
       <p><code><a href="../src/components/BlockSpacer">BlockSpacer</a></code></p>
       <p><code><a href="../src/components/BlockStack">BlockStack</a></code></p>
       <p><code><a href="../src/components/Divider">Divider</a></code></p>
-      <p><code><a href="../src/components/Grid">Grid</a></code></p>
-      <p><code><a href="../src/components/GridItem">GridItem</a></code></p>
+      <p><code><a href="../src/components/Grid">Grid</a></code> and <code><a href="../src/components/GridItem">GridItem</a></code></p>
       <p><code><a href="../src/components/InlineLayout">InlineLayout</a></code></p>
       <p><code><a href="../src/components/InlineSpacer">InlineSpacer</a></code></p>
       <p><code><a href="../src/components/InlineStack">InlineStack</a></code></p>
@@ -41,7 +40,7 @@ Checkout components are designed to be flexible, enabling you to layer and mix t
   <div class="checkout-component-grid-item">
     <h3 class="checkout-component-grid-item_title">Forms</h3>
       <p><code><a href="../src/components/Checkbox">Checkbox</a></code></p>
-      <p><code><a href="../src/components/ChoiceList">ChoiceList</a></code></p>
+      <p><code><a href="../src/components/ChoiceList">ChoiceList</a></code> and <code><a href="../src/components/Choice">Choice</a></code></p>
       <p><code><a href="../src/components/Form">Form</a></code></p>
       <p><code><a href="../src/components/PhoneField">PhoneField</a></code></p>
       <p><code><a href="../src/components/Select">Select</a></code></p>
@@ -68,7 +67,7 @@ Checkout components are designed to be flexible, enabling you to layer and mix t
     <h3 class="checkout-component-grid-item_title">Other</h3>
       <p><code><a href="../src/components/Button">Button</a></code></p>
       <p><code><a href="../src/components/Link">Link</a></code></p>
-      <p><code><a href="../src/components/List">List</a></code></p>
+      <p><code><a href="../src/components/List">List</a></code> and <code><a href="../src/components/ListItem">ListItem</a></code></p>
       <p><code><a href="../src/components/Tag">Tag</a></code></p>
   </div>
 </div>

--- a/packages/checkout-ui-extensions/src/components/Choice/Choice.ts
+++ b/packages/checkout-ui-extensions/src/components/Choice/Choice.ts
@@ -19,6 +19,7 @@ export interface ChoiceProps {
 }
 
 /**
- * Use choice lists to create a group of related options for customers to choose from. A choice list can be made up of radio buttons or checkboxes.
+ * Options inside a `ChoiceList`.
+ * The wrapping `ChoiceList` component will dictate if the choice renders as radio buttons or checkboxes.
  */
 export const Choice = createRemoteComponent<'Choice', ChoiceProps>('Choice');

--- a/packages/checkout-ui-extensions/src/components/Choice/README.md
+++ b/packages/checkout-ui-extensions/src/components/Choice/README.md
@@ -1,0 +1,13 @@
+# Choice
+
+Options inside a `ChoiceList`.
+The wrapping `ChoiceList` component will dictate if the choice renders as radio buttons or checkboxes.
+
+## Props
+optional = ?
+
+| Name | Type | Description |
+| --- | --- | --- |
+| id | <code>string</code> | A unique identifier for the choice.  |
+| disabled? | <code>boolean</code> | Whether the choice can be changed.  |
+| accessibilityLabel? | <code>string</code> | A label to use for the choice that will be used for buyers using assistive technologies. When provided, any `children` supplied to this component are hidden from being seen for accessibility purposes to prevent duplicate content from being read.  |

--- a/packages/checkout-ui-extensions/src/components/Choice/content/guidelines.md
+++ b/packages/checkout-ui-extensions/src/components/Choice/content/guidelines.md
@@ -3,3 +3,7 @@
 - Include a title that either tells customers what to do or explains their available options.
 - Label options clearly based on what the option will do.
 - Avoid options that contradict each other when you're allowing for multiple selections.
+
+## Related components
+
+- [`ChoiceList`](https://github.com/Shopify/ui-extensions/tree/main/packages/checkout-ui-extensions/src/components/ChoiceList): Use choice lists to present a list of choices where buyers can make a single selection or multiple selections.

--- a/packages/checkout-ui-extensions/src/components/ChoiceList/content/guidelines.md
+++ b/packages/checkout-ui-extensions/src/components/ChoiceList/content/guidelines.md
@@ -6,4 +6,5 @@
 
 ## Related components
 
+- [`Choice`](https://github.com/Shopify/checkout-web/tree/master/packages/checkout-ui-extensions/src/components/Choice): The options inside the `ChoiceList` component.
 - [`Checkbox`](https://github.com/Shopify/checkout-web/tree/master/packages/checkout-ui-extensions/src/components/Checkbox): Gives customers a single binary option, such as signed up for marketing, or agreeing to terms and conditions.

--- a/packages/checkout-ui-extensions/src/components/Grid/content/guidelines.md
+++ b/packages/checkout-ui-extensions/src/components/Grid/content/guidelines.md
@@ -1,0 +1,3 @@
+## Related components
+
+- [`GridItem`](https://github.com/Shopify/ui-extensions/tree/main/packages/checkout-ui-extensions/src/components/GridItem): Used as children of the `Grid` component. The `GridItem` offers a way to span the element across a number of columns and rows.

--- a/packages/checkout-ui-extensions/src/components/GridItem/content/guidelines.md
+++ b/packages/checkout-ui-extensions/src/components/GridItem/content/guidelines.md
@@ -1,0 +1,3 @@
+## Related components
+
+- [`Grid`](https://github.com/Shopify/ui-extensions/tree/main/packages/checkout-ui-extensions/src/components/Grid): Used to lay out content in a matrix of rows and columns. It should always be the parent of `GridItem` components.

--- a/packages/checkout-ui-extensions/src/components/List/content/guidelines.md
+++ b/packages/checkout-ui-extensions/src/components/List/content/guidelines.md
@@ -5,3 +5,7 @@
 - Use bullets for a text-only list of related items that don’t need to be in a specific order.
 - Use numbers for a text-only list of related items when you need to communicate order, priority, or sequence.
 - Don't use a marker when only the semantic value of a list matters, such as with a list of links.
+
+## Related components
+
+- [`ListItem`](https://github.com/Shopify/ui-extensions/tree/main/packages/checkout-ui-extensions/src/components/ListItem): Used as children of the `List` component.

--- a/packages/checkout-ui-extensions/src/components/ListItem/ListItem.ts
+++ b/packages/checkout-ui-extensions/src/components/ListItem/ListItem.ts
@@ -2,6 +2,11 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export interface ListItemProps {}
 
+/**
+ * List items are used as children of the `List` component.
+ *
+ * They usually begins with a bullet or a number.
+ */
 export const ListItem = createRemoteComponent<'ListItem', ListItemProps>(
   'ListItem',
 );

--- a/packages/checkout-ui-extensions/src/components/ListItem/README.md
+++ b/packages/checkout-ui-extensions/src/components/ListItem/README.md
@@ -1,0 +1,6 @@
+# ListItem
+
+List items are used as children of the `List` component.
+
+They usually begins with a bullet or a number.
+

--- a/packages/checkout-ui-extensions/src/components/ListItem/content/guidelines.md
+++ b/packages/checkout-ui-extensions/src/components/ListItem/content/guidelines.md
@@ -1,0 +1,3 @@
+## Related components
+
+- [`List`](https://github.com/Shopify/ui-extensions/tree/main/packages/checkout-ui-extensions/src/components/List): Displays a set of related content. Each list item usually begins with a bullet or a number.

--- a/scripts/generate-docs-checkout.ts
+++ b/scripts/generate-docs-checkout.ts
@@ -44,8 +44,6 @@ extensionPoints(checkout, {
   visibility: 'betaCheckoutExtensions',
 });
 components(checkout, componentsPageContent(checkout.shopifyDevUrl), {
-  subcomponentMap: {ChoiceList: ['Choice'], FormLayout: ['FormLayoutGroup']},
-  componentsToSkip: ['FormLayoutGroup', 'ListItem', 'Choice'],
   generateReadmes: true,
   visibility: 'betaCheckoutExtensions',
 });


### PR DESCRIPTION
### Background

Closes https://github.com/Shopify/checkout-web/issues/11053

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
