### PR TITLE
Publish

### DIFF
--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/checkout-ui-extensions-react",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "React bindings for @shopify/checkout-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions": "^0.24.0",
+    "@shopify/checkout-ui-extensions": "^0.25.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify’s Checkout",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/customer-account-ui-extensions-react",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "React bindings for @shopify/customer-account-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions-react": "^0.24.0",
-    "@shopify/customer-account-ui-extensions": "^0.0.35"
+    "@shopify/checkout-ui-extensions-react": "^0.25.0",
+    "@shopify/customer-account-ui-extensions": "^0.0.36"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <18.0.0"

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/customer-account-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify's Customer Account",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"
@@ -24,6 +24,6 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/core": "2.1.x",
-    "@shopify/checkout-ui-extensions": "^0.24.0"
+    "@shopify/checkout-ui-extensions": "^0.25.0"
   }
 }


### PR DESCRIPTION
 - @shopify/checkout-ui-extensions-react@0.25.0
 - @shopify/checkout-ui-extensions@0.25.0
 - @shopify/customer-account-ui-extensions-react@0.0.37
 - @shopify/customer-account-ui-extensions@0.0.36

### Background

This releases that latest version of `checkout-ui-extensions` and updates the dependancy for it within `customer-account-ui-extensions`.

### Solution

See https://github.com/Shopify/ui-extensions/pull/810 for details on the changes to checkout-ui-extensions.

### 🎩

You can [tophat this package](https://checkout.docs.shopify.io/docs/referencedocs/web/extensions/libraries#releasing-library-versions) by following these instructions:

Tophat your changes by copying the packages from Spin into a real [scaffolded app / extension](https://shopify.dev/docs/api/checkout-ui-extensions#scaffolding-extension). Change into the app directory on your local machine and run this:

VM=direct.$(spin show -o fqdn)
rsync -av --delete $VM:~/src/github.com/Shopify/ui-extensions/packages/checkout-ui-extensions node_modules/@shopify/ && \
   rsync -av --delete $VM:~/src/github.com/Shopify/ui-extensions/packages/checkout-ui-extensions-react node_modules/@shopify/
Use yarn --force to restore your local app afterwards.

Tip: this allows you to test the package before you proceed to publish to NPM. yarn link is not supported.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation - https://github.com/Shopify/shopify-dev/pull/32090
