### PR TITLE
[CustomerSegmentationTemplate] Add viewMajor icon in source

### DIFF
--- a/.changeset/big-oranges-dress.md
+++ b/.changeset/big-oranges-dress.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Add viewMajor to source in CustomerSegmentationTemplate

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -20,7 +20,8 @@ type Source =
   | 'uploadMajor'
   | 'buyButtonMajor'
   | 'followUpEmailMajor'
-  | 'confettiMajor';
+  | 'confettiMajor'
+  | 'viewMajor';
 
 type TemplateCategory =
   | 'firstTimeBuyers'


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/core-issues/issues/57311

Adds viewMajor icon for storefront events templates

<img width="547" alt="image" src="https://github.com/Shopify/ui-extensions/assets/17357985/ba3b2c83-3342-44cf-8862-10449c6360a5">

### Solution

Add the viewMajor in Source

