### PR TITLE
Restrict retail components by extension point

### DIFF
--- a/packages/retail-ui-extensions/src/component-sets/Basic.ts
+++ b/packages/retail-ui-extensions/src/component-sets/Basic.ts
@@ -1,0 +1,30 @@
+import {
+  Button,
+  Dialog,
+  FormattedTextField,
+  Image,
+  List,
+  RadioButtonList,
+  SearchBar,
+  SegmentedControl,
+  Stack,
+  Stepper,
+  Tag,
+  Text,
+  TextField,
+} from '../components';
+
+export type BasicComponents =
+  | typeof Button
+  | typeof Dialog
+  | typeof FormattedTextField
+  | typeof Image
+  | typeof List
+  | typeof RadioButtonList
+  | typeof SearchBar
+  | typeof SegmentedControl
+  | typeof Stack
+  | typeof Stepper
+  | typeof Tag
+  | typeof Text
+  | typeof TextField;

--- a/packages/retail-ui-extensions/src/component-sets/SmartGrid.ts
+++ b/packages/retail-ui-extensions/src/component-sets/SmartGrid.ts
@@ -1,0 +1,3 @@
+import {Tile} from '../components';
+
+export type SmartGridComponents = typeof Tile;

--- a/packages/retail-ui-extensions/src/component-sets/index.ts
+++ b/packages/retail-ui-extensions/src/component-sets/index.ts
@@ -1,0 +1,2 @@
+export type {BasicComponents} from './Basic';
+export type {SmartGridComponents} from './SmartGrid';

--- a/packages/retail-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/retail-ui-extensions/src/extension-points/extension-points.ts
@@ -1,17 +1,15 @@
+import {BasicComponents, SmartGridComponents} from 'component-sets';
 import {SmartGridApi, StandardApi} from '../extension-api';
 import {RenderExtension} from './render-extension';
-
-type Components = typeof import('../components');
-type AllComponents = Components[keyof Components];
 
 export interface ExtensionPoints {
   'Retail::SmartGrid::Tile': RenderExtension<
     StandardApi<'Retail::SmartGrid::Tile'> & SmartGridApi,
-    AllComponents
+    SmartGridComponents
   >;
   'Retail::SmartGrid::Modal': RenderExtension<
     StandardApi<'Retail::SmartGrid::Modal'>,
-    AllComponents
+    BasicComponents
   >;
 }
 


### PR DESCRIPTION
### Background

Currently we technically allow the extension points to render all components. We should limit the tile extension point to only be able to render the smart grid tile, and exclude that smart grid tile component from the modal extension point. We do block this currently on the POS side (you would get a console error), but having an advanced warning to the developer is a better experience.

### Solution

I created two component sets, and altered the extension points to accept the correct ones.

### 🎩

If you run this locally on your machine, you should get an error in VSCode when trying to render an inappropriate component.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
