### PR TITLE
patch: deprecate DiscountType

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
@@ -15,11 +15,20 @@ export interface CartApi {
   cart: CartApiContent;
 }
 
+/**
+ * @deprecated
+ * PriceOverride is no longer supported. Code discounts are only supported at the Cart level.
+ * Please migrate to using CartDiscountType and LineItemDiscountType as soon as possible.
+ */
 export type DiscountType =
   | 'Percentage'
   | 'FixedAmount'
   | 'PriceOverride'
   | 'Code';
+
+export type CartDiscountType = 'Percentage' | 'FixedAmount' | 'Code';
+
+export type LineItemDiscountType = 'Percentage' | 'FixedAmount';
 
 export interface CartApiContent {
   /** Provides a subscription to POS cart changes.
@@ -35,7 +44,7 @@ export interface CartApiContent {
    * @param amount the percentage or fixed monetary amount deducted with the discount. Pass in `undefined` if using discount codes.
    */
   applyCartDiscount(
-    type: DiscountType,
+    type: DiscountType | CartDiscountType,
     title: string,
     amount?: string,
   ): Promise<void>;
@@ -110,7 +119,7 @@ export interface CartApiContent {
    */
   setLineItemDiscount(
     uuid: string,
-    type: DiscountType,
+    type: DiscountType | LineItemDiscountType,
     title: string,
     amount: string,
   ): Promise<void>;

--- a/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
@@ -44,7 +44,7 @@ export interface CartApiContent {
    * @param amount the percentage or fixed monetary amount deducted with the discount. Pass in `undefined` if using discount codes.
    */
   applyCartDiscount(
-    type: DiscountType | CartDiscountType,
+    type: CartDiscountType,
     title: string,
     amount?: string,
   ): Promise<void>;
@@ -119,7 +119,7 @@ export interface CartApiContent {
    */
   setLineItemDiscount(
     uuid: string,
-    type: DiscountType | LineItemDiscountType,
+    type: LineItemDiscountType,
     title: string,
     amount: string,
   ): Promise<void>;

--- a/packages/retail-ui-extensions/src/extension-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/index.ts
@@ -1,5 +1,10 @@
 export type {LocaleApi} from './locale-api';
-export type {CartApiContent, DiscountType} from './cart-api/cart-api';
+export type {
+  CartApiContent,
+  DiscountType,
+  CartDiscountType,
+  LineItemDiscountType,
+} from './cart-api/cart-api';
 export type {CartApi} from './cart-api';
 export type {NavigationApi, NavigationApiContent} from './navigation-api';
 export type {SmartGridApi, SmartGridApiContent} from './smartgrid-api';

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -2,6 +2,8 @@ export type {
   LocaleApi,
   CartApiContent,
   DiscountType,
+  CartDiscountType,
+  LineItemDiscountType,
   DeviceApi,
   DeviceApiContent,
   CartApi,


### PR DESCRIPTION
### Background

PriceOverride is no longer supported. Code discounts are only supported at the Cart level.

### Solution

Deprecate existing DiscountType and create new, correct types

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [X] I have updated relevant documentation
