### PR TITLE
Remove duplicated fields from order status api

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -18,10 +18,7 @@ export interface Docs_OrderStatus_CostApi
   extends Pick<OrderStatusApi<any>, 'cost'> {}
 
 export interface Docs_OrderStatus_LocalizationApi
-  extends Pick<OrderStatusApi<any>, 'i18n' | 'localization'> {}
-
-export interface Docs_OrderStatus_DiscountsApi
-  extends Pick<OrderStatusApi<any>, 'discountAllocations' | 'discountCodes'> {}
+  extends Pick<OrderStatusApi<any>, 'localization'> {}
 
 export interface Docs_OrderStatus_DiscountsApi
   extends Pick<OrderStatusApi<any>, 'discountAllocations' | 'discountCodes'> {}

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -4,15 +4,10 @@ import type {
   CurrencyCode,
   CountryCode,
   Timezone,
-  GraphQLError,
-  StorefrontApiVersion,
   SellingPlan,
   Attribute,
   MailingAddress,
-  I18n,
   Language,
-  Storage,
-  AuthenticatedAccount,
 } from '../shared';
 import type {ExtensionTarget} from '../../targets';
 import {Extension} from '../shared';
@@ -266,16 +261,6 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
   extensionPoint: Target;
 
   /**
-   * Utilities for translating content and formatting values according to the current
-   * [`localization`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-localization)
-   * of the order.
-   *
-   * See [localization examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#example-localization)
-   * for more information.
-   */
-  i18n: I18n;
-
-  /**
    * A list of lines containing information about the items the customer intends to purchase.
    */
   lines: StatefulRemoteSubscribable<CartLine[]>;
@@ -321,16 +306,6 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
   order: StatefulRemoteSubscribable<Order | undefined>;
 
   /**
-   * Used to query the Storefront GraphQL API with a prefetched token.
-   *
-   * See [storefront api access examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#example-storefront-api-access) for more information.
-   */
-  query: <Data = unknown, Variables = {[key: string]: unknown}>(
-    query: string,
-    options?: {variables?: Variables; version?: StorefrontApiVersion},
-  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;
-
-  /**
    * Provides access to session tokens, which can be used to verify token claims on your app's server.
    *
    * See [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#example-session-token) for more information.
@@ -345,13 +320,11 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
    */
   checkoutToken: StatefulRemoteSubscribable<CheckoutToken | undefined>;
 
-  // eslint-disable-next-line no-warning-comments
-  // TODO: update the links
   /**
    * The settings matching the settings definition written in the
-   * [`shopify.ui.extension.toml`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration) file.
+   * [`shopify.ui.extension.toml`](https://shopify.dev/docs/api/customer-account-ui-extensions/configuration) file.
    *
-   *  See [settings examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#example-settings) for more information.
+   *  See [settings examples](https://shopify.dev/docs/api/customer-account-ui-extensions/apis/standardapi#example-settings) for more information.
    *
    * > Note: When an extension is being installed in the editor, the settings will be empty until
    * a merchant sets a value. In that case, this object will be updated in real time as a merchant fills in the settings.
@@ -376,32 +349,11 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
   shop: Shop;
 
   /**
-   * Key-value storage for the extension target.
-   */
-  storage: Storage;
-
-  /**
-   * Methods to interact with the extension's UI.
-   */
-  ui: Ui;
-
-  /**
    * The renderer version being used for the extension.
    *
    * @example 'unstable'
    */
   version: Version;
-
-  /**
-   * Information about the authenticated account.
-   */
-  authenticatedAccount: AuthenticatedAccount;
-}
-
-export interface Ui {
-  overlay: {
-    close(overlayId: string): void;
-  };
 }
 
 export interface SessionToken {

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -1202,3 +1202,9 @@ export interface Company {
    */
   id: string;
 }
+
+export interface Ui {
+  overlay: {
+    close(overlayId: string): void;
+  };
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -6,6 +6,7 @@ import {
   AuthenticatedAccount,
   GraphQLError,
   StorefrontApiVersion,
+  Ui,
 } from '../shared';
 
 import type {ExtensionTarget} from '../../targets';
@@ -79,17 +80,14 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * Methods to interact with the extension's UI.
    */
-  ui: {
-    overlay: {
-      close(overlayId: string): void;
-    };
-  };
+  ui: Ui;
+
   navigation: StandardExtensionNavigation;
 
   /**
    * Used to query the Storefront GraphQL API with a prefetched token.
    *
-   * See [storefront api access examples](https://shopify.dev/docs/api/customer-account-ui-extensions/apis/standard-api/storefront-api#examples) for more information.
+   * See [storefront api access examples](https://shopify.dev/docs/api/customer-account-ui-extensions/apis/storefront-api#examples) for more information.
    */
   query: <Data = unknown, Variables = {[key: string]: unknown}>(
     query: string,


### PR DESCRIPTION
### Background

Remove duplicated fields for customer account standard api and order status api

Part of this ticket https://github.com/Shopify/core-issues/issues/61073 

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

So with this branch,
- Both customer account web and customer account dev ui extension's type check still pass
- Extension still works 
  - open this in an incognito window https://customer-accounts-ui-extension-dev.fetch.brian-shen.us.spin.dev/extensions/dev-console 
  - click any of the extension targets
  - login as `dev@customer.com` and [this identity mailer](https://identity.fetch.brian-shen.us.spin.dev/services/mail/)
  - go to order details page 
  - order status page still has query in api even if it is removed from standard api. 

extension code
```
function BlockExtension() {
  const api = useApi<"customer-account.order-status.block.render">();
  function queryMe(){
    api.query(
      `query ($first: Int!) {
        products(first: $first) {
          nodes {
            id
            title
          }
        }
      }`,
      {
        variables: {first: 5},
      },
    )
      .then(console.log)
      .catch(console.error);
    }

  return <Button onPress={queryMe}>Query</Button>;
}
```

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
