### PR TITLE
Publish

### DIFF
--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/checkout-ui-extensions-react",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "React bindings for @shopify/checkout-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions": "^0.26.1",
+    "@shopify/checkout-ui-extensions": "^0.26.2",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify’s Checkout",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/customer-account-ui-extensions-react",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "React bindings for @shopify/customer-account-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions-react": "^0.26.1",
-    "@shopify/customer-account-ui-extensions": "^0.0.43"
+    "@shopify/checkout-ui-extensions-react": "^0.26.2",
+    "@shopify/customer-account-ui-extensions": "^0.0.44"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <18.0.0"

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/customer-account-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify's Customer Account",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"
@@ -24,6 +24,6 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/core": "2.1.x",
-    "@shopify/checkout-ui-extensions": "^0.26.1"
+    "@shopify/checkout-ui-extensions": "^0.26.2"
   }
 }


### PR DESCRIPTION
 - @shopify/checkout-ui-extensions-react@0.26.2
 - @shopify/checkout-ui-extensions@0.26.2
 - @shopify/customer-account-ui-extensions-react@0.0.46
 - @shopify/customer-account-ui-extensions@0.0.44

### Background

This releases that latest version of `checkout-ui-extensions` and updates the dependency for it within `customer-account-ui-extensions`.

### Solution

See https://github.com/Shopify/ui-extensions/pull/935 for details on the changes to checkout-ui-extensions.

### 🎩

Tophat your changes by copying the packages from Spin into a real [scaffolded app / extension](https://shopify.dev/docs/api/checkout-ui-extensions#scaffolding-extension). Change into the app directory on your local machine and run this:

```
VM=direct.$(spin show -o fqdn)
rsync -av --delete $VM:~/src/github.com/Shopify/ui-extensions/packages/checkout-ui-extensions node_modules/@shopify/ && \
   rsync -av --delete $VM:~/src/github.com/Shopify/ui-extensions/packages/checkout-ui-extensions-react node_modules/@shopify/
Use yarn --force to restore your local app afterwards.
```

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
