### PR TITLE
Clean up `Spacing` properties from public packages

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
@@ -335,7 +335,7 @@ export interface SpacingProps {
    *
    * - [`base`, `none`] means blockStart and blockEnd paddings are `base`, inlineStart and inlineEnd paddings are `none`
    *
-   * - [`base`, `none`, `large200`, `small200`] means blockStart padding is `base`, inlineEnd padding is `none`, blockEnd padding is `large200` and  blockStart padding is `small200`
+   * - [`base`, `none`, `loose`, `tight`] means blockStart padding is `base`, inlineEnd padding is `none`, blockEnd padding is `loose` and  blockStart padding is `tight`
    */
   padding?: MaybeResponsiveConditionalStyle<MaybeShorthandProperty<Spacing>>;
 }
@@ -467,28 +467,11 @@ export type Size =
 
 export type Spacing =
   | 'none'
-  | 'small500'
-  | 'small400'
-  | 'small300'
-  | 'small200'
-  | 'small100'
+  | 'extraTight'
+  | 'tight'
   | 'base'
-  | 'large100'
-  | 'large200'
-  | 'large300'
-  | 'large400'
-  | 'large500'
-  | SpacingDeprecated;
-
-/** @deprecated These values are deprecated and will eventually be removed.
- * Use the new values.
- *
- * `extraTight`: `small400`
- * `tight`: `small200`
- * `loose`: `large200`
- * `extraLoose`: `large500`
- */
-export type SpacingDeprecated = 'extraTight' | 'tight' | 'loose' | 'extraLoose';
+  | 'loose'
+  | 'extraLoose';
 
 export type Alignment = 'start' | 'center' | 'end';
 export type InlineAlignment = 'start' | 'center' | 'end';


### PR DESCRIPTION
### Background

closes https://github.com/Shopify/shopify-dev/issues/37586

### Solution

Removing unpublished spacing properties.

Once I'm back from vacation My primary goal will be to remove/publish/refactor this spacing properties for this to stop happening...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
