### PR TITLE
Add badge and toggleSwitch to List

### DIFF
--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@remote-ui/async-subscription": "2.1.x",
-    "@remote-ui/core": "2.1.x"
+    "@remote-ui/core": "2.1.x",
+    "react-native": "0.71.8"
   }
 }

--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -1,5 +1,28 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import {BadgeProps} from '../Badge';
+import type {
+  AccessibilityProps as RNAccessibilityProps,
+  AccessibilityPropsAndroid,
+  AccessibilityPropsIOS,
+} from 'react-native';
+
+export interface AccessibilityProps
+  extends RNAccessibilityProps,
+    AccessibilityPropsAndroid,
+    AccessibilityPropsIOS {
+  accessibilityAutoFocus?: boolean;
+  accessibilityLabelPrefix?: string;
+}
+
+export interface TestProps<T extends string = string> {
+  testID?: T;
+}
+
+export interface ToggleSwitch extends TestProps {
+  value?: boolean;
+  disabled?: boolean;
+  accessibilityDetails?: AccessibilityProps;
+}
 
 export interface ListRowLeftSide {
   /**
@@ -19,6 +42,10 @@ export interface ListRowLeftSide {
      * A link to an image to be displayed on the far left side of the row.
      */
     source: string;
+    /**
+     * A number that is displayed on the top right of the image.
+     */
+    badge?: number;
   };
 }
 
@@ -32,6 +59,10 @@ export interface ListRowRightSide {
    * @defaultValue `false`
    */
   showChevron?: boolean;
+  /**
+   * A toggle switch that is be displayed on the right side of the row.
+   */
+  toggleSwitch?: ToggleSwitch;
 }
 
 export interface ListRow {


### PR DESCRIPTION
### Background

Part of [24526](https://github.com/Shopify/pos-next-react-native/issues/24526)

This PR adds the `badge` and `toggleSwitch` properties to the `ListRowProps` of the `List` component that will be updated in version `1.2.0`.

### Solution

These types were copied from `ListRowProps` in `polaris-for-retail`.

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
