### PR TITLE
Removed baseUrl property from tsconfig

### DIFF
--- a/packages/retail-ui-extensions-react/tsconfig.json
+++ b/packages/retail-ui-extensions-react/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
+    "outDir": "build/ts",
     "jsx": "react-jsx",
     "isolatedModules": true,
     "lib": [

--- a/packages/retail-ui-extensions/tsconfig.json
+++ b/packages/retail-ui-extensions/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src",
     "isolatedModules": true,
     "lib": [


### PR DESCRIPTION
### Background

Looking into an issue where our type script components are not auto completing.

### Solution

It looks like it might be related to the way we export.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
