### PR TITLE
Made disclosure indicator on right side optional

### DIFF
--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -27,6 +27,11 @@ export interface ListRowRightSide {
    * The main label that will be displayed on the right side of the row.
    */
   label?: string;
+  /**
+   * Show a chevron. Set this to true if pressing on the row navigates to another screen.
+   * @defaultValue `false`
+   */
+  showDisclosureIndicator?: boolean;
 }
 
 export interface ListRow {


### PR DESCRIPTION
### Background

Adds the disclosure indicator to the list row right side. Optional, defaults to false.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
