### PR TITLE
Created experimental nav API for beta

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/navigation-api/navigation-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/navigation-api/navigation-api.ts
@@ -1,6 +1,17 @@
 export interface NavigationApiContent {
+  /** The name of the current screen on the stack.
+   * This property can be used to evaluate which component you want to mount.
+   */
+  currentScreen?: string;
+
   /** Dismisses the modal highest on the stack */
   dismiss(): void;
+
+  /** Pushes a screen onto the stack.
+   * @param screenName the title of the screen you want to push onto the stack. This property is then returned in this API as `currentScreen`
+   * which can then be used to determine which component should be mounted.
+   */
+  push(screenName: string): void;
 }
 
 /**

--- a/packages/retail-ui-extensions/src/extension-api/smartgrid-api/smartgrid-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/smartgrid-api/smartgrid-api.ts
@@ -1,6 +1,10 @@
 export interface SmartGridApiContent {
-  /** Opens a full screen with the Retail::SmartGrid::Modal extension point */
-  presentModal(): void;
+  /** Opens a full screen with the `Retail::SmartGrid::Modal` extension point.
+   * @param screenName you can specific a screen name, which will be returned in the `NavigationAPI` as `currentScreen`.
+   * This value can you used to evaluate which component should be mounted. The `push(screenName: string)` method in the NavigationAPI can be used then to push
+   * additional screens on top of the stack.
+   */
+  presentModal(screenName?: string): void;
 }
 
 /**


### PR DESCRIPTION
### Background

This is the API we are providing for UI extensions to be able to navigate to other screens. It's not a great API, but we just need something that will work for beta, so Stocky can internally build and test out our features.

### Solution

This API does not resemble anything like what is available in react-native such as react-navigation. To be honest, those libraries are full of clutter in my opinion, and having to define stacks and routes is not only a waste of code, but it doesn't feel native and it's confusing.

The advantage to this solution is that: 
1. The developer only needs to call one function. It feels very similar to native navigation APIs, think of `navigationController.push(detailsViewController)` in UIKit, or `NavigationLink(destination: DetailView` in SwiftUI.
2. State is preserved across previous screens on the stack. If you go back to a previous screen, it will be in the same state that it was before.
3. Because each Argo screen is just created and added on top, on demand, everything is lazy loaded.

Disadvantages:
1. The lazy loading means that a new extension point loads every time we push, causing a short but noticeable delay.
2. It's not following the react-navigation patterns, and is a work around to the limitations posed by not being able to pass in children as props in a remote context.
3. I'm not sure this approach would be compatible to what the web based UI extensions would do.

There are 3 changes: 

1. `presentModal(screenName?: string)` in the smart grid API now lets you define a screenName. This is optional, because if you are building a single screen app, and don't care about navigating to other screens, it doesn't offer any benefit to specify the screen name.
5. `push(screenName: string)` allows the developer to push another screen onto the stack. They must specify the screenName here.
6. `screenName` is a readable property that is returned via the NavigationAPI. They can then use this property to perform logic to decide which component to render. Here is an example of what partner code could look like for a multi screen app:

```ts
const SmartGridTile = () => {
  const api = useExtensionApi();

  return(
    <>
      <Tile 
        title="App" 
        subtitle="Show products" 
        enabled
        onPress={() => api.smartGrid.presentModal('ProductList')} 
      />
    </>
  );
}

const Modal = () => {
  const api = useExtensionApi();
  const currentScreen = api.navigation.currentScreen;

  if (currentScreen === "ProductList") {
    return <ProductList />
  } else if (currentScreen === "ProductDetails") {
    return <ProductDetails />
  }
}

render('Retail::SmartGrid::Tile', () => <SmartGridTile />);
render('Retail::SmartGrid::Modal', () => <Modal />);
```

The idea is that the partner does not need to define routes, or stacks or any of that stuff. Assuming that they are on the `Retail::SmartGrid::Modal` extension point, they have access to the NavigationAPI. 

In this case when the tile is tapped, presentModal is called, and the ProductList (code not shown, but you can imagine) component is rendered. ProductList then can have a button, or on the selection of a row, can then call `push(screenName: 'ProductDetails')`  to navigate to the product details.

Under the hood, POS is just pushing ArgoScreen on top of ArgoScreen, but passing through the screenName to the navigation API.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
