### PR TITLE
Added life cycle events for screen

### DIFF
--- a/packages/retail-ui-extensions/src/components/Screen/Screen.ts
+++ b/packages/retail-ui-extensions/src/components/Screen/Screen.ts
@@ -27,12 +27,16 @@ export interface ScreenSearchBarProps {
  * @property `title` the title of the screen which will be displayed on the UI.
  * @property `isLoading` displays a loading indicator when `true`. Set this to `true` when performing an asynchronous task, and then to false when the data becomes available to the UI.
  * @property `searchBar` provides the screen with a search bar at the top.
+ * @property `onNavigate` triggered when the screen is navigated to.
+ * @property `onNavigateBack` triggered when the user navigates back from this screen, or when the `Modal` containing this screen is closed.
  * @property `onReceiveParams` a callback that gets triggered when the navigation event completes and the screen receives the parameters.
  */
 export interface ScreenProps extends Destination {
   title: string;
   isLoading?: boolean;
   searchBar?: ScreenSearchBarProps;
+  onNavigate?: () => void;
+  onNavigateBack?: () => void;
   onReceiveParams?: (params: any) => void;
 }
 


### PR DESCRIPTION
### Background

Because the UI Extension's navigator and screens render right away in the UI Extension context, devs can't rely on useEffect firing when the screen is actually presented.

### Solution

This adds life cycle events to the `Screen` component which will be triggered from the useEffect hook on the host side.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
