### PR TITLE
Export the CountryCode

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/types/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/types/index.ts
@@ -6,3 +6,5 @@ export type {
   LineItem,
   CustomSale,
 } from './cart';
+
+export type {CountryCode} from './CountryCode';


### PR DESCRIPTION
### Background

Realized in the `react` package that CountryCode wasn't actually exported in any index

### Solution

export the CountryCode

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
