### PR TITLE
Publish

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/retail-ui-extensions": "1.5.0",
+    "@shopify/retail-ui-extensions": "1.5.1",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/retail-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify Point of Sale",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
 - @shopify/retail-ui-extensions-react@1.5.1
 - @shopify/retail-ui-extensions@1.5.1

### Background

Just an update to deprecate the PriceOverride discount type.
