### PR TITLE
Add data to block and action types

### DIFF
--- a/.changeset/dirty-lizards-explode.md
+++ b/.changeset/dirty-lizards-explode.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Add data type to block and action

--- a/packages/ui-extensions/src/api.ts
+++ b/packages/ui-extensions/src/api.ts
@@ -88,3 +88,10 @@ export interface Navigation {
    */
   navigate: (url: string | URL) => void;
 }
+
+export interface Data {
+  /**
+   * Information about the currently viewed or selected items.
+   */
+  selected: {id: string}[];
+}

--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -2,5 +2,6 @@ export type {I18n, I18nTranslate} from '../../api';
 export type {StandardApi} from './api/standard/standard';
 export type {CustomerSegmentationTemplateApi} from './api/customer-segmentation-template/customer-segmentation-template';
 export type {ActionExtensionApi} from './api/action/action';
+export type {BlockExtensionApi} from './api/block/block';
 export type {ProductDetailsConfigurationApi} from './api/product-configuration/product-details-configuration';
 export type {ProductVariantDetailsConfigurationApi} from './api/product-configuration/product-variant-details-configuration';

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -1,0 +1,20 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Block Extension API',
+  featureFlag: 'admin_extensibility',
+  description: 'This API is available to all block extension types.',
+  isVisualComponent: false,
+  type: 'API',
+  definitions: [
+    {
+      title: 'BlockExtensionApi',
+      description: '',
+      type: 'BlockExtensionApi',
+    },
+  ],
+  category: 'API',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.ts
@@ -2,13 +2,8 @@ import type {StandardApi} from '../standard/standard';
 import type {Data} from '../../../../api';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
-export interface ActionExtensionApi<ExtensionTarget extends AnyExtensionTarget>
+export interface BlockExtensionApi<ExtensionTarget extends AnyExtensionTarget>
   extends StandardApi<ExtensionTarget> {
-  /**
-   * Closes the extension. Calling this method is equivalent to the merchant clicking the "x" in the corner of the overlay.
-   */
-  close: () => void;
-
   /**
    * Information about the currently viewed or selected items.
    */

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -5,6 +5,7 @@ import type {
   StandardApi,
   CustomerSegmentationTemplateApi,
   ActionExtensionApi,
+  BlockExtensionApi,
   ProductDetailsConfigurationApi,
   ProductVariantDetailsConfigurationApi,
 } from './api';
@@ -52,7 +53,7 @@ export interface ExtensionTargets {
    * Renders an Admin Block in the product details page.
    */
   'admin.product-details.block.render': RenderExtension<
-    StandardApi<'admin.product-details.block.render'>,
+    BlockExtensionApi<'admin.product-details.block.render'>,
     AnyComponent
   >;
 
@@ -60,7 +61,7 @@ export interface ExtensionTargets {
    * Renders an Admin Block in the order details page.
    */
   'admin.order-details.block.render': RenderExtension<
-    StandardApi<'admin.order-details.block.render'>,
+    BlockExtensionApi<'admin.order-details.block.render'>,
     AnyComponent
   >;
 
@@ -68,7 +69,7 @@ export interface ExtensionTargets {
    * Renders an Admin Block in the customer details page.
    */
   'admin.customer-details.block.render': RenderExtension<
-    StandardApi<'admin.customer-details.block.render'>,
+    BlockExtensionApi<'admin.customer-details.block.render'>,
     AnyComponent
   >;
 


### PR DESCRIPTION
### Background

Adds `data` which was missing from action and block extensions, and also removes `i18n` since that is present in the standard API.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
