### PR TITLE
Expose secondary action on screen component

### DIFF
--- a/packages/retail-ui-extensions/src/components/Screen/Screen.ts
+++ b/packages/retail-ui-extensions/src/components/Screen/Screen.ts
@@ -7,10 +7,22 @@ export interface ScreenPresentationProps {
   sheet?: boolean;
 }
 
+/** Represents the secondary action button of a screen in the navigation stack.
+ * @property `text` displays the name of the secondary action in the action bar.
+ * @property `onPress` triggered when the secondary action button is pressed.
+ * @property `isEnabled` displays the secondary action button when set `true`.
+ */
+export interface SecondaryActionProps {
+  text: string;
+  onPress: () => void;
+  isEnabled?: boolean;
+}
+
 /** Represents a screen in the navigation stack.
  * @property `name` used to identify this screen as a destination in the navigation stack.
  * @property `title` the title of the screen which will be displayed on the UI.
  * @property `isLoading` displays a loading indicator when `true`. Set this to `true` when performing an asynchronous task, and then to false when the data becomes available to the UI.
+ * @property `secondaryAction` displays a secondary action button on the screen.
  * @property `onNavigate` triggered when the screen is navigated to.
  * @property `onNavigateBack` triggered when the user navigates back from this screen. Runs after screen is unmounted.
  * @property `overrideNavigateBack` is a callback that allows you to override the secondary navigation action. Runs when screen is mounted.
@@ -21,6 +33,7 @@ export interface ScreenProps {
   title: string;
   isLoading?: boolean;
   presentation?: ScreenPresentationProps;
+  secondaryAction?: SecondaryActionProps;
   onNavigate?: () => void;
   onNavigateBack?: () => void;
   overrideNavigateBack?: () => void;

--- a/packages/retail-ui-extensions/src/components/Screen/index.ts
+++ b/packages/retail-ui-extensions/src/components/Screen/index.ts
@@ -1,2 +1,6 @@
 export {Screen} from './Screen';
-export type {ScreenPresentationProps, ScreenProps} from './Screen';
+export type {
+  ScreenPresentationProps,
+  ScreenProps,
+  SecondaryActionProps,
+} from './Screen';

--- a/packages/retail-ui-extensions/src/components/index.ts
+++ b/packages/retail-ui-extensions/src/components/index.ts
@@ -90,7 +90,11 @@ export {Icon} from './Icon';
 export type {IconName, IconSize, IconProps} from './Icon';
 
 export {Screen} from './Screen';
-export type {ScreenPresentationProps, ScreenProps} from './Screen';
+export type {
+  ScreenPresentationProps,
+  ScreenProps,
+  SecondaryActionProps,
+} from './Screen';
 
 export {Navigator} from './Navigator';
 

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -140,6 +140,7 @@ export type {
   IconProps,
   ScreenProps,
   ScreenPresentationProps,
+  SecondaryActionProps,
 } from './components';
 
 export type {


### PR DESCRIPTION
### Background
Part of https://github.com/Shopify/pos-next-react-native/issues/27009
(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)
As part of stocky work for M2, we need to expose `secondaryAction` for the screen component. The component itself already exists. 

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)
Let me know if the typing or documentation is correct.

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
