### PR TITLE
New API functions to set staff to line items

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
@@ -101,6 +101,20 @@ export interface CartApiContent {
     amount: string,
   ): Promise<void>;
 
+  /** Sets an attributed staff to all line items in the cart.
+   * @param staffId the ID of the staff.
+   */
+  setAttributedStaff(staffId: number): Promise<void>;
+
+  /** Sets an attributed staff to a specific line items in the cart.
+   * @param staffId the ID of the staff.
+   * @param lineItemUuid the UUID of the line item.
+   */
+  setAttributedStaffToLineItem(
+    staffId: number,
+    lineItemUuid: string,
+  ): Promise<void>;
+
   /** Remove all discounts from a line item
    * @param uuid the uuid of the line item whose discounts should be removed
    */


### PR DESCRIPTION
### Background

This provides two new functions to attribute staff to line items in the cart.

### Solution

Here is what the code POS side would look like: 

https://github.com/Shopify/pos-next-react-native/pull/24657

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
