### PR TITLE
expose `Style` helper to customer-account-ui-extensions packages

### DIFF
--- a/packages/customer-account-ui-extensions-react/src/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/index.ts
@@ -1,3 +1,3 @@
-export {extend} from '@shopify/customer-account-ui-extensions';
+export {extend, Style} from '@shopify/customer-account-ui-extensions';
 export * from './components';
 export {render} from './render';

--- a/packages/customer-account-ui-extensions/src/index.ts
+++ b/packages/customer-account-ui-extensions/src/index.ts
@@ -1,4 +1,5 @@
 export * from './components';
 export {extend} from './extend';
+export * from './style';
 export * from './extension-points';
 export type {ShopifyGlobal} from './globals';

--- a/packages/customer-account-ui-extensions/src/style/index.ts
+++ b/packages/customer-account-ui-extensions/src/style/index.ts
@@ -1,0 +1,1 @@
+export {Style} from '@shopify/checkout-ui-extensions';


### PR DESCRIPTION
### Background
This PR exposes `checkout-ui-extensions`'s `Style` helper, which allows for conditional styles ([example](https://shopify.dev/api/checkout-extensions/checkout/components/grid#getting-started)) on a number of checkout components. The Shopify Returns extension will make use of `Style` to achieve mobile/desktop layouts.

### Solution
- Import `Style` helper from `checkout-ui-extensions`
- Export `Style` helper from both React and vanilla `customer-account-ui-extensions` packages

### 🎩
🍋 **[My Spin instance](https://mobile-layout.kim-hawthorne.us.spin.dev/)**
In this Spin instance, the Shopify Returns app is using the `Style` helper to render conditional layouts based on viewport size. To test, ensure that the two main content containers are stack in mobile and are side-by-side in desktop.

**Desktop**
![](https://screenshot.click/20-15-a67ej-c77td.png)

**Mobile**
✏️ Note that the padding/alignment here is wonky, but this will be resolved when [this PR](https://github.com/Shopify/buyer-returns/pull/24) is merged.

![](https://screenshot.click/20-15-x08hi-ekihb.png)




### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
