### PR TITLE
fix inline code bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "prettier": "^2.8.0",
     "react": ">=18.0.0",
     "typescript": "^4.9.0",
-    "@shopify/generate-docs": "0.10.10"
+    "@shopify/generate-docs": "0.10.13"
   }
 }

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-template-curly-in-string */
 import {LandingTemplateSchema} from '@shopify/generate-docs';
 
 const data: LandingTemplateSchema = {
@@ -154,15 +153,12 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Link to Product Page',
                 language: 'tsx',
-                code: '<Link to="shopify:admin/products/1234567890" />',
+                code: './examples/link-to-product-page.jsx',
               },
               {
                 title: 'Fetch data',
                 language: 'ts',
-                code: `fetch("shopify:admin/api/graphql.json", {
-  method: "POST",
-  body: JSON.stringify(simpleProductQuery),
-});`,
+                code: './examples/fetch-data.js',
               },
             ],
           },
@@ -175,9 +171,9 @@ const data: LandingTemplateSchema = {
             title: 'app:',
             tabs: [
               {
-                title: 'Link to Product Page',
+                title: 'Link to Settings',
                 language: 'tsx',
-                code: '<Link to="app:settings/advanced" />',
+                code: './examples/link-to-settings.jsx',
               },
             ],
           },
@@ -192,7 +188,7 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Trigger Action Extension from a Block extension',
                 language: 'tsx',
-                code: '<Link to={`extension:${extension.handle}/${extensionTarget}`} />',
+                code: './examples/link-to-action.jsx',
               },
             ],
           },
@@ -207,7 +203,7 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Link to route in your app',
                 language: 'tsx',
-                code: '<Link to={`/reviews/${product.id}`} />',
+                code: './exampels/link-to-route.jsx',
               },
             ],
           },

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/fetch-data.js
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/fetch-data.js
@@ -1,0 +1,4 @@
+fetch('shopify:admin/api/graphql.json', {
+  method: 'POST',
+  body: JSON.stringify(simpleProductQuery),
+});

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-to-action.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-to-action.jsx
@@ -1,0 +1,1 @@
+<Link to={`extension:${extension.handle}/${extensionTarget}`} />;

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-to-product-page.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-to-product-page.jsx
@@ -1,0 +1,1 @@
+<Link to="shopify:admin/products/1234567890" />;

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-to-route.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-to-route.jsx
@@ -1,0 +1,1 @@
+<Link to={`/reviews/${product.id}`} />;

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-to-settings.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-to-settings.jsx
@@ -1,0 +1,1 @@
+<Link to="app:settings/advanced" />;

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -56,7 +56,7 @@
     "@remote-ui/core": "^2.2.3"
   },
   "devDependencies": {
-    "@shopify/generate-docs": "0.10.10",
+    "@shopify/generate-docs": "0.10.13",
     "typescript": "^4.9.0"
   },
   "publishConfig": {


### PR DESCRIPTION
### Background

This fixes a mismatch where checkout UI extensions must be generated with version `0.10.13` and admin UI must be generated with `0.10.10` otherwise code within accordions don't show correctly.

This updates the `@shopify/generate-docs` package to a known stable release version of `0.10.13` that checkout UI extensions has been using for some time. This fixes a previous issue where code within an accordion would be inlined as opposed to using a code file. 


### Solution

Use files for code examples as intended and bump the version to `0.10.13` where this was fixed.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
