### PR TITLE
change dateAdded to iso string

### DIFF
--- a/.changeset/ten-cooks-fry.md
+++ b/.changeset/ten-cooks-fry.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Changing the dateAdded type from Date to ISO 8601 string

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
@@ -21,7 +21,7 @@ function App({i18n, enabledFeatures}) {
           icon='productsMajor'
           templateQuery={templateQuery}
           templateQueryToInsert={templateQueryToInsert}
-          dateAdded={new Date('2023-01-15')}
+          dateAdded={new Date('2023-01-15').toISOString()}
           category="reEngageCustomers"
         />
          <CustomerSegmentationTemplate

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -48,8 +48,8 @@ export interface CustomerSegmentationTemplateProps {
   templateQueryToInsert?: string;
   /* List of customer standard metafield used in the template's query. */
   standardMetafieldDependencies?: CustomerStandardMetafieldDependency[];
-  /* Date when the template was first introduced. A "New" badge will be rendered for recently introduced templates. */
-  dateAdded?: Date;
+  /* ISO 8601-encoded date and time string. A "New" badge will be rendered for recently introduced templates. */
+  dateAdded?: string;
   /* The category in which the template will be visible.
      When provided, the template will show in its respective category and aggregate sections.
      When missing, the template will show in the aggregate sections only */

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
@@ -17,7 +17,7 @@ export default extension(
       templateQueryToInsert: productsPurchasedOnTagsEnabled
       ? 'products_purchased(tag:'
       : 'products_purchased(id:',
-      dateAdded: new Date('2023-01-15'),
+      dateAdded: new Date('2023-01-15').toISOString(),
       category: 'reEngageCustomers'
     });
 


### PR DESCRIPTION
### Background

The `dateAdded` property introduced as a Date is not correctly proxied to our Web component. It has the same class instance limitations remote-ui mentions. (Only keeping prototype)

### Solution

Use ISO 8601 string for dates and updated the examples.

### Checklist

- [x] I have updated relevant documentation
