### PR TITLE
patch for `checkout-ui-extensions` 2023-04 (0.27)

### DIFF
--- a/packages/checkout-ui-extensions-react/src/hooks/redeemable.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/redeemable.ts
@@ -1,7 +1,7 @@
-import {
+import type {
   RedeemableChangeResult,
   RedeemableChange,
-} from '@shopify/checkout-ui-extensions/src/api/redeemable/render';
+} from '@shopify/ui-extensions/checkout';
 
 import {ExtensionHasNoMethodError} from '../errors';
 

--- a/packages/checkout-ui-extensions-react/src/hooks/tests/app-metafields.test.ts
+++ b/packages/checkout-ui-extensions-react/src/hooks/tests/app-metafields.test.ts
@@ -1,5 +1,5 @@
 import {Metafield} from '@shopify/checkout-ui-extensions';
-import faker from '@faker-js/faker';
+import {faker} from '@faker-js/faker';
 
 import {useAppMetafields} from '../app-metafields';
 

--- a/packages/checkout-ui-extensions-react/src/hooks/tests/buyer-identity.test.tsx
+++ b/packages/checkout-ui-extensions-react/src/hooks/tests/buyer-identity.test.tsx
@@ -1,5 +1,5 @@
 import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-import faker from '@faker-js/faker';
+import {faker} from '@faker-js/faker';
 
 import {ScopeNotGrantedError} from '../../errors';
 import {useCustomer, useEmail, usePhone} from '../buyer-identity';

--- a/packages/checkout-ui-extensions-react/src/hooks/tests/metafield.test.tsx
+++ b/packages/checkout-ui-extensions-react/src/hooks/tests/metafield.test.tsx
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker';
+import {faker} from '@faker-js/faker';
 import {Metafield} from '@shopify/checkout-ui-extensions';
 
 import {useMetafield} from '..';

--- a/packages/checkout-ui-extensions-react/src/hooks/tests/metafields.test.tsx
+++ b/packages/checkout-ui-extensions-react/src/hooks/tests/metafields.test.tsx
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker';
+import {faker} from '@faker-js/faker';
 import {Metafield} from '@shopify/checkout-ui-extensions';
 
 import {useMetafields} from '..';

