### PR TITLE
Expose missing components to the react package

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/checkout.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout.ts
@@ -43,6 +43,7 @@ export type {
   ExtensionTargets,
   Fit,
   GridItemSize,
+  IconSource,
   I18nTranslate,
   InlineAlignment,
   MapBounds,
@@ -54,6 +55,7 @@ export type {
   MaybeShorthandProperty,
   NonPresentationalAccessibilityRole,
   OverlayActivatorProps,
+  PaymentMethod,
   PopoverPosition,
   RenderExtension,
   RenderExtensions,
@@ -76,6 +78,7 @@ export type {
   ViewPosition,
   ViewPositionType,
   ViewLikeAccessibilityRole,
+  VisibilityProps,
   YearMonth,
 } from '@shopify/ui-extensions/checkout';
 


### PR DESCRIPTION
### Background

There are 3 components that are exported from `ui-extensions` package but not from `ui-extensions-react`. Aiming to get both packages symmetrical, this PR is exporting them in the `react` package too

### Solution


### 🎩

- Green CI

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation