### PR TITLE
support for building checkout extensibility api doc versions

### DIFF
--- a/packages/checkout-ui-extensions/docs/build-docs.sh
+++ b/packages/checkout-ui-extensions/docs/build-docs.sh
@@ -1,3 +1,12 @@
+API_VERSION=$1
+
+if [ -z $API_VERSION ]
+then
+  echo "Building docs for 'unstable' checkout UI extensions API. You can add a calver version argument (e.g. 'yarn docs:checkout 2023-04') to generate the docs for a specific version in addition to 'unstable'."
+else
+  echo "Building docs for 'unstable' and '$API_VERSION' checkout UI extensions API."
+fi
+
 COMPILE_DOCS="yarn tsc --project docs/tsconfig.docs.json --types react --moduleResolution node  --target esNext  --module CommonJS && yarn generate-docs --overridePath ./docs/typeOverride.json --input ./docs/reference ./src --typesInput ./src ../checkout-ui-extensions-react/src --output ./docs/generated"
 COMPILE_STATIC_PAGES="yarn tsc docs/staticPages/*.doc.ts --types react --moduleResolution node  --target esNext  --module CommonJS && yarn generate-docs --isLandingPage --input ./docs/staticPages --output ./docs/generated"
 
@@ -20,8 +29,17 @@ sed -i 's/https:\/\/shopify.dev//gi' ./docs/generated/generated_docs_data.json
 
 if [ -n "$SPIN" ]; then
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
-    cp ./docs/generated/* ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/checkout_extensions/
-    rsync -a --delete ./docs/screenshots/ ~/src/github.com/Shopify/shopify-dev/app/assets/images/templated-apis-screenshots/checkout-ui-extensions
+    cp ./docs/generated/* ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/checkout_extensions/unstable
+    rsync -a --delete ./docs/screenshots/ ~/src/github.com/Shopify/shopify-dev/app/assets/images/templated-apis-screenshots/checkout-ui-extensions/unstable
+
+    # Copy over to specified calver version
+    if [ $# -gt 0 ]
+    then
+      mkdir -p ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
+      cp ./docs/generated/* ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
+      rsync -a --delete ./docs/screenshots/ ~/src/github.com/Shopify/shopify-dev/app/assets/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
+    fi
+
     cd ~/src/github.com/Shopify/shopify-dev
     restart
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/checkout-ui-extensions"


### PR DESCRIPTION
### Background

This brings over the script from `checkout-web` necessary to build API docs for checkout extensibility by API version. 

### 🎩

This has already been tophatted in this [PR in checkout-web](https://github.com/Shopify/checkout-web/pull/20484).

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
