### PR TITLE
Reexport CountryCode in retail-ui-extensions-react

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "^4.5.0",
-    "@shopify/retail-ui-extensions": "^0.12.0",
+    "@shopify/retail-ui-extensions": "^0.15.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions-react/src/index.ts
+++ b/packages/retail-ui-extensions-react/src/index.ts
@@ -6,6 +6,7 @@ export type {
   AutoCapitalizationType,
   ButtonType,
   ButtonProps,
+  CountryCode,
   DialogProps,
   DialogType,
   SearchBarProps,


### PR DESCRIPTION
### Background

Need to reexport the CountryCode type so the React index looks the same as the vanilla one

### Solution

Reexport!

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
