### PR TITLE
[POC] Adding new example extension points for retail

### DIFF
--- a/packages/admin-ui-extensions/src/extension-points/identifiers/retail_store.ts
+++ b/packages/admin-ui-extensions/src/extension-points/identifiers/retail_store.ts
@@ -1,0 +1,37 @@
+import {RemoteRoot} from '@remote-ui/core';
+
+import {AllComponentsSchema} from '../../containers';
+
+import {RenderableExtensionCallback, StandardApi, ToastApi} from '../types';
+
+// Add the unique extension point(s) as a union string
+// This example only contains a single extension point
+
+export type RetailStoreExtensionPoint = 'Admin::LocationDetails::RetailStore';
+
+// Declare the Container API if needed
+export interface RetailStoreExtensionContainerApi {
+  container: unknown;
+}
+
+// Declare the Data API if needed
+export interface RetailStoreExtensionDataApi {
+  data: unknown;
+}
+
+// Update APIs for your needs
+// All Extension APIs should include the StandardApi by default
+export interface RetailStoreExtensionApi {
+  'Admin::LocationDetails::RetailStore': StandardApi<RetailStoreExtensionPoint> &
+    ToastApi &
+    RetailStoreExtensionContainerApi &
+    RetailStoreExtensionDataApi;
+}
+
+// Replace AllComponentsSchema with a schema for your needs
+export interface RetailStoreExtensionPointCallback {
+  'Admin::LocationDetails::RetailStore': RenderableExtensionCallback<
+    RetailStoreExtensionApi['Admin::LocationDetails::RetailStore'],
+    RemoteRoot<AllComponentsSchema>
+  >;
+}

--- a/packages/admin-ui-extensions/src/extension-points/identifiers/store_hours.ts
+++ b/packages/admin-ui-extensions/src/extension-points/identifiers/store_hours.ts
@@ -1,0 +1,37 @@
+import {RemoteRoot} from '@remote-ui/core';
+
+import {AllComponentsSchema} from '../../containers';
+
+import {RenderableExtensionCallback, StandardApi, ToastApi} from '../types';
+
+// Add the unique extension point(s) as a union string
+// This example only contains a single extension point
+
+export type StoreHoursExtensionPoint = 'Admin::LocationDetails::StoreHours';
+
+// Declare the Container API if needed
+export interface StoreHoursExtensionContainerApi {
+  container: unknown;
+}
+
+// Declare the Data API if needed
+export interface StoreHoursExtensionDataApi {
+  data: unknown;
+}
+
+// Update APIs for your needs
+// All Extension APIs should include the StandardApi by default
+export interface StoreHoursExtensionApi {
+  'Admin::LocationDetails::StoreHours': StandardApi<StoreHoursExtensionPoint> &
+    ToastApi &
+    StoreHoursExtensionContainerApi &
+    StoreHoursExtensionDataApi;
+}
+
+// Replace AllComponentsSchema with a schema for your needs
+export interface StoreHoursExtensionPointCallback {
+  'Admin::LocationDetails::StoreHours': RenderableExtensionCallback<
+    StoreHoursExtensionApi['Admin::LocationDetails::StoreHours'],
+    RemoteRoot<AllComponentsSchema>
+  >;
+}

--- a/packages/admin-ui-extensions/src/extension-points/index.ts
+++ b/packages/admin-ui-extensions/src/extension-points/index.ts
@@ -12,6 +12,20 @@ import {
 
 export type {PlaygroundExtensionPoint, ProductSubscriptionExtensionPoint};
 
+import {
+  StoreHoursExtensionPoint,
+  StoreHoursExtensionApi,
+  StoreHoursExtensionPointCallback,
+} from './identifiers/store_hours';
+export type {StoreHoursExtensionPoint};
+
+import {
+  RetailStoreExtensionPoint,
+  RetailStoreExtensionApi,
+  RetailStoreExtensionPointCallback,
+} from './identifiers/retail_store';
+export type {RetailStoreExtensionPoint};
+
 /*
 Placeholder for new imports
 */
@@ -24,10 +38,16 @@ export type {
 
 export type ExtensionPoint =
   | PlaygroundExtensionPoint
-  | ProductSubscriptionExtensionPoint;
+  | ProductSubscriptionExtensionPoint
+  | StoreHoursExtensionPoint
+  | RetailStoreExtensionPoint;
 
 export type ExtensionApi = PlaygroundExtensionApi &
-  ProductSubscriptionExtensionApi;
+  ProductSubscriptionExtensionApi &
+  StoreHoursExtensionApi &
+  RetailStoreExtensionApi;
 
 export type ExtensionPointCallback = PlaygroundExtensionPointCallback &
-  ProductSubscriptionExtensionPointCallback;
+  ProductSubscriptionExtensionPointCallback &
+  StoreHoursExtensionPointCallback &
+  RetailStoreExtensionPointCallback;

--- a/packages/admin-ui-extensions/src/index.ts
+++ b/packages/admin-ui-extensions/src/index.ts
@@ -52,4 +52,6 @@ export type {
   ExtensionPoint,
   ExtensionApi,
   ExtensionPointCallback,
+  StoreHoursExtensionPoint,
+  RetailStoreExtensionPoint
 } from './extension-points';


### PR DESCRIPTION
### Background

This is a proof of concept for introducing new Retail extension points into the Admin. Extension to be exposed in Location details. 

Video walkthrough: https://videobin.shopify.io/v/kdxNzk 
Summary document: https://docs.google.com/document/d/1p5u0IxscVWuDp0ps6JY4hFqW_zlc8zTJ1WE_7l-vGdU/edit#  

Related PRs: 

- shopify/admin-ui-extensions: https://github.com/Shopify/admin-ui-extensions/pull/160 
- shopify/web: https://github.com/Shopify/web/pull/82555 

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
