### PR TITLE
Made the params optional for navigation

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/navigation-api/navigation-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/navigation-api/navigation-api.ts
@@ -15,7 +15,7 @@ export interface NavigationApiContent {
    * which can then be used to determine which component should be mounted.
    * @param params the parameters you want to pass for the new screen.
    */
-  push(screenName: string, params: any): void;
+  push(screenName: string, params?: any): void;
 }
 
 /**


### PR DESCRIPTION
### Background

Partners should have to provide params when pushing a new screen. 

### Solution

Made the params optional. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
