### PR TITLE
fix spacing types for Customer Account Card

### DIFF
--- a/packages/customer-account-ui-extensions/src/components/Card/Card.ts
+++ b/packages/customer-account-ui-extensions/src/components/Card/Card.ts
@@ -1,15 +1,11 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import {Background, SpacingProps} from 'components/shared';
+import {Background, SpacingProps} from '../shared';
 
-export interface CardProps {
+export interface CardProps extends SpacingProps {
   /**
    * Adjust the background.
    */
   background?: Background;
-  /**
-   * The padding within the Card. Default is "loose"
-   */
-  padding?: SpacingProps;
 }
 
 export const Card = createRemoteComponent<'Card', CardProps>('Card');


### PR DESCRIPTION
### Background
Fixes two issues with the `Card` spacing props that lead to autocomplete and type check not working.

| Before | After |
| --- | --- |
| <img width="719" alt="Screenshot 2023-06-02 at 1 16 23 PM" src="https://github.com/Shopify/ui-extensions/assets/474248/f8a7b079-1f34-42a9-a917-15c885a793c7"> | <img width="707" alt="Screenshot 2023-06-02 at 1 45 03 PM" src="https://github.com/Shopify/ui-extensions/assets/474248/08fffb48-3e79-442a-ae0e-c51512100bdb"> |

- `SpacingProps` already contains `padding` so assigning it to `padding` didn't work. I checked [how it's used in other components](https://github.com/search?q=repo%3AShopify%2Fui-extensions+SpacingProps&type=code) and applied it similarly.
- The bigger one. `components/shared` doesn't work because TS can't resolve it. `components` isn't a node module and we generally use the node moduleResolution TS algo. What is weird tho, is that it didn't fail in this repo and resolved it as if we used [`classic` resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html#classic) which actually just walks up the tree to find the module.  This needs to be investigated seperately.

### 🎩

- Green CI

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
