### PR TITLE
Made receiving the Screen params optional

### DIFF
--- a/packages/retail-ui-extensions/src/components/Screen/Screen.ts
+++ b/packages/retail-ui-extensions/src/components/Screen/Screen.ts
@@ -2,7 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export interface ScreenProps {
   name: string;
-  onReceiveParams: (params: any) => void;
+  onReceiveParams?: (params: any) => void;
 }
 
 export const Screen = createRemoteComponent<'Screen', ScreenProps>('Screen');


### PR DESCRIPTION
### Background

Some screens don't accept parameters. It doesn't make sense to force them to implement the callback.

### Solution

Made the params callback optional. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
