### PR TITLE
docs: fix link to extension point targets on admin extensions docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -44,7 +44,7 @@ const data: LandingTemplateSchema = {
         {
           subtitle: 'Reference',
           name: 'View a list of available extension targets',
-          url: '/docs/api/admin-extensions/apis/extension-points',
+          url: '/docs/api/admin-extensions/api/extension-targets',
           type: 'app',
         },
         {


### PR DESCRIPTION
### Background

Fix broken link to extension targets on main page of Admin extensions docs