### PR TITLE
[Checkout Extensions] Pick size and redefine emphasis in Skeletons

### DIFF
--- a/packages/checkout-ui-extensions/src/components/SkeletonText/SkeletonText.ts
+++ b/packages/checkout-ui-extensions/src/components/SkeletonText/SkeletonText.ts
@@ -3,8 +3,11 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {Size} from '../shared';
 import {TextProps} from '../Text';
 
-export interface SkeletonTextProps
-  extends Omit<TextProps, 'id' | 'role' | 'appearance'> {
+export interface SkeletonTextProps extends Pick<TextProps, 'size'> {
+  /**
+   * Use to emphasize a word or a group of words compared to other nearby text.
+   */
+  emphasis?: 'strong';
   /**
    * Adjust the length of the text when no children are passed.
    */

--- a/packages/checkout-ui-extensions/src/components/SkeletonTextBlock/SkeletonTextBlock.ts
+++ b/packages/checkout-ui-extensions/src/components/SkeletonTextBlock/SkeletonTextBlock.ts
@@ -2,8 +2,11 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import {TextBlockProps} from '../TextBlock';
 
-export interface SkeletonTextBlockProps
-  extends Omit<TextBlockProps, 'id' | 'appearance'> {
+export interface SkeletonTextBlockProps extends Pick<TextBlockProps, 'size'> {
+  /**
+   * Use to emphasize a word or a group of words compared to other nearby text.
+   */
+  emphasis?: 'strong';
   /**
    * Number of lines to display when no children are passed.
    *


### PR DESCRIPTION
### Background

Port over fix created by @ncardeli  https://github.com/Shopify/checkout-web/pull/11649

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
