### PR TITLE
Fix export of CountryCode and add color options for ListItem

### DIFF
--- a/packages/retail-ui-extensions-react/src/index.ts
+++ b/packages/retail-ui-extensions-react/src/index.ts
@@ -1,5 +1,5 @@
 export {render} from './render';
-export {extend} from '@shopify/retail-ui-extensions';
+export {extend, CountryCode} from '@shopify/retail-ui-extensions';
 export {useExtensionApi, useCart, useLocale} from './extension-api';
 export * from './components';
 
@@ -8,7 +8,6 @@ export type {
   ButtonType,
   ButtonProps,
   ColorType,
-  CountryCode,
   DialogProps,
   DialogType,
   FormattedTextFieldProps,

--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -4,8 +4,10 @@ export interface ListItem {
   uuid: string;
   title: string;
   subtitle?: string;
+  subtitleColor?: 'success' | 'warning' | 'critical';
   imageUri?: string;
-  rightDetail?: string;
+  detail?: string;
+  detailColor?: 'subdued' | 'action';
   onClick?: () => void;
 }
 

--- a/packages/retail-ui-extensions/src/extension-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/index.ts
@@ -10,10 +10,11 @@ export type {SessionApiContent, SessionApi} from './session-api';
 export type {
   Address,
   Cart,
-  CountryCode,
   LineItem,
   Customer,
   Discount,
   CustomSale,
   Session,
 } from './types';
+
+export {CountryCode} from './types';

--- a/packages/retail-ui-extensions/src/extension-api/types/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/types/index.ts
@@ -7,6 +7,6 @@ export type {
   CustomSale,
 } from './cart';
 
-export type {CountryCode} from './CountryCode';
+export {CountryCode} from './CountryCode';
 
 export type {Session} from './session';

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -1,7 +1,6 @@
 export type {
   LocaleApi,
   CartApiContent,
-  CountryCode,
   DiscountType,
   CartApi,
   NavigationApi,
@@ -19,6 +18,8 @@ export type {
   Customer,
   Discount,
 } from './extension-api';
+
+export {CountryCode} from './extension-api';
 
 export {
   Text,


### PR DESCRIPTION
### Background

CountryCode was being exported as a type, so using it as a value by doing something like `CountryCode.US` was not supported in extensions.

List items should be able to have some color.

### Solution

Add color options, and export CountryCode as a value instead of a type, so it can be imported and used in extensions.

![image](https://user-images.githubusercontent.com/29490857/195891651-03b01dba-0d00-4079-8754-34751d0b59b6.png)
 Locally yalc'd the packages and implemented on POS looks like this.