### PR TITLE
CustomerSegmentationTemplate / Introduce `dateAdded` prop

### DIFF
--- a/.changeset/odd-bottles-argue.md
+++ b/.changeset/odd-bottles-argue.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Introduce dateAdded on CustomerSegmentationTemplate

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
@@ -21,6 +21,7 @@ function App({i18n, enabledFeatures, category}) {
         icon='productsMajor'
         templateQuery={templateQuery}
         templateQueryToInsert={templateQueryToInsert}
+        dateAdded={new Date('2023-01-15')}
       />
     );
   }

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -32,14 +32,16 @@ export interface CustomerSegmentationTemplateProps {
   title: string;
   /* Localized description of the template. */
   description: string;
-  /* Icon identifier for the template. This property is ignored for non-1P Segmentation templates as we fallback to the app icon */
+  /* Icon identifier for the template. This property is ignored for non-1P Segmentation templates as we fallback to the app icon. */
   icon?: Source;
-  /* ShopifyQL code snippet to render in the template with syntax highlighting */
+  /* ShopifyQL code snippet to render in the template with syntax highlighting. */
   templateQuery: string;
   /* ShopifyQL code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
   templateQueryToInsert?: string;
-  /* List of customer standard metafield used in the template's query */
+  /* List of customer standard metafield used in the template's query. */
   standardMetafieldDependencies?: CustomerStandardMetafieldDependency[];
+  /* Date when the template was first introduced. A "New" badge will be rendered for recently introduced templates. */
+  dateAdded?: Date;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
@@ -18,6 +18,7 @@ export default extension(
         templateQueryToInsert: productsPurchasedOnTagsEnabled
         ? 'products_purchased(tag:'
         : 'products_purchased(id:',
+        dateAdded: new Date('2023-01-15')
       });
 
       root.appendChild(productTemplate);


### PR DESCRIPTION
### Background

We currently display a "New" badge for recently introduced templates. Apps can feed us the date of when the template was added and we will display the badge if the date is within a month.

I've made the prop optional because but we could just set it in the past for all existing templates. I'm open to suggestions.

<img width="1183" alt="image" src="https://user-images.githubusercontent.com/3925905/222474477-23f341c4-fde4-4164-9e13-0dffb5258023.png">


### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
