### PR TITLE
Add missing exports to index chain

### DIFF
--- a/packages/retail-ui-extensions/src/components/List/index.ts
+++ b/packages/retail-ui-extensions/src/components/List/index.ts
@@ -4,4 +4,5 @@ export type {
   ListRowLeftSide,
   ListRowRightSide,
   ListProps,
+  ToggleSwitch,
 } from './List';

--- a/packages/retail-ui-extensions/src/components/Screen/index.ts
+++ b/packages/retail-ui-extensions/src/components/Screen/index.ts
@@ -1,2 +1,2 @@
 export {Screen} from './Screen';
-export type {ScreenProps} from './Screen';
+export type {ScreenPresentationProps, ScreenProps} from './Screen';

--- a/packages/retail-ui-extensions/src/components/Section/index.ts
+++ b/packages/retail-ui-extensions/src/components/Section/index.ts
@@ -1,2 +1,2 @@
 export {Section} from './Section';
-export type {SectionProps} from './Section';
+export type {SectionHeaderAction, SectionProps} from './Section';

--- a/packages/retail-ui-extensions/src/components/index.ts
+++ b/packages/retail-ui-extensions/src/components/index.ts
@@ -19,7 +19,7 @@ export type {Spacing, StackProps} from './Stack';
 export type {VerticalSpacing, HorizontalSpacing} from './Spacing';
 
 export {Section} from './Section';
-export type {SectionProps} from './Section';
+export type {SectionHeaderAction, SectionProps} from './Section';
 
 export {FormattedTextField} from './FormattedTextField';
 export type {InputType, FormattedTextFieldProps} from './FormattedTextField';
@@ -30,6 +30,7 @@ export type {
   ListRowLeftSide,
   ListRowRightSide,
   ListProps,
+  ToggleSwitch,
 } from './List';
 
 export {PinPad} from './PinPad';
@@ -89,7 +90,7 @@ export {Icon} from './Icon';
 export type {IconName, IconProps} from './Icon';
 
 export {Screen} from './Screen';
-export type {ScreenProps} from './Screen';
+export type {ScreenPresentationProps, ScreenProps} from './Screen';
 
 export {Navigator} from './Navigator';
 

--- a/packages/retail-ui-extensions/src/extension-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/index.ts
@@ -12,7 +12,7 @@ export type {
 export type {StandardApi} from './standard-api';
 
 export type {SessionApiContent, SessionApi} from './session-api';
-export type {ToastApiContent, ToastApi} from './toast-api';
+export type {ShowToastOptions, ToastApiContent, ToastApi} from './toast-api';
 export type {
   ProductSearchApi,
   ProductSearchApiContent,

--- a/packages/retail-ui-extensions/src/extension-api/toast-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/toast-api/index.ts
@@ -1,1 +1,1 @@
-export type {ToastApiContent, ToastApi} from './toast-api';
+export type {ShowToastOptions, ToastApiContent, ToastApi} from './toast-api';

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -14,6 +14,7 @@ export type {
   SessionApiContent,
   ToastApi,
   ToastApiContent,
+  ShowToastOptions,
   Session,
   ScannerSource,
   ScannerSubscriptionResult,
@@ -91,6 +92,7 @@ export type {
   NumberFieldProps,
   Segment,
   SegmentedControlProps,
+  SectionHeaderAction,
   SectionProps,
   InputType,
   TextFieldProps,
@@ -105,6 +107,7 @@ export type {
   ListRow,
   ListRowLeftSide,
   ListRowRightSide,
+  ToggleSwitch,
   PinValidationResult,
   PinLength,
   PinPadActionType,
@@ -131,6 +134,7 @@ export type {
   IconName,
   IconProps,
   ScreenProps,
+  ScreenPresentationProps,
 } from './components';
 
 export type {


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/pos-next-react-native/issues/25236

### Solution

Add missing export chains

### 🎩

Yalc and fix imports in POS

### Checklist

- [X] I have :tophat:'d these changes
