### PR TITLE
Publish checkout-ui-extensions `0.20.0`

### DIFF
--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/checkout-ui-extensions-react",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "React bindings for @shopify/checkout-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "^4.5.11",
-    "@shopify/checkout-ui-extensions": "^0.19.0",
+    "@shopify/checkout-ui-extensions": "^0.20.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify’s Checkout",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/customer-account-ui-extensions-react",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "React bindings for @shopify/customer-account-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,8 +23,8 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "^4.5.7",
-    "@shopify/checkout-ui-extensions-react": "^0.19.0",
-    "@shopify/customer-account-ui-extensions": "^0.0.18"
+    "@shopify/checkout-ui-extensions-react": "^0.20.0",
+    "@shopify/customer-account-ui-extensions": "^0.0.19"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <18.0.0"

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/customer-account-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify's Customer Account",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"
@@ -23,6 +23,6 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/core": "^2.1.15",
-    "@shopify/checkout-ui-extensions": "^0.19.0"
+    "@shopify/checkout-ui-extensions": "^0.20.0"
   }
 }


### PR DESCRIPTION
 - @shopify/checkout-ui-extensions-react@0.20.0
 - @shopify/checkout-ui-extensions@0.20.0
 - @shopify/customer-account-ui-extensions-react@0.0.19
 - @shopify/customer-account-ui-extensions@0.0.19

### Background

This PR bumps the versions and will be used to publish the packages. It is a follow-up to https://github.com/Shopify/ui-extensions/pull/520.

### Solution

Followed [package release steps](https://github.com/Shopify/ui-extensions-private/wiki/Release-steps:-Admin-and-Checkout-ui-extensions).


### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
