### PR TITLE
Publish Customer Accounts Profile Extension Targets

### DIFF
--- a/packages/customer-account-ui-extensions-react/package.json
+++ b/packages/customer-account-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/customer-account-ui-extensions-react",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "description": "React bindings for @shopify/customer-account-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -25,7 +25,7 @@
     "@remote-ui/async-subscription": "^2.1.12",
     "@remote-ui/react": "4.5.x",
     "@shopify/checkout-ui-extensions-react": "^0.27.3",
-    "@shopify/customer-account-ui-extensions": "^0.0.60"
+    "@shopify/customer-account-ui-extensions": "^0.0.61"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <18.0.0"

--- a/packages/customer-account-ui-extensions/package.json
+++ b/packages/customer-account-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/customer-account-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify's Customer Account",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
### Background

This PR is updating the extension target names for customer account profile extensions
Tags:
- https://github.com/Shopify/ui-extensions/tree/%40shopify/customer-account-ui-extensions-react%400.0.63
- https://github.com/Shopify/ui-extensions/tree/%40shopify/customer-account-ui-extensions%400.0.61

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
