### PR TITLE
Hide PolicyModal from 3P Apps

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/PolicyModal/PolicyModal.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/PolicyModal/PolicyModal.ts
@@ -1,11 +1,30 @@
-import {PolicyModal as BasePolicyModal} from '@shopify/ui-extensions/customer-account';
-import {
-  createRemoteReactComponent,
-  ReactPropsFromRemoteComponentType,
-} from '@remote-ui/react';
+import {createRemoteReactComponent} from '@remote-ui/react';
 
-export type PolicyModalProps = ReactPropsFromRemoteComponentType<
-  typeof BasePolicyModal
->;
+type PolicyType = 'refund';
 
-export const PolicyModal = createRemoteReactComponent(BasePolicyModal);
+// The interface was duplicated from the `ui-extensions` package because it no longer can be imported
+// More on the PR: https://github.com/Shopify/ui-extensions/pull/1399
+export interface PolicyModalProps {
+  /**
+   * Whether the modal should be rendered.
+   * Modal is a controlled component, so you must keep the state of the `open` prop yourself.
+   */
+  open: boolean;
+  /**
+   * Callback when either the close button, the backdrop, or the `escape` key is pressed.
+   * `onClose` is only called while the modal is open and attempts to be closed,
+   * not when it exits the viewport.
+   * You’ll usually want to use this callback to set the `open` prop to `false`.
+   */
+  onClose: () => void;
+  /**
+   * A title rendered as a `Heading` at the top of the modal.
+   */
+  title: string;
+  /**
+   * Type of policy to render.
+   */
+  type: PolicyType;
+}
+
+export const PolicyModal = createRemoteReactComponent('PolicyModal');

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Card';
 export * from './CustomerAccountAction';
 export * from './Page';
+/* @internal */
 export * from './PolicyModal';
 export * from './shared-checkout-components';

--- a/packages/ui-extensions-react/tsconfig.json
+++ b/packages/ui-extensions-react/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "build/ts",
     "rootDir": "src",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "stripInternal": true
   },
   "include": ["config/typescript/faker.d.ts", "src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/**/*.example.tsx", "src/**/tests/**"],

--- a/packages/ui-extensions/src/surfaces/customer-account/components/PolicyModal/PolicyModal.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/PolicyModal/PolicyModal.ts
@@ -2,6 +2,8 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 type PolicyType = 'refund';
 
+// The interface is duplicated in the `ui-extensions-react` package because it no longer can be imported
+// More on the PR: https://github.com/Shopify/ui-extensions/pull/1399
 export interface PolicyModalProps {
   /**
    * Whether the modal should be rendered.

--- a/packages/ui-extensions/src/surfaces/customer-account/components/index.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Card';
 export * from './CustomerAccountAction';
 export * from './Page';
+/* @internal */
 export * from './PolicyModal';
 export * from './shared-checkout-components';

--- a/packages/ui-extensions/tsconfig.json
+++ b/packages/ui-extensions/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "build/ts"
+    "outDir": "build/ts",
+    "stripInternal": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/**/*.example.*", "src/**/tests/**"]


### PR DESCRIPTION
### Background

Contributes to https://github.com/Shopify/core-issues/issues/51494

It is a requirement that Customer Account does not expose `PolicyModal` to any 3P app. This PR prevents the type definition of the `PolicyModal` from being exposed.

### Solution

This PR introduces a new tsconfig that prevents the typescript definition from being included in the bundle when building both the `ui-extensions` and `ui-extensions-react`. In order to achieve that, it is needed to add `/* @internal */` in the line before the export of the type definition.

PS: This approach does not prevent the component itself from being exposed, just the typescript definition of it. That is exactly what we want because Returns [uses it](https://github.com/Shopify/buyer-returns/blob/main/extensions/buyer-returns/src/RequestReturnPage/RequestReturnPage.tsx#L400) and it should be available to 1P apps. They will have to define it on their side.

PPS: `PolicyModal` in the `ui-extensions-react` package was importing the component from the `ui-extensions` packages, which is no longer exposing such component. Because of that, the prop types had to be duplicated in both packages. That is the tradeoff of hiding a whole component from any app.

### 🎩

- https://github.com/Shopify/buyer-returns/pull/292 should be merged
- Documentation with all explanation: https://github.com/Shopify/customer-account-web/pull/3076
- The typescript definition of the `PolicyModal` component is no longer there:

<img width="817" alt="Screenshot 2023-10-02 at 12 10 56" src="https://github.com/Shopify/ui-extensions/assets/3033781/ae425f86-e005-4017-bec8-993111b30d30">

<img width="730" alt="Screenshot 2023-10-02 at 12 11 14" src="https://github.com/Shopify/ui-extensions/assets/3033781/2442472f-96c1-4209-bb6a-1bc3f50d6a84">

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation