### PR TITLE
Publish

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "1.1.3-rc.1",
+  "version": "1.2.0-rc",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/retail-ui-extensions": "1.1.3-rc.1",
+    "@shopify/retail-ui-extensions": "1.2.0-rc",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/retail-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify Point of Sale",
-  "version": "1.1.3-rc.1",
+  "version": "1.2.0-rc",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
 - @shopify/retail-ui-extensions-react@1.2.0-rc
 - @shopify/retail-ui-extensions@1.2.0-rc

### Background

Currently, the candidate for releasing 1.2.0-rc was named `1.1.3-rc` due to some internal script limitations. This PR fixes the problem. 

### Solution

Releasing `1.2.0-rc` version. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
