### PR TITLE
Add testID to POS components

### DIFF
--- a/packages/retail-ui-extensions/src/components/Badge/Badge.ts
+++ b/packages/retail-ui-extensions/src/components/Badge/Badge.ts
@@ -1,4 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
 export type BadgeVariant =
   | 'neutral'
@@ -9,7 +10,7 @@ export type BadgeVariant =
 
 export type BadgeStatus = 'empty' | 'partial' | 'complete';
 
-export interface BadgeProps {
+export interface BadgeProps extends TestableComponentProps {
   text: string;
   variant: BadgeVariant;
   status?: BadgeStatus;

--- a/packages/retail-ui-extensions/src/components/Banner/Banner.ts
+++ b/packages/retail-ui-extensions/src/components/Banner/Banner.ts
@@ -1,8 +1,9 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
 export type BannerVariant = 'confirmation' | 'alert' | 'error' | 'information';
 
-export interface BannerProps {
+export interface BannerProps extends TestableComponentProps {
   /**
    * The title of the banner.
    */

--- a/packages/retail-ui-extensions/src/components/Button/Button.ts
+++ b/packages/retail-ui-extensions/src/components/Button/Button.ts
@@ -1,8 +1,9 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
 export type ButtonType = 'primary' | 'basic' | 'destructive' | 'plain';
 
-export interface ButtonProps {
+export interface ButtonProps extends TestableComponentProps {
   title: string;
   type?: ButtonType;
   onPress?: () => void;

--- a/packages/retail-ui-extensions/src/components/CameraScanner/CameraScanner.ts
+++ b/packages/retail-ui-extensions/src/components/CameraScanner/CameraScanner.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface CameraScannerProps {}
+export interface CameraScannerProps extends TestableComponentProps {}
 
 export const CameraScanner = createRemoteComponent<
   'CameraScanner',

--- a/packages/retail-ui-extensions/src/components/DateField/DateField.ts
+++ b/packages/retail-ui-extensions/src/components/DateField/DateField.ts
@@ -1,20 +1,21 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import {InputProps} from '../shared';
+import {InputProps, TestableComponentProps} from '../shared';
 
 export interface DateFieldProps
   extends Pick<
-    InputProps,
-    | 'value'
-    | 'error'
-    | 'label'
-    | 'placeholder'
-    | 'disabled'
-    | 'onFocus'
-    | 'onBlur'
-    | 'onChange'
-    | 'action'
-    | 'helpText'
-  > {}
+      InputProps,
+      | 'value'
+      | 'error'
+      | 'label'
+      | 'placeholder'
+      | 'disabled'
+      | 'onFocus'
+      | 'onBlur'
+      | 'onChange'
+      | 'action'
+      | 'helpText'
+    >,
+    TestableComponentProps {}
 
 export const DateField = createRemoteComponent<'DateField', DateFieldProps>(
   'DateField',

--- a/packages/retail-ui-extensions/src/components/DatePicker/DatePicker.ts
+++ b/packages/retail-ui-extensions/src/components/DatePicker/DatePicker.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface DatePickerProps {
+export interface DatePickerProps extends TestableComponentProps {
   selected?: string;
   onChange?(selected: string): void;
   visibleState: [boolean, (visible: boolean) => void];

--- a/packages/retail-ui-extensions/src/components/Dialog/Dialog.ts
+++ b/packages/retail-ui-extensions/src/components/Dialog/Dialog.ts
@@ -1,8 +1,9 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
 export type DialogType = 'default' | 'alert' | 'error' | 'destructive';
 
-export interface DialogProps {
+export interface DialogProps extends TestableComponentProps {
   title: string;
   content?: string;
   actionText: string;

--- a/packages/retail-ui-extensions/src/components/EmailField/EmailField.ts
+++ b/packages/retail-ui-extensions/src/components/EmailField/EmailField.ts
@@ -1,7 +1,14 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {InputProps, MinMaxLengthProps} from '../shared';
+import type {
+  InputProps,
+  TestableComponentProps,
+  MinMaxLengthProps,
+} from '../shared';
 
-export interface EmailFieldProps extends InputProps, MinMaxLengthProps {}
+export interface EmailFieldProps
+  extends InputProps,
+    MinMaxLengthProps,
+    TestableComponentProps {}
 
 export const EmailField = createRemoteComponent<'EmailField', EmailFieldProps>(
   'EmailField',

--- a/packages/retail-ui-extensions/src/components/FormattedTextField/FormattedTextField.ts
+++ b/packages/retail-ui-extensions/src/components/FormattedTextField/FormattedTextField.ts
@@ -1,9 +1,15 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {AutoCapitalizationType, BaseTextFieldProps} from '../shared';
+import type {
+  AutoCapitalizationType,
+  BaseTextFieldProps,
+  TestableComponentProps,
+} from '../shared';
 
 export type InputType = 'text' | 'number' | 'currency' | 'giftcard' | 'email';
 
-export interface FormattedTextFieldProps extends BaseTextFieldProps {
+export interface FormattedTextFieldProps
+  extends BaseTextFieldProps,
+    TestableComponentProps {
   inputType?: InputType;
   autoCapitalize?: AutoCapitalizationType;
   customValidator?: (text: string) => boolean;

--- a/packages/retail-ui-extensions/src/components/Icon/Icon.ts
+++ b/packages/retail-ui-extensions/src/components/Icon/Icon.ts
@@ -1,4 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
 export type IconName =
   | 'add-customer'
@@ -85,7 +86,7 @@ export type IconName =
 
 export type IconSize = 'minor' | 'major' | 'spot' | 'caption' | 'badge';
 
-export interface IconProps {
+export interface IconProps extends TestableComponentProps {
   name: IconName;
   size?: IconSize;
 }

--- a/packages/retail-ui-extensions/src/components/Image/Image.ts
+++ b/packages/retail-ui-extensions/src/components/Image/Image.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface ImageProps {
+export interface ImageProps extends TestableComponentProps {
   src?: string;
 }
 

--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import {BadgeProps} from '../Badge';
+import type {TestableComponentProps} from '../shared';
 
 export interface ToggleSwitch {
   value?: boolean;
@@ -53,7 +54,7 @@ export interface ListRowRightSide {
   toggleSwitch?: ToggleSwitch;
 }
 
-export interface ListRow {
+export interface ListRow extends TestableComponentProps {
   /**
    * The unique identifier for this list item.
    */
@@ -72,7 +73,7 @@ export interface ListRow {
   onPress?: () => void;
 }
 
-export interface ListProps {
+export interface ListProps extends TestableComponentProps {
   /**
    * A large display title at the top of the `List`.
    */

--- a/packages/retail-ui-extensions/src/components/Navigator/Navigator.ts
+++ b/packages/retail-ui-extensions/src/components/Navigator/Navigator.ts
@@ -1,9 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
 /**
  * @property `initialScreenName` sets the initial Screen by its `name` property.
  */
-export interface NavigatorProps {
+export interface NavigatorProps extends TestableComponentProps {
   initialScreenName?: string;
 }
 

--- a/packages/retail-ui-extensions/src/components/NumberField/NumberField.ts
+++ b/packages/retail-ui-extensions/src/components/NumberField/NumberField.ts
@@ -1,5 +1,9 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {InputProps, MinMaxLengthProps} from '../shared';
+import type {
+  InputProps,
+  TestableComponentProps,
+  MinMaxLengthProps,
+} from '../shared';
 
 /**
  * Represents the properties for the NumberField component.
@@ -8,7 +12,10 @@ import type {InputProps, MinMaxLengthProps} from '../shared';
  * @property {number} [max] - The highest decimal or integer to be accepted for the field.
  * @property {number} [min] - The lowest decimal or integer to be accepted for the field.
  */
-export interface NumberFieldProps extends InputProps, MinMaxLengthProps {
+export interface NumberFieldProps
+  extends InputProps,
+    TestableComponentProps,
+    MinMaxLengthProps {
   inputMode?: 'decimal' | 'numeric';
   max?: number;
   min?: number;

--- a/packages/retail-ui-extensions/src/components/PinPad/PinPad.ts
+++ b/packages/retail-ui-extensions/src/components/PinPad/PinPad.ts
@@ -1,4 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
 /**
  * Represents the result of the pin pad onSubmit function.
@@ -34,7 +35,7 @@ export interface PinPadActionType {
  * @property {function(pin: number[]): Promise<PinValidationResult>} onSubmit - The function to be called when the PIN is submitted.
  * @property {function(pin: number[]): void} [onPinEntry] - The function to be called when a PIN is entered.
  */
-export interface PinPadProps {
+export interface PinPadProps extends TestableComponentProps {
   masked?: boolean;
   minPinLength?: PinLength;
   maxPinLength?: PinLength;

--- a/packages/retail-ui-extensions/src/components/RadioButtonList/RadioButtonList.ts
+++ b/packages/retail-ui-extensions/src/components/RadioButtonList/RadioButtonList.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface RadioButtonListProps {
+export interface RadioButtonListProps extends TestableComponentProps {
   items: string[];
   onItemSelected: (item: string) => void;
   initialSelectedItem?: string;

--- a/packages/retail-ui-extensions/src/components/Screen/Screen.ts
+++ b/packages/retail-ui-extensions/src/components/Screen/Screen.ts
@@ -1,4 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
 /** Represents the presentation of a screen in the navigation stack.
  * @property `sheet` displays the screen from the bottom on `navigate` when `true`.
@@ -15,7 +16,7 @@ export interface ScreenPresentationProps {
  * @property `onNavigateBack` triggered when the user navigates back from this screen.
  * @property `onReceiveParams` a callback that gets triggered when the navigation event completes and the screen receives the parameters.
  */
-export interface ScreenProps {
+export interface ScreenProps extends TestableComponentProps {
   name: string;
   title: string;
   isLoading?: boolean;

--- a/packages/retail-ui-extensions/src/components/SearchBar/SearchBar.ts
+++ b/packages/retail-ui-extensions/src/components/SearchBar/SearchBar.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface SearchBarProps {
+export interface SearchBarProps extends TestableComponentProps {
   initialValue?: string;
   onTextChange?: (value: string) => void;
   onSearch: (value: string) => void;

--- a/packages/retail-ui-extensions/src/components/Section/Section.ts
+++ b/packages/retail-ui-extensions/src/components/Section/Section.ts
@@ -1,11 +1,12 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface SectionHeaderAction {
+export interface SectionHeaderAction extends TestableComponentProps {
   title: string;
   onPress: () => void;
 }
 
-export interface SectionProps {
+export interface SectionProps extends TestableComponentProps {
   title?: string;
   action?: SectionHeaderAction;
 }

--- a/packages/retail-ui-extensions/src/components/SegmentedControl/SegmentedControl.ts
+++ b/packages/retail-ui-extensions/src/components/SegmentedControl/SegmentedControl.ts
@@ -1,12 +1,13 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface Segment {
+export interface Segment extends TestableComponentProps {
   id: string;
   label: string;
   disabled: boolean;
 }
 
-export interface SegmentedControlProps {
+export interface SegmentedControlProps extends TestableComponentProps {
   segments: Segment[];
   selected: string;
   onSelect: (id: string) => void;

--- a/packages/retail-ui-extensions/src/components/Selectable/Selectable.ts
+++ b/packages/retail-ui-extensions/src/components/Selectable/Selectable.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface SelectableProps {
+export interface SelectableProps extends TestableComponentProps {
   onPress: () => void;
   disabled?: boolean;
 }

--- a/packages/retail-ui-extensions/src/components/Stack/Stack.ts
+++ b/packages/retail-ui-extensions/src/components/Stack/Stack.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import type {HorizontalSpacing, VerticalSpacing} from '../Spacing';
+import type {TestableComponentProps} from '../shared';
 
 export type Spacing =
   | 0.5
@@ -17,7 +18,7 @@ export type Spacing =
   | 13
   | 16;
 
-export interface StackProps {
+export interface StackProps extends TestableComponentProps {
   direction: 'vertical' | 'horizontal';
   alignment?:
     | 'flex-end'

--- a/packages/retail-ui-extensions/src/components/Stepper/Stepper.ts
+++ b/packages/retail-ui-extensions/src/components/Stepper/Stepper.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface StepperProps {
+export interface StepperProps extends TestableComponentProps {
   /**
    * The initial value of the stepper.
    */

--- a/packages/retail-ui-extensions/src/components/Text/Text.ts
+++ b/packages/retail-ui-extensions/src/components/Text/Text.ts
@@ -1,4 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
 export type TextVariant =
   | 'sectionHeader'
@@ -20,7 +21,7 @@ export type ColorType =
   | 'TextInteractive'
   | 'TextHighlight';
 
-export interface TextProps {
+export interface TextProps extends TestableComponentProps {
   variant?: TextVariant;
   color?: ColorType;
 }

--- a/packages/retail-ui-extensions/src/components/TextArea/TextArea.ts
+++ b/packages/retail-ui-extensions/src/components/TextArea/TextArea.ts
@@ -1,12 +1,19 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {InputProps, MinMaxLengthProps} from '../shared';
+import type {
+  InputProps,
+  TestableComponentProps,
+  MinMaxLengthProps,
+} from '../shared';
 
 /**
  * Represents the properties for the TextField component.
  * @typedef {Object} TextAreaProps
  * @property {number} [rows] - The initial number of lines to be displayed. Maximum of 8 lines.
  */
-export interface TextAreaProps extends InputProps, MinMaxLengthProps {
+export interface TextAreaProps
+  extends InputProps,
+    TestableComponentProps,
+    MinMaxLengthProps {
   rows?: number;
 }
 

--- a/packages/retail-ui-extensions/src/components/TextField/TextField.ts
+++ b/packages/retail-ui-extensions/src/components/TextField/TextField.ts
@@ -1,5 +1,9 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import type {BaseTextFieldProps, InputProps} from '../shared';
+import type {
+  BaseTextFieldProps,
+  InputProps,
+  TestableComponentProps,
+} from '../shared';
 
 export interface ActionProps {
   type: 'action';
@@ -36,7 +40,9 @@ export interface NewTextFieldProps extends InputProps {}
  * This TextField component will only support NewTextFieldProps in version 2.0.0.
  * Please migrate to using NewTextFieldProps as soon as possible.
  */
-export interface TextFieldProps extends BaseTextFieldProps {
+export interface TextFieldProps
+  extends BaseTextFieldProps,
+    TestableComponentProps {
   rightElementStyle?: EmbeddedElementProps;
 }
 

--- a/packages/retail-ui-extensions/src/components/Tile/Tile.ts
+++ b/packages/retail-ui-extensions/src/components/Tile/Tile.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface TileProps {
+export interface TileProps extends TestableComponentProps {
   title: string;
   subtitle?: string;
   enabled?: boolean;

--- a/packages/retail-ui-extensions/src/components/TimeField/TimeField.ts
+++ b/packages/retail-ui-extensions/src/components/TimeField/TimeField.ts
@@ -1,20 +1,22 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import {InputProps} from '../shared';
+import type {TestableComponentProps} from '../shared';
 
 export interface TimeFieldProps
   extends Pick<
-    InputProps,
-    | 'value'
-    | 'error'
-    | 'label'
-    | 'placeholder'
-    | 'disabled'
-    | 'onFocus'
-    | 'onBlur'
-    | 'onChange'
-    | 'action'
-    | 'helpText'
-  > {
+      InputProps,
+      | 'value'
+      | 'error'
+      | 'label'
+      | 'placeholder'
+      | 'disabled'
+      | 'onFocus'
+      | 'onBlur'
+      | 'onChange'
+      | 'action'
+      | 'helpText'
+    >,
+    TestableComponentProps {
   is24Hour?: boolean;
 }
 

--- a/packages/retail-ui-extensions/src/components/TimePicker/TimePicker.ts
+++ b/packages/retail-ui-extensions/src/components/TimePicker/TimePicker.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import type {TestableComponentProps} from '../shared';
 
-export interface TimePickerProps {
+export interface TimePickerProps extends TestableComponentProps {
   selected?: string;
   onChange?(selected: string): void;
   visibleState: [boolean, (visible: boolean) => void];

--- a/packages/retail-ui-extensions/src/components/index.ts
+++ b/packages/retail-ui-extensions/src/components/index.ts
@@ -78,6 +78,7 @@ export type {
   InputProps,
   InputAction,
   MinMaxLengthProps,
+  TestableComponentProps,
 } from './shared';
 
 export {Image} from './Image';

--- a/packages/retail-ui-extensions/src/components/shared/TestableComponent.ts
+++ b/packages/retail-ui-extensions/src/components/shared/TestableComponent.ts
@@ -1,0 +1,3 @@
+export interface TestableComponentProps {
+  testID?: string;
+}

--- a/packages/retail-ui-extensions/src/components/shared/index.ts
+++ b/packages/retail-ui-extensions/src/components/shared/index.ts
@@ -1,3 +1,4 @@
 export type {AutoCapitalizationType} from './auto-capitalization-type';
 export type {BaseTextFieldProps} from './BaseTextField';
+export type {TestableComponentProps} from './TestableComponent';
 export type {InputProps, InputAction, MinMaxLengthProps} from './InputField';

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -80,6 +80,7 @@ export type {
   BaseTextFieldProps,
   InputProps,
   InputAction,
+  TestableComponentProps,
   MinMaxLengthProps,
   CameraScannerProps,
   DateFieldProps,


### PR DESCRIPTION
### Background

POS is going to be writing a bunch of end to end UI tests shortly. We need to be able to identify components by unique identifier, hence we are adding test IDs here.

### Solution

These IDs are optional, and I created a reusable interface that is extended across all our components. Please make sure all the components are extended.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
