### PR TITLE
add ActionExtensionApi to customer account web ui

### DIFF
--- a/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
@@ -59,7 +59,7 @@ export interface ExtensionPoints {
     AllComponents
   >;
   'customer-account.order-status.action.render': RenderExtension<
-    StandardApi & {orderId: string},
+    StandardApi & ActionExtensionApi & {orderId: string},
     AllComponents
   >;
 }
@@ -69,6 +69,10 @@ export interface FullPageApi {
     pathname: string;
     search: string;
   }>;
+}
+
+export interface ActionExtensionApi {
+  close(): void;
 }
 
 export type ExtensionPoint = keyof ExtensionPoints;

--- a/packages/customer-account-ui-extensions/src/extension-points/index.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/index.ts
@@ -2,6 +2,7 @@ export type {
   ExtensionPoints,
   ExtensionPoint,
   FullPageApi,
+  ActionExtensionApi,
 } from './extension-points';
 export type {
   Language,


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/58096 

add ActionExtensionApi to customer account web ui
```
export interface ActionExtensionApi {
  close(): void;
}
```

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
