### PR TITLE
Update Tile props

### DIFF
--- a/packages/retail-ui-extensions/src/components/Tile/Tile.ts
+++ b/packages/retail-ui-extensions/src/components/Tile/Tile.ts
@@ -3,9 +3,10 @@ import {createRemoteComponent} from '@remote-ui/core';
 export interface TileProps {
   title: string;
   subtitle?: string;
-  enabled: boolean;
+  enabled?: boolean;
   destructive?: boolean;
-  onPress: () => void;
+  badgeValue?: number;
+  onPress?: () => void;
 }
 
 export const Tile = createRemoteComponent<'Tile', TileProps>('Tile');


### PR DESCRIPTION
### Background
Part of https://github.com/Shopify/polaris-for-retail/issues/159

We added a [new Tile component](https://github.com/Shopify/polaris-for-retail/pull/164) in polaris-for-retail that will replace the Tile component in UIExtensions. We need to update the props to reflect this.

### Solution
Update the props. Not a breaking change since changed props are optional.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
