### PR TITLE
adding bundles extension point

### DIFF
--- a/packages/admin-ui-extensions/src/extension-points/identifiers/bundles.ts
+++ b/packages/admin-ui-extensions/src/extension-points/identifiers/bundles.ts
@@ -1,0 +1,27 @@
+import {RemoteRoot} from '@remote-ui/core';
+
+import {AllComponentsSchema} from '../../containers';
+import {RenderableExtensionCallback, StandardApi, ToastApi} from '../types';
+
+export type BundlesExtensionPoint = 'Admin::Product::Bundles::Render';
+
+export interface BundlesExtensionApi {
+  'Admin::Product::Bundles::Render': StandardApi<BundlesExtensionPoint> &
+    ToastApi & {
+      data: {
+        productId: string;
+        variantId?: string;
+        // TO-DO #1: type these
+        // TO-DO #2: we don't need to pass the whole product, just the product/variant components, maybe options, variants, etc, and metafields.
+        product: any;
+        variant?: any;
+      };
+    };
+}
+
+export interface BundlesExtensionPointCallback {
+  'Admin::Product::Bundles::Render': RenderableExtensionCallback<
+    BundlesExtensionApi['Admin::Product::Bundles::Render'],
+    RemoteRoot<AllComponentsSchema>
+  >;
+}

--- a/packages/admin-ui-extensions/src/extension-points/identifiers/product_configuration.ts
+++ b/packages/admin-ui-extensions/src/extension-points/identifiers/product_configuration.ts
@@ -4,18 +4,22 @@ import {AllComponentsSchema} from '../../containers';
 import {RenderableExtensionCallback, StandardApi, ToastApi} from '../types';
 
 export type ProductConfigurationExtensionPoint =
-  'Admin::Product::Configuration::Render';
+  | 'Admin::Product::Configuration::Render'
+  | 'Admin::Variant::Configuration::Render';
 
 export interface ProductConfigurationExtensionApi {
   'Admin::Product::Configuration::Render': StandardApi<ProductConfigurationExtensionPoint> &
     ToastApi & {
       data: {
-        productId: string;
-        variantId?: string;
-        // TO-DO #1: type these
-        // TO-DO #2: we don't need to pass the whole product, just the product/variant components, maybe options, variants, etc, and metafields.
+        // TO-DO (future): full typing for Product
         product: any;
-        variant?: any;
+      };
+    };
+  'Admin::Variant::Configuration::Render': StandardApi<ProductConfigurationExtensionPoint> &
+    ToastApi & {
+      data: {
+        // TO-DO (future): full typing for Variant
+        variant: any;
       };
     };
 }
