### PR TITLE
[Checkout Extensions] Accept undefined as callback value in Stepper

### DIFF
--- a/packages/checkout-ui-extensions/src/components/Stepper/Stepper.ts
+++ b/packages/checkout-ui-extensions/src/components/Stepper/Stepper.ts
@@ -5,7 +5,7 @@ import {IconSource} from '../Icon';
 
 export interface StepperProps
   extends Pick<
-    TextFieldProps<number>,
+    TextFieldProps<number | undefined>,
     | 'id'
     | 'name'
     | 'label'

--- a/packages/checkout-ui-extensions/src/components/TextField/TextField.ts
+++ b/packages/checkout-ui-extensions/src/components/TextField/TextField.ts
@@ -5,7 +5,7 @@ import {IconSource} from '../Icon';
 
 type Type = 'text' | 'email' | 'number' | 'telephone';
 
-export interface TextFieldProps<T extends string | number> {
+export interface TextFieldProps<T extends string | number | undefined> {
   /**
    * A unique identifier for the field. When no `id` is set,
    * a globally unique value will be used instead.


### PR DESCRIPTION
### Background

The Stepper component now returns `undefined` as callback value when the field is cleared by the user.

PR for the implementation in Checkout:
https://github.com/Shopify/checkout-web/pull/11577

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
