### PR TITLE
chore: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, @global-owner1 and @global-owner2
+# will be requested for review when someone opens a pull request.
+# *       @global-owner1 @global-owner2
+
+# Order is important; the last matching pattern takes the most precedence.
+# When someone opens a pull request that only modifies JS files, only @js-owner
+# and not the global owner(s) will be requested for a review.
+# *.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be used to look up
+# users just like we do for commit author emails.
+
+* @Shopify/app-ui @Shopify/checkout-extensibility
+
+/packages/admin-ui-extensions/                    @Shopify/app-ui
+/packages/admin-ui-extensions-react/              @Shopify/app-ui
+/packages/checkout-ui-extensions/                 @Shopify/checkout-extensibility
+/packages/checkout-ui-extensions-react/           @Shopify/checkout-extensibility
+/packages/checkout-ui-extensions-run/             @Shopify/checkout-extensibility
+/packages/customer-account-ui-extensions/         @Shopify/checkout-extensibility
+/packages/customer-account-ui-extensions-react/   @Shopify/checkout-extensibility
+/packages/post-purchase-ui-extensions/            @Shopify/checkout-extensibility
+/packages/post-purchase-ui-extensions-react/      @Shopify/checkout-extensibility
+/packages/ui-extensions/                          @Shopify/app-ui @Shopify/checkout-extensibility
+/packages/ui-extensions-webpack-hot-client        @Shopify/checkout-extensibility
+/packages/web-pixel-extensions                    @Shopify/checkout-extensibility


### PR DESCRIPTION
### Background

As this repo grows, we should be explicit about codeowners. 

@js-goupil I have questions about a the `retail-ui-extensions` packages. Which team should own these?

### Solution

Add a CODEOWNERS file.

