### PR TITLE
[Customer Account] Remove unused Card props

### DIFF
--- a/packages/customer-account-ui-extensions/src/components/Card/Card.ts
+++ b/packages/customer-account-ui-extensions/src/components/Card/Card.ts
@@ -7,14 +7,6 @@ export interface CardProps {
    */
   background?: Background;
   /**
-   * Enables or disables a divider after each section. **Enabled by default**
-   */
-  includeDividers?: boolean;
-  /**
-   * The children that will be rendered inside the Card
-   */
-  fillHeight?: boolean;
-  /**
    * The padding within the Card. Default is "loose"
    */
   padding?: SpacingProps;


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/55239
Related to https://github.com/Shopify/customer-account-web/pull/2258

Removes the Card props `fillHeight` and `includeDividers` from `customer-account-ui-extensions`. These props are no longer available in `customer-account-web`. They aren't used by the `buyer-returns` or `buyer-subscriptions` extensions so it's safe to remove them.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

See https://github.com/Shopify/customer-account-web/pull/2258 for details

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
