### PR TITLE
Create a custom hook "useExtensionApi" for the "customer-account-ui-extensions-react" package

### DIFF
--- a/packages/customer-account-ui-extensions-react/README.md
+++ b/packages/customer-account-ui-extensions-react/README.md
@@ -47,3 +47,37 @@ function App(_: Props) {
   return <div>No HTML tag allowed</div>;
 }
 ```
+
+## Other React-specific APIs
+
+### `useExtensionApi()`
+
+`useExtensionApi` is a [custom React hook](https://reactjs.org/docs/hooks-intro.html) that gives you access to the full input argument provided to your extension point (this is the value that, if you were registering an extension point directly with [`shopify.extend`](../checkout-ui-extensions/documentation/globals.md), would be passed as the second argument to your callback). This allows you to access and call the main APIs between your extension and Shopify anywhere in your React component.
+
+If you are using TypeScript, you can supply the name of the extension point as a type parameter to this function. Doing so will refine the return type to be exactly the input type for that extension point, so make sure you pass the name of the extension you are actually rendering.
+
+```tsx
+import {
+  render,
+  useExtensionApi,
+  Button,
+} from '@shopify/customer-account-ui-extensions-react';
+
+render("CustomerAccount::FullPage::RenderWithin", () => <App />);
+
+function App() {
+  const {customerApi, extension, features, i18n} = useExtensionApi();
+
+  return (
+    <Button
+      onPress={() => {
+        console.log({customerApi, extension, features, i18n});
+      }}
+    >
+      Log extension API to console
+    </Button>
+  );
+}
+```
+
+This hook can only be called if you registered your extension with `render`, as that callback wraps the application in the necessary React context to make the input available anywhere in the tree.

--- a/packages/customer-account-ui-extensions-react/src/context.ts
+++ b/packages/customer-account-ui-extensions-react/src/context.ts
@@ -1,0 +1,8 @@
+import {createContext} from 'react';
+import {
+  ApiForRenderExtension,
+  RenderExtensionPoint,
+} from '@shopify/customer-account-ui-extensions';
+
+export const ExtensionApiContext =
+  createContext<ApiForRenderExtension<RenderExtensionPoint> | null>(null);

--- a/packages/customer-account-ui-extensions-react/src/errors.ts
+++ b/packages/customer-account-ui-extensions-react/src/errors.ts
@@ -1,0 +1,3 @@
+export class CustomerAccountUIExtensionError extends Error {
+  name = 'CustomerAccountUIExtensionError';
+}

--- a/packages/customer-account-ui-extensions-react/src/hooks/api.ts
+++ b/packages/customer-account-ui-extensions-react/src/hooks/api.ts
@@ -1,0 +1,26 @@
+import {useContext} from 'react';
+import {
+  RenderExtensionPoint,
+  ApiForRenderExtension,
+} from '@shopify/customer-account-ui-extensions';
+
+import {CustomerAccountUIExtensionError} from '../errors';
+import {ExtensionApiContext} from '../context';
+
+/**
+ * Returns the full API object that was passed in to your
+ * extension when it was created.
+ */
+export function useApi<
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
+>(): ApiForRenderExtension<ID> {
+  const api = useContext(ExtensionApiContext);
+
+  if (api == null) {
+    throw new CustomerAccountUIExtensionError(
+      'You can only call this hook when running as a UI extension.',
+    );
+  }
+
+  return api as ApiForRenderExtension<ID>;
+}

--- a/packages/customer-account-ui-extensions-react/src/hooks/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export {useSubscription} from './subscription';
+export {useApi} from './api';

--- a/packages/customer-account-ui-extensions-react/src/hooks/tests/api.test.tsx
+++ b/packages/customer-account-ui-extensions-react/src/hooks/tests/api.test.tsx
@@ -1,0 +1,29 @@
+import type {
+  StandardApi,
+  FullPageApi,
+} from '@shopify/customer-account-ui-extensions';
+import {useApi} from '../api';
+
+import {mount} from './mount';
+
+describe('useApi', () => {
+  it('returns api', async () => {
+    const extensionApi = {} as StandardApi & FullPageApi;
+
+    const {value} = mount.hook(
+      () => useApi<'CustomerAccount::FullPage::RenderWithin'>(),
+      {extensionApi},
+    );
+
+    expect(value).toMatchObject(extensionApi);
+  });
+
+  it('throws when not run inside a UI extension', async () => {
+    const runner = async () => {
+      return mount.hook(() => useApi());
+    };
+    await expect(runner).rejects.toThrow(
+      'You can only call this hook when running as a UI extension.',
+    );
+  });
+});

--- a/packages/customer-account-ui-extensions-react/src/hooks/tests/mount.tsx
+++ b/packages/customer-account-ui-extensions-react/src/hooks/tests/mount.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {createMount} from '@quilted/react-testing';
+import {
+  ApiForRenderExtension,
+  RenderExtensionPoint,
+} from '@shopify/customer-account-ui-extensions';
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+
+import {ExtensionApiContext} from '../../context';
+
+export const mount = createMount<Options, Options>({
+  context(options) {
+    return options;
+  },
+
+  render(element, {extensionApi}) {
+    return (
+      <ExtensionApiContext.Provider value={extensionApi as any}>
+        {element}
+      </ExtensionApiContext.Provider>
+    );
+  },
+});
+
+type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};
+
+export type PartialExtensionApi = DeepPartial<
+  ApiForRenderExtension<RenderExtensionPoint>
+>;
+
+interface Options {
+  extensionApi: PartialExtensionApi;
+}
+
+export function createMockStatefulRemoteSubscribable<T>(
+  value: T,
+): StatefulRemoteSubscribable<T> {
+  const subscribable: StatefulRemoteSubscribable<T> = {
+    get current() {
+      return value;
+    },
+    subscribe: jest.fn(),
+    destroy: jest.fn(),
+  };
+
+  return subscribable;
+}

--- a/packages/customer-account-ui-extensions-react/src/index.ts
+++ b/packages/customer-account-ui-extensions-react/src/index.ts
@@ -14,7 +14,9 @@ export type {
   Localization,
   I18nTranslate,
   I18n,
+  FullPageApi,
 } from '@shopify/customer-account-ui-extensions';
 export * from './components';
 export * from './hooks';
+export * from './context';
 export {render} from './render';

--- a/packages/customer-account-ui-extensions-react/src/render.tsx
+++ b/packages/customer-account-ui-extensions-react/src/render.tsx
@@ -2,10 +2,12 @@ import type {ReactElement} from 'react';
 import {render as remoteRender} from '@remote-ui/react';
 import {extend} from '@shopify/customer-account-ui-extensions';
 import type {
-  ApiForExtension,
   RenderExtension,
   RenderExtensionPoint,
+  ApiForRenderExtension,
 } from '@shopify/customer-account-ui-extensions';
+
+import {ExtensionApiContext} from './context';
 
 type RenderFunction<T> = RenderExtension<T, any>;
 
@@ -23,14 +25,20 @@ type RenderFunction<T> = RenderExtension<T, any>;
  */
 export function render<ExtensionPoint extends RenderExtensionPoint>(
   extensionPoint: ExtensionPoint,
-  render: (api: ApiForExtension<ExtensionPoint>) => ReactElement<any>,
+  render: (api: ApiForRenderExtension<ExtensionPoint>) => ReactElement<any>,
 ) {
   const extendCallback: RenderFunction<any> = (root, api) => {
     return new Promise<void>((resolve, reject) => {
       try {
-        remoteRender(render(api), root, () => {
-          resolve();
-        });
+        remoteRender(
+          <ExtensionApiContext.Provider value={api}>
+            {render(api as ApiForRenderExtension<ExtensionPoint>)}
+          </ExtensionApiContext.Provider>,
+          root,
+          () => {
+            resolve();
+          },
+        );
       } catch (error) {
         // Workaround for https://github.com/Shopify/ui-extensions/issues/325
         // eslint-disable-next-line no-console

--- a/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
@@ -32,7 +32,7 @@ export interface ExtensionPoints {
   >;
 }
 
-interface FullPageApi {
+export interface FullPageApi {
   location: StatefulRemoteSubscribable<{
     pathname: string;
     search: string;

--- a/packages/customer-account-ui-extensions/src/extension-points/index.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/index.ts
@@ -1,4 +1,8 @@
-export type {ExtensionPoints, ExtensionPoint} from './extension-points';
+export type {
+  ExtensionPoints,
+  ExtensionPoint,
+  FullPageApi,
+} from './extension-points';
 export type {
   Language,
   Localization,
@@ -13,6 +17,8 @@ export type {
   RenderExtensionPoint,
   RunExtensionPoint,
   ReturnTypeForExtension,
+  RenderExtensions,
+  ApiForRenderExtension,
 } from './types';
 
 export type {RenderExtension, RunExtension} from './extension-signature';

--- a/packages/customer-account-ui-extensions/src/extension-points/types.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/types.ts
@@ -70,3 +70,19 @@ type ExtractedApiFromExtension<T> = T extends RenderExtension<any, any>
  */
 export type ApiForExtension<ID extends keyof ExtensionPoints> =
   ExtractedApiFromExtension<ExtensionPoints[ID]>;
+
+/**
+ * A mapping of each “render extension” name to its callback type.
+ */
+export type RenderExtensions = {
+  [ID in RenderExtensionPoint]: ExtensionPoints[ID];
+};
+
+/**
+ * For a given rendering extension point, returns the type of the API that the
+ * extension will receive at runtime. This API type is the second argument to
+ * the callback for that extension point. The first callback for all of the rendering
+ * extension points each receive a `RemoteRoot` object.
+ */
+export type ApiForRenderExtension<ID extends keyof RenderExtensions> =
+  ExtractedApiFromRenderExtension<RenderExtensions[ID]>;


### PR DESCRIPTION
### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

Resolves https://github.com/Shopify/core-issues/issues/43251

### Solution

Most of the implementation was ~copied~ inspired by the checkout extensions with some minor type adjustments.

The tophat spinstance was created with a local built of the `customer-account-ui-extensions-react` package that uses the custom api hook. Look at [this commit](https://github.com/Shopify/customer-accounts-ui-extension-dev/commit/b54cc77f5298b8c37639d37cc2add32112401b19) for reference.

### 🎩

<img width="948" alt="image" src="https://user-images.githubusercontent.com/12151002/219626167-89bb6b92-f0d7-4ff4-b756-d332234643f1.png">

[Customer accounts on spinstance with working extension deployed](https://development-store-1.account.shopify.splendid-partners.silvio-schmidt.eu.spin.dev/e/f4cc3c44-14d7-4d69-b648-c2f54c929227)

- Go to the [spinstance](https://development-store-1.account.shopify.splendid-partners.silvio-schmidt.eu.spin.dev/e/f4cc3c44-14d7-4d69-b648-c2f54c929227) and log in to the customer accounts app.
- Open dev tools and check that you see log like in the screenshot above

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
