### PR TITLE
Fix types and extensions

### DIFF
--- a/packages/retail-ui-extensions-react/src/index.ts
+++ b/packages/retail-ui-extensions-react/src/index.ts
@@ -39,6 +39,8 @@ export type {
   Destination,
   TextProps,
   TextVariant,
+  SmartGridModalApi,
+  SmartGridTileApi,
   TextFieldProps,
   TileProps,
   IconProps,

--- a/packages/retail-ui-extensions/src/components/Modal/Modal.ts
+++ b/packages/retail-ui-extensions/src/components/Modal/Modal.ts
@@ -4,6 +4,8 @@ import {Destination} from 'extension-api';
 /** Wraps a `Navigator` or `Screen` in a `Modal`, which will present its content modally (from the bottom) when navigated to.
  * @property `name` used to identify this modal as a destination in the navigation stack.
  */
-export interface ModalProps extends Destination {}
+export interface ModalProps extends Destination {
+  name: string;
+}
 
 export const Modal = createRemoteComponent<'Modal', ModalProps>('Modal');

--- a/packages/retail-ui-extensions/src/components/Screen/Screen.ts
+++ b/packages/retail-ui-extensions/src/components/Screen/Screen.ts
@@ -32,6 +32,7 @@ export interface ScreenSearchBarProps {
  * @property `onReceiveParams` a callback that gets triggered when the navigation event completes and the screen receives the parameters.
  */
 export interface ScreenProps extends Destination {
+  name: string;
   title: string;
   isLoading?: boolean;
   searchBar?: ScreenSearchBarProps;

--- a/packages/retail-ui-extensions/src/extension-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/index.ts
@@ -3,7 +3,11 @@ export type {CartApiContent, DiscountType} from './cart-api/cart-api';
 export type {CartApi} from './cart-api';
 export type {NavigationApi, NavigationApiContent} from './navigation-api';
 export type {SmartGridApi, SmartGridApiContent} from './smartgrid-api';
-export type {StandardApi} from './standard-api';
+export type {
+  StandardApi,
+  SmartGridModalApi,
+  SmartGridTileApi,
+} from './standard-api';
 
 export type {SessionApiContent, SessionApi} from './session-api';
 export type {ToastApiContent, ToastApi} from './toast-api';

--- a/packages/retail-ui-extensions/src/extension-api/standard-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/standard-api.ts
@@ -1,6 +1,8 @@
 import type {CartApi} from './cart-api';
 import type {LocaleApi} from './locale-api';
+import {NavigationApi} from './navigation-api';
 import type {SessionApi} from './session-api';
+import {SmartGridApi} from './smartgrid-api';
 import type {ToastApi} from './toast-api';
 
 export type StandardApi<T> = {[key: string]: any} & {
@@ -9,3 +11,9 @@ export type StandardApi<T> = {[key: string]: any} & {
   CartApi &
   ToastApi &
   SessionApi;
+
+export type SmartGridTileApi = StandardApi<'pos.home.tile.render'> &
+  SmartGridApi;
+
+export type SmartGridModalApi = StandardApi<'pos.home.modal.render'> &
+  NavigationApi;

--- a/packages/retail-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/retail-ui-extensions/src/extension-points/extension-points.ts
@@ -1,16 +1,13 @@
 import {BasicComponents, SmartGridComponents} from 'component-sets';
-import {SmartGridApi, NavigationApi, StandardApi} from '../extension-api';
+import {SmartGridModalApi, SmartGridTileApi} from 'extension-api/standard-api';
 import {RenderExtension} from './render-extension';
 
 export interface ExtensionPoints {
   'pos.home.tile.render': RenderExtension<
-    StandardApi<'pos.home.tile.render'> & SmartGridApi,
+    SmartGridTileApi,
     SmartGridComponents
   >;
-  'pos.home.modal.render': RenderExtension<
-    StandardApi<'pos.home.modal.render'> & NavigationApi,
-    BasicComponents
-  >;
+  'pos.home.modal.render': RenderExtension<SmartGridModalApi, BasicComponents>;
 }
 
 export type ExtensionPoint = keyof ExtensionPoints;

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -8,6 +8,8 @@ export type {
   SmartGridApi,
   SmartGridApiContent,
   StandardApi,
+  SmartGridModalApi,
+  SmartGridTileApi,
   SessionApi,
   SessionApiContent,
   ToastApi,


### PR DESCRIPTION
### Background

Turns out extending interfaces doesn't work very well in npm land. SMH. I'm also taking the liberty to fix the lacking auto complete for the navigation API and smart grid API. The only thing I can identify is lacking vs the other APIs is that it's not explicitly included in a type. So I've created two types that build on top of the StandardApi:

- SmartGridModalAPI
- SmartGridTileAPI

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
