### PR TITLE
Wrapped Retail on changes in hooks

### DIFF
--- a/packages/retail-ui-extensions-react/src/extension-api/cart-api/cart-api.ts
+++ b/packages/retail-ui-extensions-react/src/extension-api/cart-api/cart-api.ts
@@ -1,0 +1,25 @@
+import {useEffect, useState} from 'react';
+import type {Cart} from '@shopify/retail-ui-extensions/src';
+import {useExtensionApi} from '../utils';
+
+const isCartApi = (api: any): boolean => {
+  return 'cart' in api;
+};
+
+export function useCart() {
+  const api = useExtensionApi();
+  if (!isCartApi(api)) {
+    throw new Error('No cart api found');
+  }
+
+  const {
+    cart: {initialValue, setOnChange},
+  } = api;
+  const [cart, setCart] = useState(initialValue);
+
+  useEffect(() => {
+    setOnChange((newCart: Cart) => setCart(newCart));
+  }, [setOnChange]);
+
+  return cart;
+}

--- a/packages/retail-ui-extensions-react/src/extension-api/cart-api/index.ts
+++ b/packages/retail-ui-extensions-react/src/extension-api/cart-api/index.ts
@@ -1,0 +1,1 @@
+export {useCart} from './cart-api';

--- a/packages/retail-ui-extensions-react/src/extension-api/index.ts
+++ b/packages/retail-ui-extensions-react/src/extension-api/index.ts
@@ -1,0 +1,3 @@
+export {useExtensionApi} from './utils';
+export {useCart} from './cart-api';
+export {useLocale} from './locale-api';

--- a/packages/retail-ui-extensions-react/src/extension-api/locale-api/index.ts
+++ b/packages/retail-ui-extensions-react/src/extension-api/locale-api/index.ts
@@ -1,0 +1,1 @@
+export {useLocale} from './locale-api';

--- a/packages/retail-ui-extensions-react/src/extension-api/locale-api/locale-api.ts
+++ b/packages/retail-ui-extensions-react/src/extension-api/locale-api/locale-api.ts
@@ -1,0 +1,24 @@
+import {useEffect, useState} from 'react';
+import {useExtensionApi} from '../utils';
+
+const isLocaleApi = (api: any): boolean => {
+  return 'locale' in api;
+};
+
+export function useLocale() {
+  const api = useExtensionApi();
+  if (!isLocaleApi(api)) {
+    throw new Error('No locale api found');
+  }
+
+  const {
+    locale: {initialValue, setOnChange},
+  } = api;
+  const [locale, setLocale] = useState(initialValue);
+
+  useEffect(() => {
+    setOnChange((newLocale: string) => setLocale(newLocale));
+  }, [setOnChange]);
+
+  return locale;
+}

--- a/packages/retail-ui-extensions-react/src/extension-api/utils.ts
+++ b/packages/retail-ui-extensions-react/src/extension-api/utils.ts
@@ -1,0 +1,20 @@
+import {useContext} from 'react';
+import {
+  ApiForRenderExtension,
+  RenderExtensionPoint,
+} from '@shopify/retail-ui-extensions';
+import {ExtensionApiContext} from '../context';
+
+export function useExtensionApi<
+  ID extends RenderExtensionPoint = RenderExtensionPoint
+>(): ApiForRenderExtension<ID> {
+  const api = useContext(ExtensionApiContext);
+
+  if (api == null) {
+    throw new Error(
+      'You can only call this hook when running as a UI extension.',
+    );
+  }
+
+  return api as ApiForRenderExtension<ID>;
+}

--- a/packages/retail-ui-extensions-react/src/index.ts
+++ b/packages/retail-ui-extensions-react/src/index.ts
@@ -1,5 +1,6 @@
 export {render} from './render';
 export {extend} from '@shopify/retail-ui-extensions';
+export {useExtensionApi, useCart, useLocale} from './extension-api';
 export * from './components';
 
 export type {


### PR DESCRIPTION
### Background

This PR adds three new hooks: 
1. useExtensionApi - Allows the developer to access the different API functions on the Cart, navigation etc.
2. useCart - Is a wrapper around the setOnChange handler, that acts as a subscription to Cart updates.
3. useLocale - Is a wrapper around the setOnChange handler, that acts as a subscription to Locale updates.

### Solution

This is following the same standard pattern as set in admin-ui-extensions-react

### 🎩

You'll need to be running a POS UI extension project using React. Make sure your index file is a `tsx` file.

1. You can use yalc to publish this dependency locally on your machine. Then add the dependency to your CLI project.
2 Alternatively (easier) you can copy all the files in this PR, and add them to your local project (this should work). Then call the hooks!

Here is what my app's code looks like:

```ts
import React from 'react';
import {Tile, Text, render, useCart, useExtensionApi} from '@shopify/retail-ui-extensions-react';

const SmartGridTile = () => {
  const extensionApi = useExtensionApi();
  const cart = useCart();
  const isEnabled = cart.lineItems.length > 0
  return (
    <Tile 
      title="Wonderful app" 
      subtitle={isEnabled ? 'Apply discount' : 'Add item to cart'}
      onPress={() => extensionApi.cart.applyCartDiscount('FixedAmount', 'Test', '5.00')}
      enabled={isEnabled} 
    />
  );
};

const SmartGridModal = () => {
  return <Text>Welcome to the extension!</Text>;
}

render('Retail::SmartGrid::Tile', () => <SmartGridTile />);
render('Retail::SmartGrid::Modal', () => <SmartGridModal />);

```

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
