### PR TITLE
Add padding to Stack

### DIFF
--- a/packages/retail-ui-extensions/src/components/Spacing/Spacing.ts
+++ b/packages/retail-ui-extensions/src/components/Spacing/Spacing.ts
@@ -7,8 +7,10 @@ export type VerticalSpacing =
   | 'ExtraLarge';
 
 export type HorizontalSpacing =
+  | 'HalfPoint'
   | 'ExtraSmall'
   | 'Small'
   | 'Medium'
   | 'Large'
-  | 'ExtraLarge';
+  | 'ExtraLarge'
+  | 'ExtraExtraLarge';

--- a/packages/retail-ui-extensions/src/components/Stack/Stack.ts
+++ b/packages/retail-ui-extensions/src/components/Stack/Stack.ts
@@ -1,4 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import {HorizontalSpacing, VerticalSpacing} from 'components/Spacing';
 
 export type Spacing =
   | 0.5
@@ -25,6 +26,8 @@ export interface StackProps {
     | 'space-around'
     | 'space-between'
     | 'space-evenly';
+  paddingVertical?: VerticalSpacing;
+  paddingHorizontal?: HorizontalSpacing;
   spacing?: Spacing;
   flexChildren?: boolean;
   flex?: number;


### PR DESCRIPTION
### Background

https://github.com/Shopify/pos-next-react-native/issues/18123

### Solution

Expose `paddingVertical` and `paddingHorizontal`  which are types `VerticalSpacing` and `HorizontalSpacing` to the partner. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
