### PR TITLE
fix deprecated comment for router.navigate

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -67,7 +67,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
      */
     getExtensionFullPageUrl(relative: string): Promise<string>;
     /**
-     * @deprecated This is deprecated. DO NOT USE. This will be removed soon without warning. use `api.navigate` instead.
+     * @deprecated This is deprecated. DO NOT USE. This will be removed soon without warning. use `api.navigation.navigate` instead.
      * @param to
      */
     navigate(to: string): Promise<void>;


### PR DESCRIPTION
### Background

fix deprecated comment for router.navigate

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
