### PR TITLE
apply latest dist tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - 2023-04
       - 2023-07
 
+env:
+  DIST_TAG: ${{ github.ref_name == '2023-07' && 'latest' || github.ref_name }}
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -24,7 +27,7 @@ jobs:
         uses: changesets/action@v1
         with:
           title: Version Packages (${{ github.ref_name }})
-          publish: yarn run deploy --tag ${{ github.ref_name == '2023-07' && 'latest' || github.ref_name }}
+          publish: yarn run deploy --tag $DIST_TAG
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - 2023-04
       - 2023-07
-
-env:
-  DIST_TAG: ${{ github.ref_name == '2023-07' && 'latest' || github.ref_name }}
-
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -27,7 +23,7 @@ jobs:
         uses: changesets/action@v1
         with:
           title: Version Packages (${{ github.ref_name }})
-          publish: yarn run deploy --tag $DIST_TAG
+          publish: yarn run deploy --tag ${{ github.ref_name == vars.LATEST_STABLE_VERSION && 'latest' || github.ref_name }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
         uses: changesets/action@v1
         with:
           title: Version Packages (${{ github.ref_name }})
-          publish: yarn run deploy --tag ${{ github.ref_name }}
+          publish: yarn run deploy --tag ${{ github.ref_name == '2023-07' && 'latest' || github.ref_name }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}


### PR DESCRIPTION
### Background

Specifically set the "latest" dist tag when deploying a stable version that is our latest version. 

### Solution

Use a repository variable named [LATEST_STABLE_VERSION](https://github.com/Shopify/ui-extensions/settings/variables/actions) to denote our latest version to use. When the deploy github action runs, use the "latest" dist tag when the branch matches that version.

This is better than statically referencing this value, because otherwise we'd need to manage each previous stable version's workflow so that new patches don't overwrite and set it to "latest".

> Note: Plan is to test this within `2023-07` before applying to `unstable`.

### 🎩
What's the best way to tophat this without actually deploying the package?

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
