### PR TITLE
Inline @shopify/ui-extension types into admin

### DIFF
--- a/packages/admin-ui-extensions/package.json
+++ b/packages/admin-ui-extensions/package.json
@@ -26,8 +26,7 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@remote-ui/core": "^2.1.3",
-    "@shopify/ui-extensions": "^1.0.2"
+    "@remote-ui/core": "^2.1.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/admin-ui-extensions/src/components/Banner/Banner.ts
+++ b/packages/admin-ui-extensions/src/components/Banner/Banner.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {BaseBannerProps} from '@shopify/ui-extensions';
+
+export type BannerStatus = 'critical' | 'info' | 'success' | 'warning';
 
 export interface BannerAction {
   /** Callback when the Banner action button is pressed. */
@@ -9,9 +10,18 @@ export interface BannerAction {
   content: string;
 }
 
-export interface BannerProps extends BaseBannerProps {
+export interface BannerProps {
   /** Button to display at bottom of banner. */
   action?: BannerAction;
+
+  /** Callback fired when banner is dismissed. */
+  onDismiss?: () => void;
+
+  /** Visual treatment of the banner based on message purpose. */
+  status?: BannerStatus;
+
+  /** Title of the banner. */
+  title?: string;
 }
 
 /**

--- a/packages/admin-ui-extensions/src/components/BlockStack/BlockStack.ts
+++ b/packages/admin-ui-extensions/src/components/BlockStack/BlockStack.ts
@@ -1,7 +1,20 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {BaseBlockStackProps} from '@shopify/ui-extensions';
 
-export type {BaseBlockStackProps as BlockStackProps} from '@shopify/ui-extensions';
+import type {Spacing} from '../types';
+
+export interface BlockStackProps {
+  /**
+   * Specifies the inline alignment. This affects the horizontal flow of elements.
+   * @defaultValue `leading`
+   */
+  inlineAlignment?: 'leading' | 'center' | 'trailing';
+
+  /**
+   * Adjusts spacing between children.
+   * @defaultValue 'base'
+   **/
+  spacing?: Spacing;
+}
 
 /**
  * Use to achieve no-fuss vertical centering.
@@ -9,7 +22,6 @@ export type {BaseBlockStackProps as BlockStackProps} from '@shopify/ui-extension
  * A stack is made of flexible items that wrap each of the stack’s children. Options provide control of the alignment and spacing of the items in the stack.
  * Use `StackItem` to group multiple elements inside a `BlockStack` together.
  */
-export const BlockStack = createRemoteComponent<
+export const BlockStack = createRemoteComponent<'BlockStack', BlockStackProps>(
   'BlockStack',
-  BaseBlockStackProps
->('BlockStack');
+);

--- a/packages/admin-ui-extensions/src/components/Button/Button.ts
+++ b/packages/admin-ui-extensions/src/components/Button/Button.ts
@@ -1,5 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {BaseButtonProps} from '@shopify/ui-extensions';
+
 import {IconProps} from '../Icon';
 
 type RequiredTitleOrIcon =
@@ -13,6 +13,52 @@ type RequiredTitleOrIcon =
       title?: string;
       icon: IconProps;
     };
+
+export interface BaseButtonProps {
+  /**
+   * The type of button that will be rendered.
+   *
+   * `primary`: button used for main actions or green-path. Ex: Continue to next step, Discount field
+   * `secondary`: button used for secondary actions not blocking user progress. Ex: Download Shop app
+   * `plain`: Renders a button that visually looks like a Link
+   *  @default 'secondary'
+   */
+  kind?: 'primary' | 'secondary' | 'plain';
+  /**
+   *  Specifies the color of the Button. The button will keep the style of the chosen `kind`,
+   *  but replace its color according to the appearance.
+   *
+   * `monochrome`: button will inherit the color of its parent
+   * `critical`: button will take inherit the color of the Critical color group (in Checkout)
+   *  		 and map to 'destructive' (in Admin/Polaris). Typically used for destructive actions.
+   *
+   */
+  appearance?: 'critical';
+  /** Changes the size of the button
+   * @default 'base'
+   */
+  size?: 'base' | 'large';
+  /**
+   * Whether the button should fill all available inline space.
+   * */
+  inlineSize?: 'fill';
+  /**
+   * Replaces content with a loading indicator
+   */
+  loading?: boolean;
+  /**
+   * A label that will be announced to buyers using assistive technologies
+   */
+  accessibilityLabel?: string;
+  /**
+   * Disables the button, disallowing any interaction
+   */
+  disabled?: boolean;
+  /**
+   * Callback when pressed
+   */
+  onPress?(): void;
+}
 
 export type ButtonProps = RequiredTitleOrIcon & BaseButtonProps;
 

