### PR TITLE
Propagate export to top of package

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/index.ts
@@ -12,6 +12,7 @@ export type {
 export type {
   Address,
   Cart,
+  CountryCode,
   LineItem,
   Customer,
   Discount,

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -1,6 +1,7 @@
 export type {
   LocaleApi,
   CartApiContent,
+  CountryCode,
   DiscountType,
   CartApi,
   NavigationApi,


### PR DESCRIPTION
### Background

Now it was in src/extension-api/types/index, but not propagated to the top level index.

### Solution

Propagate it to the top! (Learning process... :) )

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
