### PR TITLE
Removed unsupported textfield formatting types

### DIFF
--- a/packages/retail-ui-extensions/src/components/FormattedTextField/FormattedTextField.ts
+++ b/packages/retail-ui-extensions/src/components/FormattedTextField/FormattedTextField.ts
@@ -1,20 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import type {AutoCapitalizationType, BaseTextFieldProps} from '../shared';
 
-export type InputType =
-  | 'text'
-  | 'number'
-  | 'percent'
-  | 'boundlessPercent'
-  | 'currency'
-  | 'giftcard'
-  | 'expiry'
-  | 'date'
-  | 'zip'
-  | 'password'
-  | 'email'
-  | 'url'
-  | 'phone';
+export type InputType = 'text' | 'number' | 'currency' | 'giftcard' | 'email';
 
 export interface FormattedTextFieldProps extends BaseTextFieldProps {
   inputType?: InputType;


### PR DESCRIPTION
### Background

These text field formatters don't actually work on the POS side, so we are removing them until we get support. This is a deep tech debt issue on POS, and might take some time to get the implementations working properly.

### 🎩

Build an extension and make sure all the remaining inputTypes work properly.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
