### PR TITLE
[Customer Account Web Components] Remove duplicate exports of pressable

### DIFF
--- a/packages/customer-account-ui-extensions-react/src/components/shared-components.ts
+++ b/packages/customer-account-ui-extensions-react/src/components/shared-components.ts
@@ -35,7 +35,6 @@ export {
   View,
   Modal,
   Popover,
-  Pressable,
   ScrollView,
   Tooltip,
 } from '@shopify/checkout-ui-extensions-react';
@@ -93,7 +92,6 @@ export type {
   Spacing,
   Alignment,
   Appearance,
-  PressableProps,
   ScrollViewProps,
   TooltipProps,
 } from '@shopify/checkout-ui-extensions-react';

--- a/packages/customer-account-ui-extensions/src/components/shared-components.ts
+++ b/packages/customer-account-ui-extensions/src/components/shared-components.ts
@@ -35,7 +35,6 @@ export {
   View,
   Modal,
   Popover,
-  Pressable,
   Tooltip,
   ScrollView,
 } from '@shopify/checkout-ui-extensions';
@@ -95,7 +94,6 @@ export type {
   Spacing,
   Alignment,
   Appearance,
-  PressableProps,
   ScrollViewProps,
   TooltipProps,
 } from '@shopify/checkout-ui-extensions';


### PR DESCRIPTION
### Background

Fixes a TS issue we introduced here https://github.com/Shopify/ui-extensions/pull/862

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
