### PR TITLE
Segmentation / Introduce `CustomerSegmentationTemplate` component

### DIFF
--- a/.changeset/silent-ligers-know.md
+++ b/.changeset/silent-ligers-know.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Introduces CustomerSegmentationTemplate component

--- a/packages/ui-extensions-react/src/surfaces/admin/components.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/components.ts
@@ -12,6 +12,8 @@ export {CardSection} from './components/CardSection/CardSection';
 export type {CardSectionProps} from './components/CardSection/CardSection';
 export {Checkbox} from './components/Checkbox/Checkbox';
 export type {CheckboxProps} from './components/Checkbox/Checkbox';
+export {CustomerSegmentationTemplate} from './components/CustomerSegmentationTemplate/CustomerSegmentationTemplate';
+export type {CustomerSegmentationTemplateProps} from './components/CustomerSegmentationTemplate/CustomerSegmentationTemplate';
 export {Heading} from './components/Heading/Heading';
 export type {HeadingProps} from './components/Heading/Heading';
 export {Icon} from './components/Icon/Icon';

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -1,0 +1,7 @@
+import {CustomerSegmentationTemplate as BaseCustomerSegmentationTemplate} from '@shopify/ui-extensions/admin';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const CustomerSegmentationTemplate = createRemoteReactComponent(
+  BaseCustomerSegmentationTemplate,
+);
+export type {CustomerSegmentationTemplateProps} from '@shopify/ui-extensions/admin';

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+  reactExtension,
+  CustomerSegmentationTemplate,
+} from '@shopify/ui-extensions-react/admin';
+
+function App({i18n, enabledFeatures, category}) {
+  if (category == 'reEngageCustomers') {
+    const productsPurchasedOnTagsEnabled = enabledFeatures.includes('productsPurchasedByTags');
+    const templateQuery = productsPurchasedOnTagsEnabled
+      ? 'products_purchased(tag: (product_tag)) = true'
+      : 'products_purchased(id: (product_id)) = true';
+    const templateQueryToInsert = productsPurchasedOnTagsEnabled
+      ? 'products_purchased(tag:'
+      : 'products_purchased(id:';
+  
+    return (
+      <CustomerSegmentationTemplate
+        title={i18n.translate('product.title')}
+        description={i18n.translate('product.description')}
+        icon='productsMajor'
+        templateQuery={templateQuery}
+        templateQueryToInsert={templateQueryToInsert}
+      />
+    );
+  }
+  
+  if (category == 'location') {
+    return (
+      <CustomerSegmentationTemplate
+        title={i18n.translate('location.title')}
+        description={i18n.translate('location.description')}
+        icon='locationMajor'
+        templateQuery="customer_cities CONTAINS 'US-NY-NewYorkCity'"
+      />
+    );
+  }
+
+  return null;
+}
+
+reactExtension('admin.customers.segmentation-templates.render', ({i18n, __category, __enabledFeatures}) => <App i18n={i18n} enabledFeatures={__enabledFeatures} category={__category} />);

--- a/packages/ui-extensions/src/api.ts
+++ b/packages/ui-extensions/src/api.ts
@@ -1,3 +1,76 @@
 export interface StandardApi {
   readonly extensionPoint: string;
 }
