### PR TITLE
Add NewTextField component and deprecation comments for old TextField

### DIFF
--- a/packages/retail-ui-extensions-react/src/components/TextField/TextField.ts
+++ b/packages/retail-ui-extensions-react/src/components/TextField/TextField.ts
@@ -1,6 +1,14 @@
 import {TextField as BaseTextField} from '@shopify/retail-ui-extensions';
 import {createRemoteReactComponent} from '@remote-ui/react';
 
-export type {TextFieldProps} from '@shopify/retail-ui-extensions';
+export type {
+  TextFieldProps,
+  NewTextFieldProps,
+} from '@shopify/retail-ui-extensions';
 
+/**
+ * @deprecated
+ * This TextField component will be replaced by NewTextField in version 2.0.0.
+ * Please migrate to using NewTextField as soon as possible.
+ */
 export const TextField = createRemoteReactComponent(BaseTextField);

--- a/packages/retail-ui-extensions-react/src/components/TextField/index.ts
+++ b/packages/retail-ui-extensions-react/src/components/TextField/index.ts
@@ -1,2 +1,2 @@
 export {TextField} from './TextField';
-export type {TextFieldProps} from './TextField';
+export type {TextFieldProps, NewTextFieldProps} from './TextField';

--- a/packages/retail-ui-extensions-react/src/components/index.ts
+++ b/packages/retail-ui-extensions-react/src/components/index.ts
@@ -39,7 +39,7 @@ export type {TextProps} from './Text';
 export {TextArea} from './TextArea';
 export type {TextAreaProps} from './TextArea';
 export {TextField} from './TextField';
-export type {TextFieldProps} from './TextField';
+export type {TextFieldProps, NewTextFieldProps} from './TextField';
 export {Icon} from './Icon';
 export type {IconProps} from './Icon';
 export {Tile} from './Tile';

--- a/packages/retail-ui-extensions/src/component-sets/Basic.ts
+++ b/packages/retail-ui-extensions/src/component-sets/Basic.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-deprecated */
 import {
   Banner,
   Button,

--- a/packages/retail-ui-extensions/src/components/TextField/TextField.ts
+++ b/packages/retail-ui-extensions/src/components/TextField/TextField.ts
@@ -1,5 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {BaseTextFieldProps} from '../shared';
+import type {BaseTextFieldProps, InputProps} from '../shared';
 
 export interface ActionProps {
   type: 'action';
@@ -29,10 +29,17 @@ export type EmbeddedElementProps =
   | SuccessProps
   | PasswordProps;
 
+export interface NewTextFieldProps extends InputProps {}
 export interface TextFieldProps extends BaseTextFieldProps {
   rightElementStyle?: EmbeddedElementProps;
 }
 
-export const TextField = createRemoteComponent<'TextField', TextFieldProps>(
+/**
+ * @deprecated
+ * This TextField component will be replaced by NewTextField in version 2.0.0.
+ * Please migrate to using NewTextField as soon as possible.
+ */
+export const TextField = createRemoteComponent<
   'TextField',
-);
+  TextFieldProps | NewTextFieldProps
+>('TextField');

--- a/packages/retail-ui-extensions/src/components/TextField/index.ts
+++ b/packages/retail-ui-extensions/src/components/TextField/index.ts
@@ -5,5 +5,6 @@ export type {
   SuccessProps,
   PasswordProps,
   EmbeddedElementProps,
+  NewTextFieldProps,
   TextFieldProps,
 } from './TextField';

--- a/packages/retail-ui-extensions/src/components/index.ts
+++ b/packages/retail-ui-extensions/src/components/index.ts
@@ -47,6 +47,7 @@ export type {
   SuccessProps,
   PasswordProps,
   EmbeddedElementProps,
+  NewTextFieldProps,
   TextFieldProps,
 } from './TextField';
 

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -94,6 +94,7 @@ export type {
   SectionProps,
   InputType,
   TextFieldProps,
+  NewTextFieldProps,
   ActionProps,
   InfoProps,
   SuccessProps,


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-for-retail/issues/182

### Background

This begins the migration the previous implementation of the original TextField implementation to use the new PFR component instead. Since we are releasing rc versions, we can temporary release a NewTextField and put deprecation comments for the existing TextField until we release version 2.0.0.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
