### PR TITLE
Extension editor

### DIFF
--- a/packages/customer-account-ui-extensions-react/src/hooks/extension-editor.ts
+++ b/packages/customer-account-ui-extensions-react/src/hooks/extension-editor.ts
@@ -1,0 +1,15 @@
+import {RenderExtensionPoint} from '@shopify/customer-account-ui-extensions';
+import type {Editor} from '@shopify/customer-account-ui-extensions';
+
+import {useApi} from './api';
+
+/**
+ * Returns information about the editor where the extension is being rendered.
+ */
+export function useExtensionEditor<
+  ID extends RenderExtensionPoint = RenderExtensionPoint,
+>(): Editor | undefined {
+  const api = useApi<ID>();
+
+  return api.extension.editor;
+}

--- a/packages/customer-account-ui-extensions-react/src/hooks/tests/extension-editor.test.tsx
+++ b/packages/customer-account-ui-extensions-react/src/hooks/tests/extension-editor.test.tsx
@@ -1,0 +1,16 @@
+import {mount} from './mount';
+import {useExtensionEditor} from '../extension-editor';
+
+describe('useExtensionEditor', () => {
+  it('returns extension editor from the api', () => {
+    const {value} = mount.hook(() => useExtensionEditor(), {
+      extensionApi: {
+        extension: {
+          editor: {type: 'checkout'},
+        },
+      },
+    });
+
+    expect(value).toMatchObject({type: 'checkout'});
+  });
+});

--- a/packages/customer-account-ui-extensions/src/extension-points/index.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/index.ts
@@ -9,7 +9,7 @@ export type {
   I18nTranslate,
   I18n,
 } from './standard-api/localization';
-export type {Capability, Extension} from './standard-api/extension';
+export type {Capability, Extension, Editor} from './standard-api/extension';
 export type {Storage} from './standard-api/storage';
 
 export type {StandardApi} from './standard-api';

--- a/packages/customer-account-ui-extensions/src/extension-points/standard-api/extension.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/standard-api/extension.ts
@@ -2,6 +2,12 @@ import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 export type Capability = 'network_access';
 
+export interface Editor {
+  /**
+   * Indicates whether the extension is rendering in the checkout editor.
+   */
+  type: 'checkout';
+}
 export interface Extension {
   /**
    * The published version of the running extension point.
@@ -40,4 +46,11 @@ export interface Extension {
    * to make network calls.
    */
   capabilities: StatefulRemoteSubscribable<Capability[]>;
+
+  /**
+   * Information about the editor where the extension is being rendered.
+   *
+   * The value is undefined if the extension is not rendering in an editor.
+   */
+  editor?: Editor;
 }


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/58453 
Add UI Extension Editor interface, just like what checkout did to indicate whether it is rendered within an editor so 3rd part developers can simulate data in this case

customer-account-web side: https://github.com/Shopify/customer-account-web/pull/2664 

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

See tophat in this PR https://github.com/Shopify/customer-account-web/pull/2664 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
