### PR TITLE
Add GraphQL endpoint to extension API

### DIFF
--- a/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
@@ -17,6 +17,10 @@ export interface ExtensionPoints {
     StandardApi,
     AllComponents
   >;
+  'CustomerAccount::KitchenSink': RenderExtension<
+    StandardApi & {name: string},
+    AllComponents
+  >;
 }
 
 export type ExtensionPoint = keyof ExtensionPoints;

--- a/packages/customer-account-ui-extensions/src/extension-points/index.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/index.ts
@@ -1,4 +1,6 @@
 export type {ExtensionPoints, ExtensionPoint} from './extension-points';
+export type {RenderExtension} from './render-extension';
+export type {StandardApi} from './standard-api';
 export type {
   ApiForRenderExtension,
   ArgumentsForExtension,

--- a/packages/customer-account-ui-extensions/src/extension-points/standard-api.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/standard-api.ts
@@ -3,4 +3,9 @@ export type Version = 'unstable';
 /**
  * The following APIs are provided to all extension points.
  */
-export interface StandardApi {}
+export interface StandardApi {
+  customerApi: {
+    getEndpoint(version: 'unstable'): Promise<string>;
+    getAccessToken(): Promise<string>;
+  };
+}


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/39405. We now expose the `customerApi` property with 2 methods, which allows the extension to call the Customer API themselves.

### Solution

Implemented both as asynchronous methods instead of a `RemoteSubscribable` as initially planned, because obtaining the first access token is asynchronous in Self-Serve itself, and we don't want to block the initial rendering while we obtain it.

The Customer API only supports the `unstable` version for now, which is fine for internal use. We'll add more versions as the Customer API actually becomes versioned.

I've had to add the `CustomerAccount::KitchenSink` extension point, similar to the one they have in Checkout, because having a second extension point with a different API was making our typing fail. Adding a second one right away allowed us to fix this issue right away.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
