### PR TITLE
Adds `CustomerSegmentTemplate` component

### DIFF
--- a/.changeset/hip-olives-wave.md
+++ b/.changeset/hip-olives-wave.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Introduces CustomerSegmentTemplate component

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/CustomerSegmentTemplate.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/CustomerSegmentTemplate.ts
@@ -1,0 +1,7 @@
+import {CustomerSegmentTemplate as BaseCustomerSegmentTemplate} from '@shopify/ui-extensions/admin';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const CustomerSegmentTemplate = createRemoteReactComponent(
+  BaseCustomerSegmentTemplate,
+);
+export type {CustomerSegmentTemplateProps} from '@shopify/ui-extensions/admin';

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/CustomerSegmentTemplate.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/CustomerSegmentTemplate.example.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {
+  reactExtension,
+  CustomerSegmentTemplate,
+} from '@shopify/ui-extensions-react/admin';
+
+function App({i18n}) {
+    const templateQuery = 'products_purchased(id: (product_id)) = true';
+    const templateQueryToInsert = 'products_purchased(id:';
+
+    return (
+      <>
+        <CustomerSegmentTemplate
+          title={i18n.translate('product.title')}
+          description={i18n.translate('product.description')}
+          templateQuery={templateQuery}
+          templateQueryToInsert={templateQueryToInsert}
+          dateAdded={new Date('2023-01-15').toISOString()}
+        />
+         <CustomerSegmentTemplate
+          title={i18n.translate('location.title')}
+          description={[i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')]}
+          templateQuery="customer_cities CONTAINS 'US-NY-NewYorkCity'"
+        />
+      </>
+    );
+}
+
+reactExtension('admin.customers.segmentation-templates.render', ({i18n}) => <App i18n={i18n} />);

--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -1,6 +1,6 @@
 export type {I18n, I18nTranslate} from '../../api';
 export type {StandardApi, Navigation, Intents} from './api/standard/standard';
-export type {CustomerSegmentationTemplateApi} from './api/customer-segmentation-template/customer-segmentation-template';
+export type {CustomerSegmentTemplateApi} from './api/customer-segment-template/customer-segment-template';
 export type {ActionExtensionApi} from './api/action/action';
 export type {BlockExtensionApi} from './api/block/block';
 export type {ProductDetailsConfigurationApi} from './api/product-configuration/product-details-configuration';

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.ts
@@ -9,7 +9,7 @@ type CustomerSegmentationFeature =
   /* Enables count aggregates on functions. For example: shopify_email.opened(count_at_least: 5) = true */
   | 'aggregateFilters';
 
-export interface CustomerSegmentationTemplateApi<
+export interface CustomerSegmentTemplateApi<
   ExtensionTarget extends AnyExtensionTarget,
 > extends StandardApi<ExtensionTarget> {
   /* Utilities for translating content according to the current `localization` of the admin. */

--- a/packages/ui-extensions/src/surfaces/admin/components.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.ts
@@ -12,6 +12,8 @@ export {Checkbox} from './components/Checkbox/Checkbox';
 export type {CheckboxProps} from './components/Checkbox/Checkbox';
 export {CustomerSegmentationTemplate} from './components/CustomerSegmentationTemplate/CustomerSegmentationTemplate';
 export type {CustomerSegmentationTemplateProps} from './components/CustomerSegmentationTemplate/CustomerSegmentationTemplate';
+export {CustomerSegmentTemplate} from './components/CustomerSegmentTemplate/CustomerSegmentTemplate';
+export type {CustomerSegmentTemplateProps} from './components/CustomerSegmentTemplate/CustomerSegmentTemplate';
 export {Divider} from './components/Divider/Divider';
 export type {DividerProps} from './components/Divider/Divider';
 export {EmailField} from './components/EmailField/EmailField';

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/CustomerSegmentTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/CustomerSegmentTemplate.ts
@@ -1,0 +1,33 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+/**
+ * Reserved namespace and key for the customer standard metafield used in the template's query.
+ * More info - https://shopify.dev/docs/apps/custom-data/metafields/definitions/standard
+ */
+type CustomerStandardMetafieldDependency = 'facts.birth_date';
+
+export interface CustomerSegmentTemplateProps {
+  /* Localized title of the template. */
+  title: string;
+  /* Localized description(s) of the template. */
+  description: string | string[];
+  /* Code snippet to render in the template with syntax highlighting. */
+  templateQuery: string;
+  /* Code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
+  templateQueryToInsert?: string;
+  /* List of customer standard metafields or custom metafields used in the template's query. */
+  dependencies?: {
+    standardMetafields?: CustomerStandardMetafieldDependency[];
+    customMetafields?: string[];
+  };
+  /* ISO 8601-encoded date and time string. A "New" badge will be rendered for recently introduced templates. */
+  dateAdded?: string;
+}
+
+/**
+ * Customer segmentation templates are used to give merchants a starting point to create segments.
+ */
+export const CustomerSegmentTemplate = createRemoteComponent<
+  'CustomerSegmentTemplate',
+  CustomerSegmentTemplateProps
+>('CustomerSegmentTemplate');

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/examples/CustomerSegmentTemplate.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/examples/CustomerSegmentTemplate.example.ts
@@ -1,0 +1,28 @@
+import {
+  extension,
+  CustomerSegmentTemplate,
+} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.customers.segmentation-templates.render',
+  (root, {i18n}) => {
+    const productTemplate = root.createComponent(CustomerSegmentTemplate, {
+      title: i18n.translate('product.title'),
+      description: i18n.translate('product.description'),
+      templateQuery: 'products_purchased(id: (product_id)) = true',
+      templateQueryToInsert: 'products_purchased(id:',
+      dateAdded: new Date('2023-01-15').toISOString(),
+    });
+
+    const locationTemplate = root.createComponent(CustomerSegmentTemplate, {
+      title: i18n.translate('location.title'),
+      description: [i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')],
+      templateQuery: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
+    });
+
+    root.appendChild(productTemplate);
+    root.appendChild(locationTemplate);
+
+    root.mount();
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -45,12 +45,17 @@ export interface CustomerSegmentationTemplateProps {
   description: string | string[];
   /* Icon identifier for the template. This property is ignored for non-1P Segmentation templates as we fallback to the app icon */
   icon?: Source;
-  /* ShopifyQL code snippet to render in the template with syntax highlighting. */
+  /* Code snippet to render in the template with syntax highlighting. */
   templateQuery: string;
-  /* ShopifyQL code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
+  /* Code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
   templateQueryToInsert?: string;
   /* List of customer standard metafield used in the template's query. */
   standardMetafieldDependencies?: CustomerStandardMetafieldDependency[];
+  /* List of customer standard metafields or custom metafields used in the template's query. */
+  dependencies?: {
+    standardMetafields?: CustomerStandardMetafieldDependency[];
+    customMetafields?: string[];
+  };
   /* ISO 8601-encoded date and time string. A "New" badge will be rendered for recently introduced templates. */
   dateAdded?: string;
   /* The category in which the template will be visible.

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -3,7 +3,7 @@ import type {RenderExtension} from '../../extension';
 import type {AnyComponent, Components} from './shared';
 import type {
   StandardApi,
-  CustomerSegmentationTemplateApi,
+  CustomerSegmentTemplateApi,
   ActionExtensionApi,
   BlockExtensionApi,
   ProductDetailsConfigurationApi,
@@ -12,7 +12,7 @@ import type {
 import {AnyComponentBuilder} from '../../shared';
 
 type CustomerSegmentationTemplateComponent = AnyComponentBuilder<
-  Pick<Components, 'CustomerSegmentationTemplate'>
+  Pick<Components, 'CustomerSegmentationTemplate' | 'CustomerSegmentTemplate'>
 >;
 
 type ProductConfigurationComponents = AnyComponentBuilder<
@@ -49,7 +49,7 @@ export interface ExtensionTargets {
    * @private
    */
   'admin.customers.segmentation-templates.render': RenderExtension<
-    CustomerSegmentationTemplateApi<'admin.customers.segmentation-templates.render'>,
+    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.render'>,
     CustomerSegmentationTemplateComponent
   >;
 


### PR DESCRIPTION
Resolves https://github.com/Shopify/customer-data-platform/issues/5767

### Background

We already have a CustomerSegmentationTemplate ui extension component (see https://github.com/Shopify/ui-extensions/pull/759) that we use to render templates from our [1p app](https://github.com/Shopify/segmentation-templates-app) in the admin. 

However, we want to extend this functionality to other 1p and 3p apps, and we have different requirements for this new public component than the one we use currently (we don't want other 1p/3p apps to be able to pass a custom icon or category, we want to support custom metafields). 


### Solution

Since web uses the `unstable` version of ui-extensions, we're adding a second component that will be [documented](https://shopify.dev/docs/api/admin-extensions/components) for 1p/3p apps to use, and we will continue to use our other CustomerSegmentationTemplate for our 1p app. 

Adds the component in both `ui-extensions/components` and `ui-extensions-react/components`.

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
