### PR TITLE
Change uuid type to match other api calls and POS redux state

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
@@ -7,7 +7,11 @@ export interface CartApi {
   cart: CartApiContent;
 }
 
-export type DiscountType = 'Percentage' | 'FixedAmount' | 'Code';
+export type DiscountType =
+  | 'Percentage'
+  | 'FixedAmount'
+  | 'PriceOverride'
+  | 'Code';
 
 export interface CartApiContent {
   /** Initial value of the Cart when the screen is rendered. */
@@ -82,7 +86,7 @@ export interface CartApiContent {
    * @param amount the percentage or fixed monetary amount deducted with the discout
    */
   setLineItemDiscount(
-    uuid: number,
+    uuid: string,
     type: DiscountType,
     title: string,
     amount: string,


### PR DESCRIPTION
### Background
While working on implementation of cart API calls in POS, I noticed that `setLineItemDiscount` takes uuid as number. However all other calls uses uuid as string which also matched how redux state stores the lineItem uuid
<img width="351" alt="Screen Shot 2022-09-22 at 10 14 38 AM" src="https://user-images.githubusercontent.com/69323793/191771009-7c986f28-f2ac-461b-a1d1-99e9c4414131.png">


### Solution

This PR is a tiny change to change the type to string to match all other calls

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
