### PR TITLE
Add bullet for POS UI Extensions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ If you’re ready to start building, you’ll want to refer to the documentation
 - Building an extension for the post-purchase page of the Shopify Checkout? You should read the documentation for [`@shopify/post-purchase-ui-extensions`](./packages/post-purchase-ui-extensions) (and [`@shopify/post-purchase-ui-extensions-react`](./packages/post-purchase-ui-extensions-react), if you use React)
 - Building an extension for other parts of the Shopify Checkout? You should read the documentation for [`@shopify/checkout-ui-extensions`](./packages/checkout-ui-extensions) (and [`@shopify/checkout-ui-extensions-react`](./packages/checkout-ui-extensions-react), if you use React)
 - Building an extension for the Shopify Admin? You should read the documentation for [`@shopify/admin-ui-extensions`](./packages/admin-ui-extensions) (and [`@shopify/admin-ui-extensions-react`](./packages/admin-ui-extensions-react), if you use React)
+- Building a UI extension for the Shopify POS? You should read the documentation on [Shopify.dev](https://shopify.dev/docs/apps/pos/ui-extensions)
 
 If you want to learn a little more about the patterns found throughout these libraries, and the way that they are rendered into the applications they extend, read on!
 


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/pos-next-react-native/issues/24307

### Solution

Add a line to the README for POS UI Extensions, which links to Shopify.dev docs.

### 🎩

- Verify the link works

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
