### PR TITLE
Fix type mismatch issue for documentations

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/components/shared-checkout-components.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/shared-checkout-components.ts
@@ -142,4 +142,4 @@ export type {
   SpacingProps,
   ViewLikeAccessibilityRole,
   VisibilityProps,
-} from '../../checkout';
+} from '../../checkout/components';

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -1,5 +1,5 @@
 import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-import {AnyComponent} from '../checkout';
+import {AnyComponent} from '../checkout/shared';
 
 import {CartLineItemApi} from './api/cart-line/cart-line-item';
 import type {OrderStatusApi} from './api/order-status/order-status';


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/60107 
A fix for https://github.com/Shopify/customer-account-web/pull/3094 

Mainly when we import form checkout parent folder directly, we load almost all the types from `surface/checkout` , which will cause many type conflicts while generating documentations. 

Update some import so that types are correct in documentations. 

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

Green CI

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
