### PR TITLE
feat: expose modal component to customer account ui extensions

### DIFF
--- a/packages/customer-account-ui-extensions-react/src/components/shared-components.ts
+++ b/packages/customer-account-ui-extensions-react/src/components/shared-components.ts
@@ -32,6 +32,7 @@ export {
   TextBlock,
   TextField,
   View,
+  Modal,
 } from '@shopify/checkout-ui-extensions-react';
 
 export type {
@@ -58,6 +59,7 @@ export type {
   LinkProps,
   ListProps,
   ListItemProps,
+  ModalProps,
   SelectProps,
   SkeletonImageProps,
   SkeletonTextProps,

--- a/packages/customer-account-ui-extensions/src/components/shared-components.ts
+++ b/packages/customer-account-ui-extensions/src/components/shared-components.ts
@@ -32,6 +32,7 @@ export {
   TextBlock,
   TextField,
   View,
+  Modal,
 } from '@shopify/checkout-ui-extensions';
 
 export type {
@@ -60,6 +61,7 @@ export type {
   ListItemProps,
   MaybeConditionalStyle,
   MaybeShorthandProperty,
+  ModalProps,
   SelectProps,
   SkeletonImageProps,
   SkeletonTextProps,


### PR DESCRIPTION
### Background

Allows customer-account ui extensions to make use of the Modal component
[Customer Account Hub PR here](https://github.com/Shopify/customer-account-web/pull/1900) (tophatting instructions also there). 



### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
