### PR TITLE
Fix import typo in Stack

### DIFF
--- a/packages/retail-ui-extensions/src/components/Stack/Stack.ts
+++ b/packages/retail-ui-extensions/src/components/Stack/Stack.ts
@@ -1,5 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import {HorizontalSpacing, VerticalSpacing} from 'components/Spacing';
+import type {HorizontalSpacing, VerticalSpacing} from 'components/Spacing';
 
 export type Spacing =
   | 0.5


### PR DESCRIPTION
### Background

Added import type to horizontal and vertical spacing that the linter didn't catch. 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
