### PR TITLE
Enabled react eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
 
     // This rule is just bad
     '@typescript-eslint/consistent-indexed-object-style': 'off',
+    'react/react-in-jsx-scope': 'off',
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
     'plugin:@shopify/typescript',
     'plugin:@shopify/jest',
     'plugin:@shopify/prettier',
+    'plugin:@shopify/react',
   ],
   ignorePatterns: [
     'build/',
@@ -35,6 +36,12 @@ module.exports = {
     {
       files: ['**/.eslintrc.js'],
       env: {node: true},
+    },
+    {
+      files: ['*.stories.*', '*.test.*', '*.example.*'],
+      rules: {
+        '@shopify/jsx-no-hardcoded-content': 'off',
+      },
     },
   ],
 };

--- a/packages/checkout-ui-extensions-react/.eslintrc.js
+++ b/packages/checkout-ui-extensions-react/.eslintrc.js
@@ -1,6 +1,10 @@
 module.exports = {
   rules: {
     'react/react-in-jsx-scope': 'off',
+    'no-process-env': 'error',
+    '@typescript-eslint/ban-ts-comment': 'error',
+    '@typescript-eslint/ban-types': 'error',
+    'no-warning-comments': 'error',
   },
   overrides: [
     {

--- a/packages/checkout-ui-extensions-react/src/hooks/tests/translate.test.tsx
+++ b/packages/checkout-ui-extensions-react/src/hooks/tests/translate.test.tsx
@@ -28,6 +28,7 @@ describe('useTranslate', () => {
 
     const simpleTranslation = [
       'Hello, ',
+      // eslint-disable-next-line react/jsx-key
       <Name />,
       ' . You are applicant #',
       1,

--- a/packages/checkout-ui-extensions-react/src/hooks/translate.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/translate.ts
@@ -25,6 +25,7 @@ export function useTranslate<
 
       return translation.map((part, index) => {
         if (isValidElement(part)) {
+          // eslint-disable-next-line react/no-array-index-key
           return cloneElement(part as RemoteComponentType<any>, {key: index});
         }
         return part;


### PR DESCRIPTION
### Background
Related to https://github.com/Shopify/checkout-web/issues/19623 and https://github.com/Shopify/checkout-web/pull/20985.

This enables react eslint rules that are present and enforced in `checkout-web` and these rules should also be enforced here.

> Note
This needs to ship AFTER https://github.com/Shopify/checkout-web/pull/20985 and changes are pulled into this repo in order for CI to pass.

### 🎩
Check that this passes CI.


### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
