### PR TITLE
Add ui to Standard API to allow programatic closing of overlays

### DIFF
--- a/packages/customer-account-ui-extensions/src/extension-points/standard-api/index.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/standard-api/index.ts
@@ -60,4 +60,13 @@ export interface StandardApi {
    * Key-value storage for the extension point.
    */
   storage: Storage;
+
+  /**
+   * Methods to interact with the extension's UI.
+   */
+  ui: {
+    overlay: {
+      close(overlayId: string): void;
+    };
+  };
 }


### PR DESCRIPTION
### Background

This PR updates the type definition for the Standard API that is passed to customer account web extensions. We are adding a `ui` object that provides a method to allow programatic closing of overlays. For more info about this, see https://github.com/Shopify/buyer-subscriptions/issues/145

Part of implementing https://github.com/Shopify/checkout-web/pull/21439 for customer-account-web. 

Companion to https://github.com/Shopify/customer-account-web/pull/2512

### 🎩

- See https://github.com/Shopify/customer-account-web/pull/2512

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
