### PR TITLE
add billing address to checkout ui extensions

### DIFF
--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -613,6 +613,11 @@ export interface Checkout {
   attributes: Attribute[];
 
   /**
+   * The billing address to where the order will be charged.
+   */
+  billingAddress: MailingAddress | null;
+
+  /**
    * The three-letter code that represents the currency, for example, USD.
    * Supported codes include standard ISO 4217 codes, legacy codes, and non-
    * standard codes.


### PR DESCRIPTION
### Background

https://github.com/Shopify/ce-customer-behaviour/issues/3118

We're adding a `billingAddress` field to our `Checkout` object. 

### Solution

Simple adding of field!

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
