### PR TITLE
fix consumer scripts for some environments by using bash instead of sh

### DIFF
--- a/scripts/build-consumer-spin.sh
+++ b/scripts/build-consumer-spin.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . "$PWD/scripts/consumer-helper.sh"
 

--- a/scripts/build-consumer.sh
+++ b/scripts/build-consumer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . "$PWD/scripts/consumer-helper.sh"
 

--- a/scripts/consumer-helper.sh
+++ b/scripts/consumer-helper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 AVAILABLE_PACKAGES=('admin-ui-extensions' 'admin-ui-extensions-react' 'checkout-ui-extensions' 'checkout-ui-extensions-react' 'post-purchase-ui-extensions' 'post-purchase-ui-extensions-react' 'checkout-ui-extensions-run')
 ROOT=$(pwd)

--- a/scripts/restore-consumer-spin.sh
+++ b/scripts/restore-consumer-spin.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . "$PWD/scripts/consumer-helper.sh"
 

--- a/scripts/restore-consumer.sh
+++ b/scripts/restore-consumer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . "$PWD/scripts/consumer-helper.sh"
 


### PR DESCRIPTION
### Background

Some scripts like `scripts/build-consumer.sh` use syntax that isn't supported in `sh` on spin instances. Some linux distros symlink `sh` to `dash` which seems to have less features. 😬 

```
ls -ls /bin/sh
0 lrwxrwxrwx 1 root root 4 Oct  7  2021 /bin/sh -> dash
```

Arrays cause syntax errors:

```
sh -c 'ARG=("foo"); echo $ARG'
sh: 1: Syntax error: "(" unexpected
```

It's fine with bash:

```
bash -c 'ARG=("foo"); echo $ARG'
foo
```

Changing the shebang to use bash seems to fix those issues. :)


### 🎩

```
spin up ui-extensions -c ui-extensions.branch=fix-scripts
spin ssh --latest
cd ui-extensions
mkdir -p ../test/node_modules/@shopify
yarn build-consumer test
```

Wait a few minutes... ☕ 

```
ls ../test/node_modules/@shopify
```
should show the packages.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
