### PR TITLE
feat(retail/list): add Badges prop to List LeftSide

### DIFF
--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -16,9 +16,15 @@ export interface ListRowLeftSide {
    */
   subtitle?: readonly [string, string?, string?];
   /**
-   * A colored badge that is displayed underneath the `title` and `subtitles`.
+   * @deprecated
+   * badge will be removed in version 2.0.0 in favor of badges.
+   * Please migrate to using badges as soon as possible.
    */
   badge?: BadgeProps;
+  /**
+   * Colored badges that are displayed underneath the `title` and `subtitles`.
+   */
+  badges?: BadgeProps[];
   image?: {
     /**
      * A link to an image to be displayed on the far left side of the row.


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/pos-next-react-native/issues/26544

Adding multiple badge support to List LeftSide

### Solution

Add the `badges` prop to `ListItem` `LeftSide`. Deprecate existing singular `badge` prop.

### 🎩

### Checklist

- [X] I have :tophat:'d these changes
