### PR TITLE
Pin remote UI versions

### DIFF
--- a/packages/admin-ui-extensions-react/package.json
+++ b/packages/admin-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/admin-ui-extensions-react",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "index.js",
   "module": "index.mjs",
   "esnext": "index.esnext",
@@ -17,7 +17,7 @@
   "sideEffects": false,
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/admin-ui-extensions": "^1.0.4",
+    "@shopify/admin-ui-extensions": "^1.0.5",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/admin-ui-extensions-react/package.json
+++ b/packages/admin-ui-extensions-react/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@remote-ui/react": "^4.1.5",
+    "@remote-ui/react": "4.5.x",
     "@shopify/admin-ui-extensions": "^1.0.4",
     "@types/react": ">=17.0.0 <18.0.0"
   },

--- a/packages/admin-ui-extensions/package.json
+++ b/packages/admin-ui-extensions/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@remote-ui/core": "^2.1.3"
+    "@remote-ui/core": "2.1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/admin-ui-extensions/package.json
+++ b/packages/admin-ui-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/admin-ui-extensions",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "index.js",
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/checkout-ui-extensions-react",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "React bindings for @shopify/checkout-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions": "^0.21.0",
+    "@shopify/checkout-ui-extensions": "^0.21.1",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify’s Checkout",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -21,6 +21,6 @@
   },
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
-    "@remote-ui/core": "^2.1.15"
+    "@remote-ui/core": "2.1.x"
   }
 }

--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
-    "@remote-ui/react": "^4.5.7",
+    "@remote-ui/react": "4.5.x",
     "@shopify/checkout-ui-extensions-react": "^0.21.1",
     "@shopify/customer-account-ui-extensions": "^0.0.24"
   },

--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/customer-account-ui-extensions-react",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "React bindings for @shopify/customer-account-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,8 +23,8 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions-react": "^0.21.1",
-    "@shopify/customer-account-ui-extensions": "^0.0.24"
+    "@shopify/checkout-ui-extensions-react": "^0.21.2",
+    "@shopify/customer-account-ui-extensions": "^0.0.25"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <18.0.0"

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/customer-account-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify's Customer Account",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"
@@ -23,6 +23,6 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/core": "2.1.x",
-    "@shopify/checkout-ui-extensions": "^0.21.0"
+    "@shopify/checkout-ui-extensions": "^0.21.1"
   }
 }

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
-    "@remote-ui/core": "^2.1.15",
+    "@remote-ui/core": "2.1.x",
     "@shopify/checkout-ui-extensions": "^0.21.0"
   }
 }

--- a/packages/post-purchase-ui-extensions-react/package.json
+++ b/packages/post-purchase-ui-extensions-react/package.json
@@ -21,7 +21,7 @@
     "./*": "./*"
   },
   "dependencies": {
-    "@remote-ui/react": "^4.1.3",
+    "@remote-ui/react": "4.5.x",
     "@shopify/post-purchase-ui-extensions": "^0.13.3",
     "@types/react": ">=17.0.0 <18.0.0"
   },

--- a/packages/post-purchase-ui-extensions-react/package.json
+++ b/packages/post-purchase-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/post-purchase-ui-extensions-react",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "React bindings for @shopify/post-purchase-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/post-purchase-ui-extensions": "^0.13.3",
+    "@shopify/post-purchase-ui-extensions": "^0.13.4",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/post-purchase-ui-extensions/package.json
+++ b/packages/post-purchase-ui-extensions/package.json
@@ -21,6 +21,6 @@
     "./*": "./*"
   },
   "dependencies": {
-    "@remote-ui/core": "^2.1.3"
+    "@remote-ui/core": "2.1.x"
   }
 }

--- a/packages/post-purchase-ui-extensions/package.json
+++ b/packages/post-purchase-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/post-purchase-ui-extensions",
   "description": "The API for UI Extensions that run in the post-purchase step of Shopify’s Checkout",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/retail-ui-extensions": "^0.34.0",
+    "@shopify/retail-ui-extensions": "^0.34.1",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -21,7 +21,7 @@
     "./*": "./*"
   },
   "dependencies": {
-    "@remote-ui/react": "^4.5.0",
+    "@remote-ui/react": "4.5.x",
     "@shopify/retail-ui-extensions": "^0.34.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -21,6 +21,6 @@
     "./*": "./*"
   },
   "dependencies": {
-    "@remote-ui/core": "^2.1.6"
+    "@remote-ui/core": "2.1.x"
   }
 }

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/retail-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify Point of Sale",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,30 +2190,7 @@
   dependencies:
     "@remote-ui/rpc" "^1.3.4"
 
