### PR TITLE
Added an Icon component

### DIFF
--- a/packages/retail-ui-extensions-react/src/components/Icon/Icon.ts
+++ b/packages/retail-ui-extensions-react/src/components/Icon/Icon.ts
@@ -1,0 +1,4 @@
+import {createRemoteReactComponent} from '@remote-ui/react';
+import {Icon as BaseIcon} from '@shopify/retail-ui-extensions';
+
+export const Icon = createRemoteReactComponent(BaseIcon);

--- a/packages/retail-ui-extensions-react/src/components/Icon/index.ts
+++ b/packages/retail-ui-extensions-react/src/components/Icon/index.ts
@@ -1,0 +1,1 @@
+export {Icon} from './Icon';

--- a/packages/retail-ui-extensions-react/src/components/index.ts
+++ b/packages/retail-ui-extensions-react/src/components/index.ts
@@ -11,4 +11,5 @@ export {Stepper} from './Stepper';
 export {Tag} from './Tag';
 export {Text} from './Text';
 export {TextField} from './TextField';
+export {Icon} from './Icon';
 export {Tile} from './Tile';

--- a/packages/retail-ui-extensions-react/src/index.ts
+++ b/packages/retail-ui-extensions-react/src/index.ts
@@ -28,5 +28,7 @@ export type {
   TextVariant,
   TextFieldProps,
   TileProps,
+  IconProps,
+  IconName,
   VerticalSpacing,
 } from '@shopify/retail-ui-extensions';

--- a/packages/retail-ui-extensions/src/components/Icon/Icon.ts
+++ b/packages/retail-ui-extensions/src/components/Icon/Icon.ts
@@ -1,0 +1,41 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+export type IconName =
+  | 'add-customer'
+  | 'checkmark'
+  | 'checkmark-active'
+  | 'checkmark-inactive'
+  | 'chevron-down'
+  | 'chevron-right'
+  | 'chevron-up'
+  | 'circle-cancel'
+  | 'circle-solid'
+  | 'circle-checkmark'
+  | 'circle-info'
+  | 'circle-alert'
+  | 'custom-sale'
+  | 'radio-inactive'
+  | 'radio-active'
+  | 'discount'
+  | 'clock'
+  | 'collections'
+  | 'menu'
+  | 'horizontal-dots'
+  | 'list'
+  | 'star'
+  | 'note'
+  | 'products'
+  | 'help'
+  | 'plus'
+  | 'minus'
+  | 'send'
+  | 'settings'
+  | 'not-stocked'
+  | 'sold-out'
+  | 'gift-card';
+
+export interface IconProps {
+  name: IconName;
+}
+
+export const Icon = createRemoteComponent<'Icon', IconProps>('Icon');

--- a/packages/retail-ui-extensions/src/components/Icon/index.ts
+++ b/packages/retail-ui-extensions/src/components/Icon/index.ts
@@ -1,0 +1,2 @@
+export {Icon} from './Icon';
+export type {IconProps, IconName} from './Icon';

--- a/packages/retail-ui-extensions/src/components/index.ts
+++ b/packages/retail-ui-extensions/src/components/index.ts
@@ -50,3 +50,6 @@ export type {ImageProps} from './Image';
 
 export {RadioButtonList} from './RadioButtonList';
 export type {RadioButtonListProps} from './RadioButtonList';
+
+export {Icon} from './Icon';
+export type {IconName, IconProps} from './Icon';

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -35,6 +35,7 @@ export {
   SearchBar,
   Image,
   RadioButtonList,
+  Icon,
 } from './components';
 
 export type {
@@ -70,6 +71,8 @@ export type {
   HorizontalSpacing,
   ImageProps,
   RadioButtonListProps,
+  IconName,
+  IconProps,
 } from './components';
 
 export type {


### PR DESCRIPTION
### Background

Adds an icon component that will allow third party apps to render an Icon. I selected icons that I believe will be useful for third party apps.

### Solution

Since POS defines the size and color of icons, I've decided only to expose the icon name.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
