### PR TITLE
added isLoading to the button props interface

### DIFF
--- a/packages/retail-ui-extensions/src/components/Button/Button.ts
+++ b/packages/retail-ui-extensions/src/components/Button/Button.ts
@@ -7,6 +7,7 @@ export interface ButtonProps {
   type?: ButtonType;
   onPress?: () => void;
   isDisabled?: boolean;
+  isLoading?: boolean;
 }
 
 export const Button = createRemoteComponent<'Button', ButtonProps>('Button');


### PR DESCRIPTION
Closes https://github.com/Shopify/pos-next-react-native/issues/19328

### Background

- Currently UI Extensions miss loading state on the button to indicate that the associated button action is in progress. We want to update the button props interface to include loading information

### Solution

- added property `isLoading` to the `ButtonProps` interface

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
