### PR TITLE
fix policy modal

### DIFF
--- a/.changeset/long-doors-sell.md
+++ b/.changeset/long-doors-sell.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+fix policy modal handling

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/PolicyModal/PolicyModal.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/PolicyModal/PolicyModal.ts
@@ -27,4 +27,7 @@ export interface PolicyModalProps {
   type: PolicyType;
 }
 
-export const PolicyModal = createRemoteReactComponent('PolicyModal');
+export const PolicyModal = createRemoteReactComponent<
+  'PolicyModal',
+  PolicyModalProps
+>('PolicyModal');

--- a/packages/ui-extensions-react/tsconfig.json
+++ b/packages/ui-extensions-react/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "build/ts",
     "rootDir": "src",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "stripInternal": true
   },
   "include": ["config/typescript/faker.d.ts", "src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/**/*.example.tsx", "src/**/tests/**"],

--- a/packages/ui-extensions/tsconfig.json
+++ b/packages/ui-extensions/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "build/ts"
+    "outDir": "build/ts",
+    "stripInternal": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/**/*.example.*", "src/**/tests/**"]


### PR DESCRIPTION
### Background

Not stripping the internal fields caused clashes in an app. 

I missed moving this over. We already had this setting in internal: https://github.com/Shopify/ui-extensions/pull/1399/files#diff-256b5258d7b08eedfba647de7d28bae26f13f08d985b93f5c1ddb456644857d2R7

I also changed how the type is constructed. I have honestly no idea how/why this worked before 🤔 
We never combined the Component with its types. We're now passing the props so that the type is complete. 

🎩 will be done in said app, after merge.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
