### PR TITLE
Update Navigator to allow initial screen

### DIFF
--- a/packages/retail-ui-extensions/src/components/Navigator/Navigator.ts
+++ b/packages/retail-ui-extensions/src/components/Navigator/Navigator.ts
@@ -1,3 +1,12 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-export const Navigator = createRemoteComponent<'Navigator'>('Navigator');
+/**
+ * @property `initialScreenName` sets the initial Screen by its `name` property.
+ */
+export interface NavigatorProps {
+  initialScreenName?: string;
+}
+
+export const Navigator = createRemoteComponent<'Navigator', NavigatorProps>(
+  'Navigator',
+);

--- a/packages/retail-ui-extensions/src/components/Navigator/index.ts
+++ b/packages/retail-ui-extensions/src/components/Navigator/index.ts
@@ -1,1 +1,2 @@
 export {Navigator} from './Navigator';
+export type {NavigatorProps} from './Navigator';


### PR DESCRIPTION
### Background
Part of https://github.com/Shopify/pos-next-react-native/issues/24123

### Solution

Add an `initialScreenName` prop to the Navigator component.

### Checklist

- [X] I have :tophat:'d these changes
