### PR TITLE
Add missing exports to package.json for admin-ui-extensions to fix build issue

### DIFF
--- a/packages/admin-ui-extensions/package.json
+++ b/packages/admin-ui-extensions/package.json
@@ -11,7 +11,17 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./*": "./*"
+    "./*": "./*",
+    "./extension-api": {
+      "esnext": "./extension-api.esnext",
+      "import": "./extension-api.mjs",
+      "require": "./extension-api.js"
+    },
+    "./extension-points": {
+      "esnext": "./extension-points.esnext",
+      "import": "./extension-points.mjs",
+      "require": "./extension-points.js"
+    }
   },
   "license": "MIT",
   "sideEffects": false,


### PR DESCRIPTION
Fixes: https://github.com/Shopify/shopify-cli-extensions/issues/383

### Background

Missing exports in the package.json had extensions build failing

### Solution

Added missing exports