### PR TITLE
chore(customer-account): export capability type

### DIFF
--- a/packages/customer-account-ui-extensions/src/extension-points/index.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/index.ts
@@ -5,6 +5,8 @@ export type {
   I18nTranslate,
   I18n,
 } from './standard-api/localization';
+export type {Capability} from './standard-api/extension';
+
 export type {StandardApi} from './standard-api';
 
 export type {


### PR DESCRIPTION
### Background

Shoutout to @Safi1012 with the eagles eyes for spotting this.
We weren't exporting this type properly, despite needing to use it in the hub (see:https://github.com/Shopify/customer-account-web/pull/1722)


### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
