### PR TITLE
Checkout-ui-extensions docs patch pre-publish 04-23

### DIFF
--- a/packages/checkout-ui-extensions-react/src/hooks/buyer-journey.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/buyer-journey.ts
@@ -34,9 +34,6 @@ export function useBuyerJourneyCompleted<
 /**
  * Installs a function for intercepting and preventing progress on checkout.
  *
- * This returns a promise that resolves to a teardown function. Calling the
- * teardown function will remove the interceptor.
- *
  * To block checkout progress, you must set the [block_progress](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress)
  * capability in your extension's configuration.
  */

--- a/packages/checkout-ui-extensions/docs/build-docs.sh
+++ b/packages/checkout-ui-extensions/docs/build-docs.sh
@@ -14,6 +14,9 @@ if [ $build_exit -ne 0 ]; then
   exit $build_exit
 fi
 
+# Make sure https://shopify.dev URLs are relative so they work in Spin.
+# See https://github.com/Shopify/generate-docs/issues/181
+sed -i 's/https:\/\/shopify.dev//gi' ./docs/generated/generated_docs_data.json
 
 if [ -n "$SPIN" ]; then
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then

--- a/packages/checkout-ui-extensions/docs/reference/apis/standard.doc.ts
+++ b/packages/checkout-ui-extensions/docs/reference/apis/standard.doc.ts
@@ -22,6 +22,8 @@ const {
     buyerJourneyInterceptPageLevelError,
   'buyer-journey-intercept/target-native-field':
     buyerJourneyInterceptTargetNativeField,
+  'session-token': sessionToken,
+  'session-token-jwt': sessionTokenJwt,
 } = getExamples(['jsx', 'js']);
 
 const data: ReferenceEntityTemplateSchema = {
@@ -67,6 +69,10 @@ const data: ReferenceEntityTemplateSchema = {
           buyerJourneyInterceptPageLevelError,
           buyerJourneyInterceptExtensionBanner,
         ],
+      },
+      {
+        title: 'Session Token',
+        examples: [sessionToken, sessionTokenJwt],
       },
     ],
   },

--- a/packages/checkout-ui-extensions/docs/reference/apis/standard.doc.ts
+++ b/packages/checkout-ui-extensions/docs/reference/apis/standard.doc.ts
@@ -16,7 +16,12 @@ const {
   'settings-access': settingAccess,
   'storefront-query-api': storeFrontApiQuery,
   'storefront-query-with-fetch': storeFrontApiFetch,
-  'buyer-journey-intercept': buyerJourneyIntercept,
+  'buyer-journey-intercept/extension-banner':
+    buyerJourneyInterceptExtensionBanner,
+  'buyer-journey-intercept/page-level-error':
+    buyerJourneyInterceptPageLevelError,
+  'buyer-journey-intercept/target-native-field':
+    buyerJourneyInterceptTargetNativeField,
 } = getExamples(['jsx', 'js']);
 
 const data: ReferenceEntityTemplateSchema = {
@@ -57,7 +62,11 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         title: 'Buyer journey',
-        examples: [buyerJourneyIntercept],
+        examples: [
+          buyerJourneyInterceptTargetNativeField,
+          buyerJourneyInterceptPageLevelError,
+          buyerJourneyInterceptExtensionBanner,
+        ],
       },
     ],
   },

