### PR TITLE
Navigation API pop function

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/navigation-api/navigation-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/navigation-api/navigation-api.ts
@@ -7,6 +7,9 @@ export interface NavigationApiContent {
   /** The parameters the screen was displayed with */
   params?: any;
 
+  /** Pops the currently presented screen */
+  pop(): void;
+
   /** Dismisses the modal highest on the stack */
   dismiss(): void;
 


### PR DESCRIPTION
### Background

I was working on https://github.com/Shopify/pos-next-react-native/issues/17783 and it makes sense to include a `pop` function in our navigation, even if the navigation itself ends up being temporary. Having the option to only dismiss the whole modal doesn't make much sense. 

### Solution

Added the interface for the `pop` function. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
