### PR TITLE
Add business customer metafield types

### DIFF
--- a/packages/checkout-ui-extensions/src/extension-points/api/standard/index.ts
+++ b/packages/checkout-ui-extensions/src/extension-points/api/standard/index.ts
@@ -346,7 +346,13 @@ export interface AppMetafieldEntryTarget {
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`.
    */
-  type: 'customer' | 'product' | 'shop' | 'variant';
+  type:
+    | 'customer'
+    | 'product'
+    | 'shop'
+    | 'variant'
+    | 'company'
+    | 'companyLocation';
 
   /** The numeric owner ID that is associated with the metafield. */
   id: string;


### PR DESCRIPTION
### Background
Part of Checkout-web PR - https://github.com/Shopify/checkout-web/pull/22250
Part of https://github.com/Shopify/core-issues/issues/56101
We are adding support for b2b related metafields - `company` and `company location`. Adding required types to the standard api.

### Solution
Added additional types

### 🎩
Added types only, N/A

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
