### PR TITLE
Use relative import for TagProps in List

### DIFF
--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -1,5 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import {TagProps} from 'components/Tag';
+import {TagProps} from '../Tag';
 
 export interface ListRowLeftSide {
   /**


### PR DESCRIPTION
### Background
Resolves https://github.com/Shopify/pos-next-react-native/issues/23093

### Solution
This makes the types resolve better on the extension end. I don't know why.

### 🎩
Make an extension without these changes. Note that hovering looks like this:
![image](https://user-images.githubusercontent.com/29490857/230166039-1997dcee-6e33-481f-be07-92a444267f8f.png)

Make these changes to your dependency. Note that hovering now looks like this:
<img width="628" alt="image" src="https://user-images.githubusercontent.com/29490857/230166119-75272f45-1583-4371-baf6-d7dff65815ad.png">


### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
