### PR TITLE
Add target to link

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Link/Link.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/Link.ts
@@ -58,6 +58,11 @@ export interface LinkProps {
    * Alias for `language`
    */
   lang?: string;
+  /**
+   * Specifies where to display the linked URL
+   * @default '_self'
+   */
+  target?: '_blank' | '_self';
 }
 
 export const Link = createRemoteComponent<'Link', LinkProps>('Link');


### PR DESCRIPTION
### Background

Currently, links can only open in their own context.

### Solution

- Add `target` prop  to provide a way for links to open in a new tab
 
### 🎩

- Set up extensions spinstance with `spin up extensions` 
- Create an app and extension
  - `yarn create @Shopify/app`
  -  `yarn generate extension` (choose action or block)
- Copy your app into your Shopify directory to make sure that the build-consumer script works. `cp -R <app-path> ~/src/github.com/Shopify/<app-folder>`
- In `ui-extensions` on this branch, run:
  - `yarn build-consumer <your-app>`  
  - `yarn build-consumer-spin web` 
- Restart web after running build consumer script
- Add an external link with `target="_blank"` to your extension (make sure to import `Link`)
  - `<Link to='https://google.com' target='_blank'>Google</Link>`   
- Confirm that the `target` prop is available in the `Link` API

![Screenshot 2023-08-09 at 3 50 27 PM](https://github.com/Shopify/ui-extensions/assets/7654369/15c18819-5951-4bf5-87aa-8cead92da9e5)

- Run the app/extension `cli-spin yarn dev` and navigate to the extension
- Confirm that link opens in a new tab.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
