### PR TITLE
feat: add navigation and intents to StandardAPI

### DIFF
--- a/packages/ui-extensions/src/api.ts
+++ b/packages/ui-extensions/src/api.ts
@@ -74,3 +74,17 @@ export interface I18n {
    */
   translate: I18nTranslate;
 }
+
+export interface Intents {
+  /**
+   * The URL that was used to launch the intent.
+   */
+  launchUrl?: string | URL;
+}
+
+export interface Navigation {
+  /**
+   * A method to navigate to a specific route.
+   */
+  navigate: (url: string | URL) => void;
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
@@ -1,4 +1,9 @@
-import type {StandardApi as BaseStandardApi, I18n} from '../../../../api';
+import type {
+  StandardApi as BaseStandardApi,
+  I18n,
+  Intents,
+  Navigation,
+} from '../../../../api';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
 /**
@@ -13,4 +18,12 @@ export interface StandardApi<ExtensionTarget extends AnyExtensionTarget>
     target: ExtensionTarget;
   };
   i18n: I18n;
+  /**
+   * Provides information to the receiver the of an intent.
+   */
+  intents: Intents;
+  /**
+   * Provides methods to navigate to other features in the Admin.
+   */
+  navigation: Navigation;
 }


### PR DESCRIPTION
### Background

We need to add the new shared APIs to the StandardAPI.

![Screenshot 2023-07-18 at 8 47 52 AM](https://github.com/Shopify/ui-extensions/assets/7654369/ce19eabf-dbcc-49df-9199-5ba028a171b0)

![Screenshot 2023-07-18 at 8 48 04 AM](https://github.com/Shopify/ui-extensions/assets/7654369/7a684c5c-e3fd-460a-a004-014dc085a84e)

### Solution

Add navigation and intents to StandardAPI.

### 🎩

- Use this line in the extensions app that you are testing with: 

```js
  const {extensionPoint, navigation: {navigate}, intents} = useApi();
```
- You should see TS errors
- Check out this branch from `ui-extensions` and run `yarn build-consumer <your-app>` (Note that your app should be in the `~/src/github.com/Shopify/` directory for build-consumer to work. I have the Remix template cloned so I used: `yarn build-consumer shopify-app-template-remix`. 
- TS errors should disappear. 

![Screenshot 2023-07-18 at 8 54 34 AM](https://github.com/Shopify/ui-extensions/assets/7654369/9e506cd7-08e4-4119-b5b3-373cd4ab7b89)


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
