### PR TITLE
Added a boolean to trigger animation for lists on load more

### DIFF
--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -14,6 +14,7 @@ export interface ListItem {
 export interface ListProps {
   data: ListItem[];
   showDisclosureIndicator: boolean;
+  isLoadingMore?: boolean;
   title?: string;
   imageDisplayStrategy?: 'automatic' | 'always' | 'never';
   onEndReached?: () => void;


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/20746

### Background

When the List component reaches the end, we have a callback `onEndReached`. Here the developer can fetch more data. We recommend that when this happens, they flip `isLoadingMore` to `true`, so that a loading indicator can happen at the bottom of the list.
