### PR TITLE
Persist changes to ui-extensions

### DIFF
--- a/.changeset/silent-wolves-brake.md
+++ b/.changeset/silent-wolves-brake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Update docs for action extension GA

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -24,7 +24,7 @@ const data: LandingTemplateSchema = {
         {
           title: 'Developer preview',
           sectionContent:
-            'Admin UI action and block extensions are currently in developer preview. You can only render them while developing locally on a development store.',
+            'Admin UI action extensions are currently in developer preview. You can only render them while developing locally on a development store.',
           type: 'beta',
         },
       ],
@@ -111,7 +111,7 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       title: 'Direct API access',
       sectionContent:
-        "You can make Shopify Admin API requests directly from your extension using the [query API](/docs/api/admin-extensions/api/standard-api#standardapi-propertydetail-query) or the standard [web fetch API](https://developer.mozilla.org/en-US/docs/Web/API/fetch)!\n\nAny `fetch()` calls to Shopify's Admin GraphQL API from your extension are automatically authenticated by default. They're fast too, since requests are handled directly by Shopify.\n\nThe access scopes you have in your extension are the same as the access scopes you have in your app. If you need to make a request to a resource that requires a different access scope, update your app's access scopes.",
+        "You can make Shopify Admin API requests directly from your extension using the [query API](/docs/api/admin-extensions/api/standard-api#standardapi-propertydetail-query) or the standard [web fetch API](https://developer.mozilla.org/en-US/docs/Web/API/fetch)!\n\nAny `fetch()` calls to Shopify's Admin GraphQL API from your extension are automatically authenticated by default. They're fast too, since requests are handled directly by Shopify.\n\nDirect API requests use [Online access](https://shopify.dev/docs/apps/auth/oauth/access-modes#online-access) mode. This means Direct API calls are restricted to the scopes available to the user that's using the extension. If your extension needs to use the offline access mode, you should make requests using your app's backend.",
       anchorLink: 'direct-api-access',
       codeblock: {
         title: 'Query Shopify data',
@@ -213,6 +213,23 @@ const data: LandingTemplateSchema = {
           },
         },
       ],
+    },
+    {
+      type: 'Generic',
+      title: 'Deploying',
+      anchorLink: 'deploying',
+      sectionContent:
+        'Use the Shopify CLI to [deploy your app and its extensions](https://shopify.dev/docs/apps/deployment/extension).',
+      codeblock: {
+        title: 'Deploy an extension',
+        tabs: [
+          {
+            code: "# navigate to your app's root directory:\ncd my-app\n\n# deploy your app and its extensions:\nnpm run deploy\n# follow the steps to deploy\n",
+            language: 'bash',
+            title: 'CLI',
+          },
+        ],
+      },
     },
   ],
 };


### PR DESCRIPTION
### Background

I did this backwards :) 

PR with docs changes: https://github.com/Shopify/shopify-dev/pull/37092

This PR mirrors those back to ui-extensions so they don't get overwritten.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
