### PR TITLE
Added the shop domain to the SessionAPI

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/types/session.ts
+++ b/packages/retail-ui-extensions/src/extension-api/types/session.ts
@@ -10,6 +10,11 @@ export interface Session {
   userId: number;
 
   /**
+   * The shop domain associated with the shop currently logged into POS.
+   */
+  shopDomain: string;
+
+  /**
    * The location ID associated with the POS' current location.
    */
   locationId: number;


### PR DESCRIPTION
partially resolves https://github.com/Shopify/pos-next-react-native/issues/21311

### Background

Partners requested the access to shop domain. Makes sense considering that we already share the shop id. 

### Solution

Added the field in the API. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
