### PR TITLE
update web pixels extensions with payment gateway

### DIFF
--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -237,6 +237,13 @@ export const pixelEvents = {
               'Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), an alias for window.scrollY',
           },
         },
+        screen: {
+          ref: 'Screen',
+          metadata: {
+            description:
+              'Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen), the interface representing a screen, usually the one on which the current window is being rendered',
+          },
+        },
         screenX: {
           type: 'uint32',
           metadata: {
@@ -348,6 +355,28 @@ export const pixelEvents = {
           metadata: {
             description:
               'Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a string containing the canonical form of the origin of the specific location',
+          },
+        },
+      },
+    },
+    Screen: {
+      metadata: {
+        description:
+          'The interface representing a screen, usually the one on which the current window is being rendered',
+      },
+      properties: {
+        height: {
+          type: 'uint32',
+          metadata: {
+            description:
+              'Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen/height), the height of the screen',
+          },
+        },
+        width: {
+          type: 'uint32',
+          metadata: {
+            description:
+              'Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen/width), the width of the screen',
           },
         },
       },
@@ -554,6 +583,15 @@ export const pixelEvents = {
           metadata: {
             description:
               'The sum of all the taxes applied to the line items and shipping lines in the checkout.',
+          },
+        },
+        transactions: {
+          metadata: {
+            description:
+              'A list of transactions associated with a checkout or order.',
+          },
+          elements: {
+            ref: 'Transaction',
           },
         },
       },
@@ -1132,6 +1170,27 @@ export const pixelEvents = {
               description:
                 'A list of products returned by the search query. The first product variant for each product is returned',
             },
+          },
+        },
+      },
+    },
+    Transaction: {
+      metadata: {
+        description: 'A transaction associated with a checkout or order.',
+      },
+      properties: {
+        amount: {
+          ref: 'MoneyV2',
+          metadata: {
+            description:
+              'The monetary value with currency allocated to the transaction method.',
+          },
+        },
+        gateway: {
+          type: 'string',
+          metadata: {
+            description:
+              'The name of the payment provider used for the transaction.',
           },
         },
       },

--- a/packages/web-pixels-extension/src/types/EventBus.ts
+++ b/packages/web-pixels-extension/src/types/EventBus.ts
@@ -26,6 +26,7 @@ export interface PublisherOptions extends Record<string, unknown> {
     appId: string;
     type: string;
   };
+  eventId?: string;
 }
 
 export type SubscriberCallback<T> = (event: T) => void;

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -694,6 +694,11 @@ export interface Checkout {
    * the checkout.
    */
   totalTax: MoneyV2;
+
+  /**
+   * A list of transactions associated with a checkout or order.
+   */
+  transactions: Transaction[];
 }
 
 /**
@@ -1189,6 +1194,24 @@ export interface ProductVariant {
 }
 
 /**
+ * The interface representing a screen, usually the one on which the current
+ * window is being rendered
+ */
+export interface Screen {
+  /**
+   * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen/height),
+   * the height of the screen
+   */
+  height: number;
+
+  /**
+   * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen/width),
+   * the width of the screen
+   */
+  width: number;
+}
+
+/**
  * An object that contains the metadata of when a search has been performed.
  */
 export interface SearchResult {
@@ -1215,6 +1238,21 @@ export interface ShippingRate {
  * 8601](https://en.wikipedia.org/wiki/ISO_8601) format
  */
 export type Timestamp = string;
+
+/**
+ * A transaction associated with a checkout or order.
+ */
+export interface Transaction {
+  /**
+   * The monetary value with currency allocated to the transaction method.
+   */
+  amount: MoneyV2;
+
+  /**
+   * The name of the payment provider used for the transaction.
+   */
+  gateway: string;
+}
 
 /**
  * A snapshot of a subset of properties of the `document` object in the top
@@ -1333,6 +1371,13 @@ export interface WebPixelsWindow {
    * alias for window.scrollY
    */
   pageYOffset: number;
+
+  /**
+   * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen), the
+   * interface representing a screen, usually the one on which the current
+   * window is being rendered
+   */
+  screen: Screen;
 
   /**
    * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the

--- a/packages/web-pixels-extension/src/types/PublicApi.ts
+++ b/packages/web-pixels-extension/src/types/PublicApi.ts
@@ -1,5 +1,5 @@
 import type {EventBus} from './EventBus';
-import {VisitorApi} from './VisitorApi';
+import type {VisitorApi} from './VisitorApi';
 
 export interface PublicApi {
   publish: EventBus['publish'];

--- a/packages/web-pixels-extension/src/types/VisitorApi.ts
+++ b/packages/web-pixels-extension/src/types/VisitorApi.ts
@@ -4,7 +4,7 @@ export interface VisitorParams {
 }
 
 export interface VisitorOptions {
-  apiClientId?: string;
+  appId?: string;
 }
 export interface VisitorApi {
   visitor(params: VisitorParams, options?: VisitorOptions): boolean;


### PR DESCRIPTION
### Background

Updates our web pixels extension api! Changes include:

- payment gateway 
- screenX/screenY
- appClientID renamed to appID


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
