### PR TITLE
added optional field  to web pixel RuntimeAPI

### DIFF
--- a/packages/web-pixels-extension/src/types/web-pixel-api.ts
+++ b/packages/web-pixels-extension/src/types/web-pixel-api.ts
@@ -111,6 +111,7 @@ interface BrowserAPI {
 
 export interface WebPixelAPI {
   readonly configuration: Configuration;
+  readonly settings?: Configuration;
   readonly analytics: AnalyticsAPI;
   readonly browser: BrowserAPI;
   readonly _pixelInfo: Record<string, unknown>;


### PR DESCRIPTION
### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)
ISSUE: https://github.com/Shopify/ce-customer-behaviour/issues/1461

we must rename `configuration` to `settings` in the Runtime API.



### Solution

Adding in an optional `settings` property to support the transition until we are confident in the solution downstream

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
