### PR TITLE
add run extensions and initiate returns extension point

### DIFF
--- a/packages/customer-account-ui-extensions-react/src/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/index.ts
@@ -1,11 +1,13 @@
 export {extend, Style} from '@shopify/customer-account-ui-extensions';
 export type {
-  ApiForRenderExtension,
+  ApiForExtension,
   ArgumentsForExtension,
   ExtensionPoint,
   ExtensionPoints,
   RenderExtension,
   RenderExtensionPoint,
+  RunExtension,
+  RunExtensionPoint,
   ReturnTypeForExtension,
 } from '@shopify/customer-account-ui-extensions';
 export * from './components';

--- a/packages/customer-account-ui-extensions-react/src/render.tsx
+++ b/packages/customer-account-ui-extensions-react/src/render.tsx
@@ -2,7 +2,7 @@ import type {ReactElement} from 'react';
 import {render as remoteRender} from '@remote-ui/react';
 import {extend} from '@shopify/customer-account-ui-extensions';
 import type {
-  ApiForRenderExtension,
+  ApiForExtension,
   RenderExtension,
   RenderExtensionPoint,
 } from '@shopify/customer-account-ui-extensions';
@@ -23,7 +23,7 @@ type RenderFunction<T> = RenderExtension<T, any>;
  */
 export function render<ExtensionPoint extends RenderExtensionPoint>(
   extensionPoint: ExtensionPoint,
-  render: (api: ApiForRenderExtension<ExtensionPoint>) => ReactElement<any>,
+  render: (api: ApiForExtension<ExtensionPoint>) => ReactElement<any>,
 ) {
   const extendCallback: RenderFunction<any> = (root, api) => {
     return new Promise<void>((resolve, reject) => {

--- a/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
@@ -1,5 +1,5 @@
 import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-import {RenderExtension} from './render-extension';
+import type {RenderExtension, RunExtension} from './extension-signature';
 import type {StandardApi} from './standard-api';
 
 type Components = typeof import('../components');
@@ -18,9 +18,17 @@ export interface ExtensionPoints {
     StandardApi & FullPageApi,
     AllComponents
   >;
+  'CustomerAccount::Returns::Initiate': RunExtension<
+    StandardApi & {orderId: string},
+    void
+  >;
   'CustomerAccount::KitchenSink': RenderExtension<
     StandardApi & {name: string},
     AllComponents
+  >;
+  'CustomerAccount::KitchenSinkRun': RunExtension<
+    StandardApi & {name: string},
+    string
   >;
 }
 

--- a/packages/customer-account-ui-extensions/src/extension-points/extension-signature.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/extension-signature.ts
@@ -14,3 +14,7 @@ export interface RenderExtension<
 > {
   (root: RemoteRoot<AllowedComponents, true>, api: Api): void | Promise<void>;
 }
+
+export interface RunExtension<Api, Return> {
+  (api: Api): Promise<Return>;
+}

--- a/packages/customer-account-ui-extensions/src/extension-points/index.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/index.ts
@@ -1,9 +1,11 @@
 export type {ExtensionPoints, ExtensionPoint} from './extension-points';
-export type {RenderExtension} from './render-extension';
 export type {StandardApi, Language, Localization} from './standard-api';
 export type {
-  ApiForRenderExtension,
+  ApiForExtension,
   ArgumentsForExtension,
   RenderExtensionPoint,
+  RunExtensionPoint,
   ReturnTypeForExtension,
 } from './types';
+
+export type {RenderExtension, RunExtension} from './extension-signature';


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/43001

Adds typings for the endpoint that we'll use to allow extensions to initiate a return.

Also removes `ApiForRenderExtension` type in favor of `ApiForExtension`.

Explanation can be found here: https://github.com/Shopify/ui-extensions/pull/457/files#r958631838

### 🎩 
Please check: https://github.com/Shopify/customer-account-web/pull/1009 description

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
