### PR TITLE
Nest admin-only API types

### DIFF
--- a/.changeset/unlucky-moose-flash.md
+++ b/.changeset/unlucky-moose-flash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Nest and re-export some admin-specific API types

--- a/packages/ui-extensions/src/api.ts
+++ b/packages/ui-extensions/src/api.ts
@@ -74,24 +74,3 @@ export interface I18n {
    */
   translate: I18nTranslate;
 }
-
-export interface Intents {
-  /**
-   * The URL that was used to launch the intent.
-   */
-  launchUrl?: string | URL;
-}
-
-export interface Navigation {
-  /**
-   * A method to navigate to a specific route.
-   */
-  navigate: (url: string | URL) => void;
-}
-
-export interface Data {
-  /**
-   * Information about the currently viewed or selected items.
-   */
-  selected: {id: string}[];
-}

--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -1,5 +1,5 @@
 export type {I18n, I18nTranslate} from '../../api';
-export type {StandardApi} from './api/standard/standard';
+export type {StandardApi, Navigation, Intents} from './api/standard/standard';
 export type {CustomerSegmentationTemplateApi} from './api/customer-segmentation-template/customer-segmentation-template';
 export type {ActionExtensionApi} from './api/action/action';
 export type {BlockExtensionApi} from './api/block/block';

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.ts
@@ -1,6 +1,6 @@
 import type {StandardApi} from '../standard/standard';
-import type {Data} from '../../../../api';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+import type {Data} from '../shared';
 
 export interface ActionExtensionApi<ExtensionTarget extends AnyExtensionTarget>
   extends StandardApi<ExtensionTarget> {

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.ts
@@ -1,6 +1,6 @@
 import type {StandardApi} from '../standard/standard';
-import type {Data} from '../../../../api';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+import type {Data} from '../shared';
 
 export interface BlockExtensionApi<ExtensionTarget extends AnyExtensionTarget>
   extends StandardApi<ExtensionTarget> {

--- a/packages/ui-extensions/src/surfaces/admin/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/shared.ts
@@ -1,0 +1,6 @@
+export interface Data {
+  /**
+   * Information about the currently viewed or selected items.
+   */
+  selected: {id: string}[];
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
@@ -1,10 +1,19 @@
-import type {
-  StandardApi as BaseStandardApi,
-  I18n,
-  Intents,
-  Navigation,
-} from '../../../../api';
+import type {StandardApi as BaseStandardApi, I18n} from '../../../../api';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+
+export interface Intents {
+  /**
+   * The URL that was used to launch the intent.
+   */
+  launchUrl?: string | URL;
+}
+
+export interface Navigation {
+  /**
+   * A method to navigate to a specific route.
+   */
+  navigate: (url: string | URL) => void;
+}
 
 /**
  * The following APIs are provided to all extension targets.


### PR DESCRIPTION
This PR nests a few API types that are only available in the admin. I noticed these while I was bringing in the latest version of these files from checkout, which did not contain the very-generically-named `Data` type. I think nesting these in the admin surface is more appropriate, and we can always move them out as needed later.