### PR TITLE
useApi(): infer target from dummy argument

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/admin/hooks/api.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/hooks/api.ts
@@ -13,7 +13,7 @@ import {AdminUIExtensionError} from '../errors';
  */
 export function useApi<
   ID extends RenderExtensionTarget = RenderExtensionTarget,
->(): ApiForRenderExtension<ID> {
+>(target?: ID): ApiForRenderExtension<ID> {
   const api = useContext(ExtensionApiContext);
 
   if (api == null) {


### PR DESCRIPTION
### Background

This makes it possible to use `useApi()` in JS with full type inference. Previously this required extensive jsdoc annotations that nobody would bother doing.

### Solution

Inference from argument, the same as how `reactExtension(target)` works.

