### PR TITLE
changset should use unstable branch as base

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "fixed": [],
   "linked": [],
   "access": "restricted",
-  "baseBranch": "main",
+  "baseBranch": "unstable",
   "updateInternalDependencies": "patch",
   "ignore": []
 }


### PR DESCRIPTION
### Background

When running `yarn changset` it should be using the `unstable` branch as the base branch.

### Solution

Updates the config.

### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
