### PR TITLE
Fix typo for scanner api interface

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/scanner-api/scanner-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/scanner-api/scanner-api.ts
@@ -26,5 +26,5 @@ export interface ScannerApiContent {
 }
 
 export interface ScannerApi {
-  api: ScannerApiContent;
+  scanner: ScannerApiContent;
 }


### PR DESCRIPTION
[24242](https://github.com/Shopify/pos-next-react-native/issues/24242)

### Background

When trying to reference the scanner api it should be named `scanner` and not `api`

![image](https://user-images.githubusercontent.com/29528613/236014122-6e113427-59a5-408a-a5c6-ff796eadd793.png)

