### PR TITLE
Add new View component with background support

### DIFF
--- a/packages/customer-account-ui-extensions-react/src/components/View/View.ts
+++ b/packages/customer-account-ui-extensions-react/src/components/View/View.ts
@@ -1,0 +1,9 @@
+import {View as BaseView} from '@shopify/customer-account-ui-extensions';
+import {
+  createRemoteReactComponent,
+  ReactPropsFromRemoteComponentType,
+} from '@remote-ui/react';
+
+export type ViewProps = ReactPropsFromRemoteComponentType<typeof BaseView>;
+
+export const View = createRemoteReactComponent(BaseView);

--- a/packages/customer-account-ui-extensions-react/src/components/View/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/components/View/index.ts
@@ -1,0 +1,2 @@
+export {View} from './View';
+export type {ViewProps} from './View';

--- a/packages/customer-account-ui-extensions-react/src/components/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/components/index.ts
@@ -3,4 +3,5 @@ export * from './PaymentIcon';
 export * from './PolicyModal';
 export * from './Section';
 export * from './Thumbnail';
+export * from './View';
 export * from './shared-components';

--- a/packages/customer-account-ui-extensions-react/src/components/shared-components.ts
+++ b/packages/customer-account-ui-extensions-react/src/components/shared-components.ts
@@ -31,7 +31,6 @@ export {
   Text,
   TextBlock,
   TextField,
-  View,
 } from '@shopify/checkout-ui-extensions-react';
 
 export type {
@@ -68,7 +67,6 @@ export type {
   TextProps,
   TextBlockProps,
   TextFieldProps,
-  ViewProps,
   ViewPosition,
   ViewPositionType,
   ViewTranslate,

--- a/packages/customer-account-ui-extensions/src/components/View/View.ts
+++ b/packages/customer-account-ui-extensions/src/components/View/View.ts
@@ -1,0 +1,12 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+import {
+  ViewProps as CheckoutViewProps,
+  BackgroundProps,
+} from '@shopify/checkout-ui-extensions';
+
+export interface ViewProps
+  extends CheckoutViewProps,
+    Pick<BackgroundProps, 'background'> {}
+
+export const View = createRemoteComponent<'View', ViewProps>('View');

--- a/packages/customer-account-ui-extensions/src/components/View/index.ts
+++ b/packages/customer-account-ui-extensions/src/components/View/index.ts
@@ -1,0 +1,2 @@
+export {View} from './View';
+export type {ViewProps} from './View';

--- a/packages/customer-account-ui-extensions/src/components/index.ts
+++ b/packages/customer-account-ui-extensions/src/components/index.ts
@@ -3,4 +3,5 @@ export * from './PaymentIcon';
 export * from './PolicyModal';
 export * from './Section';
 export * from './Thumbnail';
+export * from './View';
 export * from './shared-components';

--- a/packages/customer-account-ui-extensions/src/components/shared-components.ts
+++ b/packages/customer-account-ui-extensions/src/components/shared-components.ts
@@ -31,7 +31,6 @@ export {
   Text,
   TextBlock,
   TextField,
-  View,
 } from '@shopify/checkout-ui-extensions';
 
 export type {
@@ -70,7 +69,6 @@ export type {
   TextProps,
   TextBlockProps,
   TextFieldProps,
-  ViewProps,
   ViewPosition,
   ViewPositionType,
   ViewTranslate,


### PR DESCRIPTION
### Background

Issue: https://github.com/Shopify/core-issues/issues/49805

Related PRs:
- https://github.com/Shopify/customer-account-web/pull/1557
- https://github.com/Shopify/buyer-returns/pull/147

Summary: There is no way to specify a background color fill for card-like components in Self-Serve hub extensions (in our case, [`buyer-returns`](https://github.com/Shopify/buyer-returns/pull/147)).

### Solution

This PR does the following:
- imports the `View` component from `@shopify/checkout-ui-extensions`,
- adds the `background` prop, and
- re-exports the `View` component from `@shopify/customer-account-ui-extensions`

![Screenshot 2023-01-19 at 8 42 31 AM](https://user-images.githubusercontent.com/4673905/213503799-324cdcc4-9bcc-441c-af63-7a6da2deffda.png)


### 🎩

[Spinstance](https://card-test-1.brooks-ilg.us.spin.dev/)

1. Go to [Returns extension inside Customer Account →](https://shop1.account.shopify.card-test-1.brooks-ilg.us.spin.dev/e/dev?dev=https://customer-account-web.card-test-1.brooks-ilg.us.spin.dev/proxy?target=https://buyer-returns.card-test-1.brooks-ilg.us.spin.dev/main.js)
2. Log in as `brooks.ilg@shopify.com`
3. Use one-time-passcode from [Identity Mailer →](https://identity.card-test-1.brooks-ilg.us.spin.dev/services/mail/)
4. Go to [Order 1](https://shop1.account.shopify.card-test-1.brooks-ilg.us.spin.dev/e/dev/?orderId=1)
5. Verify the LineItems and the Estimated Refund containers now have a branded background color.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