+
+/**
+ * This defines the i18n.translate() signature.
+ */
+export interface I18nTranslate {
+  /**
+   * This returns a translated string matching a key in a locale file.
+   *
+   * @example translate("banner.title")
+   */
+  <ReplacementType = string>(
+    key: string,
+    options?: {[placeholderKey: string]: ReplacementType | string | number},
+  ): ReplacementType extends string | number
+    ? string
+    : (string | ReplacementType)[];
+}
+
+export interface I18n {
+  /**
+   * Returns a localized number.
+   *
+   * This function behaves like the standard `Intl.NumberFormat()`
+   * with a style of `decimal` applied. It uses the buyer's locale by default.
+   *
+   * @param options.inExtensionLocale - if true, use the extension's locale
+   */
+  formatNumber: (
+    number: number | bigint,
+    options?: {inExtensionLocale?: boolean} & Intl.NumberFormatOptions,
+  ) => string;
+
+  /**
+   * Returns a localized currency value.
+   *
+   * This function behaves like the standard `Intl.NumberFormat()`
+   * with a style of `currency` applied. It uses the buyer's locale by default.
+   *
+   * @param options.inExtensionLocale - if true, use the extension's locale
+   */
+  formatCurrency: (
+    number: number | bigint,
+    options?: {inExtensionLocale?: boolean} & Intl.NumberFormatOptions,
+  ) => string;
+
+  /**
+   * Returns a localized date value.
+   *
+   * This function behaves like the standard `Intl.DateTimeFormatOptions()` and uses
+   * the buyer's locale by default. Formatting options can be passed in as
+   * options.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat0
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#using_options
+   *
+   * @param options.inExtensionLocale - if true, use the extension's locale
+   */
+  formatDate: (
+    date: Date,
+    options?: {inExtensionLocale?: boolean} & Intl.DateTimeFormatOptions,
+  ) => string;
+
+  /**
+   * Returns translated content in the buyer's locale,
+   * as supported by the extension.
+   *
+   * - `options.count` is a special numeric value used in pluralization.
+   * - The other option keys and values are treated as replacements for interpolation.
+   * - If the replacements are all primitives, then `translate()` returns a single string.
+   * - If replacements contain UI components, then `translate()` returns an array of elements.
+   */
+  translate: I18nTranslate;
+}

--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -1,1 +1,3 @@
+export type {I18n, I18nTranslate} from '../../api';
 export type {StandardApi} from './api/standard/standard';
+export type {CustomerSegmentationTemplateApi} from './api/customer-segmentation-template/customer-segmentation-template';

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segmentation-template/customer-segmentation-template.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segmentation-template/customer-segmentation-template.ts
@@ -1,0 +1,30 @@
+import type {StandardApi} from '../standard/standard';
+import type {I18n} from '../../../../api';
+import type {ExtensionPoint as AnyExtensionPoint} from '../../extension-points';
+
+/* List of enabled query language features during a progressive rollout */
+type CustomerSegmentationFeature =
+  /* Allows merchants to segment on products purchased by tags. For example: products_purchased(tag: 'Red hats') = true */
+  | 'productsPurchasedByTags'
+  /* Enables count aggregates on functions. For example: shopify_email.opened(count_at_least: 5) = true */
+  | 'aggregateFilters';
+
+type TemplateCategory =
+  | 'all'
+  | 'firstTimeBuyers'
+  | 'highValueCustomers'
+  | 'reEngageCustomers'
+  | 'abandonedCheckout'
+  | 'purchaseBehaviour'
+  | 'location';
+
+export interface CustomerSegmentationTemplateApi<
+  ExtensionPoint extends AnyExtensionPoint,
+> extends StandardApi<ExtensionPoint> {
+  /* Utilities for translating content according to the current `localization` of the admin. */
+  i18n: I18n;
+  /** @private */
+  __category: TemplateCategory;
+  /** @private */
+  __enabledFeatures: CustomerSegmentationFeature[];
+}

--- a/packages/ui-extensions/src/surfaces/admin/components.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.ts
@@ -12,6 +12,8 @@ export {CardSection} from './components/CardSection/CardSection';
 export type {CardSectionProps} from './components/CardSection/CardSection';
 export {Checkbox} from './components/Checkbox/Checkbox';
 export type {CheckboxProps} from './components/Checkbox/Checkbox';
