### PR TITLE
[CustomerAccount | Extensibility] Remove features type on standardApi

### DIFF
--- a/packages/customer-account-ui-extensions/src/extension-points/standard-api/index.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/standard-api/index.ts
@@ -52,11 +52,6 @@ export interface StandardApi {
   };
 
   /**
-   * A list of feature names for features enabled on a shop
-   */
-  features: string[];
-
-  /**
    * Key-value storage for the extension point.
    */
   storage: Storage;


### PR DESCRIPTION
### Background

Fixes https://github.com/Shopify/core-issues/issues/49897

### Solution

Just removed the type

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
