### PR TITLE
Make source optional for POS UI extension Lists

### DIFF
--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -23,7 +23,7 @@ export interface ListRowLeftSide {
     /**
      * A link to an image to be displayed on the far left side of the row.
      */
-    source: string;
+    source?: string;
     /**
      * A number that is displayed on the top right of the image.
      */


### PR DESCRIPTION
### Background

In case the image display strategy is always, a Partner can provide a badge with a number even when the source is empty. 

- https://github.com/Shopify/pos-next-react-native/issues/26169
- https://github.com/Shopify/pos-next-react-native/pull/26173#issuecomment-1642783877

### Solution

Make source optional. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
