### PR TITLE
remove baseUrl to fix module resolution

### DIFF
--- a/packages/checkout-ui-extensions-react/tsconfig.json
+++ b/packages/checkout-ui-extensions-react/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "jsx": "react-jsx",
     "isolatedModules": true,

--- a/packages/checkout-ui-extensions-run/tsconfig.json
+++ b/packages/checkout-ui-extensions-run/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "lib": [
       "es2015",

--- a/packages/checkout-ui-extensions/tsconfig.json
+++ b/packages/checkout-ui-extensions/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "isolatedModules": true,
     "lib": [

--- a/packages/customer-account-ui-extensions-react/tsconfig.json
+++ b/packages/customer-account-ui-extensions-react/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "jsx": "react-jsx",
     "isolatedModules": true

--- a/packages/customer-account-ui-extensions/tsconfig.json
+++ b/packages/customer-account-ui-extensions/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "isolatedModules": true
   },

--- a/packages/post-purchase-ui-extensions/tsconfig.json
+++ b/packages/post-purchase-ui-extensions/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "lib": [
       "WebWorker",

--- a/packages/retail-ui-extensions-react/tsconfig.json
+++ b/packages/retail-ui-extensions-react/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "jsx": "react-jsx",
     "isolatedModules": true,

--- a/packages/retail-ui-extensions/tsconfig.json
+++ b/packages/retail-ui-extensions/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "isolatedModules": true,
     "lib": [

--- a/packages/ui-extensions-webpack-hot-client/tsconfig.json
+++ b/packages/ui-extensions-webpack-hot-client/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "lib": [
       "es2015",

--- a/packages/web-pixels-extension/tsconfig.json
+++ b/packages/web-pixels-extension/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "isolatedModules": true
   },


### PR DESCRIPTION
### Background

Follow up for https://github.com/Shopify/ui-extensions/pull/989

[`baseUrl`](https://www.typescriptlang.org/tsconfig#baseUrl) allows to set a folder from which to resolve non-relative module names from. Which lead to us accidentally using `components/shared`. While this worked inside this repo, this doesn't work for consumers because they're not resolving with the same baseUrl config which leads to missing/broken types.

I think, it's safest to remove `baseUrl` entirely and always use proper relative paths like `../shared/foo` or node modules `my-module`.

Resolution of `components/shared` before this change:

```
======== Resolving module 'components/shared' from '/home/spin/src/github.com/Shopify/ui-extensions/packages/customer-account-ui-extensions/src/components/Card/Card.ts'. ========
Explicitly specified module resolution kind: 'NodeJs'.
'baseUrl' option is set to '/home/spin/src/github.com/Shopify/ui-extensions/packages/customer-account-ui-extensions/src', using this value to resolve non-relative module name 'components/shared'.
Resolving module name 'components/shared' relative to base url '/home/spin/src/github.com/Shopify/ui-extensions/packages/customer-account-ui-extensions/src' - '/home/spin/src/github.com/Shopify/ui-extensions/packages/customer-account-ui-extensions/src/components/shared'.
Loading module as file / folder, candidate module location '/home/spin/src/github.com/Shopify/ui-extensions/packages/customer-account-ui-extensions/src/components/shared', target file type 'TypeScript'.
File '/home/spin/src/github.com/Shopify/ui-extensions/packages/customer-account-ui-extensions/src/components/shared.ts' exist - use it as a name resolution result.
======== Module name 'components/shared' was successfully resolved to '/home/spin/src/github.com/Shopify/ui-extensions/packages/customer-account-ui-extensions/src/components/shared.ts'. ========
```

### 🎩

I've done the following to verify the changes. 

Tested the customer accounts package by running
```
yarn build-consumer customer-accounts-ui-extension-dev
```

and checking the types on the spin instance.

Also ran the entire build twice and then spot checked if `checkout-ui-extensions` and `customer-account-extensions-ui-react` produce the same result with each configuration.

Here's how I've done this.

```
# in this branch
yarn build
mv packages/customer-account-ui-extensions-react/build packages/customer-account-ui-extensions-react/build-old             
mv packages/checkout-ui-extensions/build packages/checkout-ui-extensions/build-old

git checkout main
yarn build

compare_folders packages/customer-account-ui-extensions-react/build packages/customer-account-ui-extensions-react/build-old 
compare_folders packages/checkout-ui-extensions/build packages/checkout-ui-extensions
```

<details>
  <summary>compare_folders implementation</summary>

```bash
compare_folders() {
    for file1 in "$1"/*; do
        file2="$2/$(basename "$file1")"
        if [[ -d "$file1" ]]; then
            if [[ ! -d "$file2" ]]; then
                echo "Folder structure is different"
                return
            fi
            compare_folders "$file1" "$file2"
        elif [[ -f "$file1" ]]; then
            if [[ ! -f "$file2" ]]; then
                echo "File $file2 does not exist"
                return
            elif ! cmp -s "$file1" "$file2"; then
                echo "File $file1 and $file2 have different content"
                return
            fi
        fi
    done
}
```

</details>


### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
