### PR TITLE
Add IconSize prop to Icon component

### DIFF
--- a/packages/retail-ui-extensions-react/src/index.ts
+++ b/packages/retail-ui-extensions-react/src/index.ts
@@ -23,6 +23,7 @@ export type {
   Spacing,
   TextVariant,
   IconName,
+  IconSize,
   VerticalSpacing,
 } from '@shopify/retail-ui-extensions';
 

--- a/packages/retail-ui-extensions/src/components/Icon/Icon.ts
+++ b/packages/retail-ui-extensions/src/components/Icon/Icon.ts
@@ -83,8 +83,11 @@ export type IconName =
   | 'delivery'
   | 'shop-pay';
 
+export type IconSize = 'minor' | 'major' | 'spot' | 'caption' | 'badge';
+
 export interface IconProps {
   name: IconName;
+  size?: IconSize;
 }
 
 export const Icon = createRemoteComponent<'Icon', IconProps>('Icon');

--- a/packages/retail-ui-extensions/src/components/Icon/index.ts
+++ b/packages/retail-ui-extensions/src/components/Icon/index.ts
@@ -1,2 +1,2 @@
 export {Icon} from './Icon';
-export type {IconProps, IconName} from './Icon';
+export type {IconProps, IconSize, IconName} from './Icon';

--- a/packages/retail-ui-extensions/src/components/index.ts
+++ b/packages/retail-ui-extensions/src/components/index.ts
@@ -87,7 +87,7 @@ export {RadioButtonList} from './RadioButtonList';
 export type {RadioButtonListProps} from './RadioButtonList';
 
 export {Icon} from './Icon';
-export type {IconName, IconProps} from './Icon';
+export type {IconName, IconSize, IconProps} from './Icon';
 
 export {Screen} from './Screen';
 export type {ScreenPresentationProps, ScreenProps} from './Screen';

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -133,6 +133,7 @@ export type {
   ImageProps,
   RadioButtonListProps,
   IconName,
+  IconSize,
   IconProps,
   ScreenProps,
   ScreenPresentationProps,


### PR DESCRIPTION
Part of https://github.com/Shopify/pos-next-react-native/issues/26549

### Background

Add option IconSize to icon component