--- a/packages/checkout-ui-extensions/docs/reference/apis/pickup-locations.doc.ts
+++ b/packages/checkout-ui-extensions/docs/reference/apis/pickup-locations.doc.ts
@@ -11,6 +11,8 @@ const data: ReferenceEntityTemplateSchema = {
   overviewPreviewDescription:
     'The API provided to extensions rendering before and after local pickup locations.',
   description: `
+> Caution: This feature is in developer preview and is subject to change.
+
 This API object is provided to extensions registered for the \`Checkout::PickupLocations::RenderBefore\` or \`Checkout::PickupLocations::RenderAfter\` extension points.
 
 

--- a/packages/checkout-ui-extensions/docs/reference/apis/pickup-points.doc.ts
+++ b/packages/checkout-ui-extensions/docs/reference/apis/pickup-points.doc.ts
@@ -11,6 +11,8 @@ const data: ReferenceEntityTemplateSchema = {
   overviewPreviewDescription:
     'The API provided to extensions rendering before and after pickup points.',
   description: `
+> Caution: This feature is in developer preview and is subject to change.
+
 This API object is provided to extensions registered for the \`Checkout::PickupPoints::RenderBefore\` or \`Checkout::PickupPoints::RenderAfter\` extension points.
 
 It extends the [StandardApi](/docs/api/checkout-ui-extensions/apis/standardapi) and provides a [locationFormVisible](#properties-propertydetail-locationformvisible) boolean to indicate whether the customer location input form is currently rendered and shown to the buyer.

--- a/packages/checkout-ui-extensions/docs/reference/apis/shipping-method-details.doc.ts
+++ b/packages/checkout-ui-extensions/docs/reference/apis/shipping-method-details.doc.ts
@@ -11,6 +11,8 @@ const data: ReferenceEntityTemplateSchema = {
   overviewPreviewDescription:
     'The API provided to extensions rendering after shipping method details and the expanded section of a selected shipping method.',
   description: `
+> Caution: This feature is in developer preview and is subject to change.
+
 This API object is provided to extensions registered for the \`Checkout::ShippingMethodDetails::RenderAfter\` or \`Checkout::ShippingMethodDetails::RenderExpanded\` extension points.
 
 It extends the [StandardApi](/docs/api/checkout-ui-extensions/apis/standardapi), provides a [target](#properties-propertydetail-target) object with information about the shipping method the extension is attached to, \

--- a/packages/checkout-ui-extensions/docs/reference/examples/attribute-values.example.tsx
+++ b/packages/checkout-ui-extensions/docs/reference/examples/attribute-values.example.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {
+  Text,
+  render,
+  useAttributeValues,
+} from '@shopify/checkout-ui-extensions-react';
+
+render('Checkout::Dynamic::Render', () => (
+  <Extension />
+));
+
+function Extension() {
+  const [buyerSelectedFreeTShirt, tshirtSize] =
+    useAttributeValues([
+      'buyerSelectedFreeTShirt',
+      'tshirtSize',
+    ]);
+
+  if (Boolean(buyerSelectedFreeTShirt) === true) {
+    return (
+      <Text>
+        You selected a free t-shirt, size:{' '}
+        {tshirtSize}
+      </Text>
+    );
+  }
+
+  return null;
+}

--- a/packages/checkout-ui-extensions/docs/reference/helper.docs.ts
+++ b/packages/checkout-ui-extensions/docs/reference/helper.docs.ts
@@ -314,6 +314,13 @@ The contents of the token are signed using your shared app secret.  The optional
         tabs: getExtensionCodeTabs('delivery-groups'),
       },
     },
+    'attribute-values': {
+      description: '',
+      codeblock: {
+        title: 'Attribute values',
+        tabs: getExtensionCodeTabs('attribute-values'),
+      },
+    },
   };
 }
 

--- a/packages/checkout-ui-extensions/docs/reference/hooks/attribute-values.doc.ts
+++ b/packages/checkout-ui-extensions/docs/reference/hooks/attribute-values.doc.ts
@@ -1,6 +1,6 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
-import {getLinksByTag} from '../helper.docs';
+import {getHookExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'useAttributeValues',
@@ -17,6 +17,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'UseAttributeValuesGeneratedType',
     },
   ],
+  defaultExample: getHookExample('attribute-values'),
   related: getLinksByTag('apis'),
 };
 

--- a/packages/checkout-ui-extensions/src/api.ts
+++ b/packages/checkout-ui-extensions/src/api.ts
@@ -76,6 +76,8 @@ export type {
 export type {
   AttributeChange,
   AttributeChangeResult,
+  AttributeChangeResultError,
+  AttributeChangeResultSuccess,
   CartLineChange,
   CartLineChangeResult,
   CartLineChangeResultError,

--- a/packages/checkout-ui-extensions/src/api/checkout/checkout.ts
+++ b/packages/checkout-ui-extensions/src/api/checkout/checkout.ts
@@ -339,6 +339,24 @@ export interface MetafieldRemoveChange {
   namespace: string;
 }
 
+/** Removes a cart metafield. */
+export interface MetafieldRemoveCartChange {
+  /**
+   * The type of the `MetafieldRemoveChange` API.
+   */
+  type: 'removeCartMetafield';
+
+  /**
+   * The name of the metafield to remove.
+   */
+  key: string;
+
+  /**
+   * The namespace of the metafield to remove.
+   */
+  namespace: string;
+}
+
 /**
  * Updates a metafield. If a metafield with the
  * provided key and namespace does not already exist, it gets created.
@@ -364,7 +382,39 @@ export interface MetafieldUpdateChange {
   valueType: 'integer' | 'string' | 'json_string';
 }
 
-export type MetafieldChange = MetafieldRemoveChange | MetafieldUpdateChange;
+/**
+ * Updates a cart metafield. If a metafield with the
+ * provided key and namespace does not already exist, it gets created.
+ */
+export interface MetafieldUpdateCartChange {
+  /**
+   * The type of the `MetafieldUpdateChange` API.
+   */
+  type: 'updateCartMetafield';
+
+  metafield: {
+    /** The name of the metafield to update. */
+    key: string;
+
+    /** The namespace of the metafield to add. */
+    namespace: string;
+
+    /** The new information to store in the metafield. */
+    value: string;
+
+    /**
+     * The metafield’s information type.
+     * See the [`metafields documentation`](https://shopify.dev/docs/apps/custom-data/metafields/types) for a list of supported types.
+     */
+    type: string;
+  };
+}
+
+export type MetafieldChange =
+  | MetafieldRemoveChange
+  | MetafieldUpdateChange
+  | MetafieldRemoveCartChange
+  | MetafieldUpdateCartChange;
 
 export interface MetafieldChangeResultSuccess {
   /**
@@ -397,7 +447,7 @@ export interface CheckoutApi {
    * successful, this mutation results in an update to the value retrieved
    * through the [`attributes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-applyattributechange) property.
    *
-   * > Note: This update will be ignored if the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
+   * > Note: This method will return an error if the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    */
   applyAttributeChange(change: AttributeChange): Promise<AttributeChangeResult>;
 
