### PR TITLE
Add missing settings prefix in new .toml docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/versioning-migration.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/versioning-migration.doc.ts
@@ -94,12 +94,12 @@ handle = "my-extension"
 module =  "./src/index.ts"
 target = "purchase.checkout.block.render"
 
-[[extension_points.metafields]]
+[[extensions.metafields]]
 namespace = "my_namespace"
 key = "my_key"
 
-[settings]
-[[settings.fields]]
+[extensions.settings]
+[[extensions.settings.fields]]
 key = "banner_title"
 type = "single_line_text_field"
 name = "Banner title"


### PR DESCRIPTION
### Background

Settings should be prefixed correctly. Metafields is using an older prefix iirc.

### Solution

Added the missing prefix

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
