### PR TITLE
fix(security): add CORS policy section to Admin UI Extensions docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -226,6 +226,13 @@ const data: LandingTemplateSchema = {
         ],
       },
     },
+    {
+      type: 'Generic',
+      title: 'Security',
+      anchorLink: 'security',
+      sectionContent:
+        'UI Extensions run on a different origin than the Shopify Admin. For network calls to succeed, your server must support [cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for the origin `https://extensions.shopifycdn.com`.\n\nIf you have a custom [`Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) set, you must include `https://extensions.shopifycdn.com` in the list of allowed origins.\n\nIf you are using the [Shopify App Remix Template](https://github.com/Shopify/shopify-app-template-remix), this is done automatically for you.',
+    },
   ],
 };
 


### PR DESCRIPTION
### Background

We're updating the domain for the `load.html` file in Web to the new `https://extensions.shopifycdn.com/`. If apps have a custom CORS policy in their server, they need to add this new domain to the allow list.

This change will be done in https://github.com/Shopify/web/pull/107284. However, we need to send out messaging to Partners first in case they have a different CORS policy already set.

### Solution

Add documentation for this for extension developers. This is consumed in `shopify-dev` in https://github.com/Shopify/shopify-dev/pull/38519.

### 🎩

https://shopify-dev.shopify-dev-9ncp.charlie-dobson.us.spin.dev/docs/api/admin-extensions#security

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
