### PR TITLE
Update links to point to the vault instead of the checkout microsite

### DIFF
--- a/packages/checkout-ui-extensions/docs/build-docs.sh
+++ b/packages/checkout-ui-extensions/docs/build-docs.sh
@@ -10,7 +10,7 @@ find ./ -name '*.doc*.js' -exec rm -r {} \;
 
 if [ $build_exit -ne 0 ]; then
   echo "** Failed to generate docs"
-  echo "See https://checkout.docs.shopify.io/docs/referencedocs/web/extensions/docs"
+  echo "See https://vault.shopify.io/page/Extension-Docs~SkgE.md"
   exit $build_exit
 fi
 


### PR DESCRIPTION
In a [this PR](https://github.com/Shopify/vault-pages/pull/2344), we moved our Checkout Docs microsite to Vault pages.: https://vault.shopify.io/page/checkout