### PR TITLE
Publish

### DIFF
--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/checkout-ui-extensions-react",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "React bindings for @shopify/checkout-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions": "^0.25.0",
+    "@shopify/checkout-ui-extensions": "^0.25.1",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify’s Checkout",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/customer-account-ui-extensions-react",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "React bindings for @shopify/customer-account-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions-react": "^0.25.0",
-    "@shopify/customer-account-ui-extensions": "^0.0.37"
+    "@shopify/checkout-ui-extensions-react": "^0.25.1",
+    "@shopify/customer-account-ui-extensions": "^0.0.38"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <18.0.0"

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/customer-account-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify's Customer Account",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"
@@ -24,6 +24,6 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/core": "2.1.x",
-    "@shopify/checkout-ui-extensions": "^0.25.0"
+    "@shopify/checkout-ui-extensions": "^0.25.1"
   }
 }


### PR DESCRIPTION
 - @shopify/checkout-ui-extensions-react@0.25.1
 - @shopify/checkout-ui-extensions@0.25.1
 - @shopify/customer-account-ui-extensions-react@0.0.39
 - @shopify/customer-account-ui-extensions@0.0.38

### Background

Publishes [latest checkout-ui-extension packages (patch)](https://github.com/Shopify/ui-extensions/pull/872) which is already approved and merged to `main`. This also bumps the dependancies in the `customer-account-ui-extensions` packages.

### Solution

[Releasing checkout ui extension library versions](https://checkout.docs.shopify.io/docs/referencedocs/web/extensions/libraries#releasing-library-versions).

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation: https://github.com/Shopify/shopify-dev/pull/32913
