### PR TITLE
fix documentation links #669

### DIFF
--- a/packages/admin-ui-extensions/README.md
+++ b/packages/admin-ui-extensions/README.md
@@ -24,6 +24,6 @@ extend('Playground', (root) => {
 });
 ```
 
-You can find more component usage examples alongside each component in [packages/admin-ui-extensions/src/components](packages/admin-ui-extensions/src/components)
+You can find more component usage examples alongside each component in [packages/admin-ui-extensions/src/components](/packages/admin-ui-extensions/src/components)
 
-To use the React implementation, check out [packages/admin-ui-extensions-react](packages/admin-ui-extensions/README.md).
+To use the React implementation, check out [packages/admin-ui-extensions-react](/packages/admin-ui-extensions/README.md).


### PR DESCRIPTION
### Background

They were added as relative and ending up as `https://github.com/Shopify/ui-extensions/blob/main/packages/admin-ui-extensions/packages/admin-ui-extensions/src/components` when clicked.

Fixes https://github.com/Shopify/ui-extensions/issues/669

### Solution

Add `/` to the links.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
