### PR TITLE
Revert adding buyMajor icon

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -21,8 +21,7 @@ type Source =
   | 'buyButtonMajor'
   | 'followUpEmailMajor'
   | 'confettiMajor'
-  | 'viewMajor'
-  | 'buyButtonMajor';
+  | 'viewMajor';
 
 type TemplateCategory =
   | 'firstTimeBuyers'


### PR DESCRIPTION
### Background

Reverts [accidental push to unstable to add buyMajor icon](https://github.com/Shopify/ui-extensions/commit/c8fa2cdc8c2a0da892c14b957d211fec337133be)... Not a breaking change, but reverting, then will open a pr to add the icon + add a changeset.

### Solution

Removes icon.

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
