### PR TITLE
Added callback onEndReached for List

### DIFF
--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -15,6 +15,7 @@ export interface ListProps {
   data: ListItem[];
   showDisclosureIndicator: boolean;
   title?: string;
+  onEndReached?: () => void;
 }
 
 export const List = createRemoteComponent<'List', ListProps>('List');


### PR DESCRIPTION
### Background

https://github.com/Shopify/pos-next-react-native/issues/17745

### Solution

Added `onEndReached` callback to `List` parameters 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
