### PR TITLE
Updated POS UI Extension points namespace

### DIFF
--- a/packages/retail-ui-extensions-react/src/render.tsx
+++ b/packages/retail-ui-extensions-react/src/render.tsx
@@ -16,7 +16,7 @@ import {ExtensionApiContext} from './context';
  *
  * @param extensionPoint The extension point you are registering for. This extension
  * point must be a `RenderExtensionPoint`; if you are trying to register for a non-
- * rendering extension point, like `Retail::SmartGrid::Tile`, use the
+ * rendering extension point, like `pos.home.tile.render`, use the
  * `extend()` function provided by this library instead.
  *
  * @param render The function that will be called when Shopify Point of Sale begins rendering
@@ -32,28 +32,25 @@ export function render<ExtensionPoint extends RenderExtensionPoint>(
   // type. To get around it, we’ll just fake like we are rendering the
   // Tile extension, since all render extensions have the same general
   // shape (`RenderExtension`).
-  return extend<'Retail::SmartGrid::Tile'>(
-    extensionPoint as any,
-    (root, api) => {
-      return new Promise((resolve, reject) => {
-        try {
-          remoteRender(
-            <ExtensionApiContext.Provider value={api}>
-              {render(api as ApiForRenderExtension<ExtensionPoint>)}
-            </ExtensionApiContext.Provider>,
-            root,
-            () => {
-              root.mount();
-              resolve();
-            },
-          );
-        } catch (error) {
-          // Workaround for https://github.com/Shopify/ui-extensions/issues/325
-          // eslint-disable-next-line no-console
-          console.error(error);
-          reject(error);
-        }
-      });
-    },
-  );
+  return extend<'pos.home.tile.render'>(extensionPoint as any, (root, api) => {
+    return new Promise((resolve, reject) => {
+      try {
+        remoteRender(
+          <ExtensionApiContext.Provider value={api}>
+            {render(api as ApiForRenderExtension<ExtensionPoint>)}
+          </ExtensionApiContext.Provider>,
+          root,
+          () => {
+            root.mount();
+            resolve();
+          },
+        );
+      } catch (error) {
+        // Workaround for https://github.com/Shopify/ui-extensions/issues/325
+        // eslint-disable-next-line no-console
+        console.error(error);
+        reject(error);
+      }
+    });
+  });
 }

--- a/packages/retail-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/retail-ui-extensions/src/extension-points/extension-points.ts
@@ -3,12 +3,12 @@ import {SmartGridApi, NavigationApi, StandardApi} from '../extension-api';
 import {RenderExtension} from './render-extension';
 
 export interface ExtensionPoints {
-  'Retail::SmartGrid::Tile': RenderExtension<
-    StandardApi<'Retail::SmartGrid::Tile'> & SmartGridApi,
+  'pos.home.tile.render': RenderExtension<
+    StandardApi<'pos.home.tile.render'> & SmartGridApi,
     SmartGridComponents
   >;
-  'Retail::SmartGrid::Modal': RenderExtension<
-    StandardApi<'Retail::SmartGrid::Modal'> & NavigationApi,
+  'pos.home.modal.render': RenderExtension<
+    StandardApi<'pos.home.modal.render'> & NavigationApi,
     BasicComponents
   >;
 }


### PR DESCRIPTION
### Background

https://github.com/Shopify/pos-next-react-native/issues/21278

### Solution

 - Updated pos ui extension points namespace
    - `Retail::SmartGrid::Tile` -> `pos.home.title.render`
    -  `Retail::SmartGrid::Modal` -> `pos.home.modal.render`