--- a/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/extension-banner.example.ts
+++ b/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/extension-banner.example.ts
@@ -4,28 +4,26 @@ import {
 } from '@shopify/checkout-ui-extensions';
 
 extend(
-  'Checkout::DeliveryAddress::RenderBefore',
-  (root, {buyerJourney, shippingAddress}) => {
+  'Checkout::CartLineDetails::RenderAfter',
+  (root, {buyerJourney, target}) => {
     const banner = root.createComponent(Banner);
 
-    let currentShippingCountry =
-      shippingAddress?.current?.countryCode;
-    shippingAddress?.subscribe((newAddress) => {
-      currentShippingCountry =
-        newAddress?.countryCode;
+    let quantity = target.current.quantity;
+
+    target?.subscribe((newTarget) => {
+      quantity = newTarget.quantity;
     });
 
     buyerJourney.intercept(
       ({canBlockProgress}) => {
-        return canBlockProgress &&
-          currentShippingCountry !== 'CA'
+        return canBlockProgress && quantity > 1
           ? {
               behavior: 'block',
-              reason: 'Can only ship to canada',
+              reason: 'limited stock',
               perform: (result) => {
                 if (result.behavior === 'block') {
                   banner.appendChild(
-                    'Sorry, we can only ship to Canada',
+                    'This item has a limit of one per customer.',
                   );
                   root.appendChild(banner);
                 }

--- a/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/extension-banner.example.tsx
+++ b/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/extension-banner.example.tsx
@@ -3,26 +3,25 @@ import {
   render,
   Banner,
   useBuyerJourneyIntercept,
-  useShippingAddress,
+  useTarget,
 } from '@shopify/checkout-ui-extensions-react';
 
 render(
-  'Checkout::DeliveryAddress::RenderBefore',
+  'Checkout::CartLineDetails::RenderAfter',
   () => <Extension />,
 );
 
 function Extension() {
   const [showError, setShowError] =
     useState(false);
-  const address = useShippingAddress();
+  const {quantity} = useTarget();
 
   useBuyerJourneyIntercept(
     ({canBlockProgress}) => {
-      return canBlockProgress &&
-        address?.countryCode !== 'CA'
+      return canBlockProgress && quantity > 1
         ? {
             behavior: 'block',
-            reason: 'can only ship to canada',
+            reason: 'limited stock',
             perform: (result) => {
               if (result.behavior === 'block') {
                 setShowError(true);
@@ -40,7 +39,7 @@ function Extension() {
 
   return showError ? (
     <Banner>
-      Sorry, we can only ship to Canada
+      This item has a limit of one per customer.
     </Banner>
   ) : null;
 }

--- a/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/page-level-error.example.ts
+++ b/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/page-level-error.example.ts
@@ -1,0 +1,33 @@
+import {extend} from '@shopify/checkout-ui-extensions';
+
+extend(
+  'Checkout::DeliveryAddress::RenderBefore',
+  (root, {buyerJourney, shippingAddress}) => {
+    let address = shippingAddress?.current;
+    shippingAddress?.subscribe((newAddress) => {
+      address = newAddress;
+    });
+
+    buyerJourney.intercept(
+      ({canBlockProgress}) => {
+        return canBlockProgress &&
+          address?.countryCode &&
+          address.countryCode !== 'CA'
+          ? {
+              behavior: 'block',
+              reason: 'Invalid shipping country',
+              errors: [
+                {
+                  // An error without a `target` property is shown at page level
+                  message:
+                    'Sorry, we can only ship to Canada',
+                },
+              ],
+            }
+          : {
+              behavior: 'allow',
+            };
+      },
+    );
+  },
+);

--- a/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/page-level-error.example.tsx
+++ b/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/page-level-error.example.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  render,
+  useBuyerJourneyIntercept,
+  useShippingAddress,
+} from '@shopify/checkout-ui-extensions-react';
+
+render(
+  'Checkout::DeliveryAddress::RenderBefore',
+  () => <Extension />,
+);
+
+function Extension() {
+  const address = useShippingAddress();
+
+  useBuyerJourneyIntercept(
+    ({canBlockProgress}) => {
+      return canBlockProgress &&
+        address?.countryCode &&
+        address.countryCode !== 'CA'
+        ? {
+            behavior: 'block',
+            reason: 'Invalid shipping country',
+            errors: [
+              {
+                // An error without a `target` property is shown at page level
+                message:
+                  'Sorry, we can only ship to Canada',
+              },
+            ],
+          }
+        : {
+            behavior: 'allow',
+          };
+    },
+  );
+
+  return null;
+}

--- a/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/target-native-field.example.ts
+++ b/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/target-native-field.example.ts
@@ -1,0 +1,40 @@
+import {extend} from '@shopify/checkout-ui-extensions';
+
+extend(
+  'Checkout::DeliveryAddress::RenderBefore',
+  (root, {buyerJourney, shippingAddress}) => {
+    let address = shippingAddress?.current;
+    shippingAddress?.subscribe((newAddress) => {
+      address = newAddress;
+    });
+
+    buyerJourney.intercept(
+      ({canBlockProgress}) => {
+        return canBlockProgress &&
+          address?.countryCode &&
+          address.countryCode !== 'CA'
+          ? {
+              behavior: 'block',
+              reason: 'Invalid shipping country',
+              errors: [
+                {
+                  message:
+                    'Sorry, we can only ship to Canada',
+                  // Show an error underneath the country code field
+                  target:
+                    '$.cart.deliveryGroups[0].deliveryAddress.countryCode',
+                },
+                {
+                  // In addition, show an error at the page level
+                  message:
+                    'Please use a different address.',
+                },
+              ],
+            }
+          : {
+              behavior: 'allow',
+            };
+      },
+    );
+  },
+);

--- a/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/target-native-field.example.tsx
+++ b/packages/checkout-ui-extensions/docs/reference/examples/buyer-journey-intercept/target-native-field.example.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {
+  render,
+  useBuyerJourneyIntercept,
+  useShippingAddress,
+} from '@shopify/checkout-ui-extensions-react';
+
+render(
+  'Checkout::DeliveryAddress::RenderBefore',
+  () => <Extension />,
+);
+
+function Extension() {
+  const address = useShippingAddress();
+
+  useBuyerJourneyIntercept(
+    ({canBlockProgress}) => {
+      return canBlockProgress &&
+        address?.countryCode &&
+        address.countryCode !== 'CA'
+        ? {
+            behavior: 'block',
+            reason: 'Invalid shipping country',
+            errors: [
+              {
+                message:
+                  'Sorry, we can only ship to Canada',
+                // Show an error underneath the country code field
+                target:
+                  '$.cart.deliveryGroups[0].deliveryAddress.countryCode',
+              },
+              {
+                // In addition, show an error at the page level
+                message:
+                  'Please use a different address.',
+              },
+            ],
+          }
+        : {
+            behavior: 'allow',
+          };
+    },
+  );
+
+  return null;
+}

--- a/packages/checkout-ui-extensions/docs/reference/examples/session-token-jwt.example.json
+++ b/packages/checkout-ui-extensions/docs/reference/examples/session-token-jwt.example.json
@@ -1,0 +1,16 @@
+{
+  // Shopify URL
+  "dest": "store-name.myshopify.com",
+  // The Client ID of your app
+  "aud": "<clientId>",
+  // When the token expires.  Set at 5 minutes.
+  "exp": 1679954053,
+  // When the token was actived
+  "nbf": 1679953753,
+  // When the token was issued
+  "iat": 1679953753,
+  // A secure random UUID
+  "jti": "6c992878-dbaf-48d1-bb9d-6d9b59814fd1",
+  // Optional claim present when a customer is logged in and your app has permissions to read customer data
+  "sub": "gid://shopify/Customer/<customerId>"
+}

--- a/packages/checkout-ui-extensions/docs/reference/examples/session-token.example.ts
+++ b/packages/checkout-ui-extensions/docs/reference/examples/session-token.example.ts
@@ -1,0 +1,44 @@
+import {
+  extend,
+  Banner,
+  BlockStack,
+} from '@shopify/checkout-ui-extensions';
+
+extend(
+  'Checkout::Dynamic::Render',
+  (root, {sessionToken}) => {
+    async function queryApi() {
+      // Request a new (or cached) session token from Shopify
+      const token = await sessionToken.get();
+      console.log(token);
+
+      const apiResponse = await fetchWithToken(
+        token,
+      );
+
+      // Use your response
+      console.log(apiResponse);
+    }
+
+    function fetchWithToken(token) {
+      const result = fetch(
+        'https://myapp.com/api/session-token',
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+
+      return result;
+    }
+
+    queryApi();
+
+    root.appendChild(
+      root.createComponent(Banner, {
+        title: 'Session Token Extension',
+      }),
+    );
+  },
+);

--- a/packages/checkout-ui-extensions/docs/reference/examples/session-token.example.tsx
+++ b/packages/checkout-ui-extensions/docs/reference/examples/session-token.example.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {
+  render,
+  Banner,
+  useExtensionApi,
+} from '@shopify/checkout-ui-extensions-react';
+
+render('Checkout::Dynamic::Render', () => (
+  <Extension />
+));
+
+function Extension() {
+  const {sessionToken} = useExtensionApi();
+
+  async function queryApi() {
+    // Request a new (or cached) session token from Shopify
+    const token = await sessionToken.get();
+    console.log(token);
+
+    if (token) {
+      const apiResponse = await fetchWithToken(
+        token,
+      );
+      // Use your response
+      console.log(apiResponse);
+    }
+  }
+
+  function fetchWithToken(token) {
+    const result = fetch(
+      'https://myapp.com/api/session-token',
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    return result;
+  }
+
+  queryApi();
+
+  return (
+    <Banner title="Session token Extension" />
+  );
+}

--- a/packages/checkout-ui-extensions/docs/reference/examples/subscription.example.tsx
+++ b/packages/checkout-ui-extensions/docs/reference/examples/subscription.example.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {
+  render,
+  Banner,
+  useExtensionApi,
+  useSubscription,
+} from '@shopify/checkout-ui-extensions-react';
+
+render('Checkout::Dynamic::Render', () => (
+  <Extension />
+));
+
+function Extension() {
+  const {cost} = useExtensionApi();
+
+  // Equivalent to the useTotalAmount() hook to subscribe and re-render your extension on changes
+  const totalAmount = useSubscription(
+    cost.totalAmount,
+  );
+
+  return <Banner>{totalAmount.amount}</Banner>;
+}

--- a/packages/checkout-ui-extensions/docs/reference/helper.docs.ts
+++ b/packages/checkout-ui-extensions/docs/reference/helper.docs.ts
@@ -219,6 +219,34 @@ Ensure your extension can access the Storefront API via the [\`api_access\` capa
         tabs: getExtensionCodeTabs('subscription'),
       },
     },
+    'session-token': {
+      description: `
+You can request a session token from Shopify to use with your third party API calls.  The contents of the token claims are signed using your shared app secret so you can trust any information contained in the claims came from Shopify unaltered.
+
+> Note: You will need to [enable the network_access capability](docs/api/checkout-ui-extensions/configuration#network-access) to use \`fetch()\`.
+`,
+      codeblock: {
+        title: 'Using a session token with fetch()',
+        tabs: getExtensionCodeTabs('session-token'),
+      },
+    },
+    'session-token-jwt': {
+      description: `
+The contents of the token are signed using your shared app secret.  The optional \`sub\` claim contains the customer's \`gid\` if they are logged in and your app has permission to read customer accounts. For example, a loyalty app that needs to check a customer's point balance can use the \`sub\` claim to verify the customer's account.
+
+> Caution: Session tokens are _not_ authorization tokens and do not guarantee the request originated from Shopify.
+`,
+      codeblock: {
+        title: 'Session token claims',
+        tabs: [
+          {
+            code: `${examplePath}/session-token-jwt.example.json`,
+            language: 'json',
+            title: 'session-token.jwt',
+          },
+        ],
+      },
+    },
   };
 }
 

--- a/packages/checkout-ui-extensions/docs/reference/helper.docs.ts
+++ b/packages/checkout-ui-extensions/docs/reference/helper.docs.ts
@@ -87,7 +87,8 @@ In React, you can access it from any component through the \`useExtensionApi()\`
       description: `
 Some API property values may change after the extension is rendered.
 \`StatefulRemoteSubscribable\` properties allow you to subscribe to changes and perform a function or re-render your extension.
-If you are using React, you can utilize the property's corresponding hook to subscribe to changes and automatically re-render your extension.
+
+If you are using React, you can utilize the property's corresponding hook, or the [\`useSubscription()\`](/docs/api/checkout-ui-extensions/react-hooks/utilities/usesubscription) hook to subscribe to changes and automatically re-render your extension.
       `,
       codeblock: {
         title: 'Subscribing to changes',
@@ -185,12 +186,37 @@ Ensure your extension can access the Storefront API via the [\`api_access\` capa
         tabs: getExtensionCodeTabs('query-fetch'),
       },
     },
-    'buyer-journey-intercept': {
-      description:
-        "Intercept and prevent a buyer's progress through checkout. See the [validation tutorial](/docs/apps/checkout/validation) for more examples and best practices.",
+    'buyer-journey-intercept/page-level-error': {
+      description: `Intercept and prevent a buyer's progress through checkout while displaying an error message at the page level.
+        See the [validation tutorial](/docs/apps/checkout/validation) for more examples and best practices.`,
       codeblock: {
-        title: "Block a buyer's progress",
-        tabs: getExtensionCodeTabs('buyer-journey-intercept'),
+        title: 'Block progress and show error at page level',
+        tabs: getExtensionCodeTabs('buyer-journey-intercept/page-level-error'),
+      },
+    },
+    'buyer-journey-intercept/target-native-field': {
+      description: `Intercept and prevent a buyer's progress through checkout while targeting a specific checkout UI field.
+        See the [validation tutorial](/docs/apps/checkout/validation) for more examples and best practices.`,
+      codeblock: {
+        title: 'Block progress and show error for a checkout UI field',
+        tabs: getExtensionCodeTabs(
+          'buyer-journey-intercept/target-native-field',
+        ),
+      },
+    },
+    'buyer-journey-intercept/extension-banner': {
+      description: `Intercept and prevent a buyer's progress through checkout while displaying an error message in your extension.
+        See the [validation tutorial](/docs/apps/checkout/validation) for more examples and best practices.`,
+      codeblock: {
+        title: 'Block progress and show error in your extension',
+        tabs: getExtensionCodeTabs('buyer-journey-intercept/extension-banner'),
+      },
+    },
+    subscription: {
+      description: '',
+      codeblock: {
+        title: 'Subscribing to changes',
+        tabs: getExtensionCodeTabs('subscription'),
       },
     },
   };

--- a/packages/checkout-ui-extensions/docs/reference/hooks/buyer-journey-intercept.doc.ts
+++ b/packages/checkout-ui-extensions/docs/reference/hooks/buyer-journey-intercept.doc.ts
@@ -6,9 +6,9 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'useBuyerJourneyIntercept',
   description: `Installs a function for intercepting and preventing progress on checkout.
 
-  This returns a promise that resolves to a teardown function. Calling the teardown function will remove the interceptor.
-
-  To block checkout progress, you must set the [block_progress](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress) capability in your extension's configuration.`,
+  To block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/configuration#block-progress) capability in your extension's configuration.
+  If you do, then you're expected to inform the buyer why navigation was blocked, either by passing validation errors to the checkout UI or rendering the errors in your extension.
+  `,
   isVisualComponent: false,
   type: 'hook',
   category: 'React Hooks',
@@ -19,8 +19,26 @@ const data: ReferenceEntityTemplateSchema = {
       description: '',
       type: 'UseBuyerJourneyInterceptGeneratedType',
     },
+    {
+      title: 'InterceptorRequestBlock',
+      description: 'Block the buyer from proceeding further in the checkout',
+      type: 'InterceptorRequestBlock',
+    },
+    {
+      title: 'InterceptorRequestAllow',
+      description: 'Allow the buyer to proceed further in the checkout',
+      type: 'InterceptorRequestAllow',
+    },
   ],
-  defaultExample: getHookExample('buyer-journey-intercept'),
+  defaultExample: getHookExample('buyer-journey-intercept/target-native-field'),
+  examples: {
+    description:
+      'In addition to targeting checkout UI fields, you can also pass errors to the page level or render the error in your extension.',
+    examples: [
+      getHookExample('buyer-journey-intercept/page-level-error'),
+      getHookExample('buyer-journey-intercept/extension-banner'),
+    ],
+  },
   related: [
     {
       subtitle: 'Tutorial',

--- a/packages/checkout-ui-extensions/docs/reference/hooks/session-token.doc.ts
+++ b/packages/checkout-ui-extensions/docs/reference/hooks/session-token.doc.ts
@@ -1,11 +1,11 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
-import {getLinksByTag} from '../helper.docs';
+import {getExample, getHookExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'useSessionToken',
   description:
-    'Returns a `SessionToken` object, which contains a get() method that can be used to obtain a checkout extension session token.',
+    'Provides access to session tokens, which can be used to validate requests to your app server or supported third-party APIs using the token claims.',
   isVisualComponent: false,
   type: 'hook',
   category: 'React Hooks',
@@ -18,6 +18,11 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   related: getLinksByTag('apis'),
+  defaultExample: getHookExample('session-token'),
+  examples: {
+    description: '',
+    examples: [getHookExample('session-token-jwt')],
+  },
 };
 
 export default data;

--- a/packages/checkout-ui-extensions/docs/reference/hooks/subscription.doc.ts
+++ b/packages/checkout-ui-extensions/docs/reference/hooks/subscription.doc.ts
@@ -1,6 +1,6 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
-import {getLinksByTag} from '../helper.docs';
+import {getHookExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'useSubscription',
@@ -17,6 +17,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'UseSubscriptionGeneratedType',
     },
   ],
+  defaultExample: getHookExample('subscription'),
   related: getLinksByTag('apis'),
 };
 

--- a/packages/checkout-ui-extensions/docs/staticPages/extension-overview.doc.ts
+++ b/packages/checkout-ui-extensions/docs/staticPages/extension-overview.doc.ts
@@ -38,7 +38,7 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       anchorLink: 'dynamic-extension-points',
       title: 'Dynamic extension points',
-      sectionContent: `Dynamic extension points aren't tied to specific checkout features. They can render between core features on any checkout step. Merchants can use the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor) to place the extension in any one of the [supported locations](/api/checkout-ui-extensions/extension-points-api#supported-locations) for the dynamic extension point.
+      sectionContent: `Dynamic extension points aren't tied to specific checkout features. They can render between core features on any checkout step. Merchants can use the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor) to place the extension in any one of the [supported locations](/docs/api/checkout-ui-extensions/extension-points-overview#supported-locations) for the dynamic extension point.
       \n\nWhen a checkout feature for that location is hidden, dynamic extensions are still rendered. For example, an extension placed above the shipping address will still render even for digital products which do not require a shipping address.\n\nChoose dynamic extension points when your content and functionality is self-contained and can display at any step in the checkout process. An example is a field to capture order notes from the customer.`,
       image: 'dynamic-extension-points.png',
       sectionCard: [

--- a/packages/checkout-ui-extensions/src/components/shared.ts
+++ b/packages/checkout-ui-extensions/src/components/shared.ts
@@ -335,7 +335,7 @@ export interface SpacingProps {
    *
    * - [`base`, `none`] means blockStart and blockEnd paddings are `base`, inlineStart and inlineEnd paddings are `none`
    *
-   * - [`base`, `none`, `large200`, `small200`] means blockStart padding is `base`, inlineEnd padding is `none`, blockEnd padding is `large200` and  blockStart padding is `small200`
+   * - [`base`, `none`, `loose`, `tight`] means blockStart padding is `base`, inlineEnd padding is `none`, blockEnd padding is `loose` and blockStart padding is `tight`
    */
   padding?: MaybeResponsiveConditionalStyle<MaybeShorthandProperty<Spacing>>;
 }
@@ -465,31 +465,13 @@ export type Size =
   | 'extraLarge'
   | 'fill';
 
-/* @todo: remove the type override on docs/typeOverride.json once we align with other libraries */
 export type Spacing =
   | 'none'
-  | 'small500'
-  | 'small400'
-  | 'small300'
-  | 'small200'
-  | 'small100'
   | 'base'
-  | 'large100'
-  | 'large200'
-  | 'large300'
-  | 'large400'
-  | 'large500'
-  | SpacingDeprecated;
-
-/** @deprecated These values are deprecated and will eventually be removed.
- * Use the new values.
- *
- * `extraTight`: `small400`
- * `tight`: `small200`
- * `loose`: `large200`
- * `extraLoose`: `large500`
- */
-export type SpacingDeprecated = 'extraTight' | 'tight' | 'loose' | 'extraLoose';
+  | 'extraTight'
+  | 'tight'
+  | 'loose'
+  | 'extraLoose';
 
 export type Alignment = 'start' | 'center' | 'end';
 export type InlineAlignment = 'start' | 'center' | 'end';

--- a/packages/checkout-ui-extensions/src/components/shared.ts
+++ b/packages/checkout-ui-extensions/src/components/shared.ts
@@ -335,7 +335,7 @@ export interface SpacingProps {
    *
    * - [`base`, `none`] means blockStart and blockEnd paddings are `base`, inlineStart and inlineEnd paddings are `none`
    *
-   * - [`base`, `none`, `loose`, `tight`] means blockStart padding is `base`, inlineEnd padding is `none`, blockEnd padding is `loose` and blockStart padding is `tight`
+   * - [`base`, `none`, `large200`, `small200`] means blockStart padding is `base`, inlineEnd padding is `none`, blockEnd padding is `large200` and  blockStart padding is `small200`
    */
   padding?: MaybeResponsiveConditionalStyle<MaybeShorthandProperty<Spacing>>;
 }
@@ -465,13 +465,31 @@ export type Size =
   | 'extraLarge'
   | 'fill';
 
+/* @todo: remove the type override on docs/typeOverride.json once we align with other libraries */
 export type Spacing =
   | 'none'
+  | 'small500'
+  | 'small400'
+  | 'small300'
+  | 'small200'
+  | 'small100'
   | 'base'
-  | 'extraTight'
-  | 'tight'
-  | 'loose'
-  | 'extraLoose';
+  | 'large100'
+  | 'large200'
+  | 'large300'
+  | 'large400'
+  | 'large500'
+  | SpacingDeprecated;
+
+/** @deprecated These values are deprecated and will eventually be removed.
+ * Use the new values.
+ *
+ * `extraTight`: `small400`
+ * `tight`: `small200`
+ * `loose`: `large200`
+ * `extraLoose`: `large500`
+ */
+export type SpacingDeprecated = 'extraTight' | 'tight' | 'loose' | 'extraLoose';
 
 export type Alignment = 'start' | 'center' | 'end';
 export type InlineAlignment = 'start' | 'center' | 'end';

--- a/packages/checkout-ui-extensions/src/extension-points/api/index.ts
+++ b/packages/checkout-ui-extensions/src/extension-points/api/index.ts
@@ -82,5 +82,6 @@ export type {
   Timezone,
   GraphQLError,
   StorefrontApiVersion,
+  ValidationError,
 } from './shared';
 export type {CartLineRenderAfterApi} from './cart-line-render-after';

--- a/packages/checkout-ui-extensions/src/extension-points/api/shared.ts
+++ b/packages/checkout-ui-extensions/src/extension-points/api/shared.ts
@@ -831,6 +831,13 @@ export interface GraphQLError {
 }
 
 export interface ValidationError {
+  /**
+   * Error message to be displayed to the buyer.
+   */
   message: string;
+  /**
+   * The field that the error is associated with.
+   * Example: `$.cart.deliveryGroups[0].deliveryAddress.countryCode`
+   */
   target?: string;
 }

--- a/packages/checkout-ui-extensions/src/extension-points/api/standard/index.ts
+++ b/packages/checkout-ui-extensions/src/extension-points/api/standard/index.ts
@@ -1554,9 +1554,10 @@ export interface InterceptorProps {
 
 /**
  * A function for intercepting and preventing navigation on checkout. You can block
- * navigation by returning an object with `{behavior: 'block', reason: InvalidResultReason.InvalidExtensionState}`.
+ * navigation by returning an object with
+ * `{behavior: 'block', reason: InvalidResultReason.InvalidExtensionState, errors?: ValidationErrors[]}`.
  * If you do, then you're expected to also update some part of your UI to reflect the reason why navigation
- * was blocked.
+ * was blocked, either by targeting checkout UI fields, passing errors to the page level or rendering the errors in your extension.
  */
 export type Interceptor = (
   interceptorProps: InterceptorProps,
@@ -1622,6 +1623,8 @@ export interface Customer {
    * The Store Credit Accounts owned by the customer and usable during the checkout process.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires Level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   *
+   * @private
    */
   storeCreditAccounts: StoreCreditAccount[];
 }

--- a/packages/checkout-ui-extensions/src/extension-points/api/standard/index.ts
+++ b/packages/checkout-ui-extensions/src/extension-points/api/standard/index.ts
@@ -739,8 +739,10 @@ export interface StandardApi<
   ) => Promise<{data?: Data; errors?: GraphQLError[]}>;
 
   /**
-   * Provides access to session tokens, which can be used to validate requests made to your backend or properly
-   * configured third party APIs.
+   * Provides access to session tokens, which can be used to validate requests to your app server or supported third-party APIs
+   * using the token claims.
+   *
+   * See [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#example-session-token) for more information.
    */
   sessionToken: SessionToken;
 

--- a/packages/checkout-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/checkout-ui-extensions/src/extension-points/extension-points.ts
@@ -58,12 +58,12 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
-   * A [dynamic extension point](https://shopify.dev/api/checkout-extensions/checkout#extension-points) that isn't tied to a specific checkout section or feature.
+   * A [dynamic extension point](https://shopify.dev/docs/api/checkout-ui-extensions/extension-points-overview#dynamic-extension-points) that isn't tied to a specific checkout section or feature.
    * Unlike static extension points, dynamic extension points render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
-   * The [supported locations](https://shopify.dev/api/checkout-extensions/checkout#supported-locations) for dynamic extension points can be previewed during development
-   * by [using a URL parameter](https://shopify.dev/apps/checkout/test-ui-extensions#dynamic-extension-points).
+   * The [supported locations](https://shopify.dev/docs/api/checkout-ui-extensions/extension-points-overview#supported-locations) for dynamic extension points can be previewed during development
+   * by [using a URL parameter](https://shopify.dev/docs/apps/checkout/best-practices/testing-ui-extensions#dynamic-extension-points).
    */
   'Checkout::Dynamic::Render': RenderExtension<
     StandardApi<'Checkout::Dynamic::Render'>,
@@ -78,6 +78,15 @@ export interface ExtensionPoints {
    */
   'Checkout::GiftCard::Render': RenderExtension<
     StandardApi<'Checkout::GiftCard::Render'>,
+    AllComponents
+  >;
+  /**
+   * A static extension point that renders the form fields for a payment method when selected by the buyer.
+   *
+   * @private
+   */
+  'Checkout::PaymentMethod::Render': RenderExtension<
+    StandardApi<'Checkout::PaymentMethod::Render'>,
     AllComponents
   >;
   /**

--- a/packages/checkout-ui-extensions/src/extension-points/index.ts
+++ b/packages/checkout-ui-extensions/src/extension-points/index.ts
@@ -81,6 +81,7 @@ export type {
   Order,
   GraphQLError,
   StorefrontApiVersion,
+  ValidationError,
 } from './api';
 export type {RenderExtension} from './render-extension';
 export type {

--- a/packages/checkout-ui-extensions/src/index.ts
+++ b/packages/checkout-ui-extensions/src/index.ts
@@ -89,6 +89,7 @@ export type {
   GiftCardRemoveChange,
   GraphQLError,
   StorefrontApiVersion,
+  ValidationError,
 } from './extension-points';
 
 export * from './components';


### PR DESCRIPTION
### Background

Brings the latest from checkout-ui-extension packages from `Shopify/checkout-web`. Primary purpose of this release is for documentation improvements.



### Solution
Package changes include:

**Features**
- New `Checkout::PaymentMethod::Render` extension point (private preview) 

**Docs**
- Improved buyer journey intercept examples to showcase page-level and targeting validation error messages
- Cleanup of some old doc links
- Fix for link resolution on shopify-dev for anchor links when previewing in spin
- Added example for `useSubscription` hook
- Added examples for `sessionToken`

Upon merging, this commit will be linked to a corresponding [Shopify/shopify-dev](https://github.com/Shopify/shopify-dev/pull/32913) PR that represents the doc update.

### 🎩

You can tophat the packages following these [instructions](https://checkout.docs.shopify.io/docs/referencedocs/web/extensions/libraries#2--tophat-the-packages).

You can tophat the docs that will be generated from this commit by [previewing this spin instance](https://shopify-dev.checkout-extensibility-docs-patch.james-vidler.us.spin.dev/docs/api/checkout-ui-extensions).


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
