### PR TITLE
Create a DeviceAPI for name and deviceId

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/device-api/device-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/device-api/device-api.ts
@@ -1,0 +1,17 @@
+export interface DeviceApiContent {
+  /**
+   * The name of the device
+   */
+  name: string;
+  /**
+   * The string ID of the device
+   */
+  getDeviceId(): Promise<string>;
+}
+
+/**
+ * Access information about the device, like name and ID
+ */
+export interface DeviceApi {
+  device: DeviceApiContent;
+}

--- a/packages/retail-ui-extensions/src/extension-api/device-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/device-api/index.ts
@@ -1,0 +1,1 @@
+export type {DeviceApiContent, DeviceApi} from './device-api';

--- a/packages/retail-ui-extensions/src/extension-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/index.ts
@@ -18,6 +18,7 @@ export type {
   ProductSearchApiContent,
   ProductSortType,
 } from './product-search-api';
+export type {DeviceApiContent, DeviceApi} from './device-api';
 
 export type {
   Address,

--- a/packages/retail-ui-extensions/src/extension-api/standard-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/standard-api.ts
@@ -2,10 +2,12 @@ import type {CartApi} from './cart-api';
 import type {LocaleApi} from './locale-api';
 import type {SessionApi} from './session-api';
 import type {ToastApi} from './toast-api';
+import type {DeviceApi} from './device-api';
 
 export type StandardApi<T> = {[key: string]: any} & {
   extensionPoint: T;
 } & LocaleApi &
   CartApi &
   ToastApi &
-  SessionApi;
+  SessionApi &
+  DeviceApi;

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -2,6 +2,7 @@ export type {
   LocaleApi,
   CartApiContent,
   DiscountType,
+  DeviceApi,
   CartApi,
   NavigationApi,
   NavigationApiContent,


### PR DESCRIPTION
### Background

Part of [23437](https://github.com/Shopify/pos-next-react-native/issues/23437)

Creates a DeviceAPI with `name` and `deviceId` properties.

### Solution

Create the DeviceAPI with `name` and `deviceId` properties and propagate it to the top of the `retail-ui-extensions` package.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
