### PR TITLE
update version to 0.0.0-unstable

### DIFF
--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/ui-extensions-react",
-  "version": "2022.10.6",
+  "version": "0.0.0-unstable",
   "description": "React bindings for @shopify/ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -57,7 +57,7 @@
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {
-    "@shopify/ui-extensions": "2022.10.x",
+    "@shopify/ui-extensions": "0.0.0-unstable",
     "react": ">=17.0.0 <18.0.0"
   },
   "peerDependenciesMeta": {
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
     "@quilted/react-testing": "^0.4.10",
-    "@shopify/ui-extensions": "2022.10.x",
+    "@shopify/ui-extensions": "0.0.0-unstable",
     "react": "^17.0.0"
   },
   "files": [

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/ui-extensions",
-  "version": "2022.10.6",
+  "version": "0.0.0-unstable",
   "scripts": {
     "docs:admin": "sh ./docs/surfaces/admin/build-docs.sh \"admin\"",
     "gen-docs:admin": "sh ./docs/surfaces/admin/create-doc-files.sh \"admin\"",


### PR DESCRIPTION
### Background

The `unstable` branch of this repository should have its package.json version as `0.0.0-unstable` and not have a specific stable version identifier.

### Solution

Change the package.json for both packages.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
