### PR TITLE
Include new components in BasicComponents

### DIFF
--- a/packages/retail-ui-extensions/src/component-sets/Basic.ts
+++ b/packages/retail-ui-extensions/src/component-sets/Basic.ts
@@ -3,6 +3,9 @@ import {
   Dialog,
   FormattedTextField,
   Image,
+  Icon,
+  ScrollView,
+  Selectable,
   List,
   RadioButtonList,
   SearchBar,
@@ -16,6 +19,9 @@ import {
 
 export type BasicComponents =
   | typeof Button
+  | typeof ScrollView
+  | typeof Icon
+  | typeof Selectable
   | typeof Dialog
   | typeof FormattedTextField
   | typeof Image


### PR DESCRIPTION
### Background

We recently added new types to dictate what components are allowed in what extension points. We also shipped a few new components. This PR adds the new components to the types.

### Solution

All the new components should exist in the BasicComponents. This means they can be used in the Modal EP.
 
### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
