### PR TITLE
Admin authentication

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -100,7 +100,7 @@ const data: LandingTemplateSchema = {
         title: "Make requests to your app's backend",
         tabs: [
           {
-            code: './examples/direct-api.jsx',
+            code: './examples/authenticated-fetch.jsx',
             language: 'tsx',
             title: 'Get Product Data',
           },

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -48,6 +48,12 @@ const data: LandingTemplateSchema = {
           type: 'app',
         },
         {
+          subtitle: 'App authentication',
+          name: "Make authenticated requests to your app's backend",
+          url: '#app-authentication',
+          type: 'tool',
+        },
+        {
           subtitle: 'Direct API access',
           name: 'Access the Shopify GraphQL API directly',
           url: '#direct-api-access',
@@ -80,6 +86,23 @@ const data: LandingTemplateSchema = {
             code: './examples/getting-started.sh',
             language: 'bash',
             title: 'CLI',
+          },
+        ],
+      },
+    },
+    {
+      type: 'Generic',
+      title: 'App Authentication',
+      sectionContent:
+        "Admin UI extensions can also make authenticated calls to your app's backend. When you make a `fetch()` request to your app's backend, an authorization token will be automatically added to the call's headers. There's no need to manually manage your app's session tokens.",
+      anchorLink: 'app-authentication',
+      codeblock: {
+        title: "Make requests to your app's backend",
+        tabs: [
+          {
+            code: './examples/direct-api.jsx',
+            language: 'tsx',
+            title: 'Get Product Data',
           },
         ],
       },

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -94,7 +94,7 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       title: 'App Authentication',
       sectionContent:
-        "Admin UI extensions can also make authenticated calls to your app's backend. When you make a `fetch()` request to your app's backend, an authorization token will be automatically added to the call's headers. There's no need to manually manage your app's session tokens.",
+        "Admin UI extensions can also make authenticated calls to your app's backend. When you make a `fetch()` request to your app's backend, an authorization token will be automatically added to the request headers. There's no need to manually manage your app's session tokens.",
       anchorLink: 'app-authentication',
       codeblock: {
         title: "Make requests to your app's backend",

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/authenticated-fetch.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/authenticated-fetch.jsx
@@ -1,0 +1,28 @@
+import {reactExtension, useApi, Text} from '@shopify/ui-extensions-react/admin';
+import {useEffect, useState} from 'react';
+
+//Get product info from app backend
+async function getProductInfo(id) {
+  const res = await fetch(`https://my-app.com/api/productInfo/${id}`, {
+    method: 'GET',
+  });
+  const {data} = await res.json();
+  return data;
+}
+
+const TARGET = 'admin.product-details.block.render';
+
+export default reactExtension(TARGET, () => <App />);
+
+function App() {
+  // Contextual "input" data passed to this extension:
+  const {data} = useApi(TARGET);
+
+  const [productInfo, setProductInfo] = useState();
+  useEffect(() => {
+    const productId = data.selected?.[0]?.id;
+    getProductInfo(productId).then(setProductInfo);
+  }, [data]);
+
+  return <Text>The app info from the backend is: {productInfo}</Text>;
+}


### PR DESCRIPTION
### Background

Folks kept asking if they could use these with their apps' backends, or if they could get a session token. 
### Solution

Documented how fetch requests will automatically be authenticated and added a code sample.

### 🎩

- Generate the docs
- Copy them to shopify-dev
- Preview the changes

### Checklist

- [X ] I have :tophat:'d these changes
- [ X, but this one feels like a trick question for this commit] I have updated relevant documentation
