### PR TITLE
Add checkoutToken api to unstable release

### DIFF
--- a/.changeset/yellow-frogs-help.md
+++ b/.changeset/yellow-frogs-help.md
@@ -1,0 +1,11 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+# Add checkoutToken Api
+
+Extensions now have access to the checkout token (a stable id used to identify the checkout) directly through the standard api. The checkout token will match:
+
+- **token** field in [WebPixel checkout payload](https://shopify.dev/docs/api/pixels/customer-events#checkout).
+- **checkout_token** in the [Admin REST Api Order resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object)

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/checkout-token.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/checkout-token.ts
@@ -1,0 +1,16 @@
+import {
+  CheckoutToken,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/checkout';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+/**
+ * Provides access to checkout token.
+ */
+export function useCheckoutToken<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): CheckoutToken | undefined {
+  return useSubscription(useApi<Target>().checkoutToken);
+}

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/index.ts
@@ -61,3 +61,4 @@ export {useApplyPaymentMethodAttributesChange} from './payment-method';
 export {useApplyRedeemableChange} from './redeemable';
 export {useDeliveryGroups} from './delivery-groups';
 export {useDeliveryGroup} from './delivery-group';
+export {useCheckoutToken} from './checkout-token';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/checkout-token.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/checkout-token.test.ts
@@ -1,0 +1,17 @@
+import {useCheckoutToken} from '../checkout-token';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useCheckoutToken', () => {
+  it('returns checkoutToken from the api', () => {
+    const checkoutToken = 'checkout-token';
+
+    const {value} = mount.hook(() => useCheckoutToken(), {
+      extensionApi: {
+        checkoutToken: createMockStatefulRemoteSubscribable(checkoutToken),
+      },
+    });
+
+    expect(value).toBe(checkoutToken);
+  });
+});

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/hooks/checkout-token.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/hooks/checkout-token.doc.ts
@@ -1,0 +1,23 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {getLinksByTag} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'useCheckoutToken',
+  description: '',
+  descriptionType: 'UseCheckoutTokenGeneratedType',
+  isVisualComponent: false,
+  type: 'hook',
+  category: 'React Hooks',
+  subCategory: 'Checkout Token',
+  definitions: [
+    {
+      title: '',
+      description: '',
+      type: 'UseCheckoutTokenGeneratedType',
+    },
+  ],
+  related: getLinksByTag('apis'),
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/api.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api.ts
@@ -55,6 +55,7 @@ export type {
   PickupLocationOption,
   PickupPointOption,
   NumberRange,
+  CheckoutToken,
 } from './api/standard/standard';
 export type {
   Attribute,

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -238,6 +238,7 @@ export interface AppMetafieldEntry {
 export type {ApiVersion} from '../../../../shared';
 
 export type Version = string;
+export type CheckoutToken = string;
 
 /**
  * This returns a translated string matching a key in a locale file.
@@ -471,6 +472,14 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * Settings applied to the buyer's checkout.
    */
   checkoutSettings: StatefulRemoteSubscribable<CheckoutSettings>;
+
+  /**
+   * A semi-stable id that represents the current checkout.
+   *
+   * Will match `token` field in [WebPixel](https://shopify.dev/docs/api/pixels/customer-events#checkout) checkout payloads.
+   * Will match the `checkout_token` in the [Admin REST API Order resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object).
+   */
+  checkoutToken: StatefulRemoteSubscribable<CheckoutToken | undefined>;
 
   /**
    * Details on the costs the buyer will pay for this checkout.

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -680,6 +680,7 @@ export type CustomerAccountStandardApi<Target extends keyof ExtensionTargets> =
     | 'attributes'
     | 'buyerIdentity'
     | 'checkoutSettings'
+    | 'checkoutToken'
     | 'cost'
     | 'discountCodes'
     | 'discountAllocations'


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/temp-project-mover-megswim-20250326195306/issues/390

NOTE: I only included my changes. There's an issue with the current customer-account changes that blows up the build.

### Solution

Provides stable id in checkout that can be mapped to WebPixel checkout payloads (via `token` in checkout payload) and Orders resource (via Admin REST API Orders `checkout_token`).

### 🎩

- Create a spin instance that includes the `ui-extensions` repo and checkout this branch: `denii/unstable-release-2023-09-05`
- Create a new app with checkout ui extension locally: `yarn create @shopify/app` and `yarn generate extension`
- In the local extension, use the new api, both directly and through the hook:
```
const { checkoutToken } = useApi();

const value = useSubscription(
  checkoutToken,
);
```
or
```
const hookValue = useCheckoutToken();
```
- In your app directory, run the following to copy the `ui-extensions` code into your app:
```
VM=direct.$(spin show -o fqdn)
rsync -av --delete $VM:~/src/github.com/Shopify/ui-extensions/packages/ui-extensions node_modules/@shopify/ && \
rsync -av --delete $VM:~/src/github.com/Shopify/ui-extensions/packages/ui-extensions-react node_modules/@shopify/
```
- Run `yarn dev` or `yarn build` to check that the app builds and can execute without error using the updated unstable api

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
