### PR TITLE
Rename order action menu item ui extension

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -137,7 +137,7 @@ export interface CustomerAccountExtensionTargets {
     },
     AllComponents
   >;
-  'customer-account.order-status.action.menu-item.render': RenderExtension<
+  'customer-account.order.action.menu-item.renders': RenderExtension<
     StandardApi & {orderId: string},
     AllComponents
   >;

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -137,7 +137,7 @@ export interface CustomerAccountExtensionTargets {
     },
     AllComponents
   >;
-  'customer-account.order.action.menu-item.renders': RenderExtension<
+  'customer-account.order.action.menu-item.render': RenderExtension<
     StandardApi & {orderId: string},
     AllComponents
   >;

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -141,7 +141,7 @@ export interface CustomerAccountExtensionTargets {
     StandardApi & {orderId: string},
     AllComponents
   >;
-  'customer-account.order-status.action.render': RenderExtension<
+  'customer-account.order.action.render': RenderExtension<
     StandardApi & ActionExtensionApi & {orderId: string},
     AllComponents
   >;


### PR DESCRIPTION
### Background
Renaming was updated as specified in the following issue: 

https://github.com/Shopify/core-issues/issues/58559

<img src="https://screenshot.click/27-25-z04p3-t42pv.png"/>

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
