### PR TITLE
remove obsolete extension point

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -117,10 +117,6 @@ export interface CustomerAccountExtensionTargets {
     StandardApi<'CustomerAccount::KitchenSinkRun'> & {name: string},
     string
   >;
-  'customer-account.dynamic.render': RenderExtension<
-    StandardApi<'customer-account.dynamic.render'>,
-    AllComponents
-  >;
   'customer-account.order-index.block.render': RenderExtension<
     StandardApi<'customer-account.order-index.block.render'>,
     AllComponents


### PR DESCRIPTION
### Background

This extension point was never used in prod and will never be used. We can hence remove it.


### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
