### PR TITLE
fix: do not require optional types for Badge

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.ts
@@ -27,8 +27,8 @@ interface BadgeIconProps {
 }
 
 interface BadgeNoIconProps {
-  icon: never;
-  iconPosition: never;
+  icon?: never;
+  iconPosition?: never;
 }
 
 export type BadgeProps = BadgeBaseProps & (BadgeIconProps | BadgeNoIconProps);


### PR DESCRIPTION
### Background

We wanted to have a typecheck in `Badge` component that would make `icon` and `iconPosition` optional, but `iconPosition` could only be used when `icon` is present. But by leaving out the optional part in the `never` type, we made `icon` and `iconPosition` required, with a `never` type.

### Solution
Mark `icon` and `iconPosition` optional in the `BadgeNoIconprops` interface

### 🎩

Make sure using `Badge` like this does not produces any TS errors:
```tsx
<Badge>Hello</Badge>
```

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
