### PR TITLE
Publish

### DIFF
--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/customer-account-ui-extensions-react",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "React bindings for @shopify/customer-account-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -25,7 +25,7 @@
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
     "@shopify/checkout-ui-extensions-react": "^0.24.0",
-    "@shopify/customer-account-ui-extensions": "^0.0.34"
+    "@shopify/customer-account-ui-extensions": "^0.0.35"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <18.0.0"

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/customer-account-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify's Customer Account",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
- @shopify/customer-account-ui-extensions-react@0.0.36
- @shopify/customer-account-ui-extensions@0.0.35

### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

Version bump for exposing the Popover component to customer account ui extensions

### Solution

### 🎩

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
