### PR TITLE
Expose query api for Admin extensions

### DIFF
--- a/.changeset/tiny-bees-report.md
+++ b/.changeset/tiny-bees-report.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Expose query API for Admin UI extensions

--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -11,3 +11,8 @@ export type ComponentsBuilder<ComponentTypes> = {
 
 export type AnyComponentBuilder<ComponentTypes> =
   ComponentsBuilder<ComponentTypes>[keyof ComponentsBuilder<ComponentTypes>];
+
+/**
+ * Union of supported API versions
+ */
+export type ApiVersion = '2023-04' | '2023-07' | 'unstable';

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
@@ -1,4 +1,5 @@
 import type {I18n} from '../../../../api';
+import {ApiVersion} from '../../../../shared';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
 export interface Intents {
@@ -16,6 +17,17 @@ export interface Navigation {
 }
 
 /**
+ * GraphQL error returned by the Shopify Admin API.
+ */
+export interface GraphQLError {
+  message: string;
+  locations: {
+    line: number;
+    column: string;
+  };
+}
+
+/**
  * The following APIs are provided to all extension targets.
  */
 export interface StandardApi<ExtensionTarget extends AnyExtensionTarget> {
@@ -25,17 +37,28 @@ export interface StandardApi<ExtensionTarget extends AnyExtensionTarget> {
   extension: {
     target: ExtensionTarget;
   };
+
   /**
    * Utilities for translating content according to the current localization of the admin.
    * More info - https://shopify.dev/docs/apps/checkout/best-practices/localizing-ui-extensions
    */
   i18n: I18n;
+
   /**
    * Provides information to the receiver the of an intent.
    */
   intents: Intents;
+
   /**
    * Provides methods to navigate to other features in the Admin.
    */
   navigation: Navigation;
+
+  /**
+   * Used to query the Admin GraphQL API
+   */
+  query: <Data = unknown, Variables = {[key: string]: unknown}>(
+    query: string,
+    options?: {variables?: Variables; version?: Omit<ApiVersion, '2023-04'>},
+  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/Link.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/Link.ts
@@ -58,6 +58,11 @@ export interface LinkProps {
    * Alias for `language`
    */
   lang?: string;
+  /**
+   * Specifies where to display the linked URL
+   * @default '_self'
+   */
+  target?: '_blank' | '_self';
 }
 
 export const Link = createRemoteComponent<'Link', LinkProps>('Link');

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -12,6 +12,7 @@ import type {
   MailingAddress,
 } from '../shared';
 import type {ExtensionTarget} from '../../targets';
+import {ApiVersion} from '../../../../shared';
 
 /**
  * A key-value storage object for extension targets.
@@ -234,7 +235,7 @@ export interface AppMetafieldEntry {
   metafield: AppMetafield;
 }
 
-export type ApiVersion = '2023-04' | '2023-07' | 'unstable';
+export type {ApiVersion} from '../../../../shared';
 
 export type Version = string;
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -11,6 +11,7 @@ import type {
   MailingAddress,
 } from '../shared';
 import type {ExtensionTarget} from '../../targets';
+import {ApiVersion} from '../../../../shared';
 
 /**
  * A key-value storage object for extension targets.
@@ -233,7 +234,7 @@ export interface AppMetafieldEntry {
   metafield: AppMetafield;
 }
 
-export type ApiVersion = '2023-04' | '2023-07' | 'unstable';
+export type {ApiVersion} from '../../../../shared';
 
 export type Version = string;
 


### PR DESCRIPTION
### Background

Related to https://github.com/Shopify/app-ui/issues/232

### Solution

Expose the `query` API to Admin extensions.

### 🎩

- Use the CLI to create a new app and generate an Action extension
- In this repo, run `yarn build-consumer ./your-project-dir/extensions/admin-action`
- Update the Action extension's code to the following:
```diff
// The useApi hook provides access to several useful APIs like i18n, close, and data.
-   const {extension: {target}, i18n, close, data} = useApi(TARGET);
+   const {extension: {target}, i18n, close, data, query} = useApi(TARGET);

   const [productTitle, setProductTitle] = useState('');
  // Use direct API calls to fetch data from Shopify.
  // See https://shopify.dev/docs/api/admin-graphql for more information about Shopify's GraphQL API
  useEffect(() => {
-   (async function getProductInfo() {
-     const getProductQuery = {
-       query: `query Product($id: ID!) {
-         product(id: $id) {
-           title
-         }
-       }`,
-       variables: {id: data.selected[0].id},
-     };

-    const res = await query(JSON.stringify(getProductQuery));
+    const res = await query(`query Product($id: ID!) {
+       product(id: $id) {
+         title
+       }
+     }`, {variables: {id: data.selected[0].id}});

      if (!res.ok) {
        console.error('Network error');
      }

      const productData = await res.json();
      setProductTitle(productData.data.product.title);
    })();
  }, []);
```
- Run `yarn dev` and click on the preview link for the Action extension
- Verify that the extension works to fetch product info

### Checklist

- [X] I have :tophat:'d these changes
- ~[ ] I have updated relevant documentation~ I didn't update the documentation in this PR as our docs are very out of date on this branch. We will need to continue running the docs generate command on the `unstable` branch to get the latest updates.
