### PR TITLE
Add changeset actions

### DIFF
--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -1,0 +1,36 @@
+name: Changelog Reminder
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 2022-10
+      - 2023-01
+      - unstable
+    paths:
+      - 'packages/*/src/**'
+      - 'packages/*/package.json'
+      - '!*.test.*'
+      - '!*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  remind:
+    name: Changeset Reminder
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'changeset-release/') }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mskelton/changelog-reminder-action@v2
+        with:
+          changelogRegex: "\\.changeset"
+          message: >
+            We detected some changes in `packages/*/package.json` or `packages/*/src`, and there are no updates in the `.changeset` directory.
+
+            If the changes are user-facing and should cause a version bump, run `yarn changeset` to track your changes and include them in the next release CHANGELOG.
+
+            If you are making simple updates to repo configuration, examples, or documentation, you do not need to add a changeset.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,0 +1,30 @@
+name: Changesets
+
+on:
+  push:
+    branches:
+      - 2022-10
+      - 2023-01
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  changesets:
+    name: Changesets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+
+      - uses: ./.github/workflows/actions/prepare
+
+      - id: changesets
+        name: Create release Pull Request or publish to NPM
+        uses: changesets/action@v1
+        with:
+          title: Version Packages (${{ github.ref_name }})
+          publish: yarn run build && yarn run deploy --tag ${{ github.ref_name }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Changesets
+name: Deploy
 
 on:
   push:

--- a/.github/workflows/unstable-snapshot.yml
+++ b/.github/workflows/unstable-snapshot.yml
@@ -1,0 +1,29 @@
+name: Changesets
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - unstable
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  changesets:
+    name: Changesets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+
+      - uses: ./.github/workflows/actions/prepare
+
+      - id: changesets
+        name: Create release Pull Request or publish to NPM
+        uses: changesets/action@v1
+        with:
+          publish: yarn run build && yarn run deploy:unstable
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}

--- a/.github/workflows/unstable-snapshot.yml
+++ b/.github/workflows/unstable-snapshot.yml
@@ -1,4 +1,4 @@
-name: Changesets
+name: Unstable Snapshot
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Background

This PR adds changeset actions to publish versioned branches containing the `@shopify/ui-extensions` package. It covers the three current version branches:

- [2022-10](https://github.com/Shopify/ui-extensions/tree/2022-10)
- [2023-01](https://github.com/Shopify/ui-extensions/tree/2023-01)
- [unstable](https://github.com/Shopify/ui-extensions/tree/unstable)

For the stable branches, the behavior is the following:

- When a PR is made targetting the branch, it will get a warning if it changes source code but does not provide a changeset
- Every merge into the branch will be tracked by changesets, and when there are unmerged changes, it will create a `changeset-release/<VERSION>` branch. That branch will contain a preview of what is ready to be released
- When we are comfortable with a release, we can merge the changeset release PR in. Changesets will track this and will deploy the new versions of the packages, using a tag matching the branch name

For the `unstable` branch, the behavior is a little different:

- When a PR is made targetting the branch, it will get a warning if it changes source code but does not provide a changeset
- When this branch contains changesets, any new changes applied to the branch will result in a ["snapshot" release](https://github.com/changesets/changesets/blob/main/docs/snapshot-releases.md), tagged as `unstable`.

This PR just sets up the changeset files on `main`. I have not added the scripts that they will call (`yarn deploy`/ `yarn deploy:unstable`), because I think these would be a bit confusing while we still have Lerna on `main`. Instead, I will just add those scripts to the version branches after this PR merges.