### PR TITLE
Use explicit version for the react package

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/retail-ui-extensions": "^1.1.0",
+    "@shopify/retail-ui-extensions": "1.1.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Background

The retail react package should have a strict dependency, otherwise it might be out of sync with Vanilla. Partners might experience issue due to this. 

### Solution

Remove `^` from the react dependency. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
