### PR TITLE
ImageGroup API for CustomerAccount Surface (unstable)

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/ImageGroup/ImageGroup.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/ImageGroup/ImageGroup.ts
@@ -1,0 +1,11 @@
+import {ImageGroup as BaseImageGroup} from '@shopify/ui-extensions/customer-account';
+import {
+  createRemoteReactComponent,
+  ReactPropsFromRemoteComponentType,
+} from '@remote-ui/react';
+
+export type ImageGroupProps = ReactPropsFromRemoteComponentType<
+  typeof BaseImageGroup
+>;
+
+export const ImageGroup = createRemoteReactComponent(BaseImageGroup);

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/ImageGroup/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/ImageGroup/index.ts
@@ -1,0 +1,2 @@
+export {ImageGroup} from './ImageGroup';
+export type {ImageGroupProps} from './ImageGroup';

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/index.ts
@@ -4,4 +4,5 @@ export * from './Page';
 /* @internal */
 export * from './PolicyModal';
 export * from './ResourceItem';
+export * from './ImageGroup';
 export * from './shared-checkout-components';

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.tsx
@@ -1,0 +1,32 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+export interface ImageGroupProps {
+  /**
+   * The layout of the images.
+   * When set to "grid", the images will be displayed in a grid layout with max images of 4.
+   * When set to "inline-stack", the images will be displayed in a single row with max images of 3.
+   *
+   * @default "grid"
+   */
+  variant?: 'grid' | 'inline-stack';
+
+  /**
+   * Accessibility label for the image group.
+   */
+  imagesAccessibilityLabel?: string;
+
+  /**
+   * Loading state of the component.
+   * @default false
+   */
+  loading?: boolean;
+
+  /**
+   * Total count of items.  If totalItems is greater than the number of images passed then totalItems will be displayed.
+   */
+  totalItems?: number;
+}
+
+export const ImageGroup = createRemoteComponent<'ImageGroup', ImageGroupProps>(
+  'ImageGroup',
+);

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/index.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/index.ts
@@ -1,0 +1,2 @@
+export {ImageGroup} from './ImageGroup';
+export type {ImageGroupProps} from './ImageGroup';

--- a/packages/ui-extensions/src/surfaces/customer-account/components/index.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/index.ts
@@ -4,4 +4,5 @@ export * from './Page';
 /* @internal */
 export * from './PolicyModal';
 export * from './ResourceItem';
+export * from './ImageGroup';
 export * from './shared-checkout-components';


### PR DESCRIPTION
### Background
Contributes to: https://github.com/Shopify/core-issues/issues/60848
Exposes ImageGroup component in customer-account surface.

[API  Design](https://github.com/Shopify/ui-api-design/pull/186)
[RFC](https://github.com/Shopify/ui-api-design/discussions/169)

### Solution


<details>
  <summary>Basic Grid</summary>

![image](https://github.com/Shopify/ui-extensions/assets/101111253/e3471c3f-da35-43ba-b1a7-147d56547c01)
</details>

<details>
  <summary>Inline Stack</summary>

![image](https://github.com/Shopify/ui-extensions/assets/101111253/059cb930-181b-4909-90ba-f1e2ae22120b)
</details>

<details>
  <summary>Loading</summary>

![image](https://github.com/Shopify/ui-extensions/assets/101111253/9c1a0762-d0b4-41c9-a66f-8686b7aaf210)

</details>

### 🎩

[Storybook](https://storybook-customer-account-web.image-group-pr.oleksandr-oliynyk.us.spin.dev/?path=/story/components-imagegroup--basic-grid&globals=prefers-reduced-motion:no-preference)


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
