### PR TITLE
Restricted NavigationApi to Modals

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/standard-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/standard-api.ts
@@ -1,11 +1,9 @@
 import type {CartApi} from './cart-api';
 import type {LocaleApi} from './locale-api';
-import type {NavigationApi} from './navigation-api';
 import type {SessionApi} from './session-api';
 
 export type StandardApi<T> = {[key: string]: any} & {
   extensionPoint: T;
 } & LocaleApi &
   CartApi &
-  NavigationApi &
   SessionApi;

--- a/packages/retail-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/retail-ui-extensions/src/extension-points/extension-points.ts
@@ -1,5 +1,5 @@
 import {BasicComponents, SmartGridComponents} from 'component-sets';
-import {SmartGridApi, StandardApi} from '../extension-api';
+import {SmartGridApi, NavigationApi, StandardApi} from '../extension-api';
 import {RenderExtension} from './render-extension';
 
 export interface ExtensionPoints {
@@ -8,7 +8,7 @@ export interface ExtensionPoints {
     SmartGridComponents
   >;
   'Retail::SmartGrid::Modal': RenderExtension<
-    StandardApi<'Retail::SmartGrid::Modal'>,
+    StandardApi<'Retail::SmartGrid::Modal'> & NavigationApi,
     BasicComponents
   >;
 }


### PR DESCRIPTION
### Background

`SmartGridTile` extension point shouldn't have the access to `NavigationApi`.

### Solution

Only allowing the `Modal` extension point to access `NavigationApi`.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
