### PR TITLE
Add ODP static extension targets

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -54,6 +54,14 @@ export interface OrderStatusExtensionTargets {
     OrderStatusApi<'customer-account.order-status.cart-line-list.render-after'>,
     AnyComponent
   >;
+  'customer-account.order-status.delivery-details.render-after': RenderExtension<
+    OrderStatusApi<'customer-account.order-status.delivery-details.render-after'>,
+    AnyComponent
+  >;
+  'customer-account.order-status.payment-details.render-after': RenderExtension<
+    OrderStatusApi<'customer-account.order-status.payment-details.render-after'>,
+    AnyComponent
+  >;
   /**
    * A static extension target that is rendered after a purchase below the customer information on the Order Status page.
    */


### PR DESCRIPTION
### Background

Add ODP static extension targets:
1. customer-account.order-status.delivery-details.render-after 
2. customer-account.order-status.payment-details.render-after

Figma: 
https://www.figma.com/file/5Op17XqUmqj8dCSI5RZvo6/Extensibility-Dev-Preview?type=design&node-id=1656-16556&mode=design&t=w1XfdbDu7fkk8DQN-0

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
