### PR TITLE
Publish checkout-ui-extensions@0.27.3

### DIFF
--- a/packages/checkout-ui-extensions-react/package.json
+++ b/packages/checkout-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/checkout-ui-extensions-react",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "description": "React bindings for @shopify/checkout-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.14",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions": "^0.27.2",
+    "@shopify/checkout-ui-extensions": "^0.27.3",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/checkout-ui-extensions/package.json
+++ b/packages/checkout-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify’s Checkout",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/customer-account-ui-extensions-react",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "React bindings for @shopify/customer-account-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
-    "@shopify/checkout-ui-extensions-react": "^0.27.2",
-    "@shopify/customer-account-ui-extensions": "^0.0.55"
+    "@shopify/checkout-ui-extensions-react": "^0.27.3",
+    "@shopify/customer-account-ui-extensions": "^0.0.56"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <18.0.0"

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/customer-account-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify's Customer Account",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"
@@ -24,6 +24,6 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/core": "2.1.x",
-    "@shopify/checkout-ui-extensions": "^0.27.2"
+    "@shopify/checkout-ui-extensions": "^0.27.3"
   }
 }


### PR DESCRIPTION
### Background

Publishes this [patch](https://github.com/Shopify/ui-extensions/pull/1234) for `@shopify/checkout-ui-extensions@0.27.3`.

### Solution

[Instructions](https://vault.shopify.io/page/Extension-Libraries~gkKh.md#shopifycheckout-ui-extensions-deprecated).


### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
