### PR TITLE
[customer-account] - add extension metadata to standard api

### DIFF
--- a/packages/customer-account-ui-extensions/src/extension-points/index.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/index.ts
@@ -1,11 +1,12 @@
 export type {ExtensionPoints, ExtensionPoint} from './extension-points';
 export type {
-  StandardApi,
   Language,
   Localization,
   I18nTranslate,
   I18n,
-} from './standard-api';
+} from './standard-api/localization';
+export type {StandardApi} from './standard-api';
+
 export type {
   ApiForExtension,
   ArgumentsForExtension,

--- a/packages/customer-account-ui-extensions/src/extension-points/standard-api/extension.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/standard-api/extension.ts
@@ -1,0 +1,43 @@
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+
+export type Capability = 'network_access';
+
+export interface Extension {
+  /**
+   * The published version of the running extension point.
+   *
+   * For extensions installed on a development store the value is always `0.0.0`.
+   * For unpublished extensions, the value is `undefined`.
+   *
+   * @example 3.0.10
+   */
+  version?: string;
+
+  /**
+   * The URL to the script that started the extension point.
+   */
+  scriptUrl: string;
+
+  /**
+   * Whether your extension is currently rendered to the screen.
+   *
+   * Shopify might render your extension before it's visible in the UI,
+   * typically to pre-render extensions that will appear on a later step of the
+   * checkout.
+   *
+   * Your extension might also continue to run after the buyer has navigated away
+   * from where it was rendered. The extension continues running so that
+   * your extension is immediately available to render if the buyer navigates back.
+   */
+  rendered: StatefulRemoteSubscribable<boolean>;
+
+  /**
+   * The allowed capabilities of the extension, defined
+   * in your `shopify.ui.extension.toml` file .
+   *
+   * `network_access`:
+   * You must [request access](https://shopify.dev/api/checkout-extensions/checkout/configuration#complete-a-request-for-network-access)
+   * to make network calls.
+   */
+  capabilities: StatefulRemoteSubscribable<Capability[]>;
+}

--- a/packages/customer-account-ui-extensions/src/extension-points/standard-api/index.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/standard-api/index.ts
@@ -1,0 +1,57 @@
+import {Extension} from './extension';
+import {I18n, Localization} from './localization';
+
+export type RendererVersion = 'unstable';
+
+/**
+ * The following APIs are provided to all extension points.
+ */
+export interface StandardApi {
+  customerApi: {
+    getEndpoint(version: 'unstable'): Promise<string>;
+    getAccessToken(): Promise<string>;
+  };
+
+  /**
+   * Meta information about the extension.
+   */
+  extension: Extension;
+
+  /**
+   * The renderer version being used for the extension.
+   *
+   * @example 'unstable'
+   */
+  version: RendererVersion;
+
+  /**
+   * Details about the language of the buyer.
+   */
+  localization: Localization;
+
+  /**
+   * Utilities for translating content and formatting values according to the current `localization`
+   * of the user.
+   */
+  i18n: I18n;
+
+  router: {
+    getExtensionFullPageUrl(relative: string): Promise<string>;
+    navigate(to: string): Promise<void>;
+  };
+
+  /**
+   * An authenticated redirect is a way to seamlessly integrate 3P apps
+   * built outside of self-serve into the self-serve experience. The 3P app accepts this data,
+   * bypasses any authentication screens on their side, and sends the user directly into
+   * their app to complete the task at hand. Once the task is complete, the app routes the user back into self-serve.
+   */
+  authenticatedRedirect: {
+    getStartUrl(): Promise<string>;
+  };
+
+  /**
+   * A list of feature names for features enabled on a shop
+   */
+  features: string[];
+}

--- a/packages/customer-account-ui-extensions/src/extension-points/standard-api/localization.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/standard-api/localization.ts
@@ -1,17 +1,4 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-
-export type Version = 'unstable';
-
-export interface Language {
-  /**
-   * The BCP-47 language tag. It may contain a dash followed by an ISO 3166-1 alpha-2 region code.
-   *
-   * @example 'en' for English, or 'en-US' for English local to United States.
-   * @see https://en.wikipedia.org/wiki/IETF_language_tag
-   * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
-   */
-  isoCode: string;
-}
+import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 export interface Localization {
   /**
@@ -31,6 +18,17 @@ export interface Localization {
    * extension (that is, the one matching your .default.json file).
    */
   extensionLanguage: StatefulRemoteSubscribable<Language>;
+}
+
+export interface Language {
+  /**
+   * The BCP-47 language tag. It may contain a dash followed by an ISO 3166-1 alpha-2 region code.
+   *
+   * @example 'en' for English, or 'en-US' for English local to United States.
+   * @see https://en.wikipedia.org/wiki/IETF_language_tag
+   * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+   */
+  isoCode: string;
 }
 
 /**
@@ -91,45 +89,4 @@ export interface I18n {
    * - If replacements contain UI components, then `translate()` returns an array of elements.
    */
   translate: I18nTranslate;
-}
-
-/**
- * The following APIs are provided to all extension points.
- */
-export interface StandardApi {
-  customerApi: {
-    getEndpoint(version: 'unstable'): Promise<string>;
-    getAccessToken(): Promise<string>;
-  };
-
-  /**
-   * Details about the language of the buyer.
-   */
-  localization: Localization;
-
-  /**
-   * Utilities for translating content and formatting values according to the current `localization`
-   * of the user.
-   */
-  i18n: I18n;
-
-  router: {
-    getExtensionFullPageUrl(relative: string): Promise<string>;
-    navigate(to: string): Promise<void>;
-  };
-
-  /**
-   * An authenticated redirect is a way to seamlessly integrate 3P apps
-   * built outside of self-serve into the self-serve experience. The 3P app accepts this data,
-   * bypasses any authentication screens on their side, and sends the user directly into
-   * their app to complete the task at hand. Once the task is complete, the app routes the user back into self-serve.
-   */
-  authenticatedRedirect: {
-    getStartUrl(): Promise<string>;
-  };
-
-  /**
-   * A list of feature names for features enabled on a shop
-   */
-  features: string[];
 }


### PR DESCRIPTION
### Background
This PR adds typings for adding extension metadata to the standard api of customer account ui extensions as part of 
https://github.com/Shopify/core-issues/issues/49460

Implementation: https://github.com/Shopify/customer-account-web/pull/1567

Divergences from checkout's specification:

- No `editor` property 
- Blocking removed from list of `capabilities`.
- Version is undefined for local dev extensions, but returns draft version (0.0.0) when installed on development stores.


This PR also restructures the folder structure, and collocates some types (i18n, locale for example).


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
