### PR TITLE
add untranslated title to product schema

### DIFF
--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -447,7 +447,7 @@ export const pixelEvents = {
     Checkout: {
       metadata: {
         description:
-          'A container for all the information required to checkout items and pay.',
+          'A container for all the information required to add items to checkout and pay.',
       },
       properties: {
         attributes: {
@@ -624,6 +624,12 @@ export const pixelEvents = {
             description: 'The product variant’s title.',
           },
         },
+        untranslatedTitle: {
+          type: 'string',
+          metadata: {
+            description: 'The product variant’s untranslated title.',
+          },
+        },
       },
     },
     Image: {
@@ -675,6 +681,12 @@ export const pixelEvents = {
           type: 'string',
           metadata: {
             description: 'The product’s title.',
+          },
+        },
+        untranslatedTitle: {
+          type: 'string',
+          metadata: {
+            description: 'The product’s untranslated title.',
           },
         },
         vendor: {
@@ -1040,7 +1052,7 @@ export const pixelEvents = {
     checkout_address_info_submitted: {
       metadata: {
         description:
-          'The `checkout_address_info_submitted` event logs an instance of a buyer submitting their mailing address. This event is only available in Checkouts where Checkout Extensibility for customizations is enabled.',
+          'The `checkout_address_info_submitted` event logs an instance of a buyer submitting their mailing address. This event is only available in checkouts where checkout extensibility for customizations is enabled.',
       },
       properties: {
         id: {
@@ -1241,7 +1253,7 @@ export const pixelEvents = {
     checkout_contact_info_submitted: {
       metadata: {
         description:
-          'The `checkout_contact_info_submitted` event logs an instance where a buyer submits a checkout form. This event is only available in Checkouts where Checkout Extensibility for customizations is enabled.',
+          'The `checkout_contact_info_submitted` event logs an instance where a buyer submits a checkout form. This event is only available in checkouts where checkout extensibility for customizations is enabled.',
       },
       properties: {
         id: {
@@ -1439,7 +1451,7 @@ export const pixelEvents = {
     checkout_shipping_info_submitted: {
       metadata: {
         description:
-          'The `checkout_shipping_info_submitted` event logs an instance where the buyer chooses a shipping rate. This event is only available in Checkouts where Checkout Extensibility for customizations is enabled.',
+          'The `checkout_shipping_info_submitted` event logs an instance where the buyer chooses a shipping rate. This event is only available in checkouts where checkout extensibility for customizations is enabled.',
       },
       properties: {
         id: {

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -6,8 +6,8 @@ export interface PixelEventsCheckoutAddressInfoSubmittedData {
 
 /**
  * The `checkout_address_info_submitted` event logs an instance of a buyer
- * submitting their mailing address. This event is only available in Checkouts
- * where Checkout Extensibility for customizations is enabled.
+ * submitting their mailing address. This event is only available in checkouts
+ * where checkout extensibility for customizations is enabled.
  */
 export interface PixelEventsCheckoutAddressInfoSubmitted {
   clientId: ClientId;
@@ -49,8 +49,8 @@ export interface PixelEventsCheckoutContactInfoSubmittedData {
 
 /**
  * The `checkout_contact_info_submitted` event logs an instance where a buyer
- * submits a checkout form. This event is only available in Checkouts where
- * Checkout Extensibility for customizations is enabled.
+ * submits a checkout form. This event is only available in checkouts where
+ * checkout extensibility for customizations is enabled.
  */
 export interface PixelEventsCheckoutContactInfoSubmitted {
   clientId: ClientId;
@@ -71,8 +71,8 @@ export interface PixelEventsCheckoutShippingInfoSubmittedData {
 
 /**
  * The `checkout_shipping_info_submitted` event logs an instance where the buyer
- * chooses a shipping rate. This event is only available in Checkouts where
- * Checkout Extensibility for customizations is enabled.
+ * chooses a shipping rate. This event is only available in checkouts where
+ * checkout extensibility for customizations is enabled.
  */
 export interface PixelEventsCheckoutShippingInfoSubmitted {
   clientId: ClientId;
@@ -272,8 +272,8 @@ export interface PixelEventsSearchSubmitted {
 export interface PixelEvents {
   /**
    * The `checkout_address_info_submitted` event logs an instance of a buyer
-   * submitting their mailing address. This event is only available in Checkouts
-   * where Checkout Extensibility for customizations is enabled.
+   * submitting their mailing address. This event is only available in checkouts
+   * where checkout extensibility for customizations is enabled.
    */
   checkout_address_info_submitted: PixelEventsCheckoutAddressInfoSubmitted;
 
@@ -285,15 +285,15 @@ export interface PixelEvents {
 
   /**
    * The `checkout_contact_info_submitted` event logs an instance where a buyer
-   * submits a checkout form. This event is only available in Checkouts where
-   * Checkout Extensibility for customizations is enabled.
+   * submits a checkout form. This event is only available in checkouts where
+   * checkout extensibility for customizations is enabled.
    */
   checkout_contact_info_submitted: PixelEventsCheckoutContactInfoSubmitted;
 
   /**
    * The `checkout_shipping_info_submitted` event logs an instance where the
-   * buyer chooses a shipping rate. This event is only available in Checkouts
-   * where Checkout Extensibility for customizations is enabled.
+   * buyer chooses a shipping rate. This event is only available in checkouts
+   * where checkout extensibility for customizations is enabled.
    */
   checkout_shipping_info_submitted: PixelEventsCheckoutShippingInfoSubmitted;
 
@@ -566,7 +566,8 @@ export interface CartLineCost {
 }
 
 /**
- * A container for all the information required to checkout items and pay.
+ * A container for all the information required to add items to checkout and
+ * pay.
  */
 export interface Checkout {
   attributes: Attribute[];
@@ -950,6 +951,11 @@ export interface Product {
   type: string | null;
 
   /**
+   * The product’s untranslated title.
+   */
+  untranslatedTitle: string;
+
+  /**
    * The product’s vendor name.
    */
   vendor: string;
@@ -990,6 +996,11 @@ export interface ProductVariant {
    * The product variant’s title.
    */
   title: string;
+
+  /**
+   * The product variant’s untranslated title.
+   */
+  untranslatedTitle: string;
 }
 
 /**


### PR DESCRIPTION
### Background

As part of https://github.com/Shopify/ce-customer-behaviour/issues/2344

We are adding untranslated title to our WPM api. So our partners can get the untranslated version of the lineItem title!

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

https://constellation-pppx.henry-zhou.us.spin.dev/

If you go through a checkout flow, you can see that there is now the `untranslated_title` in addition to the regular title

<img width="583" alt="Screenshot 2023-05-16 at 10 18 18 AM" src="https://github.com/Shopify/ui-extensions/assets/19720593/f097e3b3-4a00-4210-819b-4f3fba78ae8e">


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
