### PR TITLE
add customer account standard api doc types

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/authenticated-account.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/authenticated-account.ts
@@ -10,7 +10,7 @@ import {useSubscription} from './subscription';
 /**
  * Returns the current authenticated `Customer`.
  *
- * The value is `undefined` if the customer hasn't authenticated yet.
+ * The value is `undefined` if the customer isn't authenticated.
  */
 export function useAuthenticatedAccountCustomer<
   Target extends RenderExtensionTarget,
@@ -21,7 +21,7 @@ export function useAuthenticatedAccountCustomer<
 }
 
 /**
- * Provides information about the company and its location the authenticated business customer.
+ * Provides information about the company of the authenticated business customer.
  * The value is `undefined` if a business customer isn't authenticated.
  */
 export function useAuthenticatedAccountPurchasingCompany<

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/extension.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/extension.ts
@@ -3,7 +3,7 @@ import type {Extension} from '@shopify/ui-extensions/customer-account';
 import {useApi} from './api';
 
 /**
- * Returns the metadata about the extension.
+ * Returns the metadata of the extension.
  */
 export function useExtension(): Extension {
   return useApi().extension;

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -1,4 +1,5 @@
 import {OrderStatusApi} from './order-status/order-status';
+import {StandardApi} from './standard-api/standard-api';
 import {CartLineItemApi} from './cart-line/cart-line-item';
 
 export interface Docs_OrderStatus_MetafieldsApi
@@ -54,3 +55,20 @@ export interface Docs_CartLineItem_CartLinesApi
 
 export interface Docs_OrderStatus_OrderApi
   extends Pick<OrderStatusApi<any>, 'order'> {}
+
+export interface Docs_Standard_ExtensionApi
+  extends Pick<StandardApi<any>, 'extension'> {}
+
+export interface Docs_Standard_AuthenticatedAccountApi
+  extends Pick<StandardApi<any>, 'authenticatedAccount'> {}
+
+export interface Docs_Standard_VersionApi
+  extends Pick<StandardApi<any>, 'version'> {}
+
+export interface Docs_Standard_LocalizationApi
+  extends Pick<StandardApi<any>, 'localization' | 'i18n'> {}
+
+export interface Docs_Standard_StorageApi
+  extends Pick<StandardApi<any>, 'storage'> {}
+
+export interface Docs_Standard_UIApi extends Pick<StandardApi<any>, 'ui'> {}


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/60108
Please also have a review of this PR on customer account web side https://github.com/Shopify/customer-account-web/pull/3214 

adding standard api docs: https://github.com/Shopify/ui-extensions/blob/add-customer-account-standard-api-doc-types/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts#L15-L86

- extension targets ( deprecated 2023-07, not adding this )
- extension
- authenticatedAccount
- version
- localization
- i18n
- i18n sample
- router ( deprecating, not adding this )
- authenticatedRedirect
- storage
- ui

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

refer to tophat instructions in this PR  https://github.com/Shopify/customer-account-web/pull/3214

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
