### PR TITLE
Fix typo in public docs

### DIFF
--- a/packages/post-purchase-ui-extensions/src/components/Heading/Heading.ts
+++ b/packages/post-purchase-ui-extensions/src/components/Heading/Heading.ts
@@ -26,7 +26,7 @@ export interface HeadingProps {
 }
 
 /**
- * Headings are used as the titles of each major section of he checkout. Unlike HTML
+ * Headings are used as the titles of each major section of the checkout. Unlike HTML
  * headings, you do not explicitly specify the position of the heading in the document
  * outline. Instead, use headings nested in heading groups to create a document structure
  * that accessibility technologies can use to speed up navigation.

--- a/packages/post-purchase-ui-extensions/src/components/Heading/README.md
+++ b/packages/post-purchase-ui-extensions/src/components/Heading/README.md
@@ -1,6 +1,6 @@
 # Heading
 
-Headings are used as the titles of each major section of he checkout. Unlike HTML
+Headings are used as the titles of each major section of the checkout. Unlike HTML
 headings, you do not explicitly specify the position of the heading in the document
 outline. Instead, use headings nested in heading groups to create a document structure
 that accessibility technologies can use to speed up navigation.


### PR DESCRIPTION
### Background

Typo in the README and public docs for 'heading' checkout ui component. 

https://shopify.dev/api/checkout-extensions/components/heading

![25-56-vhq65-hdtco](https://user-images.githubusercontent.com/87482373/180843092-e7a8ab54-49d0-41f8-9e20-cf39c213ec8b.png)


### Solution

Fix typo. 

### Help me

Are these docs automatically generated for Shopify.dev on a daily basis? Or is it manual?