### PR TITLE
Web pixels extension fix

### DIFF
--- a/packages/web-pixels-extension/src/globals.ts
+++ b/packages/web-pixels-extension/src/globals.ts
@@ -1,10 +1,10 @@
 import {RuntimeAPI} from './types/runtime-api';
 
-type ExtensionPoint = 'WebPixel::Render';
+export const EXTENSION_POINT = 'WebPixel::Render';
 
 export interface ShopifyGlobal {
   extend(
-    extensionPoint: ExtensionPoint,
+    extensionPoint: typeof EXTENSION_POINT,
     extend: (api: RuntimeAPI) => void,
   ): void;
 }

--- a/packages/web-pixels-extension/src/register.ts
+++ b/packages/web-pixels-extension/src/register.ts
@@ -1,4 +1,9 @@
-import type {ShopifyGlobal} from './globals';
+import {ShopifyGlobal, EXTENSION_POINT} from './globals';
+import {RuntimeAPI} from './types/runtime-api';
 
-export const register: ShopifyGlobal['extend'] = (...args) =>
-  ((self as any) as {shopify: ShopifyGlobal}).shopify.extend(...args);
+declare const shopify: ShopifyGlobal;
+
+type Register = (extend: (api: RuntimeAPI) => void) => void;
+
+export const register: Register = (extend) =>
+  shopify.extend(EXTENSION_POINT, extend);


### PR DESCRIPTION
### Background

The register method did not accept a extend function.

### Solution

register now accepts a function as argument which gets passed to shopify.extend

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
