### PR TITLE
Applies the latest dist tag deploy step into `unstable` branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,3 +28,19 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+
+      - name: Set 'latest' NPM dist tag
+        if: steps.changesets.outputs.published == 'true' && github.ref_name == vars.LATEST_STABLE_VERSION
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+          for pkg in $(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | @base64'); do
+            _jq() {
+              echo ${pkg} | base64 --decode | jq -r ${1}
+            }
+            npm dist-tag add $(_jq '.name')@$(_jq '.version') latest
+          done

--- a/documentation/versions-and-deploys.md
+++ b/documentation/versions-and-deploys.md
@@ -48,4 +48,5 @@ To create a new stable version, you will need to follow these steps:
 - Push your new branch to GitHub. This will trigger the GitHub action that creates a new PR to consume all the changesets you copied over from `unstable` into your new version.
 - Pull down the branch that that was created by the GitHub action (it should have the name `changeset-release/{{BRANCH_NAME}}`). Instead of the patch version changes that were made by the action, update the version of all packages manually to be the first patch release of a new version range. For example, if you are creating a `2025-01` API version, you will set the package versions of all packages to `2025.1.0`. Make sure you apply this change both to all `package.json` files, and all `CHANGELOG.md` files.
 - Push your new changes, and make sure you get the PR reviewed by one other member of the [UI Extension Stewards GitHub team](https://github.com/orgs/Shopify/teams/ui-extension-stewards).
-- Merge the PR, and let robots release the new versions to NPM.
+- Update the [`LATEST_STABLE_VERSION`](https://github.com/Shopify/ui-extensions/settings/variables/actions) repository variable to your stable version (i.e. `2025-01`). This ensures means it will be marked with a `latest` npm dist-tag on NPM.
+- Merge the PR, and let robots release the new versions to NPM and tag it appropriately.


### PR DESCRIPTION
### Background

Backports the [same change](https://github.com/Shopify/ui-extensions/pull/1271) that was merged into `2023-07`.

It adds the 'latest' NPM dist tag when the latest stable version is being published. The 'latest' dist tag will never be applied when `unstable` is being deployed for two reasons:
1. The `deploy.yml` workflow is not enabled for the `unstable` branch
2. Even if it was, the `LATEST_STABLE_VERSION` does not equal "unstable"

Its important this change is applied to the unstable branch, so that when we cut future stable versions from this, this workflow is included.

### Solution

Backport the change already applied in https://github.com/Shopify/ui-extensions/pull/1271.

> **Note**: This change is not necessary to implement in the previous `2023-04` version because that should never apply the latest dist tag.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
