### PR TITLE
Widen @remote-ui/core dependency range to allow for 2.2.0 and above

### DIFF
--- a/.changeset/silver-rings-notice.md
+++ b/.changeset/silver-rings-notice.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Widen the dependency on `@remote-ui/core` to allow for 2.3.x and above. When updating, ensure that you deduplicate any transitive dependencies on `@remote-ui/*` packages.

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -53,7 +53,7 @@
   "sideEffects": false,
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.12",
-    "@remote-ui/core": "2.1.x"
+    "@remote-ui/core": "^2.1.16"
   },
   "devDependencies": {
     "@shopify/generate-docs": "0.10.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,42 +1917,42 @@
     react-reconciler "^0.26.0"
     react-test-renderer "^17.0.0"
 
-"@remote-ui/async-subscription@^2.1.12", "@remote-ui/async-subscription@^2.1.13":
-  version "2.1.13"
-  resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.13.tgz#458ca03d407e2bd931ef2b5246a7c2b79f44a13d"
-  integrity sha512-Mc7iZ4nCIizdG/UWTW31HdtdmGpmjTah6Im+NJgwmmXZ8cnfFjxHFgpKc+kIhJTVKdmuN4KFHmNIXVSmeMTZdA==
+"@remote-ui/async-subscription@^2.1.12", "@remote-ui/async-subscription@^2.1.14":
+  version "2.1.14"
+  resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.14.tgz#100f31a3e7d8d427ed13e064c335692abe320e20"
+  integrity sha512-m4HQ7LmBNN80d5CDG1d0MzESfXQB3tPK3cEFannUoyqZybxZst/AB8TAnwKKZcXUR1eedkZMTqH6BjEgMRzulQ==
   dependencies:
-    "@remote-ui/rpc" "^1.3.4"
+    "@remote-ui/rpc" "^1.4.3"
 
-"@remote-ui/core@^2.1.16":
-  version "2.1.16"
-  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.1.16.tgz#8b5fbfdc22a5619334d29a4cb7d4fd20bf67c5f3"
-  integrity sha512-PcaljPmv0Ra8PeRT+M/vKPTYSkU1KssjwB2gjcE+TK2zM2SBbJwB5K18MjJhNlb9n6LTFE99fDqYxc5DbCyMIg==
+"@remote-ui/core@^2.1.16", "@remote-ui/core@^2.1.17":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.2.3.tgz#5d53666d8bce9874d4976c21e88dd202e6080cd0"
+  integrity sha512-LWwAlDJw9c+b61dViU6v8ivU0AalgGikvqidVoBLt+CLjTAXMwIkzIeYdjyRyp7JgGxnTYxnmVHUdJdxX144jg==
   dependencies:
-    "@remote-ui/rpc" "^1.3.4"
-    "@remote-ui/types" "^1.1.2"
+    "@remote-ui/rpc" "^1.4.3"
+    "@remote-ui/types" "^1.1.3"
 
 "@remote-ui/react@4.5.x":
-  version "4.5.13"
-  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-4.5.13.tgz#5107c0f5687948cc68eb4e8e4efee6818c4c0152"
-  integrity sha512-T3AhJClw5clZ2QO4ay02ACtUEaCuGIGwJI0glxA2CXsqOZUpy5LWWnK5OEek/G0XWplN3Mzcx8O+5hnl3x6IvA==
+  version "4.5.14"
+  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-4.5.14.tgz#d3c12ed6b78a8c9d556eae536121474fcd4a690f"
+  integrity sha512-ZSb1jcHOUtdwXLI7lfqwweUISaykOSQk1Xp1/LqDnIq81ssgxiBYUPZbu8n+2IUZNpsHpzBVyVaJKcnpNTQFzw==
   dependencies:
-    "@remote-ui/async-subscription" "^2.1.13"
-    "@remote-ui/core" "^2.1.16"
-    "@remote-ui/rpc" "^1.3.4"
+    "@remote-ui/async-subscription" "^2.1.14"
+    "@remote-ui/core" "^2.1.17"
+    "@remote-ui/rpc" "^1.3.6"
     "@types/react" ">=17.0.0 <18.0.0"
     "@types/react-reconciler" "^0.26.0"
     react-reconciler ">=0.26.0 <0.27.0"
 
-"@remote-ui/rpc@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.3.4.tgz#99568362349c630c42c6b60d6a04a3b8c11e704e"
-  integrity sha512-KwZ2egbGQqO+DjgwoZlQ4QedMZHeFuGY/2FiGUrqvyhp4bGheSLr5bm3jF23+2tQVywUHB2gDPqzUgR/47Lb2g==
+"@remote-ui/rpc@^1.3.6", "@remote-ui/rpc@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.4.3.tgz#6dde33831c3d98e43e170f3e3c82a43f35475d09"
+  integrity sha512-+XyELrHLIJVQEuidHoqZ32+drbphY/x697vykHCinTPhhuUiZpag1DnKSxoE4UlnwBzz336UtFHZIiDGtOL2Kg==
 
-"@remote-ui/types@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@remote-ui/types/-/types-1.1.2.tgz#ae9219a56bb4bb6ff5aabfacb29a1e71adbd97d4"
-  integrity sha512-F2u6McqvHj2c89FHeozQ0O8qbqhOFMMNYR2HqF33mHCMNTEXzUVheCj7laNO1/dGNXwcJHpoWIBNwfChbEfVyA==
+"@remote-ui/types@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@remote-ui/types/-/types-1.1.3.tgz#b2a790d5be50fb82d89d4abea9883f87f83a5a25"
+  integrity sha512-P1kN1F3p0oMgnLN8Of1Ie9am3sLvJ7nhqHH1pvzkrxqjVwhhyPVZNcwOHyUNZPKp62izhDavdrcnqrdXzVJqGA==
 
 "@rollup/plugin-babel@^5.3.0":
   version "5.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,21 +1917,14 @@
     react-reconciler "^0.26.0"
     react-test-renderer "^17.0.0"
 
-"@remote-ui/async-subscription@^2.1.12":
-  version "2.1.12"
-  resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.12.tgz#e0ebc7507546f333bfbcb6a157391f2f44c29a8a"
-  integrity sha512-O+PaG8r8u+a6VBx0L20GGvbZMuCWNpmmxi+GrLzRDZOUbJCTFGnSzS7+KsTi2wRHSkVWB4W2A5jqTU1fTKf+vQ==
-  dependencies:
-    "@remote-ui/rpc" "^1.3.3"
-
-"@remote-ui/async-subscription@^2.1.13":
+"@remote-ui/async-subscription@^2.1.12", "@remote-ui/async-subscription@^2.1.13":
   version "2.1.13"
   resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.13.tgz#458ca03d407e2bd931ef2b5246a7c2b79f44a13d"
   integrity sha512-Mc7iZ4nCIizdG/UWTW31HdtdmGpmjTah6Im+NJgwmmXZ8cnfFjxHFgpKc+kIhJTVKdmuN4KFHmNIXVSmeMTZdA==
   dependencies:
     "@remote-ui/rpc" "^1.3.4"
 
-"@remote-ui/core@2.1.x", "@remote-ui/core@^2.1.16":
+"@remote-ui/core@^2.1.16":
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.1.16.tgz#8b5fbfdc22a5619334d29a4cb7d4fd20bf67c5f3"
   integrity sha512-PcaljPmv0Ra8PeRT+M/vKPTYSkU1KssjwB2gjcE+TK2zM2SBbJwB5K18MjJhNlb9n6LTFE99fDqYxc5DbCyMIg==
@@ -1950,11 +1943,6 @@
     "@types/react" ">=17.0.0 <18.0.0"
     "@types/react-reconciler" "^0.26.0"
     react-reconciler ">=0.26.0 <0.27.0"
-
-"@remote-ui/rpc@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.3.3.tgz#b10b5a4a86014d60f719d16d5dc6f50af766d192"
-  integrity sha512-HPNYiJ2h6AqzXRZFVaNZP5iaXtHk+sZHkHu8wDYe/L4FL4sEm3zf7zt5XiSOoNR7KgGxY5TTa8RiuP3BsvGqOA==
 
 "@remote-ui/rpc@^1.3.4":
   version "1.3.4"


### PR DESCRIPTION
### Background

Part of Shopify/checkout-web#24709.

Widen `@remote-ui/core` dependency range to allow for 2.2.0 and above, so that checkout-web can remove a resolution.


### Solution

- Widen the dependency range
- Update repo's resolved dependencies for `@remote-ui/*` packages to the latest, to prove that the newer versions work in this repo's tests.

### 🎩

checkout-web is already using `@remote-ui/core` 2.2.3, this has already been proven in production.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
