### PR TITLE
[Admin] Add Box component to admin surface

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/admin/components.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/components.ts
@@ -1,5 +1,7 @@
 export {AppAction} from './components/AppAction/AppAction';
 export type {AppActionProps} from './components/AppAction/AppAction';
+export {Box} from './components/Box/Box';
+export type {BoxProps} from './components/Box/Box';
 export {Button} from './components/Button/Button';
 export type {ButtonProps} from './components/Button/Button';
 export {CustomerSegmentationTemplate} from './components/CustomerSegmentationTemplate/CustomerSegmentationTemplate';

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Box/Box.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Box/Box.ts
@@ -1,0 +1,6 @@
+import {Box as BaseBox} from '@shopify/ui-extensions/admin';
+import type {BoxProps} from '@shopify/ui-extensions/admin';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const Box = createRemoteReactComponent<'Box', BoxProps>(BaseBox);
+export type {BoxProps} from '@shopify/ui-extensions/admin';

--- a/packages/ui-extensions/src/surfaces/admin/components.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.ts
@@ -1,5 +1,7 @@
 export {AppAction} from './components/AppAction/AppAction';
 export type {AppActionProps} from './components/AppAction/AppAction';
+export {Box} from './components/Box/Box';
+export type {BoxProps} from './components/Box/Box';
 export {Button} from './components/Button/Button';
 export type {ButtonProps} from './components/Button/Button';
 export {CustomerSegmentationTemplate} from './components/CustomerSegmentationTemplate/CustomerSegmentationTemplate';

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/Box.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/Box.ts
@@ -1,0 +1,90 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+export interface BoxProps {
+  /**
+   * Adjust the padding.
+   *
+   * To shorten the code, it is possible to specify all the padding for all edges of the box in one property.
+   *
+   * - `base` means block-start, inline-end, block-end and inline-start paddings are `base`.
+   * - `base none` means block-start and block-end paddings are `base`, inline-start and inline-end paddings are `none`.
+   * - `base none large` means block-start padding is `base`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
+   * - `base none large small` means block-start padding is `base`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   * - `true` applies a default padding that is appropriate for the component.
+   *
+   * Learn more about the 1-to-4-value syntax at https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box
+   */
+  padding?: MaybeAllBoxEdgesShorthandProperty<SpacingKeyword | boolean>;
+
+  /**
+   * Adjust the padding on the top edge of the box.
+   * @deprecated Using {@link paddingBlockStart} is preferred, as it repsects writing direction.
+   */
+  paddingTop?: SpacingKeyword | boolean;
+
+  /**
+   * Adjust the padding on the bottom edge of the box.
+   * @deprecated Using {@link paddingBlockEnd} is preferred, as it repsects writing direction.
+   */
+  paddingBottom?: SpacingKeyword | boolean;
+
+  /**
+   * Adjust the padding on the left edge of the box.
+   * @deprecated Using {@link paddingInlineStart} is preferred, as it repsects writing direction.
+   */
+  paddingLeft?: SpacingKeyword | boolean;
+
+  /**
+   * Adjust the padding on the right edge of the box.
+   * @deprecated Using {@link paddingInlineEnd} is preferred, as it repsects writing direction.
+   */
+  paddingRight?: SpacingKeyword | boolean;
+
+  /**
+   * Adjust the block-padding.
+   *
+   * - `base none` means block-start padding is `base`, block-end padding is `none`.
+   */
+  paddingBlock?: MaybeTwoBoxEdgesShorthandProperty<SpacingKeyword | boolean>;
+
+  /**
+   * Adjust the block-start padding.
+   */
+  paddingBlockStart?: SpacingKeyword | boolean;
+
+  /**
+   * Adjust the block-end padding.
+   */
+  paddingBlockEnd?: SpacingKeyword | boolean;
+
+  /**
+   * Adjust the inline padding.
+   *
+   * - `base none` means inline-start padding is `base`, inline-end padding is `none`.
+   */
+  paddingInline?: MaybeTwoBoxEdgesShorthandProperty<SpacingKeyword | boolean>;
+
+  /**
+   * Adjust the inline-start padding.
+   */
+  paddingInlineStart?: SpacingKeyword | boolean;
+
+  /**
+   * Adjust the inline-end padding.
+   */
+  paddingInlineEnd?: SpacingKeyword | boolean;
+}
+
+type SpacingKeyword = 'none' | 'small' | 'base' | 'large';
+
+type MaybeAllBoxEdgesShorthandProperty<T extends SpacingKeyword | boolean> =
+  | T
+  | `${T} ${T}`
+  | `${T} ${T} ${T}`
+  | `${T} ${T} ${T} ${T}`;
+
+type MaybeTwoBoxEdgesShorthandProperty<T extends SpacingKeyword | boolean> =
+  | T
+  | `${T} ${T}`;
+
+export const Box = createRemoteComponent<'Box', BoxProps>('Box');

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/README.md
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/README.md
@@ -1,0 +1,4 @@
+# Box
+
+Box is a generic container component. Its contents will always be their
+natural” size, so this component can be useful in layout components (like `Grid`) that would otherwise stretch their children to fit.

--- a/packages/ui-extensions/src/surfaces/admin/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/shared.ts
@@ -586,9 +586,9 @@ export type MainAxisAlignment =
   /** Align items at the start of the container's main axis */
   | 'flex-start'
   /** Align items to the center of the container's main axis */
-  | 'flex-center'
+  | 'center'
   /** Align items at the end of the container's main axis */
-  | 'end'
+  | 'flex-end'
   /** Distribute items evenly across the container's main axis, where the first item is flush with the start, the last is flush with the end */
   | 'space-between'
   /** Distribute items evenly across the container's main axis, with a half-size space on either end of the items */


### PR DESCRIPTION
### Background

The API and components for the Admin surface are being reviewed as we aim to unify and standardize our APIs.

### Solution

This PR adds the Box component with the first set of props.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
