### PR TITLE
Publish @shopify/web-pixels-extension@0.4.16

### DIFF
--- a/packages/web-pixels-extension/package.json
+++ b/packages/web-pixels-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/web-pixels-extension",
   "description": "Provides tools to author Web Pixels extension",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Publishes @shopify/web-pixels-extension@0.4.16

Lerna's `version` command doesn't really work if another packages was deployed since changes were merged for this package, so I had to create the tag manually.