### PR TITLE
Fix tab names for Direct API examples

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -119,12 +119,12 @@ const data: LandingTemplateSchema = {
           {
             code: './examples/direct-api-fetch.jsx',
             language: 'tsx',
-            title: 'Get Product Data with fetch',
+            title: 'Fetch Product data',
           },
           {
             code: './examples/direct-api-query.jsx',
             language: 'tsx',
-            title: 'Get Product Data with query',
+            title: 'Query Product data',
           },
         ],
       },


### PR DESCRIPTION
Fix the tab names being cut off in the docs and also switch to sentence casing to match convention

**Before**
<img width="553" alt="image" src="https://github.com/Shopify/ui-extensions/assets/29458473/c315b9e6-e21c-43a1-9566-8f8d9f5e8fe4">

**After**
<img width="587" alt="image" src="https://github.com/Shopify/ui-extensions/assets/29458473/8045ed10-514c-40aa-b3b8-5d3e9bd1080d">


