### PR TITLE
Add @Shopify/retail-succeed-extensibility to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,8 @@
 /packages/customer-account-ui-extensions-react/   @Shopify/checkout-extensibility
 /packages/post-purchase-ui-extensions/            @Shopify/checkout-extensibility
 /packages/post-purchase-ui-extensions-react/      @Shopify/checkout-extensibility
+/packages/retail-ui-extensions/			  @Shopify/retail-succeed-extensibility
+/packages/retail-ui-extensions-react/		  @Shopify/retail-succeed-extensibility
 /packages/ui-extensions/                          @Shopify/app-ui @Shopify/checkout-extensibility
 /packages/ui-extensions-webpack-hot-client        @Shopify/checkout-extensibility
 /packages/web-pixel-extensions                    @Shopify/checkout-extensibility


### PR DESCRIPTION
### Background

Right now changing anything related to retail is pinging the checkout extensibility team. This PR changes it to the retail extensibility team, since we own these packages.

### Solution

I think this should work?

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
