### PR TITLE
Cleanup exports for exposed constants and types for icons and categories

### DIFF
--- a/.changeset/fifty-pens-carry.md
+++ b/.changeset/fifty-pens-carry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add exports for InternalCustomerSegmentTemplate categories and icons

--- a/packages/ui-extensions/src/surfaces/admin/components.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.ts
@@ -29,7 +29,11 @@ export type {IconProps} from './components/Icon/Icon';
 export {InlineStack} from './components/InlineStack/InlineStack';
 export type {InlineStackProps} from './components/InlineStack/InlineStack';
 export {InternalCustomerSegmentTemplate} from './components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate';
-export type {InternalCustomerSegmentTemplateProps} from './components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate';
+export type {
+  InternalCustomerSegmentTemplateProps,
+  CustomerSegmentTemplateIcon,
+  CustomerSegmentTemplateCategory,
+} from './components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate';
 export {Image} from './components/Image/Image';
 export type {ImageProps} from './components/Image/Image';
 export {Link} from './components/Link/Link';

--- a/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate.ts
@@ -1,44 +1,36 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-export const customerSegmentTemplateIcons = [
-  'categoriesMajor',
-  'firstVisitMajor',
-  'heartMajor',
-  'marketingMajor',
-  'checkoutMajor',
-  'ordersMajor',
-  'locationMajor',
-  'emailNewsletterMajor',
-  'firstOrderMajor',
-  'billingStatementDollarMajor',
-  'diamondAlertMajor',
-  'abandonedCartMajor',
-  'calendarMajor',
-  'productsMajor',
-  'globeMajor',
-  'flagMajor',
-  'uploadMajor',
-  'buyButtonMajor',
-  'followUpEmailMajor',
-  'confettiMajor',
-  'viewMajor',
-  'buyButtonMajor',
-] as const;
-
 export type CustomerSegmentTemplateIcon =
-  typeof customerSegmentTemplateIcons[number];
-
-export const customerSegmentTemplateCategories = [
-  'firstTimeBuyers',
-  'highValueCustomers',
-  'reEngageCustomers',
-  'abandonedCheckout',
-  'purchaseBehaviour',
-  'location',
-] as const;
+  | 'categoriesMajor'
+  | 'firstVisitMajor'
+  | 'heartMajor'
+  | 'marketingMajor'
+  | 'checkoutMajor'
+  | 'ordersMajor'
+  | 'locationMajor'
+  | 'emailNewsletterMajor'
+  | 'firstOrderMajor'
+  | 'billingStatementDollarMajor'
+  | 'diamondAlertMajor'
+  | 'abandonedCartMajor'
+  | 'calendarMajor'
+  | 'productsMajor'
+  | 'globeMajor'
+  | 'flagMajor'
+  | 'uploadMajor'
+  | 'buyButtonMajor'
+  | 'followUpEmailMajor'
+  | 'confettiMajor'
+  | 'viewMajor'
+  | 'buyButtonMajor';
 
 export type CustomerSegmentTemplateCategory =
-  typeof customerSegmentTemplateCategories[number];
+  | 'firstTimeBuyers'
+  | 'highValueCustomers'
+  | 'reEngageCustomers'
+  | 'abandonedCheckout'
+  | 'purchaseBehaviour'
+  | 'location';
 
 /**
  * Reserved namespace and key for the customer standard metafield used in the template's query.
@@ -51,8 +43,8 @@ export interface InternalCustomerSegmentTemplateProps {
   title: string;
   /* Localized description(s) of the template. */
   description: string | string[];
-  /* Icon identifier for the template. This property is ignored for non-1P Segmentation templates as we fallback to the app icon */
-  icon?: CustomerSegmentTemplateIcon;
+  /* Icon identifier for the template. */
+  icon: CustomerSegmentTemplateIcon;
   /* DEPRECATED - Code snippet to render in the template with syntax highlighting. */
   templateQuery?: string;
   /* Code snippet to render in the template with syntax highlighting. */
@@ -72,10 +64,8 @@ export interface InternalCustomerSegmentTemplateProps {
   dateAdded?: string;
   /* ISO 8601-encoded date and time string. A "New" badge will be rendered for recently introduced templates. */
   createdOn?: string;
-  /* The category in which the template will be visible.
-     When provided, the template will show in its respective category and aggregate sections.
-     When missing, the template will show in the aggregate sections only */
-  category?: CustomerSegmentTemplateCategory;
+  /* The category in which the template will be visible. The template will show in its respective category and aggregate sections. */
+  category: CustomerSegmentTemplateCategory;
 }
 
 /**


### PR DESCRIPTION
### Background

Exporting the constants and types for template icons and categories so that it doesn't create long import path in the admin. 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
