### PR TITLE
Publish unstable version for upcoming 1.2.0

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "1.1.2",
+  "version": "1.1.3-unstable.0",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/retail-ui-extensions": "1.1.2",
+    "@shopify/retail-ui-extensions": "1.1.3-unstable.0",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/retail-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify Point of Sale",
-  "version": "1.1.2",
+  "version": "1.1.3-unstable.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
 - @shopify/retail-ui-extensions-react@1.1.3-unstable.0
 - @shopify/retail-ui-extensions@1.1.3-unstable.0

### Background

I followed @heltisace doc, where we specify our custom pre-release to be "unstable". However, this creates a 1.1.3-unstable, instead of 1.2.0-unstable. This is just semantics, but maybe we can consider using the default minor prerelease which would label it as 1.2.0-alpha instead. For now this is fine 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
