### PR TITLE
[CustomerSegmentationTemplate] Update `description` prop type

### DIFF
--- a/.changeset/tasty-avocados-sparkle.md
+++ b/.changeset/tasty-avocados-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+Changes typing of `description` prop of `<CustomerSegmentationTemplate/>` from `string` to `string | string[]`

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
@@ -13,7 +13,7 @@ function App({i18n, enabledFeatures, category}) {
     const templateQueryToInsert = productsPurchasedOnTagsEnabled
       ? 'products_purchased(tag:'
       : 'products_purchased(id:';
-  
+
     return (
       <CustomerSegmentationTemplate
         title={i18n.translate('product.title')}
@@ -25,12 +25,12 @@ function App({i18n, enabledFeatures, category}) {
       />
     );
   }
-  
+
   if (category == 'location') {
     return (
       <CustomerSegmentationTemplate
         title={i18n.translate('location.title')}
-        description={i18n.translate('location.description')}
+        description={[i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')]}
         icon='locationMajor'
         templateQuery="customer_cities CONTAINS 'US-NY-NewYorkCity'"
       />

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -30,9 +30,9 @@ type CustomerStandardMetafieldDependency = 'facts.birth_date';
 export interface CustomerSegmentationTemplateProps {
   /* Localized title of the template. */
   title: string;
-  /* Localized description of the template. */
-  description: string;
-  /* Icon identifier for the template. This property is ignored for non-1P Segmentation templates as we fallback to the app icon. */
+  /* Localized description(s) of the template. */
+  description: string | string[];
+  /* Icon identifier for the template. This property is ignored for non-1P Segmentation templates as we fallback to the app icon */
   icon?: Source;
   /* ShopifyQL code snippet to render in the template with syntax highlighting. */
   templateQuery: string;

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
@@ -27,7 +27,7 @@ export default extension(
     if (__category === 'location') {
       const locationTemplate = root.createComponent(CustomerSegmentationTemplate, {
         title: i18n.translate('location.title'),
-        description: i18n.translate('location.description'),
+        description: [i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')],
         icon: 'locationMajor',
         templateQuery: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
       });


### PR DESCRIPTION
### Background

- Segmentation templates in web currently accept an array of strings for the `description`. Some templates contain several sentences, and others contain 1 sentence, so this PR allows a union type to facilitate both use cases in a backwards compatible way.

### Solution

Please refer to background section

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
