### PR TITLE
Support storefront api for customer account api

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -73,5 +73,5 @@ export interface Docs_Standard_StorageApi
 
 export interface Docs_Standard_UIApi extends Pick<StandardApi<any>, 'ui'> {}
 
-export interface Docs_OrderStatus_QueryApi
-  extends Pick<OrderStatusApi<any>, 'query'> {}
+export interface Docs_Standard_QueryApi
+  extends Pick<StandardApi<any>, 'query'> {}

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -4,6 +4,8 @@ import {
   Storage,
   Language,
   AuthenticatedAccount,
+  GraphQLError,
+  StorefrontApiVersion,
 } from '../shared';
 
 import type {ExtensionTarget} from '../../targets';
@@ -83,6 +85,16 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
     };
   };
   navigation: StandardExtensionNavigation;
+
+  /**
+   * Used to query the Storefront GraphQL API with a prefetched token.
+   *
+   * See [storefront api access examples](https://shopify.dev/docs/api/customer-account-ui-extensions/apis/standard-api/storefront-api#examples) for more information.
+   */
+  query: <Data = unknown, Variables = {[key: string]: unknown}>(
+    query: string,
+    options?: {variables?: Variables; version?: StorefrontApiVersion},
+  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;
 }
 
 export interface CompanyLocationApi {


### PR DESCRIPTION
### Background

Part of Shopify/core-issues#61073

Please also have a review of customer account web side PR https://github.com/Shopify/customer-account-web/pull/3246 

Support storefront api for standard customer account ui extension api 

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

Please see the tophat here https://github.com/Shopify/customer-account-web/pull/3246 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
