### PR TITLE
Add isGiftCard prop to LineItem

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/types/cart.ts
+++ b/packages/retail-ui-extensions/src/extension-api/types/cart.ts
@@ -31,6 +31,7 @@ export interface LineItem {
   sku?: string;
   vendor?: string;
   properties: {[key: string]: string};
+  isGiftCard: boolean;
 }
 
 export interface Discount {


### PR DESCRIPTION
Part of https://github.com/Shopify/pos-next-react-native/issues/28821

### Background

Adds a prop to check if line item is giftcard
