### PR TITLE
CustomerSegmentationTemplate / Add `standardMetafieldDependencies` prop

### DIFF
--- a/.changeset/sweet-ways-hunt.md
+++ b/.changeset/sweet-ways-hunt.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Introduces standardMetafieldDependencies prop on CustomerSegmentationTemplate

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -21,17 +21,25 @@ type Source =
   | 'buyButtonMajor'
   | 'followUpEmailMajor';
 
+/**
+ * Reserved namespace and key for the customer standard metafield used in the template's query.
+ * More info - https://shopify.dev/docs/apps/custom-data/metafields/definitions/standard
+ */
+type CustomerStandardMetafieldDependency = 'facts.birth_date';
+
 export interface CustomerSegmentationTemplateProps {
-  /** Localized title of the template. */
+  /* Localized title of the template. */
   title: string;
-  /** Localized description of the template. */
+  /* Localized description of the template. */
   description: string;
-  /** Icon identifier for the template. This property is ignored for non-1P Segmentation templates as we fallback to the app icon */
+  /* Icon identifier for the template. This property is ignored for non-1P Segmentation templates as we fallback to the app icon */
   icon?: Source;
-  /** ShopifyQL code snippet to render in the template with syntax highlighting **/
+  /* ShopifyQL code snippet to render in the template with syntax highlighting */
   templateQuery: string;
-  /** ShopifyQL code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
+  /* ShopifyQL code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
   templateQueryToInsert?: string;
+  /* List of customer standard metafield used in the template's query */
+  standardMetafieldDependencies?: CustomerStandardMetafieldDependency[];
 }
 
 /**


### PR DESCRIPTION
Extensions need a way to provide which customer standard metafield they rely on. This PR introduces `standardMetafieldDependencies`. We're currently only supporting one customer standard metafield but this could change in the future.

More context in this [doc](https://docs.google.com/document/d/1Kd42wyOGL7fHIAqAlNbDCFcy2Hh012H2Y1kT08F8mWw/edit#heading=h.21aft6xgv5n4).

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
