### PR TITLE
Removed src from file imports

### DIFF
--- a/packages/retail-ui-extensions-react/src/context.ts
+++ b/packages/retail-ui-extensions-react/src/context.ts
@@ -2,7 +2,7 @@ import {createContext} from 'react';
 import {
   ApiForRenderExtension,
   RenderExtensionPoint,
-} from '@shopify/retail-ui-extensions/src';
+} from '@shopify/retail-ui-extensions';
 
 export const ExtensionApiContext = createContext<ApiForRenderExtension<
   RenderExtensionPoint

--- a/packages/retail-ui-extensions-react/src/index.ts
+++ b/packages/retail-ui-extensions-react/src/index.ts
@@ -1,5 +1,5 @@
 export {render} from './render';
-export {extend} from '@shopify/retail-ui-extensions/src';
+export {extend} from '@shopify/retail-ui-extensions';
 export * from './components';
 
 export type {

--- a/packages/retail-ui-extensions-react/src/render.tsx
+++ b/packages/retail-ui-extensions-react/src/render.tsx
@@ -1,10 +1,10 @@
 import type {ReactElement} from 'react';
 import {render as remoteRender} from '@remote-ui/react';
-import {extend} from '@shopify/retail-ui-extensions/src';
+import {extend} from '@shopify/retail-ui-extensions';
 import type {
   RenderExtensionPoint,
   ApiForRenderExtension,
-} from '@shopify/retail-ui-extensions/src';
+} from '@shopify/retail-ui-extensions';
 
 import {ExtensionApiContext} from './context';
 


### PR DESCRIPTION
### Background

There are still a few places in our react package where we specify `src` in imports from packages. Since the imports are coming from the vanilla package, we should just import it directly as everything in that package is exported properly. 

### Solution

Just removes the src from paths and import from the package.

### 🎩

Everything should build normally. It's still importing the same thing, but from the correct path (which points to the correct build output)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