@@ -408,7 +458,7 @@ export interface CheckoutApi {
    * [`lines`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-lines)
    * property.
    *
-   * > Note: This update will be ignored if the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
+   * > Note: This method will return an error if the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    */
   applyCartLinesChange(change: CartLineChange): Promise<CartLineChangeResult>;
 
@@ -419,6 +469,8 @@ export interface CheckoutApi {
    *
    * > Caution:
    * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves discount codes through a network call.
+   *
+   * > Note: This method will return an error if the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    */
   applyDiscountCodeChange(
     change: DiscountCodeChange,
@@ -432,7 +484,7 @@ export interface CheckoutApi {
    * > Caution:
    * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves gift card codes through a network call.
    *
-   * > Note: This update will be ignored if the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
+   * > Note: This method will return an error if the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    */
   applyGiftCardChange(change: GiftCardChange): Promise<GiftCardChangeResult>;
 
@@ -448,7 +500,7 @@ export interface CheckoutApi {
    * successful, this mutation results in an update to the value retrieved
    * through the [`note`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-note) property.
    *
-   * > Note: This update will be ignored if the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
+   * > Note: This method will return an error if the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    */
   applyNoteChange(change: NoteChange): Promise<NoteChangeResult>;
 }

--- a/packages/checkout-ui-extensions/src/api/shipping/shipping-method-details.ts
+++ b/packages/checkout-ui-extensions/src/api/shipping/shipping-method-details.ts
@@ -6,7 +6,7 @@ export interface ShippingMethodDetailsApi {
   /**
    * The shipping option the extension is attached to.
    */
-  target: StatefulRemoteSubscribable<ShippingOption>;
+  target: StatefulRemoteSubscribable<ShippingOption | undefined>;
 
   /**
    * Whether the shipping option the extension is attached to is currently selected in the UI.

--- a/packages/checkout-ui-extensions/src/api/standard/standard.ts
+++ b/packages/checkout-ui-extensions/src/api/standard/standard.ts
@@ -72,7 +72,7 @@ export interface Extension {
   /**
    * The API version that was set in the extension config file.
    *
-   * @example '2023-01', '2022-10'
+   * @example '2023-04'
    */
   apiVersion: ApiVersion;
 
@@ -162,6 +162,9 @@ export interface AppMetafield {
 
   /** The metafield’s information type. */
   valueType: 'boolean' | 'float' | 'integer' | 'json_string' | 'string';
+
+  /** The metafield's type name. */
+  type: string;
 }
 
 /**
@@ -173,7 +176,14 @@ export interface AppMetafieldEntryTarget {
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`.
    */
-  type: 'customer' | 'product' | 'shop' | 'variant';
+  type:
+    | 'customer'
+    | 'product'
+    | 'shop'
+    | 'variant'
+    | 'company'
+    | 'companyLocation'
+    | 'cart';
 
   /** The numeric owner ID that is associated with the metafield. */
   id: string;
@@ -194,7 +204,7 @@ export interface AppMetafieldEntry {
   metafield: AppMetafield;
 }
 
-export type ApiVersion = '2022-10' | '2023-01' | '2023-04' | 'unstable';
+export type ApiVersion = '2023-04' | 'unstable';
 
 export type Version = string;
 

--- a/packages/checkout-ui-extensions/src/extension-points.ts
+++ b/packages/checkout-ui-extensions/src/extension-points.ts
@@ -234,6 +234,8 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
+   * > Caution: This feature is in developer preview and is subject to change.
+   *
    * A static extension point that is rendered before pickup location options.
    */
   'Checkout::PickupLocations::RenderBefore': RenderExtension<
@@ -243,6 +245,8 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
+   * > Caution: This feature is in developer preview and is subject to change.
+   *
    * A static extension point that is rendered after pickup location options.
    */
   'Checkout::PickupLocations::RenderAfter': RenderExtension<
@@ -252,6 +256,8 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
+   * > Caution: This feature is in developer preview and is subject to change.
+   *
    * A static extension point that is rendered after the shipping method
    * details within the shipping method option list, for each option.
    */
@@ -262,6 +268,8 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
+   * > Caution: This feature is in developer preview and is subject to change.
+   *
    * A static extension point that is rendered under the shipping method
    * within the shipping method option list, for each option.
    */
@@ -272,6 +280,8 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
+   * > Caution: This feature is in developer preview and is subject to change.
+   *
    * A static extension point that is rendered immediately before the pickup points.
    */
   'Checkout::PickupPoints::RenderBefore': RenderExtension<
@@ -281,6 +291,8 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
+   * > Caution: This feature is in developer preview and is subject to change.
+   *
    * A static extension point that is rendered immediately after the pickup points.
    */
   'Checkout::PickupPoints::RenderAfter': RenderExtension<

--- a/packages/checkout-ui-extensions/src/index.ts
+++ b/packages/checkout-ui-extensions/src/index.ts
@@ -48,6 +48,8 @@ export type {
   Attribute,
   AttributeChange,
   AttributeChangeResult,
+  AttributeChangeResultSuccess,
+  AttributeChangeResultError,
   Merchandise,
   ImageDetails,
   Product,


### PR DESCRIPTION
### Background

Brings over the latest from `checkout-web` for the `checkout-ui-extension` package. This will bump the version to `0.27.1`.


### 🎩
Follows the [extension libraries](https://vault.shopify.io/page/Extension-Libraries~gkKh.md) instructions.

You can tophat by testing the package in a production extension using:
```
VM=direct.$(spin show -o fqdn)
rsync -av --delete $VM:~/src/github.com/Shopify/ui-extensions/packages/checkout-ui-extensions node_modules/@shopify/ && \
   rsync -av --delete $VM:~/src/github.com/Shopify/ui-extensions/packages/checkout-ui-extensions-react node_modules/@shopify/
```

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
