### PR TITLE
Fix `PixelEvents`, `EventBus` and `StandardEvents` types

### DIFF
--- a/packages/web-pixels-extension/src/types/EventBus.ts
+++ b/packages/web-pixels-extension/src/types/EventBus.ts
@@ -1,23 +1,15 @@
-import type {
-  PixelEvents,
-  PixelEventsCustomEvent as PixelEventsCustomEventOrig,
-} from './PixelEvents';
+import type {PixelEvents, CustomEvent} from './PixelEvents';
 
 export type SchemaVersion = 'v1';
 
 export interface StandardEvents extends PixelEvents {
-  all_events: PixelEvents[keyof PixelEvents];
+  all_events: PixelEvents[keyof PixelEvents] | CustomEvent;
   all_standard_events: PixelEvents[keyof PixelEvents];
-  all_custom_events: PixelEvents[keyof PixelEvents];
-}
-
-interface PixelEventsCustomEvent
-  extends Omit<PixelEventsCustomEventOrig, 'name'> {
-  name: string;
+  all_custom_events: CustomEvent;
 }
 
 export interface CustomEvents {
-  [key: string]: PixelEventsCustomEvent;
+  [key: string]: CustomEvent;
 }
 
 export type Events = StandardEvents & CustomEvents;
@@ -40,14 +32,14 @@ export type SubscriberCallback<T> = (event: T) => void;
 export type SubscriberOptions = Record<string, unknown>;
 
 export interface EventBus {
-  publish<K extends KeyOfEvent<StandardEvents>>(
+  publish<K extends KeyOfEvent<PixelEvents>>(
     name: K,
-    payload?: PublisherData<Events[K]>,
+    payload: PublisherData<PixelEvents[K]>,
     options?: PublisherOptions,
   ): boolean;
   publishCustomEvent(
     name: string,
-    payload?: PublisherCustomData<Events['custom_event']>,
+    payload?: PublisherCustomData<CustomEvent>,
     options?: PublisherOptions,
   ): boolean;
   subscribe<K extends KeyOfEvent<Events>>(

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -151,22 +151,7 @@ export interface PixelEventsCollectionViewed {
   timestamp: Timestamp;
 }
 
-/**
- * This event represents any custom events emitted by partners or merchants via
- * the `publish` method
- */
-export interface PixelEventsCustomEvent {
-  clientId: ClientId;
-  context: Context;
-  customData: CustomData | null;
-  id: Id;
-
-  /**
-   * The name of the customer event
-   */
-  name: 'custom_event';
-  timestamp: Timestamp;
-}
+export interface PixelEventsPageViewedData {}
 
 /**
  * The `page_viewed` event logs an instance where a customer visited a page.
@@ -175,6 +160,7 @@ export interface PixelEventsCustomEvent {
 export interface PixelEventsPageViewed {
   clientId: ClientId;
   context: Context;
+  data: PixelEventsPageViewedData;
   id: Id;
 
   /**
@@ -223,6 +209,28 @@ export interface PixelEventsProductAddedToCart {
    * The name of the customer event
    */
   name: 'product_added_to_cart';
+  timestamp: Timestamp;
+}
+
+export interface PixelEventsProductRemovedFromCartData {
+  cartLine: CartLine | null;
+}
+
+/**
+ * The `product_removed_from_cart` event logs an instance where a customer
+ * removes a product from their cart. This event is available on the online
+ * store page
+ */
+export interface PixelEventsProductRemovedFromCart {
+  clientId: ClientId;
+  context: Context;
+  data: PixelEventsProductRemovedFromCartData;
+  id: Id;
+
+  /**
+   * The name of the customer event
+   */
+  name: 'product_removed_from_cart';
   timestamp: Timestamp;
 }
 
@@ -339,12 +347,6 @@ export interface PixelEvents {
   collection_viewed: PixelEventsCollectionViewed;
 
   /**
-   * This event represents any custom events emitted by partners or merchants
-   * via the `publish` method
-   */
-  custom_event: PixelEventsCustomEvent;
-
-  /**
    * The `page_viewed` event logs an instance where a customer visited a page.
    * This event is available on the online store, checkout, and order status
    * pages
@@ -363,6 +365,13 @@ export interface PixelEvents {
    * product to their cart. This event is available on the online store page
    */
   product_added_to_cart: PixelEventsProductAddedToCart;
+
+  /**
+   * The `product_removed_from_cart` event logs an instance where a customer
+   * removes a product from their cart. This event is available on the online
+   * store page
+   */
+  product_removed_from_cart: PixelEventsProductRemovedFromCart;
 
   /**
    * The `product_variant_viewed` event logs an instance where a customer
@@ -736,10 +745,27 @@ export interface Context {
 }
 
 /**
- * A free-form JSON object representing data specific to a custom event provided
- * by the custom event publisher
+ * A free-form object representing data specific to a custom event provided by
+ * the custom event publisher
  */
 export type CustomData = Record<string, unknown>;
+
+/**
+ * This event represents any custom events emitted by partners or merchants via
+ * the `publish` method
+ */
+export interface CustomEvent {
+  clientId: ClientId;
+  context: Context;
+  customData: CustomData | null;
+  id: Id;
+
+  /**
+   * Arbitrary name of the custom event
+   */
+  name: string;
+  timestamp: Timestamp;
+}
 
 /**
  * A customer represents a customer account with the shop. Customer accounts
@@ -779,29 +805,29 @@ export interface Customer {
 }
 
 /**
- * A free-form JSON object representing data specific to this event provided
- * by Shopify. Refer to [standard events](#standard-events) for details on the
+ * A free-form object representing data specific to this event provided by
+ * Shopify. Refer to [standard events](#standard-events) for details on the
  * payload available to each event
  */
 export type Data = Record<string, unknown>;
 
 /**
- * An amount discounting the line that has been allocated by a discount.
+ * The discount that has been applied to the checkout line item.
  */
 export interface DiscountAllocation {
   /**
-   * Amount of discount allocated.
+   * The monetary value with currency allocated to the discount.
    */
   amount: MoneyV2;
 
   /**
-   * Information about the intent of a discount.
+   * The information about the intent of the discount.
    */
   discountApplication: DiscountApplication;
 }
 
 /**
- * Information about the intent of a discount.
+ * The information about the intent of the discount.
  */
 export interface DiscountApplication {
   /**

--- a/scripts/consumer-helper.sh
+++ b/scripts/consumer-helper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-AVAILABLE_PACKAGES=('admin-ui-extensions' 'admin-ui-extensions-react' 'checkout-ui-extensions' 'checkout-ui-extensions-react' 'post-purchase-ui-extensions' 'post-purchase-ui-extensions-react' 'checkout-ui-extensions-run' 'customer-account-ui-extensions' 'customer-account-ui-extensions-react')
+AVAILABLE_PACKAGES=('admin-ui-extensions' 'admin-ui-extensions-react' 'checkout-ui-extensions' 'checkout-ui-extensions-react' 'post-purchase-ui-extensions' 'post-purchase-ui-extensions-react' 'checkout-ui-extensions-run' 'customer-account-ui-extensions' 'customer-account-ui-extensions-react' 'web-pixels-extension')
 ROOT=$(pwd)
 
 # Font color


### PR DESCRIPTION
### Background

On all standard events, `data` is an object with some specific data. `'page_viewed'` of type `PixelEventsPageViewed` is the only one that doesn't include any explicit additional data. However, the implementation still provides an empty object.

### Solution

First, I added `PixelEventsPageViewedData` as an empty object to `page_viewed` event type. Then, I figured that some other types were slightly off, so I moved `custom_event` out of `PixelEvents` and now `CustomEvent` replaces `PixelEventsCustomEvent`.

I then updated `StandardEvents` so that the "all events" keys' possible values were properly typed. Which led me to also update the `EventBus` interface since it's not possible to publish to "all events", it's only possible to subscribe to those.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
