### PR TITLE
Made staff member id optional because it may not exist on POS

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/types/session.ts
+++ b/packages/retail-ui-extensions/src/extension-api/types/session.ts
@@ -18,5 +18,5 @@ export interface Session {
    * The staff ID who is currently pinned into the POS.
    * Note that this staff member ID may be different to the User ID, as the staff member who enters their PIN may be different to the User who logged onto POS.
    */
-  staffMemberId: number;
+  staffMemberId?: number;
 }


### PR DESCRIPTION
### Background

I'm connecting the new `SessionApi` to POS and `staffMemberId` can be `undefined`. 

### Solution

Made the parameter optional in `SessionApiContext`. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
