### PR TITLE
Update link from reference to branding under `/apps/checkout`

### DIFF
--- a/.changeset/fifty-pigs-cover.md
+++ b/.changeset/fifty-pigs-cover.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Updates the link to checkout branding tutorials

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
@@ -216,7 +216,7 @@ Checkout UI extensions don't have access to the DOM and can't return DOM nodes. 
         {
           name: 'Checkout branding',
           subtitle: 'Learn more',
-          url: '/docs/apps/checkout/advanced-checkout-branding',
+          url: '/docs/apps/checkout/styling',
           type: 'tutorial',
         },
       ],


### PR DESCRIPTION
### Background

The checkout branding IA was redone and renamed. [There's a redirect shipping](https://github.com/Shopify/shopify-dev/pull/38977), but this PR updates the link from the old page to the new one.

### Solution

- Update the link and regenerate the docs.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
