### PR TITLE
Add line items with properties

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
@@ -62,8 +62,13 @@ export interface CartApiContent {
   /** Add a line item by variant ID to the cart
    * @param variantId the product variant's numeric ID to add to the cart
    * @param quantity the number of this variant to add to the cart
+   * @param quantity the custom key to value object to attribute to the line item
    */
-  addLineItem(variantId: number, quantity: number): Promise<void>;
+  addLineItem(
+    variantId: number,
+    quantity: number,
+    properties: Record<string, string>,
+  ): Promise<void>;
 
   /** Remove the line item at this uuid from the cart
    * @param uuid the uuid of the line item that should be removed


### PR DESCRIPTION
### Background

As we are investigating https://github.com/Shopify/pos-next-react-native/issues/29183, it became clear that when we allow this functionality, the library will become the bottleneck. This is because in order to add `properties` to a line item, developers need to call and manage two `async` functions: `addLineItem` and `addLineItemProperties`. 

### Solution

`addLineItem` was modified to accept `properties`. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
