### PR TITLE
Remove unsupported props from Form component

### DIFF
--- a/.changeset/sweet-otters-shout.md
+++ b/.changeset/sweet-otters-shout.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Remove unsupport props from Form component

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ts
@@ -2,21 +2,9 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export interface FormProps {
   /**
-   * Whether input elements within the form can be automatically completed by the browser.
-   */
-  autocomplete?: boolean;
-
-  /**
    * A unique identifier for the form.
    */
   id?: string;
-
-  /**
-   * Whether the form is able to be submitted.
-   *
-   * When set to `true`, this will also disable the implicit submit behavior of the form.
-   */
-  disabled?: boolean;
 
   /**
    * A callback that is run when the form is submitted.


### PR DESCRIPTION
Remove `autocomplete` and `disabled` as we currently don't support these props for the Form component