### PR TITLE
Retail - Fixed the renderer

### DIFF
--- a/packages/retail-ui-extensions-react/src/render.tsx
+++ b/packages/retail-ui-extensions-react/src/render.tsx
@@ -1,5 +1,4 @@
 import type {ReactElement} from 'react';
-import {createElement} from 'react';
 import {render as remoteRender} from '@remote-ui/react';
 import {extend} from '@shopify/retail-ui-extensions';
 import type {
@@ -36,15 +35,24 @@ export function render<ExtensionPoint extends RenderExtensionPoint>(
   return extend<'Retail::SmartGrid::Tile'>(
     extensionPoint as any,
     (root, api) => {
-      return new Promise(() => {
-        const element = render(api as ApiForRenderExtension<ExtensionPoint>);
-        remoteRender(
-          createElement(ExtensionApiContext.Provider, {value: api}, element),
-          root,
-          () => {
-            root.mount();
-          },
-        );
+      return new Promise((resolve, reject) => {
+        try {
+          remoteRender(
+            <ExtensionApiContext.Provider value={api}>
+              {render(api as ApiForRenderExtension<ExtensionPoint>)}
+            </ExtensionApiContext.Provider>,
+            root,
+            () => {
+              root.mount();
+              resolve();
+            },
+          );
+        } catch (error) {
+          // Workaround for https://github.com/Shopify/ui-extensions/issues/325
+          // eslint-disable-next-line no-console
+          console.error(error);
+          reject(error);
+        }
       });
     },
   );


### PR DESCRIPTION
### Background

This PR fixes the render function for our React package.

### Solution

Turns out we had to call createElement for it to work properly.

### 🎩

1. You're going to need to link this version of `retail-ui-extensions-react` locally to your extension.
2. Using a regular CLI generated app extension for POS, remove `retail-ui-extensions-react` from the package.json
3. Check out this local branch. Then navigate to package/retail-ui-extensions-react. Using a tool called yalc (you'll have to install it on your machine), in your command line enter `yalc publish`.
4. Navigate to your app extension project's root directory (not inside the extensions folder). Now enter `yalc add @shopify/retail-ui-extensions-react`. This will add the locally cached version of the library to your project's dependencies.
5. Run `npm run dev` to install the local version of your dependency.
6. Next you'll need to actually write some React code! You can copy the following code from my app for the tile.

```
import React from 'react';
import {Tile, extend, render} from '@shopify/retail-ui-extensions-react';

const MyComponent = () => {
  return <Tile title="Hello" subtitle="Hello" onPress={() => {}} enabled />
};

render('Retail::SmartGrid::Tile', () => <MyComponent />);
```

7. Do the usual steps to run your app extension locally and add the QR code to POS. 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
