### PR TITLE
Expose location to full page extensions

### DIFF
--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -21,6 +21,7 @@
     "./": "./"
   },
   "dependencies": {
+    "@remote-ui/async-subscription": "^2.1.10",
     "@remote-ui/react": "^4.5.2",
     "@shopify/checkout-ui-extensions-react": "^0.17.1",
     "@shopify/customer-account-ui-extensions": "^0.0.8"
@@ -34,6 +35,7 @@
     }
   },
   "devDependencies": {
+    "@testing-library/react-hooks": "^8.0.1",
     "react": "^17.0.0"
   }
 }

--- a/packages/customer-account-ui-extensions-react/src/hooks/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export {useSubscription} from './subscription';

--- a/packages/customer-account-ui-extensions-react/src/hooks/subscription.ts
+++ b/packages/customer-account-ui-extensions-react/src/hooks/subscription.ts
@@ -1,0 +1,42 @@
+import {useEffect, useState} from 'react';
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+
+type Subscriber<T> = Parameters<StatefulRemoteSubscribable<T>['subscribe']>[0];
+
+/**
+ * Subscribes to the special wrapper type that all “changeable” values in
+ * Customer Account use. This hook extracts the most recent value from that
+ * object, and subscribes to update the value when changes occur in Customer
+ * Account.
+ */
+export function useSubscription<T>(
+  subscription: StatefulRemoteSubscribable<T>,
+): T {
+  const [value, setValue] = useState(subscription.current);
+
+  useEffect(() => {
+    let didUnsubscribe = false;
+
+    const checkForUpdates: Subscriber<T> = (newValue) => {
+      if (didUnsubscribe) {
+        return;
+      }
+
+      setValue(newValue);
+    };
+
+    const unsubscribe = subscription.subscribe(checkForUpdates);
+
+    // Because we're subscribing in a passive effect, it's possible for an
+    // update to occur between render and the effect handler. Check for this
+    // and schedule an update if work has occurred.
+    checkForUpdates(subscription.current);
+
+    return () => {
+      didUnsubscribe = true;
+      unsubscribe();
+    };
+  }, [subscription]);
+
+  return value;
+}

--- a/packages/customer-account-ui-extensions-react/src/hooks/tests/subscription.test.ts
+++ b/packages/customer-account-ui-extensions-react/src/hooks/tests/subscription.test.ts
@@ -1,0 +1,73 @@
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import {act, renderHook} from '@testing-library/react-hooks';
+import {useSubscription} from '../subscription';
+
+describe('useSubscription()', () => {
+  it('updates the value when it changes', () => {
+    const statefulRemoteSubscribable = createMockStatefulRemoteSubscribable(
+      'hello',
+    );
+
+    const {result, rerender} = renderHook(() => {
+      return useSubscription(statefulRemoteSubscribable);
+    });
+    expect(result.current).toBe('hello');
+
+    act(() => {
+      statefulRemoteSubscribable.subscribe.mock.calls.forEach(
+        ([subscribeCallback]) => {
+          subscribeCallback('world');
+        },
+      );
+    });
+
+    rerender();
+    expect(result.current).toBe('world');
+  });
+
+  it('stops subscribing from future updates when unsubscribed is called', () => {
+    const statefulRemoteSubscribable = createMockStatefulRemoteSubscribable(
+      'hello',
+    );
+    const unsubscribe = jest.fn();
+    statefulRemoteSubscribable.subscribe.mockReturnValue(unsubscribe);
+
+    const {result, rerender, unmount} = renderHook(() => {
+      return useSubscription(statefulRemoteSubscribable);
+    });
+    expect(result.current).toBe('hello');
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+
+    act(() => {
+      statefulRemoteSubscribable.subscribe.mock.calls.forEach(
+        ([subscribeCallback]) => {
+          subscribeCallback('world');
+        },
+      );
+    });
+
+    rerender();
+    expect(result.current).toBe('hello');
+  });
+});
+
+export function createMockStatefulRemoteSubscribable<T>(value: T) {
+  const subscribable = {
+    get current() {
+      return value;
+    },
+    subscribe: jest.fn<
+      ReturnType<StatefulRemoteSubscribable<T>['subscribe']>,
+      Parameters<StatefulRemoteSubscribable<T>['subscribe']>
+    >(),
+    destroy: jest.fn<
+      ReturnType<StatefulRemoteSubscribable<T>['destroy']>,
+      Parameters<StatefulRemoteSubscribable<T>['destroy']>
+    >(),
+  };
+
+  return subscribable;
+}

--- a/packages/customer-account-ui-extensions-react/src/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/index.ts
@@ -1,3 +1,4 @@
 export {extend, Style} from '@shopify/customer-account-ui-extensions';
 export * from './components';
+export * from './hooks';
 export {render} from './render';

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -21,6 +21,7 @@
     "./": "./"
   },
   "dependencies": {
+    "@remote-ui/async-subscription": "^2.1.10",
     "@remote-ui/core": "^2.1.10",
     "@shopify/checkout-ui-extensions": "^0.17.1"
   }

--- a/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
@@ -1,3 +1,4 @@
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 import {RenderExtension} from './render-extension';
 import type {StandardApi} from './standard-api';
 
@@ -14,13 +15,20 @@ type AllComponents = Components[keyof Components];
  */
 export interface ExtensionPoints {
   'CustomerAccount::FullPage::RenderWithin': RenderExtension<
-    StandardApi,
+    StandardApi & FullPageApi,
     AllComponents
   >;
   'CustomerAccount::KitchenSink': RenderExtension<
     StandardApi & {name: string},
     AllComponents
   >;
+}
+
+interface FullPageApi {
+  location: StatefulRemoteSubscribable<{
+    pathname: string;
+    search: string;
+  }>;
 }
 
 export type ExtensionPoint = keyof ExtensionPoints;

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,6 +932,13 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.4.5", "@babel/runtime@^7.8.4":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
@@ -2582,6 +2589,14 @@
   integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
   dependencies:
     defer-to-connect "^1.0.1"
+
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -10137,6 +10152,13 @@ rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/42207. Exposes the current route data to full page extensions so they can do internal routing themselves.

### Solution

In addition to adding the `location` property in the API, this PR also adds a new hook called `useSubscription` that extensions can use in order to unwrap a `StatefulRemoteSubscribable` from the API. The hook simply transforms the subscribable into a reactive value within React's lifecycle.

### 🎩

Added our first test for the newly introduced hook.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
