### PR TITLE
Apply patch for updated types

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/buyer-identity.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/buyer-identity.test.tsx
@@ -19,7 +19,7 @@ function createMockCustomer(customer = {}) {
     firstName,
     lastName,
     email: faker.internet.email(),
-    phone: faker.phone.phoneNumber(),
+    phone: faker.phone.number(),
     ...customer,
   };
 }
@@ -151,7 +151,7 @@ describe('buyerIdentity Hooks', () => {
     });
 
     it('returns phone with CustomerPersonalData and CustomerEmail ApprovalScopes', () => {
-      const phone = faker.phone.phoneNumber();
+      const phone = faker.phone.number();
       const hook = mount.hook(() => usePhone(), createUsePhoneContext(phone));
       expect(hook?.current).toBe(phone);
     });

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -342,7 +342,7 @@ export interface MetafieldRemoveChange {
 /** Removes a cart metafield. */
 export interface MetafieldRemoveCartChange {
   /**
-   * The type of the `MetafieldRemoveChange` API.
+   * The type of the `MetafieldRemoveCartChange` API.
    */
   type: 'removeCartMetafield';
 
@@ -388,7 +388,7 @@ export interface MetafieldUpdateChange {
  */
 export interface MetafieldUpdateCartChange {
   /**
-   * The type of the `MetafieldUpdateChange` API.
+   * The type of the `MetafieldUpdateCartChange` API.
    */
   type: 'updateCartMetafield';
 
@@ -489,9 +489,12 @@ export interface CheckoutApi {
   applyGiftCardChange(change: GiftCardChange): Promise<GiftCardChangeResult>;
 
   /**
-   * Performs an update on a piece of metadata attached to the checkout. If
-   * successful, this mutation results in an update to the value retrieved
-   * through the [`metafields`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-metafields) property.
+   * Performs an update on a piece of metadata attached to the cart or checkout:
+   * - If `type` is `updateMetafield` or `removeMetafield`, this mutation results in an update to the value retrieved through the [`metafields`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-metafields) property. Metafields written by `updateMetafield` are carried over to the order.
+   * - If `type` is `updateCartMetafield` or `removeCartMetafield`, this mutation updates the metafield attached to the cart and results in an update to the value retrieved through the [`appMetafields`](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/apis/standardapi#properties-propertydetail-appmetafields) property. Metafields written by `updateCartMetafields` are updated on the cart object only and are **not** carried over to the order.
+   *
+   * > Tip:
+   * > Cart metafields are only available on carts created via the Storefront API version `2023-04` or later.
    */
   applyMetafieldChange(change: MetafieldChange): Promise<MetafieldChangeResult>;
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-locations.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-locations.ts
@@ -4,5 +4,5 @@ export interface PickupLocationsApi {
   /**
    * Whether the customer location input form is shown to the buyer.
    */
-  locationFormVisible: StatefulRemoteSubscribable<boolean>;
+  isLocationFormVisible: StatefulRemoteSubscribable<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-points.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-points.ts
@@ -4,5 +4,5 @@ export interface PickupPointsApi {
   /**
    * Whether the customer location input form is shown to the buyer.
    */
-  locationFormVisible: StatefulRemoteSubscribable<boolean>;
+  isLocationFormVisible: StatefulRemoteSubscribable<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-method-details.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-method-details.ts
@@ -6,7 +6,7 @@ export interface ShippingMethodDetailsApi {
   /**
    * The shipping option the extension is attached to.
    */
-  target: StatefulRemoteSubscribable<ShippingOption | undefined>;
+  target: StatefulRemoteSubscribable<ShippingOption>;
 
   /**
    * Whether the shipping option the extension is attached to is currently selected in the UI.

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -417,6 +417,9 @@ export interface StandardApi<Target extends ExtensionPoint = ExtensionPoint> {
    * being purchased by the customer.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   *
+   * > Tip:
+   * > Cart metafields are only available on carts created via the Storefront API version `2023-04` or later.
    */
   appMetafields: StatefulRemoteSubscribable<AppMetafieldEntry[]>;
 
@@ -505,16 +508,9 @@ export interface StandardApi<Target extends ExtensionPoint = ExtensionPoint> {
   localization: Localization;
 
   /**
-   * The metafields that apply to the current checkout. The actual resource
-   * on which these metafields exist depends on the source of the checkout:
+   * The metafields that apply to the current checkout.
    *
-   * - If the source is an order, then the metafields are on the order.
-   * - If the source is a draft order, then the initial value of metafields are
-   *   from the draft order, and any new metafields you write are applied
-   *   to the order created by this checkout.
-   * - For all other sources, the metafields are only stored locally on the
-   *   client creating the checkout, and are applied to the order that
-   *   results from checkout.
+   * Metafields are stored locally on the client and are applied to the order object after the checkout completes.
    *
    * These metafields are shared by all extensions running on checkout, and
    * persist for as long as the customer is working on this checkout.
@@ -1076,7 +1072,7 @@ export interface SelectedPaymentOption {
   /**
    * The unique handle referencing `PaymentOption.handle`.
    *
-   * See [availablePaymentOptions](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/apis/standardapi#properties-propertydetail-availablepaymentoptions).
+   * See [availablePaymentOptions](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-availablepaymentoptions).
    */
   handle: string;
 }
@@ -1343,7 +1339,7 @@ export interface DeliveryGroup {
   /**
    * Whether delivery is required for the delivery group.
    */
-  deliveryRequired: boolean;
+  isDeliveryRequired: boolean;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/extension-points.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/extension-points.ts
@@ -234,8 +234,6 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
-   * > Caution: This feature is in developer preview and is subject to change.
-   *
    * A static extension point that is rendered before pickup location options.
    */
   'Checkout::PickupLocations::RenderBefore': RenderExtension<
@@ -245,8 +243,6 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
-   * > Caution: This feature is in developer preview and is subject to change.
-   *
    * A static extension point that is rendered after pickup location options.
    */
   'Checkout::PickupLocations::RenderAfter': RenderExtension<
@@ -256,8 +252,6 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
-   * > Caution: This feature is in developer preview and is subject to change.
-   *
    * A static extension point that is rendered after the shipping method
    * details within the shipping method option list, for each option.
    */
@@ -268,8 +262,6 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
-   * > Caution: This feature is in developer preview and is subject to change.
-   *
    * A static extension point that is rendered under the shipping method
    * within the shipping method option list, for each option.
    */
@@ -280,8 +272,6 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
-   * > Caution: This feature is in developer preview and is subject to change.
-   *
    * A static extension point that is rendered immediately before the pickup points.
    */
   'Checkout::PickupPoints::RenderBefore': RenderExtension<
@@ -291,8 +281,6 @@ export interface ExtensionPoints {
     AllComponents
   >;
   /**
-   * > Caution: This feature is in developer preview and is subject to change.
-   *
    * A static extension point that is rendered immediately after the pickup points.
    */
   'Checkout::PickupPoints::RenderAfter': RenderExtension<


### PR DESCRIPTION
### Background

Applies this [specific patch from checkout-ui-extensions](https://github.com/Shopify/ui-extensions/pull/1204). This is required because there are some minor type changes and these packages should be kept in-sync.

### Solution

Ran this [script](https://github.com/Shopify/checkout-web/issues/22495#issuecomment-1630964805) to sync the latest changes, then only included the changes that were in [this patch PR](https://github.com/Shopify/ui-extensions/pull/1204) and discarded the rest. 

**Note**: This ui-extensions package has deviated slightly since there were some [changes from 2023-07 that were backported](https://github.com/Shopify/ui-extensions/pull/1135) into this version. These don't affect any public extension APIs though.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
