### PR TITLE
Add shipping method list api for Checkout::ShippingMethods::RenderBefore/After

### DIFF
--- a/packages/checkout-ui-extensions/docs/reference/apis/shipping-method-list.doc.ts
+++ b/packages/checkout-ui-extensions/docs/reference/apis/shipping-method-list.doc.ts
@@ -1,0 +1,33 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {
+  getExample,
+  getLinksByTag,
+  REQUIRES_PROTECTED_CUSTOMER_DATA,
+} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'ShippingMethodListApi',
+  overviewPreviewDescription:
+    'The API provided to extensions rendering before and after each shipping group',
+  description: `
+This API object is provided to extensions registered for the \`Checkout::ShippingMethods::RenderBefore\` or \`Checkout::ShippingMethods::RenderAfter\` extension points.
+
+It extends the [StandardApi](/docs/api/checkout-ui-extensions/apis/standardapi) and provides a [deliveryGroupId](#properties-propertydetail-target) object with information about the shipping group the extension is attached to.
+`,
+  requires: REQUIRES_PROTECTED_CUSTOMER_DATA,
+  isVisualComponent: false,
+  category: 'APIs',
+  definitions: [
+    {
+      title: 'Properties',
+      description:
+        'See the [StandardApi examples](/docs/api/checkout-ui-extensions/apis/standardapi#examples) for more information on how to use the API.',
+      type: 'ShippingMethodListApi',
+    },
+  ],
+  defaultExample: getExample('shipping-method-list/default', ['jsx', 'js']),
+  related: getLinksByTag('apis', 'ShippingMethodListApi'),
+};
+
+export default data;

--- a/packages/checkout-ui-extensions/docs/reference/examples/shipping-method-list/default.example.ts
+++ b/packages/checkout-ui-extensions/docs/reference/examples/shipping-method-list/default.example.ts
@@ -1,0 +1,13 @@
+import {extend} from '@shopify/checkout-ui-extensions';
+
+extend(
+  'Checkout::ShippingMethods::RenderBefore',
+  (root, {deliveryGroupId, deliveryGroups}) => {
+    const deliveryGroupAttached = deliveryGroups.current.find(({id}) => deliveryGroupId === id);
+
+    const titleText = root.createText(
+      `Delivery group type: ${deliveryGroupAttached.groupType}`,
+    );
+    root.appendChild(titleText);
+  },
+);

--- a/packages/checkout-ui-extensions/docs/reference/examples/shipping-method-list/default.example.tsx
+++ b/packages/checkout-ui-extensions/docs/reference/examples/shipping-method-list/default.example.tsx
@@ -1,0 +1,25 @@
+import React, {useState} from 'react';
+import {
+  render,
+  Text,
+  useExtensionApi,
+  useDeliveryGroups,
+} from '@shopify/checkout-ui-extensions-react';
+
+render(
+  'Checkout::ShippingMethods::RenderBefore',
+  () => <Extension />,
+);
+
+function Extension() {
+  const {deliveryGroupId} =
+    useExtensionApi<'Checkout::ShippingMethods::RenderBefore'>();
+  const deliveryGroups = useDeliveryGroups();
+  const deliveryGroupAttached = deliveryGroups.find(({id}) => deliveryGroupId === id);
+
+  return (
+    <Text>
+      Delivery group type: {deliveryGroupAttached.groupType}
+    </Text>
+  );
+}

--- a/packages/checkout-ui-extensions/docs/reference/helper.docs.ts
+++ b/packages/checkout-ui-extensions/docs/reference/helper.docs.ts
@@ -90,6 +90,13 @@ export function getExamples(
         tabs: getExtensionCodeTabs('shipping-method-details/default'),
       },
     },
+    'shipping-method-list/default': {
+      description: '',
+      codeblock: {
+        title: '',
+        tabs: getExtensionCodeTabs('shipping-method-list/default'),
+      },
+    },
     'pickup-locations/default': {
       description: '',
       codeblock: {

--- a/packages/checkout-ui-extensions/docs/reference/helper.docs.ts
+++ b/packages/checkout-ui-extensions/docs/reference/helper.docs.ts
@@ -374,6 +374,12 @@ const links: {[key: string]: LinkType[]} = {
       url: '/docs/api/checkout-ui-extensions/apis/extensionpoints',
       type: 'ExtensionPoints',
     },
+    {
+      name: 'ShippingMethodListApi',
+      subtitle: 'APIs',
+      url: '/docs/api/checkout-ui-extensions/apis/shippingmethodlistapi',
+      type: 'ShippingMethodListApi',
+    },
   ],
   configuration: [
     {

--- a/packages/checkout-ui-extensions/src/api.ts
+++ b/packages/checkout-ui-extensions/src/api.ts
@@ -115,6 +115,7 @@ export type {CartLineDetailsApi} from './api/cart-line/cart-line-details';
 export type {PickupLocationsApi} from './api/pickup/pickup-locations';
 export type {PickupPointsApi} from './api/pickup/pickup-points';
 export type {ShippingMethodDetailsApi} from './api/shipping/shipping-method-details';
+export type {ShippingMethodListApi} from './api/shipping/shipping-method-list';
 
 export type {
   PaymentMethodAttributesResult,

--- a/packages/checkout-ui-extensions/src/api/shipping/shipping-method-list.ts
+++ b/packages/checkout-ui-extensions/src/api/shipping/shipping-method-list.ts
@@ -1,0 +1,6 @@
+export interface ShippingMethodListApi {
+  /**
+   * The delivery group the extension is attached to.
+   */
+  deliveryGroupId?: string;
+}

--- a/packages/checkout-ui-extensions/src/extension-points.ts
+++ b/packages/checkout-ui-extensions/src/extension-points.ts
@@ -9,6 +9,7 @@ import type {
   StandardApi,
   CheckoutApi,
   OrderStatusApi,
+  ShippingMethodListApi,
 } from './api';
 
 type Components = typeof import('./components');
@@ -222,7 +223,9 @@ export interface ExtensionPoints {
    * header and shipping method options.
    */
   'Checkout::ShippingMethods::RenderBefore': RenderExtension<
-    CheckoutApi & StandardApi<'Checkout::ShippingMethods::RenderBefore'>,
+    ShippingMethodListApi &
+      CheckoutApi &
+      StandardApi<'Checkout::ShippingMethods::RenderBefore'>,
     AllComponents
   >;
   /**
@@ -230,7 +233,9 @@ export interface ExtensionPoints {
    * options.
    */
   'Checkout::ShippingMethods::RenderAfter': RenderExtension<
-    CheckoutApi & StandardApi<'Checkout::ShippingMethods::RenderAfter'>,
+    ShippingMethodListApi &
+      CheckoutApi &
+      StandardApi<'Checkout::ShippingMethods::RenderAfter'>,
     AllComponents
   >;
   /**

--- a/packages/checkout-ui-extensions/src/index.ts
+++ b/packages/checkout-ui-extensions/src/index.ts
@@ -124,6 +124,7 @@ export type {
   PickupPointsApi,
   PickupLocationsApi,
   ShippingMethodDetailsApi,
+  ShippingMethodListApi,
 } from './api';
 export type {RenderExtension} from './render-extension';
 


### PR DESCRIPTION
### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)
For https://github.com/Shopify/checkout-web/issues/27000

Adds a ShippingMethodListApi to the `Checkout::ShippingMethod::RenderBefore/After` extension points with the `deliveryGroupId` extended property. 

### Solution

Adding a new api to the ShippingMethod render before/after. A feature is coming up that will duplicate extensions in each groups when used in the 2024-01 or unstable Api. 

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
