### PR TITLE
Adds b2bEnabled enabledFeature on CustomerSegmentTemplateApi

### DIFF
--- a/.changeset/curvy-turkeys-leave.md
+++ b/.changeset/curvy-turkeys-leave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Adds b2bEnabled enabledFeature on CustomerSegmentTemplateApi

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.ts
@@ -4,10 +4,8 @@ import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-target
 
 /* List of enabled query language features during a progressive rollout */
 type CustomerSegmentationFeature =
-  /* Allows merchants to segment on products purchased by tags. For example: products_purchased(tag: 'Red hats') = true */
-  | 'productsPurchasedByTags'
-  /* Enables count aggregates on functions. For example: shopify_email.opened(count_at_least: 5) = true */
-  | 'aggregateFilters';
+  /* Enables templates using filters only available when B2B is enabled. For example: companies IS NOT NULL */
+  'b2bEnabled';
 
 export interface CustomerSegmentTemplateApi<
   ExtensionTarget extends AnyExtensionTarget,

--- a/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate.ts
@@ -21,8 +21,7 @@ export type CustomerSegmentTemplateIcon =
   | 'buyButtonMajor'
   | 'followUpEmailMajor'
   | 'confettiMajor'
-  | 'viewMajor'
-  | 'buyButtonMajor';
+  | 'viewMajor';
 
 export type CustomerSegmentTemplateCategory =
   | 'firstTimeBuyers'

--- a/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/examples/InternalCustomerSegmentTemplate.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/examples/InternalCustomerSegmentTemplate.example.ts
@@ -6,30 +6,38 @@ import {
 export default extension(
   'admin.customers.segmentation-templates.render',
   (root, {i18n, __enabledFeatures}) => {
-    const productsPurchasedOnTagsEnabled = __enabledFeatures.includes('productsPurchasedByTags');
-    const productTemplate = root.createComponent(InternalCustomerSegmentTemplate, {
-      title: i18n.translate('product.title'),
-      description: i18n.translate('product.description'),
-      icon: 'productsMajor',
-      query: productsPurchasedOnTagsEnabled
-        ? 'products_purchased(tag: (product_tag)) = true'
-        : 'products_purchased(id: (product_id)) = true',
-      queryToInsert: productsPurchasedOnTagsEnabled
-        ? 'products_purchased(tag:'
-        : 'products_purchased(id:',
-      dateAdded: new Date('2023-01-15').toISOString(),
-      category: 'reEngageCustomers',
-    });
+    const b2bEnabled =
+      __enabledFeatures.includes('b2bEnabled');
+    const companiesTemplate = root.createComponent(
+      InternalCustomerSegmentTemplate,
+      {
+        title: i18n.translate('companies.title'),
+        description: i18n.translate('companies.description'),
+        icon: 'buyButtonMajor',
+        query: 'companies IS NOT NULL',
+        dateAdded: new Date('2023-01-15').toISOString(),
+        category: 'reEngageCustomers',
+      },
+    );
 
-    const locationTemplate = root.createComponent(InternalCustomerSegmentTemplate, {
-      title: i18n.translate('location.title'),
-      description: [i18n.translate('location.firstParagraph'), i18n.translate('location.secondParagraph')],
-      icon: 'locationMajor',
-      query: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
-      category: 'location',
-    });
+    const locationTemplate = root.createComponent(
+      InternalCustomerSegmentTemplate,
+      {
+        title: i18n.translate('location.title'),
+        description: [
+          i18n.translate('location.firstParagraph'),
+          i18n.translate('location.secondParagraph'),
+        ],
+        icon: 'locationMajor',
+        query: "customer_cities CONTAINS 'US-NY-NewYorkCity'",
+        category: 'location',
+      },
+    );
 
-    root.appendChild(productTemplate);
+    if (b2bEnabled) {
+      root.appendChild(companiesTemplate);
+    }
+
     root.appendChild(locationTemplate);
 
     root.mount();


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/core-issues/issues/60600 (more context in https://github.com/Shopify/core-issues/issues/58095)

We want to have a template in customer segmentation that only appears in shops on the plus plan. 

### Solution

- Adds b2bEnabled `enabledFeature` to our API
- Removes other enabledFeatures we are no longer using. The beta flags for these features have been removed.
- Cleans up InternalCustomerSegmentTemplate example to use b2bEnabled enabledFeature instead of productPurchasedOnTags
- Cleans up icon list as buyButtonMajor was listed twice

### 🎩

- Nothing to tophat. We aren't even using enabledFeatures in our [1p app](https://github.com/search?q=repo%3AShopify%2Fsegmentation-templates-app%20enabledFeatures&type=code) or in [web](https://github.com/Shopify/web/blob/main/app/sections/Customers/components/SegmentEditor/components/Templates/Templates.tsx) currently. 
- Green CI 🟢 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
