### PR TITLE
Added ability to specify if you want images and placeholders or not

### DIFF
--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -15,6 +15,7 @@ export interface ListProps {
   data: ListItem[];
   showDisclosureIndicator: boolean;
   title?: string;
+  imageDisplayStrategy?: 'automatic' | 'always' | 'never';
   onEndReached?: () => void;
 }
 


### PR DESCRIPTION
### Background

This PR adds some specifications as to how a developer may want to enforce images and placeholders.

### Solution

When rendering a list, you now have the option to choose to never display images and placeholders, to always display (which means if you don't have a valid image uri, a placeholder will be displayed), or to choose automatic, in which case if the app detects that the data set has at least one item with an image Uri, images and placeholders will be set.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
