### PR TITLE
profile dynamic extension for customer accounts

### DIFF
--- a/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
+++ b/packages/customer-account-ui-extensions/src/extension-points/extension-points.ts
@@ -6,6 +6,7 @@ import {FullExtensionNavigation} from './standard-api/navigation';
 type Components = typeof import('../components');
 
 type AllComponents = Components[keyof Components];
+
 /**
  * A UI extension will register for one or more extension points using `shopify.extend()`.
  * An extension point in a UI extension is a plain JavaScript function.
@@ -39,24 +40,24 @@ export interface ExtensionPoints {
     StandardApi<'customer-account.order-index.block.render'>,
     AllComponents
   >;
-  'customer-account.account-information.block.render': RenderExtension<
-    StandardApi<'customer-account.account-information.block.render'>,
+  'customer-account.profile.block.render': RenderExtension<
+    StandardApi<'customer-account.profile.block.render'>,
     AllComponents
   >;
-  'customer-account.account-information.company-details.render-after': RenderExtension<
-    StandardApi<'customer-account.account-information.company-details.render-after'>,
+  'customer-account.profile.company-details.render-after': RenderExtension<
+    StandardApi<'customer-account.profile.company-details.render-after'>,
     AllComponents
   >;
-  'customer-account.account-information.addresses.render-after': RenderExtension<
-    StandardApi<'customer-account.account-information.addresses.render-after'>,
+  'customer-account.profile.addresses.render-after': RenderExtension<
+    StandardApi<'customer-account.profile.addresses.render-after'>,
     AllComponents
   >;
-  'customer-account.account-information.payment.render-after': RenderExtension<
-    StandardApi<'customer-account.account-information.payment.render-after'>,
+  'customer-account.profile.payment.render-after': RenderExtension<
+    StandardApi<'customer-account.profile.payment.render-after'>,
     AllComponents
   >;
-  'customer-account.account-information.location.render-after': RenderExtension<
-    StandardApi<'customer-account.account-information.location.render-after'>,
+  'customer-account.profile.staff-and-permission.render-after': RenderExtension<
+    StandardApi<'customer-account.profile.staff-and-permission.render-after'>,
     AllComponents
   >;
   'customer-account.order-status.action.menu-item.render': RenderExtension<


### PR DESCRIPTION
### Background

The account information section is being renamed to "profile" and thus the target extension names have also been accordingly updated. 

### Solution

Renaming dynamic extension targets as described in the following figma: https://www.figma.com/file/5Op17XqUmqj8dCSI5RZvo6/Extensibility-Dev-Preview?type=design&node-id=1656-12269&mode=design&t=rhwyvX5uTcEgqSkz-4

Also, confirmed with @joao-quintino that the static extension names will also be renamed to `profile`


### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
