### PR TITLE
Fix osp examples

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/order-status/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/order-status/default.example.ts
@@ -4,7 +4,7 @@ import {
 } from '@shopify/ui-extensions/checkout';
 
 export default extension(
-  'customer-account.order-details.customer-information.render-after',
+  'customer-account.order-status.customer-information.render-after',
   (root, {order}) => {
     let bannerShown = false;
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/order-status/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/order-status/default.example.tsx
@@ -5,7 +5,7 @@ import {
 } from '@shopify/ui-extensions-react/checkout';
 
 export default reactExtension(
-  'customer-account.order-details.customer-information.render-after',
+  'customer-account.order-status.customer-information.render-after',
   () => <Extension />,
 );
 


### PR DESCRIPTION
### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

Targets in examples for OSP were not correctly updated with the latest extension point target at edition.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

Fixes on unstable for now.

This mirrors the changes made in https://github.com/Shopify/checkout-web/pull/25584 and https://github.com/Shopify/shopify-dev/pull/37062

### Questions

* Should I also update the 2023-04 and 2023-07 versions ? How do we manage changes like those ? I don't think there's any release needed for any of those changes.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
