### PR TITLE
Update prop descriptions for Page and ResourceItem

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.ts
@@ -18,28 +18,30 @@ export interface PageProps {
   primaryAction?: RemoteFragment;
 
   /**
-   * Label for the primary action grouping.
+   * Label for the primary action grouping. If a label is not provided, default text is used.
    *
    * @defaultValue "More actions"
    */
   primaryActionLabel?: string;
 
   /**
-   * Accessibility label for the primary action grouping.
+   * Accessibility label for the primary action grouping. If an accessibility label is not provided,
+   * default text is used.
    *
    * @defaultValue "More actions"
    */
   primaryActionAccessibilityLabel?: string;
 
   /**
-   * The secondary action provided as a button, that is placed in the secondary position of the page.
+   * The action grouping, provided as button(s), that is placed in the secondary position of the page.
    */
   secondaryAction?: RemoteFragment;
 
   /**
    * Indicates that the page is in a loading state.
    *
-   * When `true`, the page will be replaced by loading indicators (for example: skeletons or spinners).
+   * When `true`, the page shows loading indicators for the UI elements that it is owns.
+   * The page is not responsible for the loading indicators of any content that is passed as `children`.
    *
    * @defaultValue false
    */

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ResourceItem/ResourceItem.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ResourceItem/ResourceItem.ts
@@ -10,19 +10,25 @@ export interface ResourceItemProps
   action?: RemoteFragment;
 
   /**
-   * Label for the action grouping
+   * Label for the action grouping. If a label is not provided, default text is used.
+   *
+   * @defaultValue "More actions"
    */
   actionLabel?: string;
 
   /**
-   * Accessibility label for the action grouping
+   * Accessibility label for the action grouping. If an accessibility label is not provided,
+   * default text is used.
+   *
+   * @defaultValue "More actions"
    */
   actionAccessibilityLabel?: string;
 
   /**
    * Indicates that the item is in a loading state.
    *
-   * When `true`, the item will be replaced by loading indicators (for example: skeletons or spinners).
+   * When `true`, the item shows loading indicators for the UI elements that it is owns.
+   * The item is not responsible for the loading indicators of any content that is passed as `children`.
    *
    * @defaultValue false
    */


### PR DESCRIPTION
### Background

Related to https://github.com/Shopify/core-issues/issues/59115
Related to https://github.com/Shopify/core-issues/issues/59116

Now that the [Page API](https://github.com/Shopify/ui-api-design/pull/152) and [ResourceItem API](https://github.com/Shopify/ui-api-design/pull/160) have been aligned, we can update the prop descriptions with what was agreed upon.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
