### PR TITLE
Add toast API to ui extensions

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/index.ts
@@ -6,6 +6,7 @@ export type {SmartGridApi, SmartGridApiContent} from './smartgrid-api';
 export type {StandardApi} from './standard-api';
 
 export type {SessionApiContent, SessionApi} from './session-api';
+export type {ToastApiContent, ToastApi} from './toast-api';
 
 export type {
   Address,

--- a/packages/retail-ui-extensions/src/extension-api/toast-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/toast-api/index.ts
@@ -1,0 +1,1 @@
+export type {ToastApiContent, ToastApi} from './toast-api';

--- a/packages/retail-ui-extensions/src/extension-api/toast-api/toast-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/toast-api/toast-api.ts
@@ -1,0 +1,15 @@
+export interface ToastApiContent {
+  /**
+   * Show a toast.
+   * @param content The text content to display.
+   * @param duration The duration of the toast in ms. Defaults to 5000.
+   */
+  show: (content: string, duration?: number) => void;
+}
+
+/**
+ * Show a toast.
+ */
+export interface ToastApi {
+  toast: ToastApiContent;
+}

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -10,6 +10,8 @@ export type {
   StandardApi,
   SessionApi,
   SessionApiContent,
+  ToastApi,
+  ToastApiContent,
   Session,
   Address,
   Cart,


### PR DESCRIPTION
### Background
https://github.com/Shopify/pos-next-react-native/issues/19327
Adds the toast API.

### Solution
Add it in the pattern of other API's

### 🎩 
I've tested this API on POS by hand and it looks good. Is this all I need to change for this part to work? Did I miss any indexes or places? Nothing to add to the `react` package since there's no React-specific stuff going on here, right?