### PR TITLE
Publish 1.5.0-rc.1

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "1.5.0-rc.0",
+  "version": "1.5.0-rc.1",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/retail-ui-extensions": "1.5.0-rc.0",
+    "@shopify/retail-ui-extensions": "1.5.0-rc.1",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/retail-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify Point of Sale",
-  "version": "1.5.0-rc.0",
+  "version": "1.5.0-rc.1",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Part of https://github.com/Shopify/pos-next-react-native/issues/27744

Changes:
 - @shopify/retail-ui-extensions-react: 1.5.0-rc.0 => 1.5.0-rc.1
 - @shopify/retail-ui-extensions: 1.5.0-rc.0 => 1.5.0-rc.1