### PR TITLE
Add back button hijacking callback to screen component

### DIFF
--- a/packages/retail-ui-extensions/src/components/Screen/Screen.ts
+++ b/packages/retail-ui-extensions/src/components/Screen/Screen.ts
@@ -12,7 +12,8 @@ export interface ScreenPresentationProps {
  * @property `title` the title of the screen which will be displayed on the UI.
  * @property `isLoading` displays a loading indicator when `true`. Set this to `true` when performing an asynchronous task, and then to false when the data becomes available to the UI.
  * @property `onNavigate` triggered when the screen is navigated to.
- * @property `onNavigateBack` triggered when the user navigates back from this screen.
+ * @property `onNavigateBack` triggered when the user navigates back from this screen. Runs after screen is unmounted.
+ * @property `overrideNavigateBack` is a callback that allows you to override the secondary navigation action. Runs when screen is mounted.
  * @property `onReceiveParams` a callback that gets triggered when the navigation event completes and the screen receives the parameters.
  */
 export interface ScreenProps {
@@ -22,6 +23,7 @@ export interface ScreenProps {
   presentation?: ScreenPresentationProps;
   onNavigate?: () => void;
   onNavigateBack?: () => void;
+  overrideNavigateBack?: () => void;
   onReceiveParams?: (params: any) => void;
 }
 


### PR DESCRIPTION
Part of https://github.com/Shopify/pos-next-react-native/issues/26548

### Background
Stocky wants to implement the ability to display a dialog when the back button is pressed resulting in the screen in not navigating back. Currently `onNavigateBack` only performs some sort of logic after the screen is unmounted however we need another callback to run while mounted. 

You can see a draft POS Screen implementation below which adds a secondary action depending if this prop is not undefined:

```ts
    <Container
      title={title}
      inset="none"
      scrollViewAsContainer={false}
      secondaryAction={
        onSecondaryActionPressed
          ? {
              text: i18n.translate('Screen.back'),
              onPress: () => {
                onSecondaryActionPressed();
              },
            }
          : undefined
      }
    >
```

<img src="https://github.com/Shopify/ui-extensions/assets/29528613/98b51fa2-01a6-4d45-9e7d-b9681a8c6ef3" width="500" height="500">

### Solution

Open to discussion about naming and callback type. We need to make it clear on the differentiation between this callback and the onNavigateBack callback... 