### PR TITLE
Make Card component available to ui-extensions

### DIFF
--- a/packages/customer-account-ui-extensions-react/src/components/Card/Card.ts
+++ b/packages/customer-account-ui-extensions-react/src/components/Card/Card.ts
@@ -1,0 +1,9 @@
+import {Card as BaseCard} from '@shopify/customer-account-ui-extensions';
+import {
+  createRemoteReactComponent,
+  ReactPropsFromRemoteComponentType,
+} from '@remote-ui/react';
+
+export type CardProps = ReactPropsFromRemoteComponentType<typeof BaseCard>;
+
+export const Card = createRemoteReactComponent(BaseCard);

--- a/packages/customer-account-ui-extensions-react/src/components/Card/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/components/Card/index.ts
@@ -1,0 +1,2 @@
+export {Card} from './Card';
+export type {CardProps} from './Card';

--- a/packages/customer-account-ui-extensions-react/src/components/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Card';
 export * from './PageBlock';
 export * from './PaymentIcon';
 export * from './PolicyModal';

--- a/packages/customer-account-ui-extensions/src/components/Card/Card.ts
+++ b/packages/customer-account-ui-extensions/src/components/Card/Card.ts
@@ -1,0 +1,23 @@
+import {createRemoteComponent} from '@remote-ui/core';
+import {Background, SpacingProps} from 'components/shared';
+
+export interface CardProps {
+  /**
+   * Adjust the background.
+   */
+  background?: Background;
+  /**
+   * Enables or disables a divider after each section. **Enabled by default**
+   */
+  includeDividers?: boolean;
+  /**
+   * The children that will be rendered inside the Card
+   */
+  fillHeight?: boolean;
+  /**
+   * The padding within the Card. Default is "loose"
+   */
+  padding?: SpacingProps;
+}
+
+export const Card = createRemoteComponent<'Card', CardProps>('Card');

--- a/packages/customer-account-ui-extensions/src/components/Card/index.ts
+++ b/packages/customer-account-ui-extensions/src/components/Card/index.ts
@@ -1,0 +1,2 @@
+export {Card} from './Card';
+export type {CardProps} from './Card';

--- a/packages/customer-account-ui-extensions/src/components/index.ts
+++ b/packages/customer-account-ui-extensions/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Card';
 export * from './PageBlock';
 export * from './PaymentIcon';
 export * from './PolicyModal';


### PR DESCRIPTION
### Background

Main issue: https://github.com/Shopify/core-issues/issues/49805

Required for: 
- https://github.com/Shopify/customer-account-web/pull/1573
- https://github.com/Shopify/buyer-returns/pull/153

![Screenshot 2023-01-20 at 4 29 41 PM](https://user-images.githubusercontent.com/4673905/213830649-ad82c5cc-ea49-4abf-8c74-610a13331528.png)


### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

[Spinstance](https://buyer-returns-5fkg.brooks-ilg.us.spin.dev/)

1. Go to [Returns extension inside Customer Account →](https://shop1.account.shopify.buyer-returns-5fkg.brooks-ilg.us.spin.dev/e/dev?dev=https://customer-account-web.buyer-returns-5fkg.brooks-ilg.us.spin.dev/proxy?target=https://buyer-returns.buyer-returns-5fkg.brooks-ilg.us.spin.dev/main.js)
2. Log in as `brooks.ilg@shopify.com`
3. Use one-time-passcode from [Identity Mailer →](https://identity.buyer-returns-5fkg.brooks-ilg.us.spin.dev/services/mail/)
4. Go to [Order 1](https://shop1.account.shopify.buyer-returns-5fkg.brooks-ilg.us.spin.dev/e/dev/?orderId=1)
5. Verify the LineItems and the Estimated Refund containers now have a branded background color.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
