### PR TITLE
Revert scanner data subscribable to not be undefined

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/scanner-api/scanner-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/scanner-api/scanner-api.ts
@@ -5,9 +5,9 @@ export type ScannerSource = 'camera' | 'external' | 'embedded';
 
 export interface ScannerSubscriptionResult {
   /** The string data from the last scanner event received. */
-  data: string;
+  data?: string;
   /** The scanning source from which the scan event came. */
-  source: ScannerSource;
+  source?: ScannerSource;
 }
 
 export interface ScannerApiContent {
@@ -16,9 +16,7 @@ export interface ScannerApiContent {
    * You can utilize `makeStatefulSubscribable` on a `RemoteSubscribable` to implement multiple subscriptions.
    * Using `makeStatefulSubscribable` or the corresponding hooks counts as a subscription.
    */
-  scannerDataSubscribable: RemoteSubscribable<
-    ScannerSubscriptionResult | undefined
-  >;
+  scannerDataSubscribable: RemoteSubscribable<ScannerSubscriptionResult>;
   /** Creates a subscription to the scanning sources available on the POS device.
    * Provides an initial value and a callback to subsribe to value changes. Currently supports only one subscription.
    * You can utilize `makeStatefulSubscribable` on a `RemoteSubscribable` to implement multiple subscriptions.


### PR DESCRIPTION
### Background

Extension will not load if a developer attempts to access the `ScannerSubscriptionResult` interface but the entire  RemoteSubscribable is undefined. We can fix this by just making the interface props optional.

