### PR TITLE
feat: export Badge from ui-extensions-react

### DIFF
--- a/.changeset/serious-cheetahs-smash.md
+++ b/.changeset/serious-cheetahs-smash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-react': patch
+---
+
+Add Badge component to admin

--- a/packages/ui-extensions-react/src/surfaces/admin/components.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/components.ts
@@ -2,6 +2,8 @@ export {AdminAction} from './components/AdminAction/AdminAction';
 export type {AdminActionProps} from './components/AdminAction/AdminAction';
 export {AdminBlock} from './components/AdminBlock/AdminBlock';
 export type {AdminBlockProps} from './components/AdminBlock/AdminBlock';
+export {Badge} from './components/Badge/Badge';
+export type {BadgeProps} from './components/Badge/Badge';
 export {Banner} from './components/Banner/Banner';
 export type {BannerProps} from './components/Banner/Banner';
 export {BlockStack} from './components/BlockStack/BlockStack';


### PR DESCRIPTION
### Background

The new Badge component isn't exported from `@shopify/ui-extensions-react`.

### Solution

Export it.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