+export {CustomerSegmentationTemplate} from './components/CustomerSegmentationTemplate/CustomerSegmentationTemplate';
+export type {CustomerSegmentationTemplateProps} from './components/CustomerSegmentationTemplate/CustomerSegmentationTemplate';
 export {Heading} from './components/Heading/Heading';
 export type {HeadingProps} from './components/Heading/Heading';
 export {Icon} from './components/Icon/Icon';

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -1,0 +1,43 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+type Source =
+  | 'categoriesMajor'
+  | 'firstVisitMajor'
+  | 'heartMajor'
+  | 'marketingMajor'
+  | 'checkoutMajor'
+  | 'ordersMajor'
+  | 'locationMajor'
+  | 'emailNewsletterMajor'
+  | 'firstOrderMajor'
+  | 'billingStatementDollarMajor'
+  | 'diamondAlertMajor'
+  | 'abandonedCartMajor'
+  | 'calendarMajor'
+  | 'productsMajor'
+  | 'globeMajor'
+  | 'flagMajor'
+  | 'uploadMajor'
+  | 'buyButtonMajor'
+  | 'followUpEmailMajor';
+
+export interface CustomerSegmentationTemplateProps {
+  /** Localized title of the template. */
+  title: string;
+  /** Localized description of the template. */
+  description: string;
+  /** Icon identifier for the template. This property is ignored for non-1P Segmentation templates as we fallback to the app icon */
+  icon?: Source;
+  /** ShopifyQL code snippet to render in the template with syntax highlighting **/
+  templateQuery: string;
+  /** ShopifyQL code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
+  templateQueryToInsert?: string;
+}
+
+/**
+ * Customer segmentation templates are used to give merchants a starting point to create segments.
+ */
+export const CustomerSegmentationTemplate = createRemoteComponent<
+  'CustomerSegmentationTemplate',
+  CustomerSegmentationTemplateProps
+>('CustomerSegmentationTemplate');

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
@@ -1,0 +1,39 @@
+import {
+  extension,
+  CustomerSegmentationTemplate,
+} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.customers.segmentation-templates.render',
+  (root, {i18n, __category, __enabledFeatures}) => {
+    if (__category === 'reEngageCustomers') {
+      const productsPurchasedOnTagsEnabled = __enabledFeatures.includes('productsPurchasedByTags');
+      const productTemplate = root.createComponent(CustomerSegmentationTemplate, {
+        title: i18n.translate('product.title'),
+        description: i18n.translate('product.description'),
+        icon: 'productsMajor',
+        templateQuery: productsPurchasedOnTagsEnabled
+        ? 'products_purchased(tag: (product_tag)) = true'
+        : 'products_purchased(id: (product_id)) = true',
+        templateQueryToInsert: productsPurchasedOnTagsEnabled
+        ? 'products_purchased(tag:'
+        : 'products_purchased(id:',
+      });
+
+      root.appendChild(productTemplate);
+    }
+
+    if (__category === 'location') {
+      const locationTemplate = root.createComponent(CustomerSegmentationTemplate, {
+        title: i18n.translate('location.title'),
+        description: i18n.translate('location.description'),
+        icon: 'locationMajor',
+        templateQuery: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
+      });
+
+      root.appendChild(locationTemplate);
+    }
+
+    root.mount();
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/extension-points.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-points.ts
@@ -1,10 +1,19 @@
 import type {RenderExtension} from '../../extension';
 
-import type {AnyComponent} from './shared';
-import type {StandardApi} from './api';
+import type {AnyComponent, Components} from './shared';
+import type {StandardApi, CustomerSegmentationTemplateApi} from './api';
+import {AnyComponentBuilder} from '../../shared';
+
+type CustomerSegmentationTemplateComponent = AnyComponentBuilder<
+  Pick<Components, 'CustomerSegmentationTemplate'>
+>;
 
 export interface ExtensionPoints {
   Playground: RenderExtension<StandardApi<'Playground'>, AnyComponent>;
+  'admin.customers.segmentation-templates.render': RenderExtension<
+    CustomerSegmentationTemplateApi<'admin.customers.segmentation-templates.render'>,
+    CustomerSegmentationTemplateComponent
+  >;
 }
 
 export type ExtensionPoint = keyof ExtensionPoints;

--- a/packages/ui-extensions/src/surfaces/checkout/api.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api.ts
@@ -1,3 +1,4 @@
+export type {I18n, I18nTranslate} from '../../api';
 export type {CountryCode, CurrencyCode, Timezone} from './api/shared';
 export type {
   StandardApi,
@@ -58,8 +59,6 @@ export type {
   DiscountCodeChangeResult,
   DiscountCodeChangeResultError,
   DiscountCodeChangeResultSuccess,
-  I18n,
-  I18nTranslate,
   Currency,
   Language,
   Localization,

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1,6 +1,5 @@
 import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-
-import type {StandardApi as BaseStandardApi} from '../../../../api';
+import type {StandardApi as BaseStandardApi, I18n} from '../../../../api';
 import type {ExtensionPoint as AnyExtensionPoint} from '../../extension-points';
 import type {CurrencyCode, CountryCode, Timezone} from '../shared';
 
@@ -349,79 +348,6 @@ export interface AppMetafieldEntry {
 }
 
 export type Version = 'unstable';
-
-/**
- * This defines the i18n.translate() signature.
- */
-export interface I18nTranslate {
-  /**
-   * This returns a translated string matching a key in a locale file.
-   *
-   * @example translate("banner.title")
-   */
-  <ReplacementType = string>(
-    key: string,
-    options?: {[placeholderKey: string]: ReplacementType | string | number},
-  ): ReplacementType extends string | number
-    ? string
-    : (string | ReplacementType)[];
-}
-
-export interface I18n {
-  /**
-   * Returns a localized number.
-   *
-   * This function behaves like the standard `Intl.NumberFormat()`
-   * with a style of `decimal` applied. It uses the buyer's locale by default.
-   *
-   * @param options.inExtensionLocale - if true, use the extension's locale
-   */
-  formatNumber: (
-    number: number | bigint,
-    options?: {inExtensionLocale?: boolean} & Intl.NumberFormatOptions,
-  ) => string;
-
-  /**
-   * Returns a localized currency value.
-   *
-   * This function behaves like the standard `Intl.NumberFormat()`
-   * with a style of `currency` applied. It uses the buyer's locale by default.
-   *
-   * @param options.inExtensionLocale - if true, use the extension's locale
-   */
-  formatCurrency: (
-    number: number | bigint,
-    options?: {inExtensionLocale?: boolean} & Intl.NumberFormatOptions,
-  ) => string;
-
-  /**
-   * Returns a localized date value.
-   *
-   * This function behaves like the standard `Intl.DateTimeFormatOptions()` and uses
-   * the buyer's locale by default. Formatting options can be passed in as
-   * options.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat0
-   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#using_options
-   *
-   * @param options.inExtensionLocale - if true, use the extension's locale
-   */
-  formatDate: (
-    date: Date,
-    options?: {inExtensionLocale?: boolean} & Intl.DateTimeFormatOptions,
-  ) => string;
-
-  /**
-   * Returns translated content in the buyer's locale,
-   * as supported by the extension.
-   *
-   * - `options.count` is a special numeric value used in pluralization.
-   * - The other option keys and values are treated as replacements for interpolation.
-   * - If the replacements are all primitives, then `translate()` returns a single string.
-   * - If replacements contain UI components, then `translate()` returns an array of elements.
-   */
-  translate: I18nTranslate;
-}
 
 export interface Language {
   /**


### PR DESCRIPTION
### Background
Fixes https://github.com/Shopify/core-issues/issues/51784
We are building a new rendering UI extension for Customer Segmentation. We're introducing a new component called `CustomerSegmentationTemplate` that will be used to render segmentation templates in the Admin:

<img width="295" alt="Screenshot 2023-02-22 at 3 09 10 PM" src="https://user-images.githubusercontent.com/3925905/220747617-d10aec9a-b33b-4f93-b6a0-8500bb60cae2.png">

### Solution

This PR adds the required interfaces for `CustomerSegmentationTemplate` in `@shopify/ui-extensions/admin` and `@shopify/ui-extensions-react/admin`. See code examples in PR.

### 🎩

🍏 CI. You can also generate a build (`yarn build`) and consume these new changes in your app extension.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
