### PR TITLE
Fix ui-extensions package build issues

### DIFF
--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -8,10 +8,10 @@
   "typesVersions": {
     "*": {
       "admin": [
-        "./build/typescript/surfaces/admin/index.d.ts"
+        "./build/ts/surfaces/admin/index.d.ts"
       ],
       "checkout": [
-        "./build/typescript/surfaces/checkout/index.d.ts"
+        "./build/ts/surfaces/checkout/index.d.ts"
       ]
     }
   },

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "module": "index.mjs",
   "esnext": "index.esnext",
-  "types": "./build/typescript/index.d.ts",
+  "types": "./build/ts/index.d.ts",
   "typesVersions": {
     "*": {
       "admin": [

--- a/packages/ui-extensions/sewing-kit.config.ts
+++ b/packages/ui-extensions/sewing-kit.config.ts
@@ -2,8 +2,8 @@ import {createPackage} from '@sewing-kit/config';
 import {uiExtensionsPackage} from '../../config/sewing-kit';
 
 export default createPackage((pkg) => {
-  pkg.entry({root: './src/index.ts'});
-  pkg.entry({name: 'admin', root: './src/surfaces/admin/index.ts'});
-  pkg.entry({name: 'checkout', root: './src/surfaces/checkout/index.ts'});
+  pkg.entry({root: './src'});
+  pkg.entry({name: 'admin', root: './src/surfaces/admin'});
+  pkg.entry({name: 'checkout', root: './src/surfaces/checkout'});
   pkg.use(uiExtensionsPackage());
 });


### PR DESCRIPTION
### Background

The `@shopify/ui-extensions` I published last week has two build issues, both of which are fixed by this PR:

- The built entry files incorrectly include `index.ts` in their re-exports, making it so the exports don't resolve
- The `types` and `typesVersions` package.json keys were pointing at non-existent files