### PR TITLE
[Post-purchase]: Revert back to `extension point` terminology

### DIFF
--- a/packages/post-purchase-ui-extensions-react/src/components/Button/examples/basic-button.example.tsx
+++ b/packages/post-purchase-ui-extensions-react/src/components/Button/examples/basic-button.example.tsx
@@ -12,7 +12,7 @@ function App() {
         console.log(`Extension point: ${extensionPoint}`);
       }}
     >
-      Log target to console
+      Log extension point to console
     </Button>
   );
 }

--- a/packages/post-purchase-ui-extensions/documentation/components.md
+++ b/packages/post-purchase-ui-extensions/documentation/components.md
@@ -2,7 +2,7 @@
 
 App Bridge Checkout provides many powerful UI components that a [rendering extension](./rendering.md) can use to build an interface. This UI is rendered natively by Shopify, so you can depend on it to be performant, accessible, and work in all of Checkout’s supported browsers.
 
-The following components are available as part of App Bridge Checkout for Checkout, but make sure that you check the documentation for your [target](./extension-points.md) to ensure the component is available in the targets you are targeting.
+The following components are available as part of App Bridge Checkout for Checkout, but make sure that you check the documentation for your [extension point](./extension-points.md) to ensure the component is available in the extension points you are targeting.
 
 - [Banner](../src/components/Banner)
 - [BlockStack](../src/components/BlockStack)

--- a/packages/post-purchase-ui-extensions/documentation/extension-points.md
+++ b/packages/post-purchase-ui-extensions/documentation/extension-points.md
@@ -1,14 +1,14 @@
-This API reference describes the technical details of how to build your Post Purchase UI Extensions. It covers the available targets, including their input and output types and their structure.
+This API reference describes the technical details of how to build your Post Purchase UI Extensions. It covers the available extension points, including their input and output types and their structure.
 
 For more information, refer to [the post-purchase extension overview](/docs/apps/checkout/product-offers/post-purchase) and [Building a post-purchase checkout extension](/docs/apps/checkout/product-offers/post-purchase/getting-started).
 
-## Targets
+## Extension points
 
