### PR TITLE
Bump retail-ui-extensions-react to 0.18.0

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
 - @shopify/retail-ui-extensions-react@0.18.0

### Background

Bumps the new version which includes APIs and hooks for the react library.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
