### PR TITLE
Remove the `checkout_extensions` feature flag from generated checkout UI pages

### DIFF
--- a/scripts/generate-docs-checkout.ts
+++ b/scripts/generate-docs-checkout.ts
@@ -49,9 +49,12 @@ const extensionPointsPageContent = (url: string): PartialStaticContent[] => [
 ];
 
 // Checkout docs
-extensionPoints(checkout, extensionPointsPageContent(checkout.shopifyDevUrl));
+extensionPoints(checkout, extensionPointsPageContent(checkout.shopifyDevUrl), {
+  visibility: 'visible',
+});
 components(checkout, componentsPageContent(checkout.shopifyDevUrl), {
   generateReadmes: true,
+  visibility: 'visible',
   conditionalDocs: [
     {
       sourceFile: `${checkout.inputRoot}/documentation/conditional-props.md`,
@@ -60,4 +63,6 @@ components(checkout, componentsPageContent(checkout.shopifyDevUrl), {
   ],
   componentsToSkip: ['isConditionalStyle'],
 });
-gettingStarted(checkout);
+gettingStarted(checkout, {
+  visibility: 'visible',
+});

--- a/scripts/generate-docs-checkout.ts
+++ b/scripts/generate-docs-checkout.ts
@@ -49,12 +49,9 @@ const extensionPointsPageContent = (url: string): PartialStaticContent[] => [
 ];
 
 // Checkout docs
-extensionPoints(checkout, extensionPointsPageContent(checkout.shopifyDevUrl), {
-  visibility: 'betaCheckoutExtensions',
-});
+extensionPoints(checkout, extensionPointsPageContent(checkout.shopifyDevUrl));
 components(checkout, componentsPageContent(checkout.shopifyDevUrl), {
   generateReadmes: true,
-  visibility: 'betaCheckoutExtensions',
   conditionalDocs: [
     {
       sourceFile: `${checkout.inputRoot}/documentation/conditional-props.md`,
@@ -63,6 +60,4 @@ components(checkout, componentsPageContent(checkout.shopifyDevUrl), {
   ],
   componentsToSkip: ['isConditionalStyle'],
 });
-gettingStarted(checkout, {
-  visibility: 'betaCheckoutExtensions',
-});
+gettingStarted(checkout);


### PR DESCRIPTION
### Background

The `checkout_extensions` feature flag for Shopify.dev is no longer needed.

### Solution

To generate reference docs without the `feature_flag` key/value in frontmatter, rm `visibility: 'betaCheckoutExtensions'` from `generate-docs-checkout.ts`

Companion PR to https://github.com/Shopify/shopify-dev/pull/23161

### 🎩

Can't currently tophat due to type resolution errors and a RangeError (Maximum call stack size exceeded)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
