### PR TITLE
Added a param to hide a banner action

### DIFF
--- a/packages/retail-ui-extensions/src/components/Banner/Banner.ts
+++ b/packages/retail-ui-extensions/src/components/Banner/Banner.ts
@@ -3,10 +3,31 @@ import {createRemoteComponent} from '@remote-ui/core';
 export type BannerVariant = 'confirmation' | 'alert' | 'error' | 'information';
 
 export interface BannerProps {
+  /**
+   * The title of the banner.
+   */
   title: string;
+  /**
+   * Banners have multiple variants that can be used to
+   * change the color and style of the banner.
+   */
   variant: BannerVariant;
+  /**
+   * @defaultValue 'dismiss'
+   */
   action?: string;
+  /**
+   * Dismisses the banner by default.
+   */
   onPress?: () => void;
+  /**
+   * Use this parameter to hide the action button.
+   */
+  hideAction?: boolean;
+  /**
+   * Whether or not the banner is visible.
+   * @defaultValue true
+   */
   visible: boolean;
 }
 


### PR DESCRIPTION
partially_resolves https://github.com/Shopify/pos-next-react-native/issues/23438

### Background

Some partners might wish to display a banner but show no action. Zapiet requested this feature as a part of our EA agreement. 

### Solution

Added a parameter. Added some documentation. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
