### PR TITLE
Publish checkout-ui-extensions version 0.27.2

### DIFF
--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/checkout-ui-extensions-react",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "React bindings for @shopify/checkout-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.14",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions": "^0.27.1",
+    "@shopify/checkout-ui-extensions": "^0.27.2",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify’s Checkout",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/customer-account-ui-extensions-react",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "React bindings for @shopify/customer-account-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions-react": "^0.27.1",
-    "@shopify/customer-account-ui-extensions": "^0.0.53"
+    "@shopify/checkout-ui-extensions-react": "^0.27.2",
+    "@shopify/customer-account-ui-extensions": "^0.0.54"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <18.0.0"

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/customer-account-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify's Customer Account",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"
@@ -24,6 +24,6 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/core": "2.1.x",
-    "@shopify/checkout-ui-extensions": "^0.27.1"
+    "@shopify/checkout-ui-extensions": "^0.27.2"
   }
 }


### PR DESCRIPTION
### Background

Bumps the versions for the packages to be published. Follows the[ PR that merged changes](https://github.com/Shopify/ui-extensions/pull/1204).

### Solution

The result of running `yarn version-bump:checkout` for a patch for `checkout-ui-extensions`.

### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
