### PR TITLE
Update `CustomerSegmentTemplate` prop names

### DIFF
--- a/.changeset/five-dancers-poke.md
+++ b/.changeset/five-dancers-poke.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Update CustomerSegmentTemplate prop names

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/CustomerSegmentTemplate.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/CustomerSegmentTemplate.example.tsx
@@ -5,22 +5,22 @@ import {
 } from '@shopify/ui-extensions-react/admin';
 
 function App({i18n}) {
-    const templateQuery = 'products_purchased(id: (product_id)) = true';
-    const templateQueryToInsert = 'products_purchased(id:';
+    const query = 'products_purchased(id: (product_id)) = true';
+    const queryToInsert = 'products_purchased(id:';
 
     return (
       <>
         <CustomerSegmentTemplate
           title={i18n.translate('product.title')}
           description={i18n.translate('product.description')}
-          templateQuery={templateQuery}
-          templateQueryToInsert={templateQueryToInsert}
+          query={query}
+          queryToInsert={queryToInsert}
           dateAdded={new Date('2023-01-15').toISOString()}
         />
          <CustomerSegmentTemplate
           title={i18n.translate('location.title')}
           description={[i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')]}
-          templateQuery="customer_cities CONTAINS 'US-NY-NewYorkCity'"
+          query="customer_cities CONTAINS 'US-NY-NewYorkCity'"
         />
       </>
     );

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.tsx
@@ -6,10 +6,10 @@ import {
 
 function App({i18n, enabledFeatures}) {
     const productsPurchasedOnTagsEnabled = enabledFeatures.includes('productsPurchasedByTags');
-    const templateQuery = productsPurchasedOnTagsEnabled
+    const query = productsPurchasedOnTagsEnabled
       ? 'products_purchased(tag: (product_tag)) = true'
       : 'products_purchased(id: (product_id)) = true';
-    const templateQueryToInsert = productsPurchasedOnTagsEnabled
+    const queryToInsert = productsPurchasedOnTagsEnabled
       ? 'products_purchased(tag:'
       : 'products_purchased(id:';
 
@@ -19,16 +19,16 @@ function App({i18n, enabledFeatures}) {
           title={i18n.translate('product.title')}
           description={i18n.translate('product.description')}
           icon='productsMajor'
-          templateQuery={templateQuery}
-          templateQueryToInsert={templateQueryToInsert}
-          dateAdded={new Date('2023-01-15').toISOString()}
+          query={query}
+          queryToInsert={queryToInsert}
+          createdOn={new Date('2023-01-15').toISOString()}
           category="reEngageCustomers"
         />
          <CustomerSegmentationTemplate
           title={i18n.translate('location.title')}
           description={[i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')]}
           icon='locationMajor'
-          templateQuery="customer_cities CONTAINS 'US-NY-NewYorkCity'"
+          query="customer_cities CONTAINS 'US-NY-NewYorkCity'"
           category='location'
         />
       </>

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/CustomerSegmentTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/CustomerSegmentTemplate.ts
@@ -11,17 +11,23 @@ export interface CustomerSegmentTemplateProps {
   title: string;
   /* Localized description(s) of the template. */
   description: string | string[];
-  /* Code snippet to render in the template with syntax highlighting. */
+  /* DEPRECATED - Code snippet to render in the template with syntax highlighting. */
   templateQuery: string;
-  /* Code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
+  /* Code snippet to render in the template with syntax highlighting. */
+  query: string;
+  /* DEPRECATED - Code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
   templateQueryToInsert?: string;
+  /* Code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
+  queryToInsert?: string;
   /* List of customer standard metafields or custom metafields used in the template's query. */
   dependencies?: {
     standardMetafields?: CustomerStandardMetafieldDependency[];
     customMetafields?: string[];
   };
-  /* ISO 8601-encoded date and time string. A "New" badge will be rendered for recently introduced templates. */
+  /* DEPRECATED - ISO 8601-encoded date and time string. A "New" badge will be rendered for recently introduced templates. */
   dateAdded?: string;
+  /* ISO 8601-encoded date and time string. A "New" badge will be rendered for recently introduced templates. */
+  createdOn?: string;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/examples/CustomerSegmentTemplate.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/examples/CustomerSegmentTemplate.example.ts
@@ -9,15 +9,15 @@ export default extension(
     const productTemplate = root.createComponent(CustomerSegmentTemplate, {
       title: i18n.translate('product.title'),
       description: i18n.translate('product.description'),
-      templateQuery: 'products_purchased(id: (product_id)) = true',
-      templateQueryToInsert: 'products_purchased(id:',
-      dateAdded: new Date('2023-01-15').toISOString(),
+      query: 'products_purchased(id: (product_id)) = true',
+      queryToInsert: 'products_purchased(id:',
+      createdOn: new Date('2023-01-15').toISOString(),
     });
 
     const locationTemplate = root.createComponent(CustomerSegmentTemplate, {
       title: i18n.translate('location.title'),
       description: [i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')],
-      templateQuery: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
+      query: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
     });
 
     root.appendChild(productTemplate);

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/CustomerSegmentationTemplate.ts
@@ -45,19 +45,25 @@ export interface CustomerSegmentationTemplateProps {
   description: string | string[];
   /* Icon identifier for the template. This property is ignored for non-1P Segmentation templates as we fallback to the app icon */
   icon?: Source;
-  /* Code snippet to render in the template with syntax highlighting. */
+  /* DEPRECATED - Code snippet to render in the template with syntax highlighting. */
   templateQuery: string;
-  /* Code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
+  /* Code snippet to render in the template with syntax highlighting. */
+  query: string;
+  /* DEPRECATED - Code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
   templateQueryToInsert?: string;
-  /* List of customer standard metafield used in the template's query. */
+  /* Code snippet to insert in the segment editor. If missing, `templateQuery` will be used. */
+  queryToInsert?: string;
+  /* DEPRECATED - List of customer standard metafield used in the template's query. */
   standardMetafieldDependencies?: CustomerStandardMetafieldDependency[];
   /* List of customer standard metafields or custom metafields used in the template's query. */
   dependencies?: {
     standardMetafields?: CustomerStandardMetafieldDependency[];
     customMetafields?: string[];
   };
-  /* ISO 8601-encoded date and time string. A "New" badge will be rendered for recently introduced templates. */
+  /* DEPRECATED - ISO 8601-encoded date and time string. A "New" badge will be rendered for recently introduced templates. */
   dateAdded?: string;
+  /* ISO 8601-encoded date and time string. A "New" badge will be rendered for recently introduced templates. */
+  createdOn?: string;
   /* The category in which the template will be visible.
      When provided, the template will show in its respective category and aggregate sections.
      When missing, the template will show in the aggregate sections only */

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentationTemplate/examples/CustomerSegmentationTemplate.example.ts
@@ -11,12 +11,12 @@ export default extension(
       title: i18n.translate('product.title'),
       description: i18n.translate('product.description'),
       icon: 'productsMajor',
-      templateQuery: productsPurchasedOnTagsEnabled
-      ? 'products_purchased(tag: (product_tag)) = true'
-      : 'products_purchased(id: (product_id)) = true',
-      templateQueryToInsert: productsPurchasedOnTagsEnabled
-      ? 'products_purchased(tag:'
-      : 'products_purchased(id:',
+      query: productsPurchasedOnTagsEnabled
+        ? 'products_purchased(tag: (product_tag)) = true'
+        : 'products_purchased(id: (product_id)) = true',
+      queryToInsert: productsPurchasedOnTagsEnabled
+        ? 'products_purchased(tag:'
+        : 'products_purchased(id:',
       dateAdded: new Date('2023-01-15').toISOString(),
       category: 'reEngageCustomers'
     });
@@ -25,7 +25,7 @@ export default extension(
       title: i18n.translate('location.title'),
       description: [i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')],
       icon: 'locationMajor',
-      templateQuery: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
+      query: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
       category: 'location'
     });
 


### PR DESCRIPTION
- Close https://github.com/Shopify/customer-data-platform/issues/5836

### Background

We are cleaning up the `CustomerSegmentTemplate` prop names to make them more stream lined before we expose the API to partners. 

### Solution

Renaming the following props: 

- `templateQuery` -> `query`
- `templateQueryInsert` -> `queryInsert`
- `dateAdded` -> `createdOn`


Marking the previous as deprecated until we add support for the new props in web and in our 1P application: segmentation-templates-app.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
