### PR TITLE
add rc stack for customer account

### DIFF
--- a/shipit.customer-account-rc.yml
+++ b/shipit.customer-account-rc.yml
@@ -1,0 +1,13 @@
+ci:
+  require:
+    - lint
+    - test
+    - type-check
+dependencies:
+  override:
+    - yarn install --frozen-lockfile --no-progress
+deploy:
+  pre:
+    - yarn run build
+  override:
+    - yarn run deploy --dist-tag=next


### PR DESCRIPTION
### Background

Will allow us to deploy rc packages for customer account without getting into the way of admin experiments and the like.

https://shipit.shopify.io/shopify/ui-extensions/customer-account-rc

I believe this needs to be merged before we can test if it works. 😅 