### PR TITLE
Fix checkout surface exports

### DIFF
--- a/.changeset/angry-rabbits-occur.md
+++ b/.changeset/angry-rabbits-occur.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Fix exports for Checkout's surface

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -28,9 +28,9 @@
     },
     "./checkout": {
       "types": "./build/ts/surfaces/checkout.d.ts",
-      "esnext": "./checkout.esnext",
-      "import": "./checkout.mjs",
-      "require": "./checkout.js"
+      "esnext": "./build/esnext/surfaces/checkout.esnext",
+      "import": "./build/esm/surfaces/checkout.mjs",
+      "require": "./build/cjs/surfaces/checkout.js"
     }
   },
   "dependencies": {

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -21,9 +21,9 @@
     },
     "./checkout": {
       "types": "./build/ts/surfaces/checkout.d.ts",
-      "esnext": "./checkout.esnext",
-      "import": "./checkout.mjs",
-      "require": "./checkout.js"
+      "esnext": "./build/esnext/surfaces/checkout.esnext",
+      "import": "./build/esm/surfaces/checkout.mjs",
+      "require": "./build/cjs/surfaces/checkout.js"
     }
   },
   "license": "MIT",


### PR DESCRIPTION
While testing this library using the CLI, I got this error when trying access the esm exports

![image](https://user-images.githubusercontent.com/29458473/215609163-d838cdf2-e784-494d-86cb-afc7fc7f4110.png)

This PR fixes the exports for Checkout to have the correct paths.