### PR TITLE
Backport extension APIs to 2023-04

### DIFF
--- a/.changeset/kind-carpets-applaud.md
+++ b/.changeset/kind-carpets-applaud.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions-react': major
+'@shopify/ui-extensions-react': minor
 ---
 
 Rename `useExtensionData()` to `useExtension()`

--- a/.changeset/kind-carpets-applaud.md
+++ b/.changeset/kind-carpets-applaud.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-react': major
+---
+
+Rename `useExtensionData()` to `useExtension()`

--- a/.changeset/little-sheep-join.md
+++ b/.changeset/little-sheep-join.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-react': patch
+---
+
+Allow passing target name to `useApi()` for type inference

--- a/.changeset/neat-vans-heal.md
+++ b/.changeset/neat-vans-heal.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Backported `Extension.target` field for checkout UI extensions

--- a/.changeset/odd-crabs-eat.md
+++ b/.changeset/odd-crabs-eat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-react': minor
+---
+
+Make @shopify/ui-extensions a peer dependency for React library

--- a/.changeset/pink-poets-confess.md
+++ b/.changeset/pink-poets-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Preserve generic type argument for `I18nTranslate` function

--- a/.changeset/slimy-timers-heal.md
+++ b/.changeset/slimy-timers-heal.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-react': patch
+---
+
+Allow React extensions to return asynchronous results

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -45,13 +45,16 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/ui-extensions": "2023.4.1",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {
+    "@shopify/ui-extensions": "2023.4.x",
     "react": ">=17.0.0 <18.0.0"
   },
   "peerDependenciesMeta": {
+    "@shopify/ui-extensions": {
+      "optional": false
+    },
     "react": {
       "optional": false
     }

--- a/packages/ui-extensions-react/src/surfaces/admin/hooks/api.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/hooks/api.ts
@@ -13,7 +13,7 @@ import {AdminUIExtensionError} from '../errors';
  */
 export function useApi<
   ID extends RenderExtensionTarget = RenderExtensionTarget,
->(): ApiForRenderExtension<ID> {
+>(_id?: ID): ApiForRenderExtension<ID> {
   const api = useContext(ExtensionApiContext);
 
   if (api == null) {

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/api.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/api.ts
@@ -16,9 +16,9 @@ import {ExtensionApiContext} from '../context';
  *
  * For reference, see [ExtensionPoints](https://shopify.dev/docs/api/checkout-ui-extensions/apis/extensionpoints) to determine what API object will be returned by your extension point.
  */
-export function useApi<
-  ID extends RenderExtensionPoint = RenderExtensionPoint,
->(): ApiForRenderExtension<ID> {
+export function useApi<ID extends RenderExtensionPoint = RenderExtensionPoint>(
+  _id?: ID,
+): ApiForRenderExtension<ID> {
   const api = useContext(ExtensionApiContext);
 
   if (api == null) {

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/extension.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/extension.ts
@@ -8,8 +8,15 @@ import {useApi} from './api';
 /**
  * Returns the metadata about the extension.
  */
-export function useExtensionData<
+export function useExtension<
   ID extends RenderExtensionPoint = RenderExtensionPoint,
 >(): Extension {
   return useApi<ID>().extension;
 }
+
+/**
+ * Returns the metadata about the extension.
+ *
+ * @deprecated Use `useExtension()` instead.
+ */
+export const useExtensionData = useExtension;

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/index.ts
@@ -26,7 +26,7 @@ export {useTarget} from './target';
 export {useAppMetafields} from './app-metafields';
 export {useShop} from './shop';
 export {useStorage} from './storage';
-export {useExtensionData} from './extension-data';
+export {useExtension, useExtensionData} from './extension';
 export {useSubscription} from './subscription';
 export {useCustomer, useEmail, usePhone} from './buyer-identity';
 export {useTranslate} from './translate';

--- a/packages/ui-extensions-react/src/surfaces/checkout/tests/react-extension.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/tests/react-extension.test.tsx
@@ -54,16 +54,17 @@ describe('render()', () => {
     console.error = consoleError;
   });
 
-  it('calls extension() with the extension point', () => {
-    reactExtension('Checkout::Dynamic::Render', () => <></>);
+  it('calls extension() with the extension point', async () => {
+    await reactExtension('Checkout::Dynamic::Render', () => <></>);
+
     expect(extension).toHaveBeenCalledWith(
       'Checkout::Dynamic::Render',
       expect.any(Function),
     );
   });
 
-  it('reports errors thrown during reconcilation onto global this', () => {
-    reactExtension('Checkout::Dynamic::Render', () => {
+  it('reports errors thrown during reconcilation onto global this', async () => {
+    await reactExtension('Checkout::Dynamic::Render', () => {
       return <Thrown />;
     });
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -10,6 +10,7 @@ import type {
   SellingPlan,
   Attribute,
 } from '../shared';
+import type {ExtensionPoint} from '../../extension-points';
 
 /**
  * A key-value storage object for extension points.
@@ -59,7 +60,7 @@ export type Capability = 'api_access' | 'network_access' | 'block_progress';
 /**
  * Meta information about an extension point.
  */
-export interface Extension {
+export interface Extension<Target extends ExtensionPoint = ExtensionPoint> {
   /**
    * The identifier that specifies where in Shopify’s UI your code is being
    * injected. This will be one of the targets you have included in your
@@ -69,7 +70,7 @@ export interface Extension {
    * @see https://shopify.dev/docs/api/checkout-ui-extensions/unstable/extension-targets-overview
    * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
    */
-  target: import('../../extension-points').ExtensionPoint;
+  target: Target;
 
   /**
    * The published version of the running extension point.
@@ -396,9 +397,7 @@ export interface BuyerJourney {
   completed: StatefulRemoteSubscribable<boolean>;
 }
 
-export interface StandardApi<
-  ExtensionPoint extends import('../../extension-points').ExtensionPoint,
-> {
+export interface StandardApi<Target extends ExtensionPoint = ExtensionPoint> {
   /**
    * Methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
    */
@@ -467,7 +466,7 @@ export interface StandardApi<
   /**
    * Meta information about the extension.
    */
-  extension: Extension;
+  extension: Extension<Target>;
 
   /**
    * The identifier that specifies where in Shopify’s UI your code is being

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -61,6 +61,17 @@ export type Capability = 'api_access' | 'network_access' | 'block_progress';
  */
 export interface Extension {
   /**
+   * The identifier that specifies where in Shopify’s UI your code is being
+   * injected. This will be one of the targets you have included in your
+   * extension’s configuration file.
+   *
+   * @example 'Checkout::Dynamic::Render'
+   * @see https://shopify.dev/docs/api/checkout-ui-extensions/unstable/extension-targets-overview
+   * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
+   */
+  target: import('../../extension-points').ExtensionPoint;
+
+  /**
    * The published version of the running extension point.
    *
    * For unpublished extensions, the value is `undefined`.
@@ -459,8 +470,13 @@ export interface StandardApi<
   extension: Extension;
 
   /**
-   * The identifier of the running extension point.
-   * @example 'Checkout::PostPurchase::Render'
+   * The identifier that specifies where in Shopify’s UI your code is being
+   * injected. This will be one of the targets you have included in your
+   * extension’s configuration file.
+   *
+   * @example 'Checkout::Dynamic::Render'
+   * @see https://shopify.dev/docs/api/checkout-ui-extensions/unstable/extension-targets-overview
+   * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
    */
   extensionPoint: ExtensionPoint;
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -225,12 +225,14 @@ export type Version = string;
  *
  * @example translate("banner.title")
  */
-export type I18nTranslate<ReplacementType = string> = (
-  key: string,
-  options?: {[placeholderKey: string]: ReplacementType | string | number},
-) => ReplacementType extends string | number
-  ? string
-  : (string | ReplacementType)[];
+export interface I18nTranslate {
+  <ReplacementType = string>(
+    key: string,
+    options?: {[placeholderKey: string]: ReplacementType | string | number},
+  ): ReplacementType extends string | number
+    ? string
+    : (string | ReplacementType)[];
+}
 
 export interface I18n {
   /**


### PR DESCRIPTION
### Background

This PR is backporting some final changes made to the `unstable`/ `2023-07` branch of UI extensions back to `2023-05`.