### PR TITLE
removing legacy extension target

### DIFF
--- a/.changeset/big-pumpkins-enjoy.md
+++ b/.changeset/big-pumpkins-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Removing legacy customer account extension targets

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -95,11 +95,6 @@ export interface OrderStatusExtensionTargets {
 export type OrderStatusExtensionTarget = keyof OrderStatusExtensionTargets;
 
 export interface CustomerAccountExtensionTargets {
-  'CustomerAccount::FullPage::RenderWithin': RenderExtension<
-    Omit<StandardApi<'CustomerAccount::FullPage::RenderWithin'>, 'navigation'> &
-      FullPageApi,
-    AllComponents
-  >;
   'customer-account.page.render': RenderExtension<
     Omit<StandardApi<'customer-account.page.render'>, 'navigation'> &
       FullPageApi,


### PR DESCRIPTION
### Background

Removing a legacy extension target name
Part of https://github.com/Shopify/core-issues/issues/62713

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
