### PR TITLE
Publish

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "1.3.0-rc.4",
+  "version": "1.3.0-rc.5",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/retail-ui-extensions": "1.3.0-rc.4",
+    "@shopify/retail-ui-extensions": "1.3.0-rc.5",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/retail-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify Point of Sale",
-  "version": "1.3.0-rc.4",
+  "version": "1.3.0-rc.5",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
 - @shopify/retail-ui-extensions-react@1.3.0-rc.5
 - @shopify/retail-ui-extensions@1.3.0-rc.5

### Background

The omission of the src folders caused a problem with typescript in the react package.

### Solution

Revert the omission change.

### 🎩

Verify that the typescript declarations for components resolves correctly.

### Checklist

- [X] I have :tophat:'d these changes
