### PR TITLE
Ignore src folder in published packages

### DIFF
--- a/packages/retail-ui-extensions-react/.npmignore
+++ b/packages/retail-ui-extensions-react/.npmignore
@@ -1,0 +1,4 @@
+.*
+node_modules
+src
+tsconfig.json

--- a/packages/retail-ui-extensions/.npmignore
+++ b/packages/retail-ui-extensions/.npmignore
@@ -1,0 +1,4 @@
+.*
+node_modules
+src
+tsconfig.json


### PR DESCRIPTION
### Background

Should resolve an issue with TS compiler for consumers:
```
node_modules/@shopify/retail-ui-extensions/src/globals.ts:13:14 - error TS2717: Subsequent property declarations must have the same type.  Property 'shopify' must be of type 'ShopifyGlobal', but here has type 'ShopifyGlobal'.

13     readonly shopify: ShopifyGlobal;
                ~~~~~~~

  node_modules/@shopify/retail-ui-extensions/build/ts/globals.d.ts:8:18
    8         readonly shopify: ShopifyGlobal;
                       ~~~~~~~
    'shopify' was also declared here.
```

Usually packages don't include `src` folder to avoid this kind of issues in case of declaring global vars.

### Solution

Added `.npmignore` file that lists files that we want to skip publishing.

### 🎩

The only way to test it is to publish as RC and check what a package consists of.
 
### Checklist

- ~~[ ] I have :tophat:'d these changes~~
- ~~[ ] I have updated relevant documentation~~
