### PR TITLE
Remove deprecated fields from doc

### DIFF
--- a/.changeset/small-phones-visit.md
+++ b/.changeset/small-phones-visit.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+remove deprecated fields from doc in customer account ui extensions

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -1,6 +1,7 @@
 import {OrderStatusApi} from './order-status/order-status';
 import {StandardApi} from './standard-api/standard-api';
 import {CartLineItemApi} from './cart-line/cart-line-item';
+import {FullPageApi} from '../targets';
 
 export interface Docs_OrderStatus_MetafieldsApi
   extends Pick<OrderStatusApi<any>, 'appMetafields' | 'metafields'> {}
@@ -72,3 +73,7 @@ export interface Docs_Standard_UIApi extends Pick<StandardApi<any>, 'ui'> {}
 
 export interface Docs_Standard_QueryApi
   extends Pick<StandardApi<any>, 'query'> {}
+
+export interface Docs_StandardApi extends Omit<StandardApi<any>, 'router'> {}
+
+export interface Docs_FullPageApi extends Omit<FullPageApi, 'location'> {}

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -57,8 +57,19 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    */
   i18n: I18n;
 
+  /**
+   *  @deprecated This is deprecated. DO NOT USE. This will be removed soon without warning.
+   */
   router: {
+    /**
+     * @deprecated This is deprecated. DO NOT USE. This will be removed soon without warning. use shopify protocol `extension://{{relative_path}} instead.
+     * @param relative
+     */
     getExtensionFullPageUrl(relative: string): Promise<string>;
+    /**
+     * @deprecated This is deprecated. DO NOT USE. This will be removed soon without warning. use `api.navigate` instead.
+     * @param to
+     */
     navigate(to: string): Promise<void>;
   };
 

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -259,6 +259,9 @@ export type AllowedComponentsForRenderExtension<
 > = ExtractedAllowedComponentsFromRenderExtension<RenderExtensions[Target]>;
 
 export interface FullPageApi {
+  /**
+   * @deprecated This is deprecated. DO NOT USE. This will be removed soon without warning. use `api.navigation.currentEntry` and `api.navigation.addEventListener` instead.
+   */
   location: StatefulRemoteSubscribable<{
     pathname: string;
     search: string;


### PR DESCRIPTION
### Background

remove deprecated fields from doc in customer account ui extensions

Please also have a review of this PR customer account web side https://github.com/Shopify/customer-account-web/pull/3318 

- `standradApi.router`
- `fullpageApi.location` 

### 🎩

Spin: https://shopify-dev.pic.brian-shen.us.spin.dev/docs/api/customer-account-ui-extensions/unstable/targets/full-page/customer-account-page-render
Staging4: https://shopify-dev-staging4.shopifycloud.com/docs/api/customer-account-ui-extensions/unstable/targets/full-page/customer-account-page-render#fullpageapi-propertydetail-location 

<img width="2560" alt="Screenshot 2023-11-03 at 10 17 50" src="https://github.com/Shopify/ui-extensions/assets/12724940/cc8b14b9-d89c-4236-9662-c81b30afa44d">


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
