### PR TITLE
Update B2B profile extension targets

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -70,6 +70,11 @@ export interface CustomerAccountExtensionTargets {
       FullPageApi,
     AllComponents
   >;
+  'customer-account.page.render': RenderExtension<
+    Omit<StandardApi<'customer-account.page.render'>, 'navigation'> &
+      FullPageApi,
+    AllComponents
+  >;
   'CustomerAccount::Returns::Initiate': RunExtension<
     StandardApi<'CustomerAccount::Returns::Initiate'> & {orderId: string},
     void
@@ -94,10 +99,6 @@ export interface CustomerAccountExtensionTargets {
     StandardApi<'customer-account.profile.block.render'>,
     AllComponents
   >;
-  'customer-account.profile.company-details.render-after': RenderExtension<
-    StandardApi<'customer-account.profile.company-details.render-after'>,
-    AllComponents
-  >;
   'customer-account.profile.addresses.render-after': RenderExtension<
     StandardApi<'customer-account.profile.addresses.render-after'>,
     AllComponents
@@ -106,9 +107,21 @@ export interface CustomerAccountExtensionTargets {
     StandardApi<'customer-account.profile.payment.render-after'>,
     AllComponents
   >;
-  'customer-account.profile.staff-and-permissions.render-after': RenderExtension<
-    StandardApi<'customer-account.profile.staff-and-permissions.render-after'>,
+  'customer-account.profile.company-details.render-after': RenderExtension<
+    StandardApi<'customer-account.profile.company-details.render-after'>,
     AllComponents
+  >;
+  'customer-account.profile.company-location-addresses.render-after': RenderExtension<
+    StandardApi<'customer-account.profile.company-location-addresses.render-after'>,
+    AllComponents & {locationId: string}
+  >;
+  'customer-account.profile.company-location-payment.render-after': RenderExtension<
+    StandardApi<'customer-account.profile.company-location-payment.render-after'>,
+    AllComponents & {locationId: string}
+  >;
+  'customer-account.profile.company-location-staff.render-after': RenderExtension<
+    StandardApi<'customer-account.profile.company-location-staff.render-after'>,
+    AllComponents & {locationId: string}
   >;
   'customer-account.order-status.action.menu-item.render': RenderExtension<
     StandardApi & {orderId: string},


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/57077 

Update B2B profile extension targets and full page extension target name. 
For location related extension targets, we will provide a `locationId` parameter. 

Figma: 
https://www.figma.com/file/5Op17XqUmqj8dCSI5RZvo6/Extensibility-Dev-Preview?type=design&node-id=1656-12268&mode=design&t=0T2ytBkSPUm64hj4-0 

<img width="647" alt="Screenshot 2023-09-12 at 12 02 32" src="https://github.com/Shopify/ui-extensions/assets/12724940/20edae35-d291-483c-9917-f920817f76c6">

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
