### PR TITLE
Adds features to extension api

### DIFF
--- a/packages/customer-account-ui-extensions/src/extension-points/standard-api.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/standard-api.ts
@@ -127,4 +127,9 @@ export interface StandardApi {
   authenticatedRedirect: {
     getStartUrl(): Promise<string>;
   };
+
+  /**
+   * A list of feature names for features enabled on a shop
+   */
+  features: string[];
 }


### PR DESCRIPTION
### Background
* As part of the Buyer Trust Program, merchants can enable structured return policies on their store. This feature is gated behind a feature flag, as not all merchants will have access to structured policies, nor will they have it enabled.
* When a merchant has the structured policies flag enabled, the buyer gets an enriched return experience: they can see an estimated refund total for the return (includes taxes & other fees), as well as reasons items in their order may be ineligible for return. 
* Currently, there is no way for feature flags to be consumed by extensions.

#### Relation information
* Slack [thread](https://shopify.slack.com/archives/C0308QJFNQ4/p1668715175617589) that kicked-off the discussion around consuming feature flags
* Task: https://github.com/Shopify/core-issues/issues/46845
* Project story: https://github.com/Shopify/core-issues/issues/46689
* Context on the decision to surface return policy information in buyer-returns: https://vault.shopify.io/gsd/projects/24167/decisions/912
#### Related PRs
* core: https://github.com/Shopify/shopify/pull/391058#pullrequestreview-1191203413
* shopify/customer-account-web (almost out of WIP): https://github.com/Shopify/customer-account-web/pull/1339/files/b4d603f464c645f2d492410a4ed6713921e45b47..95e21fc59cd6b7be4eb83ad8bad1a8daaf882084
* buyer-returns (WIP): https://github.com/Shopify/buyer-returns/pull/119/files

### Solution
* Expose a features field to the extensibility API, so that it can be consumed by self-serve. 
* **This is a low fidelity solution to support the need for feature flag evaluation in buyer-returns** 
* The work on structured policies introduced a use-case for exposing features to extensions, and it deserves more consideration beyond this PR.
* If there is anything that I can do to ensure this gets the planning it deserves, please let me know.

### 🎩
* This [spinstance](https://feature-flag.sam-goldsmith.us.spin.dev/) 🌀 has the feature implemented E2E. It will log enabled feature flags to the console (from the buyer-returns app, for now) when you begin the return request.
#### 🎩 Steps
1. You can toggle `admin_structured_return_policies` in [services internal](https://app.shopify.feature-flag.sam-goldsmith.us.spin.dev/services/internal/shops/1)
2. Go to the [return request flow](https://shop1.account.shopify.feature-flag.sam-goldsmith.us.spin.dev/e/dev/?orderId=1)
3. If prompted for a 6-digit code, you'll find that in [identity mailer](https://identity.feature-flag.sam-goldsmith.us.spin.dev/services/mail/)
4. Once in the app and with a request started, you can see beta flags printed to the console (only temporarily, for 🎩 purposes, as I don't know of a better way 😬)
- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
