### PR TITLE
[Customer Account] Add navigate and getExtensionFullPageUrl methods to StandardApi

### DIFF
--- a/packages/customer-account-ui-extensions/src/extension-points/standard-api.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/standard-api.ts
@@ -32,4 +32,8 @@ export interface StandardApi {
    * Details about the language of the buyer. More could be added in the future.
    */
   localization: Localization;
+  router: {
+    getExtensionFullPageUrl(relative: string): Promise<string>;
+    navigate(to: string): Promise<void>;
+  };
 }


### PR DESCRIPTION
### Background

Part of 
- https://github.com/Shopify/core-issues/issues/39485.

### Solution

2 new methods have been added to the `StandardApi`, under the `router` property.

`getExtensionFullPageUrl` accepts a relative path and returns a path leading to the full page extension of the calling app. This can be used by extensions to generate links to their full page extension to start a flow.

`navigate` accepts a URL and navigates the browser to it. It can be an absolute URL, in which case the customer leaves Customer Account. Or it can be a relative URL, in which case the customer goes to that page within Self-Serve.

### 🎩

1. Spin instance: https://buyer-returns-gsq3.mathieu-lagace.us.spin.dev
1. Authenticate to Customer Account
1. Register the app locally by using the first link to Customer Account.
1. In the console, you should see `/e/dev/new` as a warning. This is the result of calling `router.getExtensionFullPageUrl('/new')` in the app.
1. There should be a button `Click me` to test `navigate`. It will redirect to the order list page.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
