### PR TITLE
Hide line-components-render from 2023-07

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/versioning-migration.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/versioning-migration.doc.ts
@@ -212,7 +212,6 @@ Extension targets are more flexible and powerful than extension points and they 
 |---|---|
 | Checkout::Actions::RenderBefore | purchase.checkout.actions.render-before |
 | Checkout::CartLineDetails::RenderAfter | purchase.checkout.cart-line-item.render-after |
-| Checkout::CartLineDetails::RenderLineComponents | purchase.cart-line-item.line-components.render |
 | Checkout::CartLines::RenderAfter | purchase.checkout.cart-line-list.render-after |
 | Checkout::Contact::RenderAfter | purchase.checkout.contact.render-after |
 | Checkout::DeliveryAddress::RenderBefore | purchase.checkout.delivery-address.render-before |

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -81,6 +81,7 @@ export interface ExtensionTargets {
   /**
    * A static extension target that renders on every line item, inside the details
    * under the line item properties element. It replaces the default component rendering.
+   * @private
    */
   'purchase.cart-line-item.line-components.render': RenderExtension<
     CartLineItemApi &
@@ -92,6 +93,7 @@ export interface ExtensionTargets {
    * under the line item properties element. It replaces the default component rendering.
    *
    * @deprecated Use `purchase.cart-line-item.line-components.render` instead.
+   * @private
    */
   'Checkout::CartLineDetails::RenderLineComponents': RenderExtension<
     CartLineItemApi &


### PR DESCRIPTION
### Background

See https://github.com/Shopify/checkout-web/pull/27953#issuecomment-1795905947. See description of the same PR for more context.

This PR makes the line-components-render extension private

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
