### PR TITLE
Removed placeholder prop from DateField and TimeField as it is not su…

### DIFF
--- a/packages/retail-ui-extensions/src/components/DateField/DateField.ts
+++ b/packages/retail-ui-extensions/src/components/DateField/DateField.ts
@@ -7,7 +7,6 @@ export interface DateFieldProps
     | 'value'
     | 'error'
     | 'label'
-    | 'placeholder'
     | 'disabled'
     | 'onFocus'
     | 'onBlur'

--- a/packages/retail-ui-extensions/src/components/TimeField/TimeField.ts
+++ b/packages/retail-ui-extensions/src/components/TimeField/TimeField.ts
@@ -7,7 +7,6 @@ export interface TimeFieldProps
     | 'value'
     | 'error'
     | 'label'
-    | 'placeholder'
     | 'disabled'
     | 'onFocus'
     | 'onBlur'


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/27604

### Background

Follow-up of https://github.com/Shopify/pos-next-react-native/issues/27487

`placeholder` prop is not supported in DateField and TimeField as we always default to current date and time and there is no customization available at this point.

### Solution

- Removed the prop

### Checklist

~- [ ] I have :tophat:'d these changes~
- [X] I have updated relevant documentation
