### PR TITLE
Fix entity in HeadingGroup example (React)

### DIFF
--- a/packages/checkout-ui-extensions-react/src/components/HeadingGroup/examples/basic-headinggroup.example.tsx
+++ b/packages/checkout-ui-extensions-react/src/components/HeadingGroup/examples/basic-headinggroup.example.tsx
@@ -9,13 +9,13 @@ render('Checkout::Dynamic::Render', () => <App />);
 function App() {
   return (
     <>
-      <Heading>Heading &lt;h1&rt;</Heading>
+      <Heading>Heading &lt;h1&gt;</Heading>
 
       <HeadingGroup>
-        <Heading>Heading &lt;h2&rt;</Heading>
+        <Heading>Heading &lt;h2&gt;</Heading>
 
         <HeadingGroup>
-          <Heading>Heading &lt;h3&rt;</Heading>
+          <Heading>Heading &lt;h3&gt;</Heading>
         </HeadingGroup>
       </HeadingGroup>
     </>


### PR DESCRIPTION


### Background

https://github.com/Shopify/ui-extensions/blob/eed8155bea3fb47c0115daa88fb870cbc903ddf9/packages/checkout-ui-extensions-react/src/components/HeadingGroup/examples/basic-headinggroup.example.tsx#L12-L18

### Solution

- Change invalid `&rt;` to correct entity `&gt;` (greater than)
- Fixes #424

### Checklist

- [x] I have updated relevant documentation (via this PR)
