### PR TITLE
Change kind's @default value to secondary in documentation

### DIFF
--- a/packages/ui-extensions/src/types/Button.ts
+++ b/packages/ui-extensions/src/types/Button.ts
@@ -5,7 +5,7 @@ export interface BaseButtonProps {
    * `primary`: button used for main actions or green-path. Ex: Continue to next step, Discount field
    * `secondary`: button used for secondary actions not blocking user progress. Ex: Download Shop app
    * `plain`: Renders a button that visually looks like a Link
-   *  @default 'primary'
+   *  @default 'secondary'
    */
   kind?: 'primary' | 'secondary' | 'plain';
   /**


### PR DESCRIPTION
### Background
The default value of kind in the Button is `secondary` and not `primary` [more details in the issue here](https://github.com/Shopify/ui-extensions-private/issues/1674)

### Solution

Change the documentation to `secondary`