-"@remote-ui/async-subscription@^2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.9.tgz#84f413e40a8136ba28ee6ee0f946e4c1f85832d7"
-  integrity sha512-+5UmqyjQJXLJLOVbEBvfzc/Yt4mV/9J36IGJhCJdpdEmIBde7DjkWBt91eSFxa3+Zx6Enq1unkBl4rqosYgpgw==
-  dependencies:
-    "@remote-ui/rpc" "^1.3.0"
-
-"@remote-ui/core@^2.1.10", "@remote-ui/core@^2.1.3", "@remote-ui/core@^2.1.6":
-  version "2.1.10"
-  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.1.10.tgz#f91dfa84744bcefe0989ff682297e795feb9b151"
-  integrity sha512-zHDO9yxli61QrfQO8U7HP82KHYLtBRjFUDrsVxMOsZpmMQI53wBX0ohWtcEqZUjcmf1l67ck03GFMOr3L3uGpw==
-  dependencies:
-    "@remote-ui/rpc" "^1.3.0"
-    "@remote-ui/types" "^1.1.2"
-
-"@remote-ui/core@^2.1.15":
-  version "2.1.15"
-  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.1.15.tgz#5cbd15c4917d6d975e3039566607fa5afbe44366"
-  integrity sha512-w3EFxm8s67H2snp50iFCBXZrMFl/83iGEpZc8yCgGncPACcKt0KrY/SjEFkZ3B0OZhXcTtSwIp145YoXzHr0Bg==
-  dependencies:
-    "@remote-ui/rpc" "^1.3.3"
-    "@remote-ui/types" "^1.1.2"
-
-"@remote-ui/core@^2.1.16":
+"@remote-ui/core@2.1.x", "@remote-ui/core@^2.1.16":
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.1.16.tgz#8b5fbfdc22a5619334d29a4cb7d4fd20bf67c5f3"
   integrity sha512-PcaljPmv0Ra8PeRT+M/vKPTYSkU1KssjwB2gjcE+TK2zM2SBbJwB5K18MjJhNlb9n6LTFE99fDqYxc5DbCyMIg==
@@ -2232,35 +2209,6 @@
     "@types/react" ">=17.0.0 <18.0.0"
     "@types/react-reconciler" "^0.26.0"
     react-reconciler ">=0.26.0 <0.27.0"
-
-"@remote-ui/react@^4.1.3", "@remote-ui/react@^4.1.5", "@remote-ui/react@^4.5.0":
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-4.5.2.tgz#e58992cfe5b5bdcc60bd75ce4dcc431e29e6bae7"
-  integrity sha512-2DKqo0x31Tk+9nqfNaBeOvOVl51fw9EYoJj7qTniPE2K2XncJIJsqghd9Ok2yyxXKoMZvBCG4F/uZ4R8onJ6Iw==
-  dependencies:
-    "@remote-ui/async-subscription" "^2.1.9"
-    "@remote-ui/core" "^2.1.10"
-    "@remote-ui/rpc" "^1.3.0"
-    "@types/react" ">=17.0.0 <18.0.0"
-    "@types/react-reconciler" "^0.26.0"
-    react-reconciler ">=0.26.0 <0.27.0"
-
-"@remote-ui/react@^4.5.7":
-  version "4.5.7"
-  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-4.5.7.tgz#c826c1bc37fb59d26e85d807b5ea0180fbe74a7f"
-  integrity sha512-immiTS6pWpr3of0d9JwAW/M5uuNoqM4IyK4hU6/l/N0hy517fuWfir8rXj/TdqGYAq4uyC7NBZf8Kv+njfxRKQ==
-  dependencies:
-    "@remote-ui/async-subscription" "^2.1.12"
-    "@remote-ui/core" "^2.1.15"
-    "@remote-ui/rpc" "^1.3.3"
-    "@types/react" ">=17.0.0 <18.0.0"
-    "@types/react-reconciler" "^0.26.0"
-    react-reconciler ">=0.26.0 <0.27.0"
-
-"@remote-ui/rpc@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.3.0.tgz#e9469803e8024707f096bd52041fdfe61154dac8"
-  integrity sha512-tO0nYON8IhErx/DYxufo7ccwnSh1Vo5mS41HAjUQ+fCctNmRABug0tjvCdOq1E6R6JAq1EbxN0U5w+7pYMcaFg==
 
 "@remote-ui/rpc@^1.3.3":
   version "1.3.3"


### PR DESCRIPTION
### Background

`@remote-ui/core@2.2.0` and `@remote-ui/react@4.6.0` make use of new core APIs for manipulating the remote root. However, the current structure of most remote-ui uses at Shopify has the host owning the version of `@remote-ui/core`, and none of them have support for the new APIs yet. Most developers will get the new version of `@remote-ui/react` because it is only a minor version, but because `@remote-ui/react` assumes it has the correct version of `@remote-ui/core`, it will break when run in a host with an older version.

Until hosts are updated to use the new version of `@remote-ui/core`, this PR pins all versions of remote-ui to the ones before the new APIs were added. This prevents consumers installing these versions of the packages from accidentally getting code depending on `@remote-ui/core@2.2.0`.
