### PR TITLE
re-export extension types in react package

### DIFF
--- a/packages/customer-account-ui-extensions-react/src/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/index.ts
@@ -1,3 +1,12 @@
 export {extend, Style} from '@shopify/customer-account-ui-extensions';
+export type {
+  ApiForRenderExtension,
+  ArgumentsForExtension,
+  ExtensionPoint,
+  ExtensionPoints,
+  RenderExtension,
+  RenderExtensionPoint,
+  ReturnTypeForExtension,
+} from '@shopify/customer-account-ui-extensions';
 export * from './components';
 export {render} from './render';


### PR DESCRIPTION
### Background
Otherwise consumers would need to install customer-account-web to have access to those. 

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
