### PR TITLE
customer account information static extension

### DIFF
--- a/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
@@ -38,6 +38,22 @@ export interface ExtensionPoints {
     StandardApi<'customer-account.account-information.block.render'>,
     AllComponents
   >;
+  'customer-account.account-information.company-details.render-after': RenderExtension<
+    StandardApi<'customer-account.account-information.company-details.render-after'>,
+    AllComponents
+  >;
+  'customer-account.account-information.addresses.render-after': RenderExtension<
+    StandardApi<'customer-account.account-information.addresses.render-after'>,
+    AllComponents
+  >;
+  'customer-account.account-information.payment.render-after': RenderExtension<
+    StandardApi<'customer-account.account-information.payment.render-after'>,
+    AllComponents
+  >;
+  'customer-account.account-information.location.render-after': RenderExtension<
+    StandardApi<'customer-account.account-information.location.render-after'>,
+    AllComponents
+  >;
   'customer-account.order-status.action.menu-item.render': RenderExtension<
     StandardApi & {orderId: string},
     AllComponents


### PR DESCRIPTION
### Background

Part of this ticket https://github.com/Shopify/core-issues/issues/58896 

add static extension points for customer account web information page

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
