### PR TITLE
Update Image src prop description

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.ts
@@ -17,7 +17,8 @@ import type {
 
 export interface ImageProps extends BorderProps, CornerProps, IdProps {
   /**
-   * The URL or path to the image. Supports the `resolution` and `viewportInlineSize` conditional styles only.
+   * The remote URL or path to the image on the Shopify store. Supports the
+   * `resolution` and `viewportInlineSize` conditional styles only.
    */
   source: Required<
     MaybeConditionalStyle<


### PR DESCRIPTION
Clarify that the path is to the file on the Shopify store

### Background

The documentation is not clear that path refers to the path to the image on the Shopify store, and not the path to the local image. This was causing confusion for developers.

### Solution

Update the docs.

### 🎩

- ...

### Checklist

- [] I have :tophat:'d these changes
- [x] I have updated relevant documentation
