### PR TITLE
web pixels: export schema as ts instead of js

### DIFF
--- a/packages/web-pixels-extension/src/index.ts
+++ b/packages/web-pixels-extension/src/index.ts
@@ -1,3 +1,4 @@
 export {register} from './register';
 export type {ShopifyGlobal} from './globals';
 export * from './types';
+export {pixelEvents} from './schemas/pixel-events';

--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -1,4 +1,4 @@
-const pixelEvents = {
+export const pixelEvents = {
   definitions: {
     Browser: {
       properties: {
@@ -1472,5 +1472,3 @@ const pixelEvents = {
     },
   },
 };
-
-export default pixelEvents;

--- a/packages/web-pixels-extension/src/types/index.ts
+++ b/packages/web-pixels-extension/src/types/index.ts
@@ -19,6 +19,10 @@ export type {
   MailingAddress,
   ProductVariant,
   PixelEventsProductAddedToCartData,
+  PixelEventsCheckoutStarted,
+  PixelEventsCheckoutCompleted,
+  PixelEventsCheckoutStartedData,
+  PixelEventsCheckoutCompletedData,
 } from './PixelEvents';
 export type {
   PublisherData,


### PR DESCRIPTION
### Background

followup of https://github.com/Shopify/web-pixels-manager/pull/338

### Solution

get around web's webpack config by using a ts file here instead

you can see it working in [spin](https://admin.web.pixels-autocomplete-pt.eric-berndt.us.spin.dev/store/shop1/settings/customer_events/pixels/2)

<img width="1552" alt="Screenshot 2023-04-25 at 3 49 32 PM" src="https://user-images.githubusercontent.com/19786312/234423953-4aea6be8-f751-4082-a8d9-f0e60dd64931.png">

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
