### PR TITLE
fix: Update component links to polaris.shopify.com

### DIFF
--- a/packages/admin-ui-extensions/src/components/Card/content/guidelines.md
+++ b/packages/admin-ui-extensions/src/components/Card/content/guidelines.md
@@ -6,4 +6,4 @@
 | ----------------------------------------------------------- | ------------------------------ |
 | Cards should be at the top level of the component hierarchy | Use too many secondary actions |
 
-For more guidelines, refer to Polaris' [Card best practices](https://polaris.shopify.com/components/layout-andstructure/card#best-practices).
+For more guidelines, refer to Polaris' [Card best practices](https://polaris.shopify.com/components/layout-and-structure/card#best-practices).

--- a/packages/admin-ui-extensions/src/components/Heading/content/guidelines.md
+++ b/packages/admin-ui-extensions/src/components/Heading/content/guidelines.md
@@ -8,4 +8,4 @@
 | Use headings to support the hierarchy and structure of the page | Nest too many Headings in one area |
 | Place Headings at the top of a page or section they refer to    |                                    |
 
-For more guidelines, refer to Polaris' [Heading best practices](https://polaris.shopify.com/components/typography/text).
+For more guidelines, refer to Polaris' [Text best practices](https://polaris.shopify.com/components/typography/text#best-practices).


### PR DESCRIPTION
### Background

Part of [Polaris#8185](https://github.com/Shopify/polaris/issues/8185).

The Polaris style guide was updated with new groupings for components which affects links.

### Solution

- Adds link to Text best practices (which is a new section shipped this morning)
- Fixes typo in URL

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
