### PR TITLE
Rename extension points to extension targets in admin surface

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/admin/context.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/context.ts
@@ -1,8 +1,8 @@
 import {createContext} from 'react';
 import type {
   ApiForRenderExtension,
-  RenderExtensionPoint,
+  RenderExtensionTarget,
 } from '@shopify/ui-extensions/admin';
 
 export const ExtensionApiContext =
-  createContext<ApiForRenderExtension<RenderExtensionPoint> | null>(null);
+  createContext<ApiForRenderExtension<RenderExtensionTarget> | null>(null);

--- a/packages/ui-extensions-react/src/surfaces/admin/hooks/api.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/hooks/api.ts
@@ -1,6 +1,6 @@
 import {useContext} from 'react';
 import {
-  RenderExtensionPoint,
+  RenderExtensionTarget,
   ApiForRenderExtension,
 } from '@shopify/ui-extensions/admin';
 
@@ -12,7 +12,7 @@ import {AdminUIExtensionError} from '../errors';
  * extension when it was created.
  */
 export function useApi<
-  ID extends RenderExtensionPoint = RenderExtensionPoint,
+  ID extends RenderExtensionTarget = RenderExtensionTarget,
 >(): ApiForRenderExtension<ID> {
   const api = useContext(ExtensionApiContext);
 
@@ -29,7 +29,7 @@ export function useApi<
  * @deprecated you shoud be importing useApi instead
  */
 export function useExtensionApi<
-  ID extends RenderExtensionPoint = RenderExtensionPoint,
+  ID extends RenderExtensionTarget = RenderExtensionTarget,
 >(): ApiForRenderExtension<ID> {
   return useApi();
 }

--- a/packages/ui-extensions-react/src/surfaces/admin/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/render.tsx
@@ -3,8 +3,8 @@ import {render as remoteRender} from '@remote-ui/react';
 
 import {extension} from '@shopify/ui-extensions/admin';
 import type {
-  ExtensionPoints,
-  RenderExtensionPoint,
+  ExtensionTargets,
+  RenderExtensionTarget,
   ApiForRenderExtension,
 } from '@shopify/ui-extensions/admin';
 
@@ -23,10 +23,10 @@ import {ExtensionApiContext} from './context';
  * extension, and must return a React element that will be rendered into the extension
  * point you specified.
  */
-export function reactExtension<ExtensionPoint extends RenderExtensionPoint>(
+export function reactExtension<ExtensionPoint extends RenderExtensionTarget>(
   target: ExtensionPoint,
   render: (api: ApiForRenderExtension<ExtensionPoint>) => ReactElement<any>,
-): ExtensionPoints[ExtensionPoint] {
+): ExtensionTargets[ExtensionPoint] {
   // TypeScript can’t infer the type of the callback because it’s a big union
   // type. To get around it, we’ll just fake like we are rendering the
   // Playground extension, since all render extensions have the same general

--- a/packages/ui-extensions/src/surfaces/admin.ts
+++ b/packages/ui-extensions/src/surfaces/admin.ts
@@ -1,6 +1,6 @@
 export * from './admin/api';
 export * from './admin/components';
-export * from './admin/extension-points';
+export * from './admin/extension-targets';
 export * from './admin/extension';
 export * from './admin/shared';
 export * from './admin/globals';

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.ts
@@ -1,9 +1,9 @@
 import type {StandardApi} from '../standard/standard';
 import type {I18n} from '../../../../api';
-import type {ExtensionPoint as AnyExtensionPoint} from '../../extension-points';
+import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
-export interface ActionExtensionApi<ExtensionPoint extends AnyExtensionPoint>
-  extends StandardApi<ExtensionPoint> {
+export interface ActionExtensionApi<ExtensionTarget extends AnyExtensionTarget>
+  extends StandardApi<ExtensionTarget> {
   /* Utilities for translating content according to the current `localization` of the admin. */
   i18n: I18n;
 

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segmentation-template/customer-segmentation-template.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segmentation-template/customer-segmentation-template.ts
@@ -1,6 +1,6 @@
 import type {StandardApi} from '../standard/standard';
 import type {I18n} from '../../../../api';
-import type {ExtensionPoint as AnyExtensionPoint} from '../../extension-points';
+import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
 /* List of enabled query language features during a progressive rollout */
 type CustomerSegmentationFeature =
@@ -10,8 +10,8 @@ type CustomerSegmentationFeature =
   | 'aggregateFilters';
 
 export interface CustomerSegmentationTemplateApi<
-  ExtensionPoint extends AnyExtensionPoint,
-> extends StandardApi<ExtensionPoint> {
+  ExtensionTarget extends AnyExtensionTarget,
+> extends StandardApi<ExtensionTarget> {
   /* Utilities for translating content according to the current `localization` of the admin. */
   i18n: I18n;
   /** @private */

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
@@ -1,14 +1,16 @@
 import type {StandardApi as BaseStandardApi, I18n} from '../../../../api';
-import type {ExtensionPoint as AnyExtensionPoint} from '../../extension-points';
+import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
 /**
- * The following APIs are provided to all extension points.
+ * The following APIs are provided to all extension targets.
  */
-export interface StandardApi<ExtensionPoint extends AnyExtensionPoint>
+export interface StandardApi<ExtensionTarget extends AnyExtensionTarget>
   extends BaseStandardApi {
   /**
-   * The identifier of the running extension point.
+   * The identifier of the running extension target.
    */
-  extensionPoint: ExtensionPoint;
+  extension: {
+    target: ExtensionTarget;
+  };
   i18n: I18n;
 }

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -12,7 +12,7 @@ type CustomerSegmentationTemplateComponent = AnyComponentBuilder<
   Pick<Components, 'CustomerSegmentationTemplate'>
 >;
 
-export interface ExtensionPoints {
+export interface ExtensionTargets {
   Playground: RenderExtension<StandardApi<'Playground'>, AnyComponent>;
   'admin.customers.segmentation-templates.render': RenderExtension<
     CustomerSegmentationTemplateApi<'admin.customers.segmentation-templates.render'>,
@@ -74,45 +74,45 @@ export interface ExtensionPoints {
   >;
 }
 
-export type ExtensionPoint = keyof ExtensionPoints;
+export type ExtensionTarget = keyof ExtensionTargets;
 
-export type ExtensionForExtensionPoint<T extends ExtensionPoint> =
-  ExtensionPoints[T];
+export type ExtensionForExtensionTarget<T extends ExtensionTarget> =
+  ExtensionTargets[T];
 
 /**
- * For a given extension point, returns the value that is expected to be
- * returned by that extension point’s callback type.
+ * For a given extension target, returns the value that is expected to be
+ * returned by that extension target’s callback type.
  */
-export type ReturnTypeForExtension<ID extends keyof ExtensionPoints> =
-  ReturnType<ExtensionPoints[ID]>;
+export type ReturnTypeForExtension<ID extends keyof ExtensionTargets> =
+  ReturnType<ExtensionTargets[ID]>;
 
 /**
- * For a given extension point, returns the tuple of arguments that would
- * be provided to that extension point’s callback type.
+ * For a given extension target, returns the tuple of arguments that would
+ * be provided to that extension target’s callback type.
  */
-export type ArgumentsForExtension<ID extends keyof ExtensionPoints> =
-  Parameters<ExtensionPoints[ID]>;
+export type ArgumentsForExtension<ID extends keyof ExtensionTargets> =
+  Parameters<ExtensionTargets[ID]>;
 
 /**
- * A union type containing all of the extension points that follow the pattern of
+ * A union type containing all of the extension targets that follow the pattern of
  * accepting a [`@remote-ui/core` `RemoteRoot`](https://github.com/Shopify/remote-ui/tree/main/packages/core)
  * and an additional `api` argument, and using those arguments to render
  * UI.
  */
-export type RenderExtensionPoint = {
-  [ID in keyof ExtensionPoints]: ExtensionPoints[ID] extends RenderExtension<
+export type RenderExtensionTarget = {
+  [ID in keyof ExtensionTargets]: ExtensionTargets[ID] extends RenderExtension<
     any,
     any
   >
     ? ID
     : never;
-}[keyof ExtensionPoints];
+}[keyof ExtensionTargets];
 
 /**
  * A mapping of each “render extension” name to its callback type.
  */
 export type RenderExtensions = {
-  [ID in RenderExtensionPoint]: ExtensionPoints[ID];
+  [ID in RenderExtensionTarget]: ExtensionTargets[ID];
 };
 
 type ExtractedApiFromRenderExtension<T> = T extends RenderExtension<
@@ -126,17 +126,17 @@ type ExtractedAllowedComponentsFromRenderExtension<T> =
   T extends RenderExtension<any, infer Components> ? Components : never;
 
 /**
- * For a given rendering extension point, returns the type of the API that the
+ * For a given rendering extension target, returns the type of the API that the
  * extension will receive at runtime. This API type is the second argument to
- * the callback for that extension point. The first callback for all of the rendering
- * extension points each receive a `RemoteRoot` object.
+ * the callback for that extension target. The first callback for all of the rendering
+ * extension targets each receive a `RemoteRoot` object.
  */
 export type ApiForRenderExtension<ID extends keyof RenderExtensions> =
   ExtractedApiFromRenderExtension<RenderExtensions[ID]>;
 
 /**
- * For a given rendering extension point, returns the UI components that the
- * extension point supports.
+ * For a given rendering extension target, returns the UI components that the
+ * extension target supports.
  */
 export type AllowedComponentsForRenderExtension<
   ID extends keyof RenderExtensions,

--- a/packages/ui-extensions/src/surfaces/admin/extension.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension.ts
@@ -1,8 +1,9 @@
 import {createExtensionRegistrationFunction} from '../../utilities/registration';
 
-import type {ExtensionPoints} from './extension-points';
+import type {ExtensionTargets} from './extension-targets';
 
 export * from '../../extension';
 
-export const extension = createExtensionRegistrationFunction<ExtensionPoints>();
+export const extension =
+  createExtensionRegistrationFunction<ExtensionTargets>();
 export const extend = extension;

--- a/packages/ui-extensions/src/surfaces/admin/globals.ts
+++ b/packages/ui-extensions/src/surfaces/admin/globals.ts
@@ -1,8 +1,8 @@
-import type {ExtensionPoints} from './extension-points';
+import type {ExtensionTargets} from './extension-targets';
 
 export interface ShopifyGlobal {
-  extend<ExtensionPoint extends keyof ExtensionPoints>(
-    extensionPoint: ExtensionPoint,
-    extend: ExtensionPoints[ExtensionPoint],
+  extend<ExtensionTarget extends keyof ExtensionTargets>(
+    extension: ExtensionTarget,
+    extend: ExtensionTargets[ExtensionTarget],
   ): void;
 }


### PR DESCRIPTION
### Background

Resolves part of: https://github.com/Shopify/app-ui/issues/226

### Solution

Rename ExtensionPoints to ExtensionTargets


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
