### PR TITLE
[segmentation] moving category from api to props

### DIFF
--- a/.changeset/hot-jobs-return.md
+++ b/.changeset/hot-jobs-return.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Moving the Segmentation TemplateCategory from the api to the CustomerSegmentationTemplate component props.

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
@@ -4,8 +4,7 @@ import {
   CustomerSegmentationTemplate,
 } from '@shopify/ui-extensions-react/admin';
 
-function App({i18n, enabledFeatures, category}) {
-  if (category == 'reEngageCustomers') {
+function App({i18n, enabledFeatures}) {
     const productsPurchasedOnTagsEnabled = enabledFeatures.includes('productsPurchasedByTags');
     const templateQuery = productsPurchasedOnTagsEnabled
       ? 'products_purchased(tag: (product_tag)) = true'
@@ -15,29 +14,25 @@ function App({i18n, enabledFeatures, category}) {
       : 'products_purchased(id:';
 
     return (
-      <CustomerSegmentationTemplate
-        title={i18n.translate('product.title')}
-        description={i18n.translate('product.description')}
-        icon='productsMajor'
-        templateQuery={templateQuery}
-        templateQueryToInsert={templateQueryToInsert}
-        dateAdded={new Date('2023-01-15')}
-      />
+      <>
+        <CustomerSegmentationTemplate
+          title={i18n.translate('product.title')}
+          description={i18n.translate('product.description')}
+          icon='productsMajor'
+          templateQuery={templateQuery}
+          templateQueryToInsert={templateQueryToInsert}
+          dateAdded={new Date('2023-01-15')}
+          category="reEngageCustomers"
+        />
+         <CustomerSegmentationTemplate
+          title={i18n.translate('location.title')}
+          description={[i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')]}
+          icon='locationMajor'
+          templateQuery="customer_cities CONTAINS 'US-NY-NewYorkCity'"
+          category='location'
+        />
+      </>
     );
-  }
-
-  if (category == 'location') {
-    return (
-      <CustomerSegmentationTemplate
-        title={i18n.translate('location.title')}
-        description={[i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')]}
-        icon='locationMajor'
-        templateQuery="customer_cities CONTAINS 'US-NY-NewYorkCity'"
-      />
-    );
-  }
-
-  return null;
 }
 
-reactExtension('admin.customers.segmentation-templates.render', ({i18n, __category, __enabledFeatures}) => <App i18n={i18n} enabledFeatures={__enabledFeatures} category={__category} />);
+reactExtension('admin.customers.segmentation-templates.render', ({i18n, __enabledFeatures}) => <App i18n={i18n} enabledFeatures={__enabledFeatures} />);

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segmentation-template/customer-segmentation-template.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segmentation-template/customer-segmentation-template.ts
@@ -9,22 +9,11 @@ type CustomerSegmentationFeature =
   /* Enables count aggregates on functions. For example: shopify_email.opened(count_at_least: 5) = true */
   | 'aggregateFilters';
 
-type TemplateCategory =
-  | 'all'
-  | 'firstTimeBuyers'
-  | 'highValueCustomers'
-  | 'reEngageCustomers'
-  | 'abandonedCheckout'
-  | 'purchaseBehaviour'
-  | 'location';
-
 export interface CustomerSegmentationTemplateApi<
   ExtensionPoint extends AnyExtensionPoint,
 > extends StandardApi<ExtensionPoint> {
   /* Utilities for translating content according to the current `localization` of the admin. */
   i18n: I18n;
-  /** @private */
-  __category: TemplateCategory;
   /** @private */
   __enabledFeatures: CustomerSegmentationFeature[];
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -21,6 +21,14 @@ type Source =
   | 'buyButtonMajor'
   | 'followUpEmailMajor';
 
+type TemplateCategory =
+  | 'firstTimeBuyers'
+  | 'highValueCustomers'
+  | 'reEngageCustomers'
+  | 'abandonedCheckout'
+  | 'purchaseBehaviour'
+  | 'location';
+
 /**
  * Reserved namespace and key for the customer standard metafield used in the template's query.
  * More info - https://shopify.dev/docs/apps/custom-data/metafields/definitions/standard
@@ -42,6 +50,10 @@ export interface CustomerSegmentationTemplateProps {
   standardMetafieldDependencies?: CustomerStandardMetafieldDependency[];
   /* Date when the template was first introduced. A "New" badge will be rendered for recently introduced templates. */
   dateAdded?: Date;
+  /* The category in which the template will be visible.
+     When provided, the template will show in its respective category and aggregate sections.
+     When missing, the template will show in the aggregate sections only */
+  category?: TemplateCategory;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
@@ -5,35 +5,32 @@ import {
 
 export default extension(
   'admin.customers.segmentation-templates.render',
-  (root, {i18n, __category, __enabledFeatures}) => {
-    if (__category === 'reEngageCustomers') {
-      const productsPurchasedOnTagsEnabled = __enabledFeatures.includes('productsPurchasedByTags');
-      const productTemplate = root.createComponent(CustomerSegmentationTemplate, {
-        title: i18n.translate('product.title'),
-        description: i18n.translate('product.description'),
-        icon: 'productsMajor',
-        templateQuery: productsPurchasedOnTagsEnabled
-        ? 'products_purchased(tag: (product_tag)) = true'
-        : 'products_purchased(id: (product_id)) = true',
-        templateQueryToInsert: productsPurchasedOnTagsEnabled
-        ? 'products_purchased(tag:'
-        : 'products_purchased(id:',
-        dateAdded: new Date('2023-01-15')
-      });
+  (root, {i18n, __enabledFeatures}) => {
+    const productsPurchasedOnTagsEnabled = __enabledFeatures.includes('productsPurchasedByTags');
+    const productTemplate = root.createComponent(CustomerSegmentationTemplate, {
+      title: i18n.translate('product.title'),
+      description: i18n.translate('product.description'),
+      icon: 'productsMajor',
+      templateQuery: productsPurchasedOnTagsEnabled
+      ? 'products_purchased(tag: (product_tag)) = true'
+      : 'products_purchased(id: (product_id)) = true',
+      templateQueryToInsert: productsPurchasedOnTagsEnabled
+      ? 'products_purchased(tag:'
+      : 'products_purchased(id:',
+      dateAdded: new Date('2023-01-15'),
+      category: 'reEngageCustomers'
+    });
 
-      root.appendChild(productTemplate);
-    }
+    const locationTemplate = root.createComponent(CustomerSegmentationTemplate, {
+      title: i18n.translate('location.title'),
+      description: [i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')],
+      icon: 'locationMajor',
+      templateQuery: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
+      category: 'location'
+    });
 
-    if (__category === 'location') {
-      const locationTemplate = root.createComponent(CustomerSegmentationTemplate, {
-        title: i18n.translate('location.title'),
-        description: [i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')],
-        icon: 'locationMajor',
-        templateQuery: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
-      });
-
-      root.appendChild(locationTemplate);
-    }
+    root.appendChild(productTemplate);
+    root.appendChild(locationTemplate);
 
     root.mount();
   },


### PR DESCRIPTION
### Background

Moves the category from the api to the props. This will make web control the rendering of the `all` while allowing developers to add a template to a single category. When the category is missing, Web will render the template in the `All` or the respective `app` section only. 

We currently have to update the api to show the new category. We could also leverage the context to control the rendering. Open to suggestions.

### 🎩

Nothing to tophat.

### Checklist

- [x] I have updated relevant documentation
