### PR TITLE
Support building checkout docs in-repo

### DIFF
--- a/.changeset/sixty-kangaroos-smoke.md
+++ b/.changeset/sixty-kangaroos-smoke.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Added ability to generate docs from within the repository.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ packages/*/*.js
 packages/*/bin
 !packages/*/.eslintrc.js
 *.log
+packages/ui-extensions/docs/**/generated
 
 # IntelliJ IDE ignore
 .idea

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "predeploy": "yarn build",
     "deploy": "changeset publish",
     "predeploy:unstable": "yarn build",
-    "docs:checkout": "yarn workspace @shopify/ui-extensions build-docs",
+    "docs:checkout": "yarn workspace @shopify/ui-extensions docs:checkout",
     "deploy:unstable": "changeset version --snapshot unstable && changeset publish --tag unstable --no-git-tag",
     "lint": "loom lint",
     "nuke": "rm -rf node_modules && yarn cache clean && rm -rf .loom && git clean -xdf ./packages; rm -rf ./build",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "predeploy": "yarn build",
     "deploy": "changeset publish",
     "predeploy:unstable": "yarn build",
+    "docs:checkout": "yarn workspace @shopify/ui-extensions build-docs",
     "deploy:unstable": "changeset version --snapshot unstable && changeset publish --tag unstable --no-git-tag",
     "lint": "loom lint",
     "nuke": "rm -rf node_modules && yarn cache clean && rm -rf .loom && git clean -xdf ./packages; rm -rf ./build",

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@shopify/ui-extensions",
   "version": "2022.10.6",
+  "scripts": {
+    "docs:checkout": "sh ./docs/surfaces/checkout/build-docs.sh"
+  },
   "main": "index.js",
   "module": "index.mjs",
   "esnext": "index.esnext",
@@ -42,7 +45,8 @@
     "@remote-ui/core": "2.1.x"
   },
   "devDependencies": {
-    "@shopify/generate-docs": "0.10.7"
+    "@shopify/generate-docs": "0.10.7",
+    "typescript": "^4.9.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
### Background
Support for generating docs within this repo using `yarn docs:checkout`.

### Solution
Point to the script, add gitignore for generated files.

### 🎩

1. Run `spin up checkout-web:api-docs`
2. In spin shell `cd ui-extensions && git checkout jkv/generate-docs`
3. `yarn && yarn docs:checkout`
4. Verify the output on the shopify dev link that is shown
https://shopify-dev.ui-extensions-unstable.james-vidler.us.spin.dev/docs/api/checkout-ui-extensions
### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
