### PR TITLE
Update link and text to styling tutorials

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
@@ -216,7 +216,7 @@ Checkout UI extensions don't have access to the DOM and can't return DOM nodes. 
         {
           name: 'Checkout branding',
           subtitle: 'Learn more',
-          url: '/docs/apps/checkout/advanced-checkout-branding',
+          url: '/docs/apps/checkout/styling',
           type: 'tutorial',
         },
       ],

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
@@ -214,7 +214,7 @@ Checkout UI extensions don't have access to the DOM and can't return DOM nodes. 
           type: 'tutorial',
         },
         {
-          name: 'Checkout branding',
+          name: 'Checkout styling',
           subtitle: 'Learn more',
           url: '/docs/apps/checkout/styling',
           type: 'tutorial',


### PR DESCRIPTION
### Background

Checkout branding has been redone. This updates a link to that section.

### 🎩
https://shopify-dev.update-branding-link1.ren-chaturvedi.us.spin.dev/docs/api/checkout-ui-extensions#security

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
