### PR TITLE
Added option to exclude @private annotated fields from docgen

### DIFF
--- a/scripts/typedoc/shopify-dev-renderer/extension-points.ts
+++ b/scripts/typedoc/shopify-dev-renderer/extension-points.ts
@@ -18,6 +18,7 @@ const additionalPropsTables: string[] = [];
 interface Options {
   visibility?: Visibility;
   title?: string;
+  excludePrivateFields?: boolean;
 }
 
 export interface PartialStaticContent {
@@ -31,7 +32,11 @@ export async function extensionPoints(
   options: Options = {},
 ) {
   const extensionsIndex = resolve(`${paths.inputRoot}/src/index.ts`);
-  const {visibility = 'hidden', title = 'Checkout'} = options;
+  const {
+    visibility = 'hidden',
+    title = 'Checkout',
+    excludePrivateFields = true,
+  } = options;
   const visibilityFrontMatter = visibilityToFrontMatterMap.get(visibility);
 
   const graph = await createDependencyGraph(extensionsIndex);
@@ -84,6 +89,9 @@ export async function extensionPoints(
       additionalPropsTables,
       undefined,
       undefined,
+      {
+        excludePrivateFields,
+      },
     );
   });
 

--- a/scripts/typedoc/shopify-dev-renderer/shared/index.ts
+++ b/scripts/typedoc/shopify-dev-renderer/shared/index.ts
@@ -181,6 +181,10 @@ const PII_APPENDS = [
   },
 ];
 
+interface Options {
+  excludePrivateFields?: boolean;
+}
+
 export function propsTable(
   name: string,
   docs: Documentation | undefined,
@@ -190,6 +194,7 @@ export function propsTable(
   additionalPropsTables: string[],
   titleAndDocs = true,
   headingLevel = 2,
+  options: Options = {},
 ) {
   let markdown = '';
 
@@ -216,7 +221,10 @@ export function propsTable(
   );
   const propertySignatures: PropertySignature[] = properties.filter(
     (property): property is PropertySignature =>
-      property.kind === 'PropertySignature',
+      property.kind === 'PropertySignature' &&
+      (options.excludePrivateFields
+        ? !property.docs?.content.includes('@private')
+        : true),
   );
 
   if (indexSignatures?.length) {
@@ -227,11 +235,17 @@ export function propsTable(
       exports,
       dir,
       additionalPropsTables,
+      false,
+      [],
+      options,
     )}]: ${propType(
       property.value,
       exports,
       dir,
       additionalPropsTables,
+      false,
+      [],
+      options,
     )}</code>`;
   } else if (propertySignatures?.length) {
     const table = [];
@@ -261,6 +275,9 @@ export function propsTable(
             exports,
             dir,
             additionalPropsTables,
+            false,
+            [],
+            options,
           );
           const type = `<code>(${thisParamType}): ${thisPropType}</code>`;
           const description = propDocs
@@ -282,6 +299,7 @@ export function propsTable(
             additionalPropsTables,
             false,
             findRepeatingTypes(value, exports),
+            options,
           )}</code>`;
 
           const content = propDocs ? strip(propDocs.content) : '';
@@ -301,6 +319,9 @@ export function propsTable(
                       exports,
                       dir,
                       additionalPropsTables,
+                      false,
+                      [],
+                      options,
                     )}</code>: ${type.comments.join(' ')}`,
                   );
                 }
@@ -434,6 +455,7 @@ function propType(
   additionalPropsTables: string[],
   inArrayType = false,
   repeatingTypes: string[] = [],
+  options: Options = {},
 ): any {
   let params = '';
   if (value.params != null && value.params.length > 0) {
@@ -453,6 +475,7 @@ function propType(
           additionalPropsTables,
           inArrayType,
           repeatingTypes,
+          options,
         ),
       )
       .join(', ')}<wbr>>`;
@@ -482,6 +505,7 @@ function propType(
         additionalPropsTables,
         true,
         repeatingTypes,
+        options,
       )}[]`;
     case 'NumberType':
       return 'number';
@@ -521,6 +545,7 @@ function propType(
             additionalPropsTables,
             inArrayType,
             repeatingTypes,
+            options,
           );
         }
 
@@ -552,6 +577,7 @@ function propType(
         additionalPropsTables,
         inArrayType,
         repeatingTypes,
+        options,
       );
     }
     case 'InterfaceType':
@@ -569,6 +595,7 @@ function propType(
           additionalPropsTables,
           true,
           3,
+          options,
         ),
       );
       return `${anchorLink(value.name)}${params}`;
@@ -610,6 +637,7 @@ function propType(
               additionalPropsTables,
               false,
               repeatingTypes,
+              options,
             )}`,
         )
         .join(', ')}}`;
@@ -641,6 +669,9 @@ function propType(
             exports,
             dir,
             additionalPropsTables,
+            false,
+            [],
+            options,
           )}}`;
         })
         .join('');