--- a/packages/admin-ui-extensions/src/components/Heading/Heading.ts
+++ b/packages/admin-ui-extensions/src/components/Heading/Heading.ts
@@ -1,10 +1,17 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {BaseHeadingProps} from '@shopify/ui-extensions';
 
 type Level = 1 | 2 | 3 | 4 | 5 | 6;
 
-export interface HeadingProps extends Omit<BaseHeadingProps, 'level'> {
+export interface HeadingProps {
   /**
+   * Unique identifier. Typically used to make the heading a target
+   * that another component can refer to in order to provide an alternative
+   * accessibility label.
+   */
+  id?: string;
+
+  /**
+   * The visual level of the heading.
    * @default 2
    */
   level?: Level;

--- a/packages/admin-ui-extensions/src/components/InlineStack/InlineStack.ts
+++ b/packages/admin-ui-extensions/src/components/InlineStack/InlineStack.ts
@@ -1,7 +1,26 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {BaseInlineStackProps} from '@shopify/ui-extensions';
 
-export type {BaseInlineStackProps as InlineStackProps} from '@shopify/ui-extensions';
+import type {Spacing} from '../types';
+
+export interface InlineStackProps {
+  /**
+   * Specifies the block alignment. This affects the vertical flow of elements.
+   * @defaultValue `leading`
+   */
+  blockAlignment?: 'leading' | 'center' | 'trailing' | 'baseline';
+
+  /**
+   * Specifies the inline alignment. This affects the horizontal flow of elements.
+   * @defaultValue `leading`
+   */
+  inlineAlignment?: 'leading' | 'center' | 'trailing';
+
+  /**
+   * Adjust spacing between children.
+   * @defaultValue 'base'
+   **/
+  spacing?: Spacing;
+}
 
 /**
  * Use to lay out a horizontal row of components.
@@ -11,5 +30,5 @@ export type {BaseInlineStackProps as InlineStackProps} from '@shopify/ui-extensi
  */
 export const InlineStack = createRemoteComponent<
   'InlineStack',
-  BaseInlineStackProps
+  InlineStackProps
 >('InlineStack');

--- a/packages/admin-ui-extensions/src/components/types.ts
+++ b/packages/admin-ui-extensions/src/components/types.ts
@@ -1,3 +1,11 @@
+export type Spacing =
+  | 'none'
+  | 'extraTight'
+  | 'tight'
+  | 'base'
+  | 'loose'
+  | 'extraLoose';
+
 export interface Action {
   /**
    * Action label text.

--- a/packages/admin-ui-extensions/tsconfig.json
+++ b/packages/admin-ui-extensions/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "outDir": "build/ts"
   },
-  "references": [{"path": "../ui-extensions"}],
+  "references": [],
   "include": ["./src/**/*.ts"],
   "exclude": ["./src/**/*.example.*"]
 }


### PR DESCRIPTION
I'd like to use `@shopify/ui-extensions` as the library the new cross-surface UI extension type (https://vault.shopify.io/gsd/projects/30726), in line with the [UI extension libraries RFC](https://github.com/Shopify/ui-extensions-private/discussions/1788#discussioncomment-3511173).

This package is currently used as a dependency for `@shopify/admin-ui-extensions`, as a provider of types we thought might be shared across surfaces. To avoid any breaking changes to the admin typings as we implement the cross-surface extension type, I have inlined the types the admin was depending on into that library.