### PR TITLE
Workaround for extension errors not shown during initial render

### DIFF
--- a/packages/checkout-ui-extensions-react/src/render.tsx
+++ b/packages/checkout-ui-extensions-react/src/render.tsx
@@ -47,6 +47,9 @@ export function render<ExtensionPoint extends RenderExtensionPoint>(
             },
           );
         } catch (error) {
+          // Workaround for https://github.com/Shopify/ui-extensions/issues/325
+          // eslint-disable-next-line no-console
+          console.error(error);
           reject(error);
         }
       });

--- a/packages/customer-account-ui-extensions-react/src/render.tsx
+++ b/packages/customer-account-ui-extensions-react/src/render.tsx
@@ -33,6 +33,9 @@ export function render<ExtensionPoint extends RenderExtensionPoint>(
           },
         );
       } catch (error) {
+        // Workaround for https://github.com/Shopify/ui-extensions/issues/325
+        // eslint-disable-next-line no-console
+        console.error(error);
         reject(error);
       }
     });


### PR DESCRIPTION
### Background

Address issue https://github.com/Shopify/ui-extensions/issues/325

### Solution

This PR is a port of @marvinhagemeister done at the source.
https://github.com/Shopify/checkout-web/pull/11674

I've also set the same logs in the `customer-account-ui-extensions-react` which is a recent copy of the Checkout render function.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