@@ -660,6 +691,7 @@ function propType(
         additionalPropsTables,
         false,
         repeatingTypes,
+        options,
       )}`;
     case 'MethodSignatureType':
       return `(${paramsType(
@@ -674,6 +706,7 @@ function propType(
         additionalPropsTables,
         false,
         repeatingTypes,
+        options,
       )}`;
     case 'MappedType':
       // eslint-disable-next-line no-case-declarations
@@ -691,6 +724,7 @@ function propType(
         additionalPropsTables,
         false,
         repeatingTypes,
+        options,
       )} extends ${propType(
         value.extendsType,
         exports,
@@ -698,6 +732,7 @@ function propType(
         additionalPropsTables,
         false,
         repeatingTypes,
+        options,
       )} ? ${propType(
         value.trueType,
         exports,
@@ -705,6 +740,7 @@ function propType(
         additionalPropsTables,
         false,
         repeatingTypes,
+        options,
       )} : ${propType(
         value.falseType,
         exports,
@@ -712,6 +748,7 @@ function propType(
         additionalPropsTables,
         false,
         repeatingTypes,
+        options,
       )}`;
     case 'IndexSignatureType':
       return `[${paramsType(
@@ -726,6 +763,7 @@ function propType(
         additionalPropsTables,
         false,
         repeatingTypes,
+        options,
       )}`;
     case 'TupleType':
       return `[${value.elements
@@ -737,6 +775,7 @@ function propType(
             additionalPropsTables,
             false,
             repeatingTypes,
+            options,
           );
         })
         .join(', ')}]`;


### PR DESCRIPTION
### Background
[Slack thread](https://shopify.slack.com/archives/C04848YTM0F/p1674169208981939)

I [published an internal change](https://github.com/Shopify/checkout-web/pull/16456) and annotated the field with `@private`, but docs were still generated for the field and it appeared on the docsite:
<img width="1789" alt="Screenshot 2023-01-20 at 9 47 02 AM" src="https://user-images.githubusercontent.com/3619012/213726862-c981e7c3-7e67-4149-bf29-f5bc3cbd9fc1.png">

### Solution
This PR introduces a new option `excludePrivateFields` that suppresses properties annotated with `@private` in the generated docs.


### 🎩
- Check out shopify/ui-extensions locally
- Check out shopify/shopify-dev locally
- Add a `@private` interface type to any interface in [checkout-ui-extensions/ ... /index.ts](https://github.com/Shopify/ui-extensions/blob/main/packages/checkout-ui-extensions/src/extension-points/api/standard/index.ts). For example:
```ts
interface CartLine {
  /** @private */
  __lineComponents: <some existing interface type here>;
}
```
- Add a `@private` simple type to any interface in [checkout-ui-extensions/ ... /index.ts](https://github.com/Shopify/ui-extensions/blob/main/packages/checkout-ui-extensions/src/extension-points/api/standard/index.ts). For example:
```ts
interface CartLine {
  /** @private */
  __test: <string, number, ...>;
}
```
- Run `yarn docs:checkout` in ui-extensions
- Open shopify-dev, verify that the fields doesn't appear in the generated doc files
- Remove the `@private` annotations and rerun `yarn docs:checkout`, the fields should now appear in the generated doc files

### Open questions
- I've only added the option to the [extension-points.ts](https://github.com/Shopify/ui-extensions/pull/699/files#diff-124aa9f4072d2a06ef08a0cfdffcd0fab939f6a2aa4edf4e830b24e6d04a24ccR21) docs generator. Should this also be added to [api-admin](https://github.com/Shopify/ui-extensions/blob/main/scripts/typedoc/shopify-dev-renderer/api-admin.ts#L86) and [components.ts](https://github.com/Shopify/ui-extensions/blob/main/scripts/typedoc/shopify-dev-renderer/components/components.ts#L12) generators?
- I didn't see tests for this, if there are any can someone point me at them 🙏 

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation ⚠️  ** is there any?**
