### PR TITLE
Publish `@shopify/web-pixels-extension@0.3.0`

### DIFF
--- a/packages/web-pixels-extension/package.json
+++ b/packages/web-pixels-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/web-pixels-extension",
   "description": "Provides tools to author Web Pixels extension",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
 - @shopify/web-pixels-extension@0.3.0

### Background
Recently updated the web pixels extension types. This PR publishes the changes under a new version.

Should ship after https://github.com/Shopify/web-pixels-manager/pull/161

### Solution

- `yarn version-bump:web-pixels`
- pushed branch with `--follow-tags`

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
