### PR TITLE
[Customer Account] Exclude tests from tsconfig.json

### DIFF
--- a/packages/customer-account-ui-extensions-react/tsconfig.json
+++ b/packages/customer-account-ui-extensions-react/tsconfig.json
@@ -8,6 +8,7 @@
     "isolatedModules": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/tests/**"],
   "references": [
     {"path": "../customer-account-ui-extensions"},
     {"path": "../checkout-ui-extensions-react"}

--- a/packages/customer-account-ui-extensions/tsconfig.json
+++ b/packages/customer-account-ui-extensions/tsconfig.json
@@ -7,5 +7,6 @@
     "isolatedModules": true
   },
   "include": ["src/**/*.ts"],
+  "exclude": ["src/**/tests/**"],
   "references": [{"path": "../checkout-ui-extensions"}]
 }


### PR DESCRIPTION
### Background

I added a test in https://github.com/Shopify/ui-extensions/pull/428, and these files are not excluded from our tsconfig.json as they should be.

### Solution

Excluded tests from both `tsconfig.json`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
