### PR TITLE
Web pixels extension fix readme

### DIFF
--- a/packages/web-pixels-extension/README.md
+++ b/packages/web-pixels-extension/README.md
@@ -15,7 +15,7 @@ Registering a Web Pixels Extension:
 ```js
 import {register} from '@shopify/web-pixels-extension';
 
-register(({configuration, analytics, browser}) => {
+register(async ({configuration, analytics, browser}) => {
   const origin = await browser.origin.get();
 
   window.my_pixel.configure({


### PR DESCRIPTION
### Background

`async` was missing from the function passed to `register` method.

### Solution

Add the keyword `async` before the function declaration.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
