### PR TITLE
fix customer account build

### DIFF
--- a/.changeset/good-bikes-matter.md
+++ b/.changeset/good-bikes-matter.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+fix customer-account surface build and context

--- a/packages/ui-extensions-react/loom.config.ts
+++ b/packages/ui-extensions-react/loom.config.ts
@@ -6,5 +6,9 @@ export default createPackage((pkg) => {
   pkg.entry({root: './src/index.ts'});
   pkg.entry({name: 'checkout', root: './src/surfaces/checkout.ts'});
   pkg.entry({name: 'admin', root: './src/surfaces/admin.ts'});
+  pkg.entry({
+    name: 'customer-account',
+    root: './src/surfaces/customer-account.ts',
+  });
   pkg.use(defaultProjectPlugin({react: true}));
 });

--- a/packages/ui-extensions-react/src/surfaces/customer-account/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/render.tsx
@@ -8,7 +8,7 @@ import type {
   ApiForRenderExtension,
 } from '@shopify/ui-extensions/customer-account';
 
-import {ExtensionApiContext} from '../checkout/context';
+import {ExtensionApiContext} from './context';
 
 /**
  * Registers your React-based UI Extension to run for the selected extension target.
@@ -44,8 +44,6 @@ export function reactExtension<Target extends RenderExtensionTarget>(
       await new Promise<void>((resolve, reject) => {
         try {
           remoteRender(
-            // @ts-expect-error This is a hack around some type conflicts between the
-            // customer-account version of this target’s API and the checkout version.
             <ExtensionApiContext.Provider value={api}>
               <ErrorBoundary>{element}</ErrorBoundary>
             </ExtensionApiContext.Provider>,

--- a/packages/ui-extensions/loom.config.ts
+++ b/packages/ui-extensions/loom.config.ts
@@ -6,5 +6,9 @@ export default createPackage((pkg) => {
   pkg.entry({root: './src/index.ts'});
   pkg.entry({name: 'checkout', root: './src/surfaces/checkout.ts'});
   pkg.entry({name: 'admin', root: './src/surfaces/admin.ts'});
+  pkg.entry({
+    name: 'customer-account',
+    root: './src/surfaces/customer-account.ts',
+  });
   pkg.use(defaultProjectPlugin());
 });


### PR DESCRIPTION
### Background

Tried to actually import from this package and it failed:

```
ENOENT: no such file or directory, open '/home/spin/src/github.com/[SNIP]/node_modules/@shopify/ui-extensions/build/cjs/surfaces/customer-account.js'
```

Noticed that `customer-account` wasn't properly configured to be emitted.

### Solution

- include customer-account in build config

I 🎩 locally by building the package and copying it into the consuming `node_modules`. I'm not sure this can be done without much effort. Since nobody is using this yet for customer account (as is apparent by the bug existing in the first place), I'd be ok to ship it like this.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
