### PR TITLE
Revert "Ignore src folder in published packages"

### DIFF
--- a/packages/retail-ui-extensions-react/.npmignore
+++ b/packages/retail-ui-extensions-react/.npmignore
@@ -1,4 +1,0 @@
-.*
-node_modules
-src
-tsconfig.json

--- a/packages/retail-ui-extensions/.npmignore
+++ b/packages/retail-ui-extensions/.npmignore
@@ -1,4 +1,0 @@
-.*
-node_modules
-src
-tsconfig.json


### PR DESCRIPTION
### Background

https://github.com/Shopify/pos-next-react-native/issues/26233

tl;dr: Typescript is not resolving prop types correctly after this merged.

@accet-shop and @rtymchyk, @heltisace suggested that this may mess with Stocky tests in some way. If we can find a way to fix the typescript stuff without reverting this, that would be a much better solution. However, we do need to get the typescript working by the release of 1.3.0, which is scheduled for Aug 9.

### Solution

We spent a lot of time trying to fix this without reverting these changes since they are consistent with other packages in this repository.

### 🎩

Build `retail-ui-extensions-react` and verify that the typescript declaration files can resolve props of components correctly.

