### PR TITLE
make LineItem discounts an array

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/types/cart.ts
+++ b/packages/retail-ui-extensions/src/extension-api/types/cart.ts
@@ -26,7 +26,7 @@ export interface LineItem {
   title?: string;
   variantId?: number;
   productId?: number;
-  discount?: Discount;
+  discounts: Discount[];
   taxable: boolean;
   sku?: string;
   vendor?: string;


### PR DESCRIPTION
### Background
https://github.com/Shopify/pos-next-react-native/issues/21640

### Solution
Make the discounts on LineItems an array to support multiple discounts in the future.

### 🎩
Local branch of POS using yalc to install these packages and tested on an extension

### Checklist

- [X] I have :tophat:'d these changes
