### PR TITLE
feat(Badge): add optional BadgeStatus to Badge component

### DIFF
--- a/packages/retail-ui-extensions/src/components/Badge/Badge.ts
+++ b/packages/retail-ui-extensions/src/components/Badge/Badge.ts
@@ -7,9 +7,12 @@ export type BadgeVariant =
   | 'success'
   | 'highlight';
 
+export type BadgeStatus = 'empty' | 'partial' | 'complete';
+
 export interface BadgeProps {
   text: string;
   variant: BadgeVariant;
+  status?: BadgeStatus;
 }
 
 export const Badge = createRemoteComponent<'Badge', BadgeProps>('Badge');


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/pos-next-react-native/issues/24563

Adding the optional badge prop that's already supported in PFR.

### Solution

Add it.

### 🎩

Locally install the package in some project (yalc, pack, etc) and verify that the prop is there. Not really necessary for something this simple.

### Checklist

- [X] I have :tophat:'d these changes
