### PR TITLE
Publish

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
 - @shopify/retail-ui-extensions-react@0.22.0

### Background

retail-ui-extensions-react@0.21.1 was published accidentally with retail-ui-extensions@0.22.0

### Solution

Now they will match and all will be right