-An App Bridge Checkout extension will register for one or more targets using [`shopify.extend()`](#globals). An target in an App Bridge Checkout extension is a plain JavaScript function. This function receives some API for interacting with the application, and is expected to return a value in a specific shape. The input arguments and the output type are different for each target.
+An App Bridge Checkout extension will register for one or more extension points using [`shopify.extend()`](#globals). An extension point in an App Bridge Checkout extension is a plain JavaScript function. This function receives some API for interacting with the application, and is expected to return a value in a specific shape. The input arguments and the output type are different for each extension point.
 
-The current targets are available for post-purchase:
+The current extension points are available for post-purchase:
 
-- [`Checkout::PostPurchase::ShouldRender` and `Checkout::PostPurchase::Render`](/docs/api/checkout-extensions/post-purchase/targets), used to build post-purchase interstitials for cross sell applications.
+- [`Checkout::PostPurchase::ShouldRender` and `Checkout::PostPurchase::Render`](/docs/api/checkout-extensions/post-purchase/api), used to build post-purchase interstitials for cross sell applications.
 
 ## Configuration file
 
@@ -41,30 +41,30 @@ https://your-test-store.myshopify.com/46071709864/checkouts/a7706e44c6c6b99b9899
 
 ### Shopify-specific globals
 
-The most important API to an App Bridge Checkout extension is `shopify`, an object that is globally available. This object has a single method, `extend` that takes two arguments. One is the name of an [available target](#extension-points), and the other is a function to call when Shopify is ready to run the target. The function you pass is called with at least one input argument, depending on the target. Refer to the documentation for the target you are targeting to see what you have access to.
+The most important API to an App Bridge Checkout extension is `shopify`, an object that is globally available. This object has a single method, `extend` that takes two arguments. One is the name of an [available extension point](#extension-points), and the other is a function to call when Shopify is ready to run the extension point. The function you pass is called with at least one input argument, depending on the extension point. Refer to the documentation for the extension point you are targeting to see what you have access to.
 
 ```ts
 shopify.extend('Checkout::PostPurchase::ShouldRender', (...args) => {
-  // Implement your Checkout::PostPurchase::ShouldRender target logic here
+  // Implement your Checkout::PostPurchase::ShouldRender extension point logic here
 });
 ```
 
-This library provides an alias for `shopify.extend` in the form of the `extend()` export. This function is also strongly-typed. If you’re working in an editor that supports TypeScript’s language server (we recommend [VSCode](https://code.visualstudio.com)), then you get feedback about the input arguments to that target.
+This library provides an alias for `shopify.extend` in the form of the `extend()` export. This function is also strongly-typed. If you’re working in an editor that supports TypeScript’s language server (we recommend [VSCode](https://code.visualstudio.com)), then you get feedback about the input arguments to that extension point.
 
 ```ts
 import {extend} from '@shopify/post-purchase-ui-extensions';
 
 extend('Checkout::PostPurchase::ShouldRender', (api) => {
-  // Implement your Checkout::PostPurchase::ShouldRender target logic here
+  // Implement your Checkout::PostPurchase::ShouldRender extension point logic here
   // If you hover over `api` in an editor that supports TypeScript, you’ll see
-  // the properties and methods available for this target, even if you
+  // the properties and methods available for this extension point, even if you
   // are writing your extension in "vanilla" JavaScript.
 });
 ```
 
-For extensions that render UI, like [`Checkout::PostPurchase::ShouldRender`](#extension-points), the first argument is always a [`@remote-ui` `RemoteRoot` object](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoteroot) that allows you to render UI components into your target in checkout. You do not need to explicitly call [`mount()`](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoterootmount) on this object; once the callback you registered for this target ends (or, if it returns a `Promise`, once that promise resolves), your initial UI will be rendered.
+For extensions that render UI, like [`Checkout::PostPurchase::ShouldRender`](#extension-points), the first argument is always a [`@remote-ui` `RemoteRoot` object](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoteroot) that allows you to render UI components into your extension point in checkout. You do not need to explicitly call [`mount()`](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoterootmount) on this object; once the callback you registered for this extension point ends (or, if it returns a `Promise`, once that promise resolves), your initial UI will be rendered.
 
-That’s really all the global API you need to know to start writing a UI extension. You’ll find the documentation for additional APIs that are provided when an target is run in the [targets documentation](#targets).
+That’s really all the global API you need to know to start writing a UI extension. You’ll find the documentation for additional APIs that are provided when an extension point is run in the [extension points documentation](#extension-points).
 
 ### Web platform globals
 

--- a/packages/post-purchase-ui-extensions/documentation/globals.md
+++ b/packages/post-purchase-ui-extensions/documentation/globals.md
@@ -2,30 +2,30 @@
 
 ### Shopify-specific globals
 
-The most important API to an App Bridge Checkout extension is `shopify`, an object that is globally available. This object has a single method, `extend` that takes two arguments. One is the name of an [available target](#extension-points), and the other is a function to call when Shopify is ready to run the target. The function you pass is called with at least one input argument, depending on the target. Refer to the documentation for the target you are targeting to see what you have access to.
+The most important API to an App Bridge Checkout extension is `shopify`, an object that is globally available. This object has a single method, `extend`. `extend` takes two arguments: the name of an [available extension point](./extension-points.md), and a function to call when Shopify is ready to run the extension point. The function you pass is called with at least one input argument, depending on the extension point — please refer to the documentation for the extension point you are targeting to see what you have access to.
 
 ```ts
 shopify.extend('Checkout::PostPurchase::ShouldRender', (...args) => {
-  // Implement your Checkout::PostPurchase::ShouldRender target logic here
+  // Implement your Checkout::PostPurchase::ShouldRender extension point logic here
 });
 ```
 
-This library provides an alias for `shopify.extend` in the form of the `extend()` export. This function is also strongly-typed. If you’re working in an editor that supports TypeScript’s language server (we recommend [VSCode](https://code.visualstudio.com)), then you get feedback about the input arguments to that target.
+This library provides an alias for `shopify.extend` in the form of the `extend()` export. This function is also strongly-typed, so you will get feedback about the input arguments to that extension point if you are working in an editor that supports TypeScript’s language server (we recommend [VSCode](https://code.visualstudio.com)).
 
 ```ts
 import {extend} from '@shopify/post-purchase-ui-extensions';
 
 extend('Checkout::PostPurchase::ShouldRender', (api) => {
-  // Implement your Checkout::PostPurchase::ShouldRender target logic here
+  // Implement your Checkout::PostPurchase::ShouldRender extension point logic here
   // If you hover over `api` in an editor that supports TypeScript, you’ll see
-  // the properties and methods available for this target, even if you
+  // the properties and methods available for this extension point, even if you
   // are writing your extension in "vanilla" JavaScript.
 });
 ```
 
-For extensions that render UI, like [`Checkout::PostPurchase::ShouldRender`](#extension-points), the first argument is always a [`@remote-ui` `RemoteRoot` object](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoteroot) that allows you to render UI components into your target in checkout. You do not need to explicitly call [`mount()`](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoterootmount) on this object; once the callback you registered for this target ends (or, if it returns a `Promise`, once that promise resolves), your initial UI will be rendered.
+For extensions that render UI, like [`Checkout::PostPurchase::ShouldRender`](./extension-points.md), the first argument is always a [`@remote-ui` `RemoteRoot` object](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoteroot) that allows you to render UI components into your extension point in checkout. You do not need to explicitly call [`mount()`](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoterootmount) on this object; once the callback you registered for this extension point ends (or, if it returns a `Promise`, once that promise resolves), your initial UI will be rendered.
 
-That’s really all the global API you need to know to start writing a UI extension. You’ll find the documentation for additional APIs that are provided when an target is run in the [targets documentation](#targets).
+That’s really all the global API you need to know to start writing a UI extension. You’ll find the documentation for additional APIs that are provided when an extension point is run in the [extension points documentation](./extension-points.md).
 
 ### Web platform globals
 

--- a/packages/post-purchase-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/post-purchase-ui-extensions/src/extension-points/extension-points.ts
@@ -12,7 +12,7 @@ type AllComponents = Components[keyof Components];
 
 /** Post-purchase checkout extensions allow developers and Plus merchants to add a post-purchase page directly into the Shopify checkout.
  * The page appears after the order is confirmed, but before the thank you page.
- * Post-purchase checkout extensions can use the `ShouldRender` and `Render` targets.
+ * Post-purchase checkout extensions can use the `ShouldRender` and `Render` extension points.
  * For more information, refer to the [post-purchase checkout extensions overview](/docs/apps/checkout/product-offers/post-purchase).
  */
 export interface ExtensionPoints {
@@ -20,13 +20,13 @@ export interface ExtensionPoints {
     StandardApi<'Checkout::KitchenSink'>,
     AllComponents
   >;
-  /** The `Render` target is used to render the section in the post-purchase page.
+  /** The `Render` extension point is used to render the section in the post-purchase page.
   Also, it provides additional functionality, such as communicating with Shopify to add items to the initial purchase. */
   'Checkout::PostPurchase::Render': RenderExtension<
     PostPurchaseRenderApi,
     AllComponents
   >;
-  /** The `ShouldRender` target is used to determine whether a post-purchase page should be shown to the customer.
+  /** The `ShouldRender` extension point is used to determine whether a post-purchase page should be shown to the customer.
   It also allows data to be pre-cached and used when the page renders. */
   'Checkout::PostPurchase::ShouldRender': (
     api: PostPurchaseShouldRenderApi,


### PR DESCRIPTION
## This PR:
- Reverts back to using the term `extension point` in a post-purchase source content, as we're not yet changing to `target` for Summer Editions
- Partially fixes https://github.com/Shopify/shopify-dev/issues/34417
- Relates to https://github.com/Shopify/ui-extensions/pull/1019 and https://github.com/Shopify/checkout-web/pull/23410
