### PR TITLE
Update Background type values

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
@@ -162,8 +162,11 @@ export type CornerRadiusDeprecated = 'tight' | 'loose';
 export interface BackgroundProps {
   /**
    * Adjust the background.
+   *
+   * @defaultValue 'transparent'
    */
   background?: MaybeConditionalStyle<Background>;
+
   /**
    * Sets one or multiple responsive background images.
    */
@@ -485,7 +488,7 @@ export type Alignment = 'start' | 'center' | 'end';
 export type InlineAlignment = 'start' | 'center' | 'end';
 export type BlockAlignment = Alignment | 'baseline';
 
-export type Background = 'transparent' | 'color1' | 'color2' | 'color3';
+export type Background = 'transparent' | 'base' | 'subdued';
 export type BackgroundFit = 'cover' | 'contain';
 export type BackgroundPosition = 'top' | 'bottom' | 'left' | 'right' | 'center';
 export type BackgroundRepeat = 'repeat' | 'noRepeat';


### PR DESCRIPTION
### Background

This update is related to this https://github.com/Shopify/checkout-web/pull/26499 and got missed in https://github.com/Shopify/ui-extensions/pull/1437. Need these values for exposing the background prop in the customer account surface.

It should have been part of [this changeset](https://github.com/Shopify/ui-extensions/blob/lsit/fix-background-type/.changeset/big-pets-drop.md) so I don't think I need to add another. Let me know if I do.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

https://shopify-dev.checkout-web-api-docs-6bhk.lianne-sit.us.spin.dev/docs/api/checkout-ui-extensions/unstable/components/structure/view#viewprops-propertydetail-background

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
