### PR TITLE
Expose Popover component to customer account ui extensions

### DIFF
--- a/packages/customer-account-ui-extensions-react/src/components/shared-components.ts
+++ b/packages/customer-account-ui-extensions-react/src/components/shared-components.ts
@@ -33,6 +33,7 @@ export {
   TextField,
   View,
   Modal,
+  Popover,
 } from '@shopify/checkout-ui-extensions-react';
 
 export type {
@@ -60,6 +61,7 @@ export type {
   ListProps,
   ListItemProps,
   ModalProps,
+  PopoverProps,
   SelectProps,
   SkeletonImageProps,
   SkeletonTextProps,

--- a/packages/customer-account-ui-extensions/src/components/shared-components.ts
+++ b/packages/customer-account-ui-extensions/src/components/shared-components.ts
@@ -33,6 +33,7 @@ export {
   TextField,
   View,
   Modal,
+  Popover,
 } from '@shopify/checkout-ui-extensions';
 
 export type {
@@ -62,6 +63,7 @@ export type {
   MaybeConditionalStyle,
   MaybeShorthandProperty,
   ModalProps,
+  PopoverProps,
   SelectProps,
   SkeletonImageProps,
   SkeletonTextProps,


### PR DESCRIPTION
### Background

Allows customer account ui extensions to make use of the Popover component

Tophat instructions in accompanying customer account web pr https://github.com/Shopify/customer-account-web/pull/1971

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
