### PR TITLE
Add Page component

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/Page/Page.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/Page/Page.ts
@@ -1,0 +1,11 @@
+import {Page as BasePage} from '@shopify/ui-extensions/customer-account';
+import {
+  createRemoteReactComponent,
+  ReactPropsFromRemoteComponentType,
+} from '@remote-ui/react';
+
+export type PageProps = ReactPropsFromRemoteComponentType<typeof BasePage>;
+
+export const Page = createRemoteReactComponent(BasePage, {
+  fragmentProps: ['actions', 'backAction'],
+});

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/Page/Page.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/Page/Page.ts
@@ -7,5 +7,5 @@ import {
 export type PageProps = ReactPropsFromRemoteComponentType<typeof BasePage>;
 
 export const Page = createRemoteReactComponent(BasePage, {
-  fragmentProps: ['actions', 'backAction'],
+  fragmentProps: ['primaryAction', 'secondaryAction'],
 });

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/Page/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/Page/index.ts
@@ -1,0 +1,2 @@
+export {Page} from './Page';
+export type {PageProps} from './Page';

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/index.ts
@@ -1,5 +1,7 @@
 export * from './Card';
 export * from './CustomerAccountAction';
+export * from './Page';
+export * from './PaymentIcon';
 export * from './PolicyModal';
 export * from './Thumbnail';
 export * from './shared-checkout-components';

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/index.ts
@@ -1,7 +1,6 @@
 export * from './Card';
 export * from './CustomerAccountAction';
 export * from './Page';
-export * from './PaymentIcon';
 export * from './PolicyModal';
 export * from './Thumbnail';
 export * from './shared-checkout-components';

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.ts
@@ -3,48 +3,47 @@ import type {RemoteFragment} from '@remote-ui/core';
 
 export interface PageProps {
   /**
-   * The text to be used as title, in large type
+   * The text to be used as title.
    */
   title: string;
 
   /**
-   * The content of the page.
-   * We will adopt what is decided as type in this discussion:
-   * https://github.com/Shopify/ui-api-design/issues/139
-   */
-  children: RemoteFragment;
-
-  /**
-   * Flag that indicates if the page skeleton should be displayed. Optional.
-   * Defaults to false. When true, a Skeleton component will be rendered as header.
-   */
-  loading?: boolean;
-
-  /**
-   * The text to be used as subtitle, in regular type. Optional
+   * The text to be used as subtitle.
    */
   subtitle?: string;
 
   /**
-   * The action to be used as the back button. Optional. Expected to be a Button.
-   * When provided, only `to`, `onPress` and `accessibilityLabel` will be used. The rest will be ignored by the Customer Account.
+   * The action grouping, provided as button(s), that is placed in the primary position of the page.
    */
-  backAction?: RemoteFragment;
+  primaryAction?: RemoteFragment;
 
   /**
-   * The list of actions. Optional. Expected to be a fragment with a list of Buttons.
-   * Customer Account implementation details:
-   * When provided, the first 2 actions will always be displayed.
-   * When there are 3 or more, the first one is displayed and the rest will be displayed in a dropdown.
+   * Label for the primary action grouping.
+   *
+   * @defaultValue "More actions"
    */
-  actions?: RemoteFragment;
+  primaryActionLabel?: string;
 
   /**
-   * The label to be used in the dropdown that contains the actions when ther are 3 or more actions.
-   * Optional.
-   * Defaults to "More actions".
+   * Accessibility label for the primary action grouping.
+   *
+   * @defaultValue "More actions"
    */
-  actionsLabel?: string;
+  primaryActionAccessibilityLabel?: string;
+
+  /**
+   * The secondary action provided as a button, that is placed in the secondary position of the page.
+   */
+  secondaryAction?: RemoteFragment;
+
+  /**
+   * Indicates that the page is in a loading state.
+   *
+   * When `true`, the page will be replaced by loading indicators (for example: skeletons or spinners).
+   *
+   * @defaultValue false
+   */
+  loading?: boolean;
 }
 
 export const Page = createRemoteComponent<'Page', PageProps>('Page');

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.ts
@@ -38,6 +38,13 @@ export interface PageProps {
    * When there are 3 or more, the first one is displayed and the rest will be displayed in a dropdown.
    */
   actions?: RemoteFragment;
+
+  /**
+   * The label to be used in the dropdown that contains the actions when ther are 3 or more actions.
+   * Optional.
+   * Defaults to "More actions".
+   */
+  actionsLabel?: string;
 }
 
 export const Page = createRemoteComponent<'Page', PageProps>('Page');

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.ts
@@ -1,0 +1,43 @@
+import {createRemoteComponent} from '@remote-ui/core';
+import type {RemoteFragment} from '@remote-ui/core';
+
+export interface PageProps {
+  /**
+   * The text to be used as title, in large type
+   */
+  title: string;
+
+  /**
+   * The content of the page.
+   * We will adopt what is decided as type in this discussion:
+   * https://github.com/Shopify/ui-api-design/issues/139
+   */
+  children: RemoteFragment;
+
+  /**
+   * Flag that indicates if the page skeleton should be displayed. Optional.
+   * Defaults to false. When true, a Skeleton component will be rendered as header.
+   */
+  loading?: boolean;
+
+  /**
+   * The text to be used as subtitle, in regular type. Optional
+   */
+  subtitle?: string;
+
+  /**
+   * The action to be used as the back button. Optional. Expected to be a Button.
+   * When provided, only `to`, `onPress` and `accessibilityLabel` will be used. The rest will be ignored by the Customer Account.
+   */
+  backAction?: RemoteFragment;
+
+  /**
+   * The list of actions. Optional. Expected to be a fragment with a list of Buttons.
+   * Customer Account implementation details:
+   * When provided, the first 2 actions will always be displayed.
+   * When there are 3 or more, the first one is displayed and the rest will be displayed in a dropdown.
+   */
+  actions?: RemoteFragment;
+}
+
+export const Page = createRemoteComponent<'Page', PageProps>('Page');

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/index.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/index.ts
@@ -1,0 +1,2 @@
+export {Page} from './Page';
+export type {PageProps} from './Page';

--- a/packages/ui-extensions/src/surfaces/customer-account/components/index.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/index.ts
@@ -1,5 +1,7 @@
 export * from './Card';
 export * from './CustomerAccountAction';
+export * from './Page';
+export * from './PaymentIcon';
 export * from './PolicyModal';
 export * from './Thumbnail';
 export * from './shared-checkout-components';

--- a/packages/ui-extensions/src/surfaces/customer-account/components/index.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/index.ts
@@ -1,7 +1,6 @@
 export * from './Card';
 export * from './CustomerAccountAction';
 export * from './Page';
-export * from './PaymentIcon';
 export * from './PolicyModal';
 export * from './Thumbnail';
 export * from './shared-checkout-components';


### PR DESCRIPTION
### Background

Contributes to https://github.com/Shopify/core-issues/issues/59115
RFC: https://github.com/Shopify/ui-api-design/discussions/146


### Solution

Expose Page component and its Props.

### 🎩

Page Being used in extension: 
[Spin](https://development-store-1.account.shopify.page-component-tophat.oleksandr-oliynyk.eu.spin.dev/pages/dev-651cadbd-9a98-4c76-b0e0-a007766590a4/) - dev@shopify.com 


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
