### PR TITLE
chore: fix the build-consumer-spin script

### DIFF
--- a/scripts/consumer-helper.sh
+++ b/scripts/consumer-helper.sh
@@ -4,17 +4,17 @@ AVAILABLE_PACKAGES=('admin-ui-extensions' 'admin-ui-extensions-react' 'checkout-
 ROOT=$(pwd)
 
 # Font color
-ORANGE='\033[1;31m'
-GREEN='\033[0;32m'
-CYAN='\033[0;36m'
-NONE='\033[0m'
+ORANGE=$'\e[1;31m'
+GREEN=$'\e[0;32m'
+CYAN=$'\e[0;36m'
+NONE=$'\e[0m'
 
 # Font styles
-DIM='\033[2m'
+DIM=$'\e[2m'
 BOLD=$(tput bold)
 NORMAL=$(tput sgr0)
 
-spinUrl=`spin info fqdn`
+spinUrl=`spin show --latest --output=fqdn`
 projectDirectoryOrWorkspace=$1
 packageName=$2
 packages=()
@@ -27,10 +27,10 @@ function set_globals() {
   else
     echo "🌀 Running command on spin: $spinUrl"
     projectName="$(cut -d'.' -f1 <<<"$projectDirectoryOrWorkspace")"
-    targetRoot="src/github.com/shopify/$projectName"
+    targetRoot="src/github.com/Shopify/$projectName"
     noTargetError="A workspace is required: "
   fi
-  
+
   shopifyNodeModulesDir="$targetRoot/node_modules/@shopify"
 }
 
@@ -47,13 +47,13 @@ function copy_to_target {
   local package=$1
   local packageFile=$2
 
-  echo "copy_to_target -->"
-
   if [[ -z $spin ]]; then
     targetDir=$(resolve "$ROOT/../$projectDirectoryOrWorkspace/node_modules/@shopify/$package")
   else
     targetDir="$shopifyNodeModulesDir/$package"
   fi
+
+  echo "copy_to_target --> $targetDir"
 
   if (run_command "[ -d $targetDir ]"); then
     debug $debug "rm -rf $targetDir"
@@ -246,7 +246,7 @@ function restore_consumer {
     run_command "cd $targetRoot"
 
     echo "Running \`yarn install\` from $targetRoot"
-    
+
     installCmd="yarn install --force --ignore-engines"
 
     debug $debug "$installCmd"


### PR DESCRIPTION
### Background

`spin` was updated and the command used in the script no longer worked.

### Solution

use `spin show` instead of `spin info` and capitalize `shopify` in `targetRoot="src/github.com/Shopify/$projectName"` to reflect the right path.

### 🎩

- checkout this branch
- run `yarn build-consumer-spin <workspace short name>` (I used `checkout-web` because it didn't have the packages in the node_modules so it was easy to see if they were copied)
- go to your spin instance's workspace `spin ssh` (choose the latest one, that's the one that the build-consumer-spin targets)
- cd to the worspace you chose `cd checkout-web` and open VS code `code .` (not that for web and shopify, node_modules are hidden so you have to cd into them to be able to see changes `cd web/node_module && code.`)
- open `node_modules/@shopify` and you should see the updated version of the packages you targeted

### Checklist

- [ ] I have :tophat:'d these changes
