### PR TITLE
Create new empty packages for Customer Account

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "type-check": "sk type-check",
     "version-bump:admin": "lerna version --no-push --ignore-changes 'packages/!(admin*|ui-extensions)/**' --include-merged-tags",
     "version-bump:checkout": "lerna version --no-push --ignore-changes 'packages/!(checkout*)/**' --include-merged-tags",
+    "version-bump:customer-account": "lerna version --no-push --ignore-changes 'packages/!(customer-account*)/**' --include-merged-tags",
     "version-bump:post-purchase": "lerna version --no-push --ignore-changes 'packages/!(post-purchase*)/**' --include-merged-tags",
     "version-bump:retail": "lerna version --no-push --ignore-changes 'packages/!(retail*)/**' --include-merged-tags"
   },

--- a/packages/customer-account-ui-extensions-react/README.md
+++ b/packages/customer-account-ui-extensions-react/README.md
@@ -1,0 +1,49 @@
+# Customer Account UI Extensions (React)
+
+This library provides utilities for writing Customer Account UI extensions using [React](https://reactjs.org).
+
+## Installation
+
+```bash
+$ yarn add @shopify/customer-account-ui-extensions-react
+```
+
+## Usage
+
+To use the React bindings in a UI extension, start by importing `React` as you normally would. All of the [core features of React](https://reactjs.org/docs/getting-started.html) are available, including hooks, context, and more.
+
+```tsx
+import {Button, render} from '@shopify/customer-account-ui-extensions-react';
+
+render('CustomerAccount::FullPage::RenderWithin', () => <App />);
+
+interface Props {}
+
+function App(_: Props) {
+  return (
+    <Button
+      onPress={() => {
+        console.log('Pressed');
+      }}
+    >
+      Press me
+    </Button>
+  );
+}
+```
+
+If you’ve ever used React on the web, you’re probably used to returning DOM nodes as part of your React components. Because UI extensions execute in a web worker and have no access to the DOM, returning DOM components is an error in UI extensions. Instead, you can return the components you import from `@shopify/customer-account-ui-extensions-react`, which are the equivalent of the DOM in Customer Account — they are the “leaf” elements, the lowest-level UI primitives that exist.
+
+For example, the following will throw an error:
+
+```tsx
+import {render} from '@shopify/customer-account-ui-extensions-react';
+
+render('CustomerAccount::FullPage::RenderWithin', () => <App />);
+
+interface Props {}
+
+function App(_: Props) {
+  return <div>No HTML tag allowed</div>;
+}
+```

--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@shopify/customer-account-ui-extensions-react",
+  "version": "0.0.1",
+  "description": "React bindings for @shopify/customer-account-ui-extensions",
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "sideEffects": false,
+  "license": "MIT",
+  "main": "index.js",
+  "module": "index.mjs",
+  "esnext": "index.esnext",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "esnext": "./index.esnext",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./": "./"
+  },
+  "dependencies": {
+    "@shopify/customer-account-ui-extensions": "^0.0.1"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0 <18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "react": "^17.0.0"
+  }
+}

--- a/packages/customer-account-ui-extensions-react/sewing-kit.config.ts
+++ b/packages/customer-account-ui-extensions-react/sewing-kit.config.ts
@@ -1,0 +1,7 @@
+import {createPackage} from '@sewing-kit/config';
+import {uiExtensionsPackage} from '../../config/sewing-kit';
+
+export default createPackage((pkg) => {
+  pkg.entry({root: './src/index'});
+  pkg.use(uiExtensionsPackage());
+});

--- a/packages/customer-account-ui-extensions-react/src/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/index.ts
@@ -1,0 +1,1 @@
+export const cats = 'are the best';

--- a/packages/customer-account-ui-extensions-react/tsconfig.json
+++ b/packages/customer-account-ui-extensions-react/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../config/typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "build/ts",
+    "baseUrl": "src",
+    "rootDir": "src",
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/customer-account-ui-extensions/README.md
+++ b/packages/customer-account-ui-extensions/README.md
@@ -1,0 +1,29 @@
+# Customer Account UI Extensions
+
+Customer Account UI Extensions is a library that enables developers to write custom JavaScript to be sent to and rendered within the Shopify Customer Account web application.
+
+## Usage
+
+There are multiple ways to use Customer Account UI Extensions components in your extension.
+
+### Vanilla JS
+
+Adding a button looks like the following:
+
+```js
+import {extend, Button} from '@shopify/customer-account-ui-extensions';
+
+extend('CustomerAccount::FullPage::RenderWithin', (root, api) => {
+  const button = root.createComponent(Button, {
+    title: 'Press Me',
+    primary: true,
+    onPress: () => console.log('Pressed'),
+  });
+
+  root.appendChild(button);
+});
+```
+
+### React
+
+To use the React implementation, check out [packages/customer-account-ui-extensions-react](packages/customer-account-ui-extensions/README.md).

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@shopify/customer-account-ui-extensions",
+  "description": "The API for UI Extensions that run in Shopify's Customer Account",
+  "version": "0.0.1",
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "sideEffects": false,
+  "license": "MIT",
+  "main": "index.js",
+  "module": "index.mjs",
+  "esnext": "index.esnext",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "esnext": "./index.esnext",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./": "./"
+  },
+  "dependencies": {}
+}

--- a/packages/customer-account-ui-extensions/sewing-kit.config.ts
+++ b/packages/customer-account-ui-extensions/sewing-kit.config.ts
@@ -1,0 +1,7 @@
+import {createPackage} from '@sewing-kit/config';
+import {uiExtensionsPackage} from '../../config/sewing-kit';
+
+export default createPackage((pkg) => {
+  pkg.entry({root: './src/index'});
+  pkg.use(uiExtensionsPackage());
+});

--- a/packages/customer-account-ui-extensions/src/index.ts
+++ b/packages/customer-account-ui-extensions/src/index.ts
@@ -1,0 +1,1 @@
+export const cats = 'are the best';

--- a/packages/customer-account-ui-extensions/tsconfig.json
+++ b/packages/customer-account-ui-extensions/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../config/typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "build/ts",
+    "baseUrl": "src",
+    "rootDir": "src",
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     {"path": "./tsconfig.repo.json"},
     {"path": "./packages/checkout-ui-extensions"},
     {"path": "./packages/checkout-ui-extensions-react"},
+    {"path": "./packages/customer-account-ui-extensions"},
+    {"path": "./packages/customer-account-ui-extensions-react"},
     {"path": "./packages/post-purchase-ui-extensions"},
     {"path": "./packages/post-purchase-ui-extensions-react"},
     {"path": "./packages/ui-extensions-webpack-hot-client"},


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/39369. Created 2 new packages, `customer-account-ui-extensions` and `customer-account-ui-extensions-react`, to support extensibility in Customer Account.

### Solution

The content of the code is a stub in both packages for the time being. The idea is to just have the placeholders, and start filling it out next week.

They are a modified copy of what was already in `checkout` and `admin` respective packages. I have removed the parts we're not supporting yet and most of the documentation. We'll add it later as we start supporting more features.

### 🎩

N/A

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have updated relevant documentation
