### PR TITLE
[Checkout Docs] Update path for fs.existsSync when searching for webm files

### DIFF
--- a/scripts/typedoc/shopify-dev-renderer/components/components.ts
+++ b/scripts/typedoc/shopify-dev-renderer/components/components.ts
@@ -352,7 +352,7 @@ function renderExampleMediaFor(
     `${shopifyDevAssetsPath}/components/${filename}.mp4`,
   );
   const mediaWEBM = resolve(
-    `${shopifyDevAssetsUrl}/components/${filename}.webm`,
+    `${shopifyDevAssetsPath}/components/${filename}.webm`,
   );
 
   let hasFile = false;


### PR DESCRIPTION
My bad. A mistake I made in this [PR](https://github.com/Shopify/ui-extensions/pull/353/files#diff-1a9d5deedb03802d52931231bad2116a381e9bf41777211186a80df0a09eac74R351-R356) that I only noticed now that we have mp4+webm files in shopify-dev.