### PR TITLE
backport customer account fixes

### DIFF
--- a/.changeset/good-bikes-matter.md
+++ b/.changeset/good-bikes-matter.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+fix customer-account surface build and context

--- a/packages/ui-extensions-react/loom.config.ts
+++ b/packages/ui-extensions-react/loom.config.ts
@@ -6,5 +6,9 @@ export default createPackage((pkg) => {
   pkg.entry({root: './src/index.ts'});
   pkg.entry({name: 'checkout', root: './src/surfaces/checkout.ts'});
   pkg.entry({name: 'admin', root: './src/surfaces/admin.ts'});
+  pkg.entry({
+    name: 'customer-account',
+    root: './src/surfaces/customer-account.ts',
+  });
   pkg.use(defaultProjectPlugin({react: true}));
 });

--- a/packages/ui-extensions-react/src/surfaces/customer-account/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/render.tsx
@@ -8,7 +8,7 @@ import type {
   ApiForRenderExtension,
 } from '@shopify/ui-extensions/customer-account';
 
-import {ExtensionApiContext} from '../checkout/context';
+import {ExtensionApiContext} from './context';
 
 /**
  * Registers your React-based UI Extension to run for the selected extension target.
@@ -44,8 +44,6 @@ export function reactExtension<Target extends RenderExtensionTarget>(
       await new Promise<void>((resolve, reject) => {
         try {
           remoteRender(
-            // @ts-expect-error This is a hack around some type conflicts between the
-            // customer-account version of this target’s API and the checkout version.
             <ExtensionApiContext.Provider value={api}>
               <ErrorBoundary>{element}</ErrorBoundary>
             </ExtensionApiContext.Provider>,

--- a/packages/ui-extensions/loom.config.ts
+++ b/packages/ui-extensions/loom.config.ts
@@ -6,5 +6,9 @@ export default createPackage((pkg) => {
   pkg.entry({root: './src/index.ts'});
   pkg.entry({name: 'checkout', root: './src/surfaces/checkout.ts'});
   pkg.entry({name: 'admin', root: './src/surfaces/admin.ts'});
+  pkg.entry({
+    name: 'customer-account',
+    root: './src/surfaces/customer-account.ts',
+  });
   pkg.use(defaultProjectPlugin());
 });


### PR DESCRIPTION
### Background

brings https://github.com/Shopify/ui-extensions/pull/1264 to the `2023-07` version.

@vividviolet I just picked all the commits from the other PR, including the changeset. Is that correct or would we need to create a different changeset for the stable version?