### PR TITLE
Adding scrollView wrapper

### DIFF
--- a/packages/retail-ui-extensions-react/src/components/ScrollView/ScrollView.ts
+++ b/packages/retail-ui-extensions-react/src/components/ScrollView/ScrollView.ts
@@ -1,0 +1,4 @@
+import {createRemoteReactComponent} from '@remote-ui/react';
+import {ScrollView as BaseScrollView} from '@shopify/retail-ui-extensions';
+
+export const ScrollView = createRemoteReactComponent(BaseScrollView);

--- a/packages/retail-ui-extensions-react/src/components/ScrollView/index.ts
+++ b/packages/retail-ui-extensions-react/src/components/ScrollView/index.ts
@@ -1,0 +1,1 @@
+export {ScrollView} from './ScrollView';

--- a/packages/retail-ui-extensions-react/src/components/index.ts
+++ b/packages/retail-ui-extensions-react/src/components/index.ts
@@ -8,6 +8,7 @@ export {SearchBar} from './SearchBar';
 export {SegmentedControl} from './SegmentedControl';
 export {Stack} from './Stack';
 export {Stepper} from './Stepper';
+export {ScrollView} from './ScrollView';
 export {Tag} from './Tag';
 export {Text} from './Text';
 export {TextField} from './TextField';

--- a/packages/retail-ui-extensions/src/components/ScrollView/ScrollView.ts
+++ b/packages/retail-ui-extensions/src/components/ScrollView/ScrollView.ts
@@ -1,0 +1,3 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+export const ScrollView = createRemoteComponent<'ScrollView'>('ScrollView');

--- a/packages/retail-ui-extensions/src/components/ScrollView/index.ts
+++ b/packages/retail-ui-extensions/src/components/ScrollView/index.ts
@@ -1,0 +1,1 @@
+export {ScrollView} from './ScrollView';

--- a/packages/retail-ui-extensions/src/components/index.ts
+++ b/packages/retail-ui-extensions/src/components/index.ts
@@ -37,6 +37,8 @@ export type {TagVariant, TagProps} from './Tag';
 export {Stepper} from './Stepper';
 export type {StepperProps} from './Stepper';
 
+export {ScrollView} from './ScrollView';
+
 export {Dialog} from './Dialog';
 export type {DialogType, DialogProps} from './Dialog';
 

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -31,6 +31,7 @@ export {
   SegmentedControl,
   Tag,
   Stepper,
+  ScrollView,
   Dialog,
   SearchBar,
   Image,


### PR DESCRIPTION
### Background

Added scrollView wrapper component to `retail-ui-extensions` and `retail-ui-extensions-react` packages. 
I added the minimum props I believe we need to make the component functional
```ts
export interface ScrollViewProps {
  flex?: number;
  scrollEventThrottle?: number;
  keyboardShouldPersistTaps?: boolean | 'always' | 'never' | 'handled';
}
```

### Solution


### 🎩

Please comment on other props that you might think are needed

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
