### PR TITLE
Revert API type changes

### DIFF
--- a/packages/retail-ui-extensions-react/src/index.ts
+++ b/packages/retail-ui-extensions-react/src/index.ts
@@ -39,8 +39,6 @@ export type {
   Destination,
   TextProps,
   TextVariant,
-  SmartGridModalApi,
-  SmartGridTileApi,
   TextFieldProps,
   TileProps,
   IconProps,

--- a/packages/retail-ui-extensions/src/extension-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/index.ts
@@ -3,11 +3,7 @@ export type {CartApiContent, DiscountType} from './cart-api/cart-api';
 export type {CartApi} from './cart-api';
 export type {NavigationApi, NavigationApiContent} from './navigation-api';
 export type {SmartGridApi, SmartGridApiContent} from './smartgrid-api';
-export type {
-  StandardApi,
-  SmartGridModalApi,
-  SmartGridTileApi,
-} from './standard-api';
+export type {StandardApi} from './standard-api';
 
 export type {SessionApiContent, SessionApi} from './session-api';
 export type {ToastApiContent, ToastApi} from './toast-api';

--- a/packages/retail-ui-extensions/src/extension-api/standard-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/standard-api.ts
@@ -1,8 +1,6 @@
 import type {CartApi} from './cart-api';
 import type {LocaleApi} from './locale-api';
-import {NavigationApi} from './navigation-api';
 import type {SessionApi} from './session-api';
-import {SmartGridApi} from './smartgrid-api';
 import type {ToastApi} from './toast-api';
 
 export type StandardApi<T> = {[key: string]: any} & {
@@ -11,9 +9,3 @@ export type StandardApi<T> = {[key: string]: any} & {
   CartApi &
   ToastApi &
   SessionApi;
-
-export type SmartGridTileApi = StandardApi<'pos.home.tile.render'> &
-  SmartGridApi;
-
-export type SmartGridModalApi = StandardApi<'pos.home.modal.render'> &
-  NavigationApi;

--- a/packages/retail-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/retail-ui-extensions/src/extension-points/extension-points.ts
@@ -1,13 +1,16 @@
 import {BasicComponents, SmartGridComponents} from 'component-sets';
-import {SmartGridModalApi, SmartGridTileApi} from 'extension-api/standard-api';
+import {SmartGridApi, NavigationApi, StandardApi} from '../extension-api';
 import {RenderExtension} from './render-extension';
 
 export interface ExtensionPoints {
   'pos.home.tile.render': RenderExtension<
-    SmartGridTileApi,
+    StandardApi<'pos.home.tile.render'> & SmartGridApi,
     SmartGridComponents
   >;
-  'pos.home.modal.render': RenderExtension<SmartGridModalApi, BasicComponents>;
+  'pos.home.modal.render': RenderExtension<
+    StandardApi<'pos.home.modal.render'> & NavigationApi,
+    BasicComponents
+  >;
 }
 
 export type ExtensionPoint = keyof ExtensionPoints;

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -8,8 +8,6 @@ export type {
   SmartGridApi,
   SmartGridApiContent,
   StandardApi,
-  SmartGridModalApi,
-  SmartGridTileApi,
   SessionApi,
   SessionApiContent,
   ToastApi,


### PR DESCRIPTION
### Background

Turns out the previous changes broke all the API typing. The api auto completes as any in the UI Extension. 

### Solution

Reverts the changes that broke the typing

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