@@ -23,6 +27,10 @@ export interface ProductConfigurationExtensionApi {
 export interface ProductConfigurationExtensionPointCallback {
   'Admin::Product::Configuration::Render': RenderableExtensionCallback<
     ProductConfigurationExtensionApi['Admin::Product::Configuration::Render'],
+    RemoteRoot<AllComponentsSchema>
+  >;
+  'Admin::Variant::Configuration::Render': RenderableExtensionCallback<
+    ProductConfigurationExtensionApi['Admin::Variant::Configuration::Render'],
     RemoteRoot<AllComponentsSchema>
   >;
 }

--- a/packages/admin-ui-extensions/src/extension-points/identifiers/product_configuration.ts
+++ b/packages/admin-ui-extensions/src/extension-points/identifiers/product_configuration.ts
@@ -3,10 +3,11 @@ import {RemoteRoot} from '@remote-ui/core';
 import {AllComponentsSchema} from '../../containers';
 import {RenderableExtensionCallback, StandardApi, ToastApi} from '../types';
 
-export type BundlesExtensionPoint = 'Admin::Product::Bundles::Render';
+export type ProductConfigurationExtensionPoint =
+  'Admin::Product::Configuration::Render';
 
-export interface BundlesExtensionApi {
-  'Admin::Product::Bundles::Render': StandardApi<BundlesExtensionPoint> &
+export interface ProductConfigurationExtensionApi {
+  'Admin::Product::Configuration::Render': StandardApi<ProductConfigurationExtensionPoint> &
     ToastApi & {
       data: {
         productId: string;
@@ -19,9 +20,9 @@ export interface BundlesExtensionApi {
     };
 }
 
-export interface BundlesExtensionPointCallback {
-  'Admin::Product::Bundles::Render': RenderableExtensionCallback<
-    BundlesExtensionApi['Admin::Product::Bundles::Render'],
+export interface ProductConfigurationExtensionPointCallback {
+  'Admin::Product::Configuration::Render': RenderableExtensionCallback<
+    ProductConfigurationExtensionApi['Admin::Product::Configuration::Render'],
     RemoteRoot<AllComponentsSchema>
   >;
 }

--- a/packages/admin-ui-extensions/src/extension-points/index.ts
+++ b/packages/admin-ui-extensions/src/extension-points/index.ts
@@ -11,15 +11,15 @@ import {
 } from './identifiers/product_subscription';
 
 import {
-  BundlesExtensionPoint,
-  BundlesExtensionApi,
-  BundlesExtensionPointCallback,
-} from './identifiers/bundles';
+  ProductConfigurationExtensionPoint,
+  ProductConfigurationExtensionApi,
+  ProductConfigurationExtensionPointCallback,
+} from './identifiers/product_configuration';
 
 export type {
   PlaygroundExtensionPoint,
   ProductSubscriptionExtensionPoint,
-  BundlesExtensionPoint,
+  ProductConfigurationExtensionPoint,
 };
 
 /*
@@ -35,12 +35,12 @@ export type {
 export type ExtensionPoint =
   | PlaygroundExtensionPoint
   | ProductSubscriptionExtensionPoint
-  | BundlesExtensionPoint;
+  | ProductConfigurationExtensionPoint;
 
 export type ExtensionApi = PlaygroundExtensionApi &
   ProductSubscriptionExtensionApi &
-  BundlesExtensionApi;
+  ProductConfigurationExtensionApi;
 
 export type ExtensionPointCallback = PlaygroundExtensionPointCallback &
   ProductSubscriptionExtensionPointCallback &
-  BundlesExtensionPointCallback;
+  ProductConfigurationExtensionPointCallback;

--- a/packages/admin-ui-extensions/src/extension-points/index.ts
+++ b/packages/admin-ui-extensions/src/extension-points/index.ts
@@ -10,7 +10,17 @@ import {
   ProductSubscriptionExtensionPointCallback,
 } from './identifiers/product_subscription';
 
-export type {PlaygroundExtensionPoint, ProductSubscriptionExtensionPoint};
+import {
+  BundlesExtensionPoint,
+  BundlesExtensionApi,
+  BundlesExtensionPointCallback,
+} from './identifiers/bundles';
+
+export type {
+  PlaygroundExtensionPoint,
+  ProductSubscriptionExtensionPoint,
+  BundlesExtensionPoint,
+};
 
 /*
 Placeholder for new imports
@@ -24,10 +34,13 @@ export type {
 
 export type ExtensionPoint =
   | PlaygroundExtensionPoint
-  | ProductSubscriptionExtensionPoint;
+  | ProductSubscriptionExtensionPoint
+  | BundlesExtensionPoint;
 
 export type ExtensionApi = PlaygroundExtensionApi &
-  ProductSubscriptionExtensionApi;
+  ProductSubscriptionExtensionApi &
+  BundlesExtensionApi;
 
 export type ExtensionPointCallback = PlaygroundExtensionPointCallback &
-  ProductSubscriptionExtensionPointCallback;
+  ProductSubscriptionExtensionPointCallback &
+  BundlesExtensionPointCallback;


### PR DESCRIPTION
### Background

Adding a new extension point `Admin::Product::Bundles::Render`

### Solution

We were going to implement this in the new `ui_extensions` spec, but due to time constraints, we're de-pivoting to implement in the old `@shopify/admin-ui-extensions` package (but the `ui_extensions` spec will still be used)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
