### PR TITLE
Added a function to add a cart note

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
@@ -73,6 +73,11 @@ export interface CartApiContent {
    */
   removeCartProperties(keys: string[]): Promise<void>;
 
+  /** Adds or modifies a cart note.
+   * @param note the note to set on the cart. This will override the existing note.
+   */
+  setCartNote(note: string): Promise<void>;
+
   /** Adds custom properties to the specified line item
    * @param uuid the uuid of the line item to which the properties should be stringd
    * @param properties the custom key to value object to attribute to the line item


### PR DESCRIPTION
### Background
https://github.com/Shopify/pos-next-react-native/issues/24327

Adds the ability to add a cart note. This ends up populating the note field on an Order.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
