### PR TITLE
feat: add loading to AdminAction component

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.ts
@@ -16,6 +16,11 @@ export interface AdminActionProps {
    * Sets the Secondary action button of the container. This component must a button component.
    */
   secondaryAction?: RemoteFragment;
+
+  /**
+   * Sets the loading state of the action modal
+   */
+  loading?: boolean;
 }
 /**
  * AdminAction is a component used by Admin Action extensions to configure a primary and secondary action and title.


### PR DESCRIPTION
### What this changes

This adds the `loading` prop to the AdminAction component. This prop will enable extensions to properly set their loading state.

### 🎩
Refer to this PR for tophatting: https://github.com/Shopify/web/pull/101455

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
