### PR TITLE
Keep generated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ packages/*/*.js
 packages/*/bin
 !packages/*/.eslintrc.js
 *.log
-packages/ui-extensions/docs/**/generated
 
 # IntelliJ IDE ignore
 .idea

--- a/packages/ui-extensions/docs/surfaces/checkout/generated/generated_static_pages.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/generated/generated_static_pages.json
@@ -1,0 +1,912 @@
+[
+  {
+    "title": "Configuration",
+    "description": "\nWhen you create a [checkout UI extension](/api/checkout-ui-extensions/), an [app extension configuration](/docs/apps/app-extensions/configuration) `shopify.extension.toml` file is automatically generated in your extension's directory.\n\nThis guide describes [extension targeting](#targets), [capabilities](#capabilities), [metafields](#metafields), and the [settings](#settings-definition) you can configure in the app extension configuration.\n",
+    "id": "configuration",
+    "sections": [
+      {
+        "type": "Generic",
+        "anchorLink": "how-it-works",
+        "title": "How it works",
+        "sectionContent": "\nYou define properties for your checkout UI extension in the extension configuration file. The `shopify.extension.toml` file contains the extension's configuration, which includes the extension name, targets, metafields, capabilities, and settings.\n\nWhen an extension is published to Shopify, the contents of the settings file are pushed alongside the extension.\n",
+        "codeblock": {
+          "title": "shopify.extension.toml",
+          "tabs": [
+            {
+              "title": "shopify.extension.toml",
+              "code": "api_version = \"2023-07\"\n\n[[extensions]]\ntype = \"ui_extension\"\nname = \"My checkout extension\"\nhandle = \"checkout-ui\"\n\n[[extensions.targeting]]\ntarget = \"purchase.checkout.block.render\"\nmodule = \"./Checkout.jsx\"\n\n[extensions.capabilities]\nnetwork_access = true\nblock_progress = true\napi_access = true\n\n[extensions.capabilities.collect_buyer_consent]\nsms_marketing = true\n\n[[extensions.metafields]]\nnamespace = \"my-namespace\"\nkey = \"my-key\"\n[[extensions.metafields]]\nnamespace = \"my-namespace\"\nkey = \"my-other-key\"\n\n[extensions.settings]\n[[extensions.settings.fields]]\nkey = \"field_key\"\ntype = \"boolean\"\nname = \"field-name\"\n[[extensions.settings.fields]]\nkey = \"field_key_2\"\ntype = \"number_integer\"\nname = \"field-name-2\"\n",
+              "language": "toml"
+            }
+          ]
+        },
+        "sectionNotice": [
+          {
+            "title": "Tip",
+            "sectionContent": "\nYou can configure more than one type of extension within a configuration file.\n",
+            "type": "info"
+          }
+        ],
+        "sectionCard": [
+          {
+            "name": "App extension configuration",
+            "subtitle": "Learn more",
+            "url": "/docs/apps/app-extensions/configuration",
+            "type": "gear"
+          }
+        ]
+      },
+      {
+        "type": "GenericAccordion",
+        "anchorLink": "targets",
+        "title": "Targets",
+        "sectionContent": "\n[Targets](/docs/api/checkout-ui-extensions/extension-targets-overview) represent where your checkout UI extension will be injected. You may have one or many targets defined in your app extension configuration using the `targeting` field.\n\nAlong with the `target`, Shopify needs to know which code to execute for it. You specify the path to your code file by using the  `module` property.\n\n\n      ",
+        "accordionContent": [
+          {
+            "title": "Supporting a single extension target",
+            "description": "\n          Your code should have a default export if it only supports a single extension target.\n          ",
+            "codeblock": {
+              "title": "Single extension target",
+              "tabs": [
+                {
+                  "title": "shopify.extension.toml",
+                  "code": "# ...\n\n[[extensions.targeting]]\ntarget = \"purchase.checkout.block.render\"\nmodule = \"./Block.jsx\"\n\n# ...\n",
+                  "language": "toml"
+                },
+                {
+                  "title": "Block.jsx",
+                  "code": "// ...\n\nexport default reactExtension(\n  'purchase.checkout.block.render',\n  &lt;Extension /&gt;,\n);\n\nfunction Extension() {\n  // ...\n}\n",
+                  "language": "jsx"
+                }
+              ]
+            }
+          },
+          {
+            "title": "Supporting multiple extension targets",
+            "description": "\n          You can support multiple extension targets within a single configuration file. However, you must provide a separate file per extension target using the `export default` declaration.\n          ",
+            "codeblock": {
+              "title": "Multiple extension targets",
+              "tabs": [
+                {
+                  "title": "shopify.extension.toml",
+                  "code": "# ...\n\n[[extensions.targeting]]\ntarget = \"purchase.checkout.actions.render-before\"\nmodule = \"./Actions.jsx\"\n\n[[extensions.targeting]]\ntarget = \"purchase.checkout.shipping-option-item.render-after\"\nmodule = \"./ShippingOptions.jsx\"\n\n# ...\n",
+                  "language": "toml"
+                },
+                {
+                  "title": "Actions.jsx",
+                  "code": "// ...\n\n// ./Actions.jsx\nexport default reactExtension(\n  'purchase.checkout.actions.render-before',\n  &lt;Extension /&gt;,\n);\n\nfunction Extension() {\n  // ...\n}\n",
+                  "language": "jsx"
+                },
+                {
+                  "title": "ShippingOptions.jsx",
+                  "code": "// ...\n\n// ./ShippingOptions.jsx\nexport default reactExtension(\n  'purchase.checkout.shipping-option-item.render-after',\n  &lt;Extension /&gt;,\n);\n\nfunction Extension() {\n  // ...\n}\n",
+                  "language": "jsx"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "capabilities",
+        "title": "Capabilities",
+        "sectionContent": "\nDefines the [capabilities](/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-extension) associated with your extension.\n| Property | Description  |\n|---|---|\n| [`api_access`](#api-access) | Allows your extension to query the Storefront API.\n| [`network_access`](#network-access) | Allows your extension make external network calls.\n| [`block_progress`](#block-progress) | States that your extension might block the buyer's progress.\n| [`collect_buyer_consent`](#collect-buyer-consent) | Allows your extension to collect buyer consent for specific policies such as SMS marketing.\n",
+        "codeblock": {
+          "title": "Capabilities",
+          "tabs": [
+            {
+              "title": "shopify.extension.toml",
+              "code": "# ...\n\n[extensions.capabilities]\napi_access = true\nnetwork_access = true\nblock_progress = true\n\n[extensions.capabilities.collect_buyer_consent]\nsms_marketing = true\n\n# ...\n\n",
+              "language": "toml"
+            }
+          ]
+        }
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "api-access",
+        "title": "Storefront API access",
+        "sectionContent": "The following section describes the use cases of the `api_access` capability and the [Storefront API](/api/storefront) access scopes.",
+        "codeblock": {
+          "title": "Enable Storefront API access",
+          "tabs": [
+            {
+              "title": "shopify.extension.toml",
+              "code": "# ...\n\n[extensions.capabilities]\napi_access = true\n\n# ...\n",
+              "language": "toml"
+            }
+          ]
+        },
+        "sectionCard": [
+          {
+            "name": "API access examples",
+            "subtitle": "See",
+            "url": "/docs/api/checkout-ui-extensions/apis/standardapi#example-storefront-api-access",
+            "type": "blocks"
+          }
+        ],
+        "sectionSubContent": [
+          {
+            "title": "When to use Storefront API access",
+            "sectionContent": "API access is used when your extension needs to retrieve data from the [Storefront API](/api/storefront). For example, you may need to [fetch product data](/apps/checkout/product-offers/add-product-offer), check the product tags on an item in the cart, or convert a product's price to another currency.\n\n> Tip:\n> Shopify handles the authentication for all API calls from an extension.\n"
+          },
+          {
+            "title": "Methods for accessing the Storefront API",
+            "sectionContent": "Enabling the `api_access` capability allows you to use the Standard API [`query`](/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-query) method and the global `fetch` to retrieve data from the [Storefront API](/api/storefront) without manually managing token aquisition and refresh.\n\n`query` lets you request a single GraphQL response from the Storefront API.\n\nIf you prefer to construct GraphQL requests yourself or you would like to use a full-featured GraphQL client such as Apollo or urql, our custom `fetch` global automatically appends the required access tokens.\n\nThe GraphQL client of your choice shouldn’t use any DOM APIs, as they aren’t available in a checkout UI extension's Web Worker.\n\n> Note: Both `query` and `fetch` will work for calling the Storefront API with the `api_access` capability enabled. If you are using `fetch` to get data external to Shopify, refer to the [`network_access`](/api/checkout-ui-extensions/configuration#network-access) capability."
+          },
+          {
+            "title": "Storefront API access scopes",
+            "sectionContent": "\nYour extensions will have the following unauthenticated access scopes to the Storefront API:\n\n- <code>unauthenticated_read_product_publications</code>\n- <code>unauthenticated_read_collection_publications</code>\n- <code>unauthenticated_read_product_listings</code>\n- <code>unauthenticated_read_product_tags</code>\n- <code>unauthenticated_read_selling_plans</code>\n- <code>unauthenticated_read_collection_listings</code>\n- <code>unauthenticated_read_metaobjects</code>\n"
+          }
+        ]
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "network-access",
+        "title": "Network access",
+        "sectionContent": "\nThe following section describes use cases for requesting network access, alternatives to requesting network access, and steps for completing a request for network access.\n> Caution:\n> If your extension specifies the `network_access` capability, you must request access in order to publish your extension.\n",
+        "codeblock": {
+          "title": "Enable network access",
+          "tabs": [
+            {
+              "title": "shopify.extension.toml",
+              "code": "# ...\n\n[extensions.capabilities]\nnetwork_access = true\n\n# ...\n",
+              "language": "toml"
+            }
+          ]
+        },
+        "sectionSubContent": [
+          {
+            "title": "When to request network access",
+            "sectionContent": "If you need to get data into checkout that you can't currently get from Shopify, then you should request network access. For example, you might need to fetch additional data to render loyalty points."
+          },
+          {
+            "title": "Alternatives to network access",
+            "sectionContent": "\nInstead of fetching data with an external network call, consider retrieving the data from a metafield. Your app may be able to use the [Admin API](/docs/api/admin) to write [metafields](/api/admin-graphql/latest/objects/metafield) on the shop, product, or customer ahead of checkout.\n\nRetrieving data from [metafields](/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-appmetafields) during checkout is faster since it won't introduce an external network call. This allows you to rely on Shopify for the uptime, scaling, and durability of the data storage.\n"
+          },
+          {
+            "title": "Complete a request for network access",
+            "sectionContent": "\n1. Go to your [Partner Dashboard](https://partners.shopify.com/current/apps).\n2. Click the name of the app that you want to change.\n3. Click **API access**.\n4. Under **Allow network access in checkout UI extensions**, click **Allow network access**\n\n   Your request is automatically approved and your app is immediately granted the approval scope that's required for your checkout UI extension to make external network calls.\n\n5. Add <code>network_access = true</code> to the <code>[extensions.capabilities]</code> section of your extension's configuration file."
+          },
+          {
+            "title": "Required CORS headers",
+            "sectionContent": "\nUI extensions run in a [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) but the exact origin they run on may change without notice. When receiving network requests from extensions, your server must support [cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for any origin by always returning this response header:\n\n<code>Access-Control-Allow-Origin: *</code>\n"
+          },
+          {
+            "title": "Security considerations",
+            "sectionContent": "\nWhen processing HTTP requests on your API server, you cannot guarantee that your own extension will have made every request. When responding with sensitive data, keep in mind that requests could originate from anywhere on the Internet.\n\nYour extension can pass a [session token](/docs/api/checkout-ui-extensions/unstable/apis/session-token) to your API server but this only guarantees the integrity of its claims. It does not guarantee the request itself originated from Shopify. For example, your API server could trust the session token's `sub` claim (the customer ID) but it could not trust a `?customer_id=` query parameter.\n\nConsider a scenario where your extension retrieves a discount code from your API server and [applies it to the checkout](/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-applydiscountcodechange). It would not be safe to expose an API endpoint named `/get-discount-code` if any buyer could make a direct HTTP request and obtain a discount code.\n"
+          },
+          {
+            "title": "App Proxy",
+            "sectionContent": "\nUI extensions can make fetch requests to [App Proxy](/docs/apps/online-store/app-proxies) URLs, but there are some differences and limitations related to the security context within which UI extensions run.\n\nUI extension requests made to the App Proxy will execute as CORS requests. See _Required CORS headers_ above for information about requirements related to CORS.\n\nUI extension requests made to the App Proxy will not assign the <code>logged_in_customer_id</code> query parameter. Instead use a [session token](/docs/api/checkout-ui-extensions/unstable/apis/session-token) which provides the <code>sub</code> claim for the logged in customer.\n\nUI extension requests made to the App Proxy of password protected shops is not supported. Extension requests come from a web worker which does not share the same session as the parent window.\n\nThe App Proxy doesn't handle all [HTTP request methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods). Specifically, <code>CONNECT</code> and <code>TRACE</code> are unsupported.\n"
+          }
+        ]
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "block-progress",
+        "title": "Block progress",
+        "sectionContent": "The following section describes blocking the buyer's progress through checkout, and how you can detect whether the merchant has allowed it.",
+        "sectionCard": [
+          {
+            "name": "Blocking examples",
+            "subtitle": "See",
+            "url": "/docs/api/checkout-ui-extensions/apis/standardapi#example-buyer-journey",
+            "type": "blocks"
+          }
+        ],
+        "codeblock": {
+          "title": "Enable progress blocking",
+          "tabs": [
+            {
+              "title": "shopify.extension.toml",
+              "code": "# ...\n\n[extensions.capabilities]\nblock_progress = true\n\n# ...\n\n",
+              "language": "toml"
+            }
+          ]
+        },
+        "sectionSubContent": [
+          {
+            "title": "When to request blocking progress",
+            "sectionContent": "\nIf your extension relies on specific input then you might need to block the buyer's progress until they've provided all required information. You can do this with a [buyer journey](/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-buyerjourney) intercept, by returning `behavior: 'block'`.\n\nFor example, for some purchases you need to collect and verify a customer's age. For the order to be valid, you need to verify that an age is set and that it's greater than or equal to a minimum value.\n\nIn order to block checkout progress, your extension must have the `block_progress` capability.\n"
+          },
+          {
+            "title": "Granting the capability to block progress",
+            "sectionContent": "\nSetting `block_progress` in the `shopify.extension.toml` file informs merchants that your extension blocks the buyer's progress for invalid orders. Merchants can allow or disallow this capability in the checkout editor.\n\n> Note:\n> When running a local extension with the `block_progress` capability, it will be automatically granted. This simulates a scenario where the merchant has allowed the capability.\n"
+          },
+          {
+            "title": "Detecting the ability to block progress",
+            "sectionContent": "\nIn your extension, look for `block_progress` in [extension.capabilities](/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-extension) to see if the merchant has granted the blocking capability.\n\nIf the merchant declined the permission for your app to block progress, the `behavior: 'block'` option in the [buyer journey](/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-buyerjourney) intercept will be treated as `behavior: 'allow'`, and checkout will proceed as normal.\n\nWhen developing a local extension, you can remove the `block_progress` capability from your `shopify.extension.toml` file to simulate a merchant disallowing the capability.\n\n> Tip:\n> We recommend having some UI to cover cases where you can't block checkout progress. For example, you might want to show a warning rather than block checkout progress when an order doesn't pass validation."
+          }
+        ]
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "collect-buyer-consent",
+        "title": "Collect buyer consent",
+        "sectionContent": "If your extension utilizes the [ConsentCheckbox](/docs/api/checkout-ui-extensions/components/forms/consentcheckbox) or [ConsentPhoneField](/docs/api/checkout-ui-extensions/components/forms/consentphonefield) components to render a customized UI for collecting buyer consent, you must first declare that capability in your configuration file.",
+        "sectionSubContent": [
+          {
+            "title": "SMS Marketing",
+            "sectionContent": "In order to collect buyer consent for SMS marketing, you'll need to specifically declare this intent using `sms_marketing = true` in your toml configuration. This corresponds to the `policy` prop for the `Consent` components."
+          }
+        ],
+        "codeblock": {
+          "title": "Collect buyer consent",
+          "tabs": [
+            {
+              "title": "shopify.extension.toml",
+              "code": "# ...\n\n[extensions.capabilities.collect_buyer_consent]\nsms_marketing = true\n\n# ...\n\n",
+              "language": "toml"
+            }
+          ]
+        }
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "metafields",
+        "title": "Metafields",
+        "sectionContent": "\nDefines the [metafields](/docs/apps/custom-data/metafields) that are available to your extension.\n\nEach extension target uses the metafields defined in `[[extensions.metafields]]` unless they specify their own `[[extensions.targeting.metafields]]`.\n\nSupported resource metafield types include:\n\n| Resource | Description |\n|---| --- |\n| `cart` | The cart associated with the current checkout. |\n| `company` | The company for B2B checkouts. |\n| `companyLocation` | The company's location for B2B checkouts. |\n| `customer` | The customer account that is interacting with the current checkout. |\n| `product` | The products that the customer intends to purchase. |\n| `shop` | The shop that is associated with the current checkout. |\n| `shopUser` | The Shop App user that is associated with the current checkout if there is one. |\n| `variant` | The product variants that the customer intends to purchase. |\n\nYou retrieve these metafields in your extension by reading [`appMetafields`](/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-appmetafields).\n\n> Tip:\n> You may write to `cart` metafields by using [`applyMetafieldsChange`](/docs/api/checkout-ui-extensions/apis/checkoutapi#properties-propertydetail-applymetafieldchange) with `type: \"updateCartMetafield\"`.\n      ",
+        "codeblock": {
+          "title": "Metafields",
+          "tabs": [
+            {
+              "title": "Metafields",
+              "code": "# ...\n\n# The metafields for the extension\n[[extensions.metafields]]\nnamespace = \"my-namespace\"\nkey = \"my-key\"\n[[extensions.metafields]]\nnamespace = \"my-namespace\"\nkey = \"my-other-key\"\n\n[[extensions.targeting]]\ntarget = \"purchase.checkout.actions.render-before\"\nmodule = \"./Actions.jsx\"\n\n  # For the above target, use these metafields\n  [[extensions.targeting.metafields]]\n  namespace = \"my-namespace\"\n  key = \"my-target-key\"\n\n[[extensions.targeting]]\ntarget = \"purchase.checkout.shipping-option-item.render-after\"\nmodule = \"./ShippingOptions.jsx\"\n\n\n",
+              "language": "toml"
+            }
+          ]
+        },
+        "sectionCard": [
+          {
+            "name": "useAppMetafields",
+            "subtitle": "Hook",
+            "url": "/docs/api/checkout-ui-extensions/react-hooks/metafields/useappmetafields",
+            "type": "blocks"
+          },
+          {
+            "name": "useApplyMetafieldsChange",
+            "subtitle": "Hook",
+            "url": "/docs/api/checkout-ui-extensions/react-hooks/metafields/useapplymetafieldschange",
+            "type": "blocks"
+          }
+        ]
+      },
+      {
+        "type": "Markdown",
+        "anchorLink": "settings-definition",
+        "title": "Settings definition",
+        "sectionContent": "The settings for a checkout UI extension define a set of fields that the merchant can set a value for from the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor). You can use validation options to apply additional constraints to the data that the setting can store, such as a minimum or maximum value. \n\n Each settings definition can include up to 20 settings. \n\n > Note: \n > All setting inputs are optional. You should code the extension so that it still works if the merchant hasn't set a value for the setting.",
+        "sectionSubContent": [
+          {
+            "title": "Properties",
+            "sectionContent": "The following table describes the properties that you can use to define a setting:\n\n | Property  | Required? | Description | Example |\n|---|---|---|---|\n| `key` | Yes | The key of the setting. When a merchant configures a value for this setting, the value will be exposed under this `key` when running your extension    | <pre>\"banner_title\"</pre> |\n| `type` | Yes | The [type](#supported-setting-types) of setting. | <pre>\"single_line_text_field\"</pre> |\n| `name` | Yes | The name of the setting. `name` is displayed to the merchant in the checkout editor. | <pre>\"Banner title\"</pre> |\n| `description` | No | The description of the setting. `description` is displayed to the merchant in the checkout editor. | <pre>\"Enter a title for the banner.\"</pre> |\n| `validations` | No | Constraints on the setting input that Shopify validates. | <pre>validations: <br> name = \"max\",<br> value = \"25\"</pre> |"
+          },
+          {
+            "title": "Supported setting types",
+            "sectionContent": "The setting type determines the type of information that the setting can store. The setting types have built-in validation on the setting input. \n\n Settings can have the following types: \n\n| Type | Description | Example value |\n|---|---|---|\n| `boolean` | A true or false value. | <pre>true</pre> |\n| `date` | A date in ISO 8601 format without a presumed time zone. | <pre>2022-02-02</pre> |\n| `date_time` | A date and time in ISO 8601 format without a presumed time zone. | <pre>2022-01-01T12:30:00</pre> |\n| `single_line_text_field` | A single line string. | <pre>Canada</pre> |\n| `multi_line_text_field` | A multi-line string. | <pre>Canada<br>United States<br>Brazil<br>Australia</pre> |\n| `number_integer` | A whole number in the range of +/-9,007,199,254,740,991. | <pre>10</pre> |\n| `number_decimal` | A number with decimal places in the range of +/-9,999,999,999,999.999999999. | <pre>10.4</pre> |\n| `variant_reference` | A globally-unique identifier (GID) for a product variant. | <pre>gid://shopify/ProductVariant/1<pre> |"
+          },
+          {
+            "title": "Validation options",
+            "sectionContent": "Each setting can include validation options. Validation options enable you to apply additional constraints to the data that a setting can store, such as a minimum or maximum value, or a regular expression. The setting's `type` determines the available validation options. \n\n You can include a validation option for a setting using the validation `name` and a corresponding `value`. The appropriate value depends on the setting type to which the validation applies.\n\n The following table outlines the available validation options with supported types for applying constraints to a setting:\n\n | Validation option | Description | Supported types | Example |\n|---|---|---|---|\n| Minimum length | The minimum length of a text value. | <ul><li><code>single_line_text_field</code></li><li><code>multi_line_text_field</code></li></ul> | <pre>[[extensions.settings.fields.validations]]<br> name = \"min\"<br> value = \"8\"</pre> |\n| Maximum length | The maximum length of a text value. | <ul><li><code>single_line_text_field</code></li><li><code>multi_line_text_field</code></li></ul> | <pre>[[extensions.settings.fields.validations]]<br> name = \"max\"<br> value = \"25\"</pre> |\n| Regular expression | A regular expression. Shopify supports [RE2](https://github.com/google/re2/wiki/Syntax). | <ul><li><code>single_line_text_field</code></li><li><code>multi_line_text_field</code></li></ul> | <pre>[[extensions.settings.fields.validations]]<br> name = \"regex\"<br> value = \"(@)(.+)$\"</pre> |\n| Choices | A list of up to 128 predefined options that limits the values allowed for the metafield.  | `single_line_text_field` | <pre>[[extensions.settings.fields.validations]]<br> name = \"choices\"<br> value = \"[\"red\", \"green\", \"blue\"]\"</pre> |\n| Minimum date | The minimum date in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. | `date` | <pre>[[extensions.settings.fields.validations]]<br> name = \"min\"<br> value = \"2022-01-01\"</pre> |\n| Maximum date | The maximum date in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. | `date` | <pre>[[extensions.settings.fields.validations]]<br> name = \"max\"<br> value = \"2022-03-03\"</pre> |\n| Minimum datetime | The minimum date and time in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. | `date_time` | <pre>[[extensions.settings.fields.validations]]<br> name = \"min\"<br> value = \"2022-03-03T16:30:00\"</pre> |\n| Maximum datetime | The maximum date and time in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. |  `date_time` | <pre>[[extensions.settings.fields.validations]]<br> name = \"max\"<br> value = \"2022-03-03T17:30:00\"</pre> |\n| Minimum integer | The minimum integer number. | `number_integer` | <pre>[[extensions.settings.fields.validations]]<br> name = \"min\"<br> value = \"9\"</pre> |\n| Maximum integer | The maximum integer number. | `number_integer` | <pre>[[extensions.settings.fields.validations]]<br> name = \"max\"<br> value = \"15\"</pre> |\n| Minimum decimal | The minimum decimal number. |  `number_decimal` | <pre>[[extensions.settings.fields.validations]]<br> name = \"min\"<br> value = \"0.5\"</pre> |\n| Maximum decimal | The maximum decimal number. |  `number_decimal` | <pre>[[extensions.settings.fields.validations]]<br> name = \"max\"<br> value = \"1.99\"</pre> |\n| Maximum precision | The maximum number of decimal places to store for a decimal number. | `number_decimal` | <pre>[[extensions.settings.fields.validations]]<br> name = \"max_precision\"<br> value = \"2\"</pre> |"
+          }
+        ]
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "example-settings-definition",
+        "title": "Example settings definition",
+        "sectionContent": "The following example shows a settings definition that defines a setting named `banner_title` of type `single_line_text_field`. When the merchant sets a value for this setting from the checkout editor, Shopify validates that the provided value is between 5 and 20 characters in length \n\n Learn more about the settings api by completing our [custom banners example](/apps/checkout/custom-banners/add-custom-banner).",
+        "sectionCard": [
+          {
+            "name": "Settings example code",
+            "subtitle": "See",
+            "url": "/docs/api/checkout-ui-extensions/apis/standardapi#example-settings",
+            "type": "blocks"
+          }
+        ],
+        "codeblock": {
+          "title": "Example settings",
+          "tabs": [
+            {
+              "title": "shopify.extension.toml",
+              "code": "api_version = \"2023-07\"\n\n[[extensions]]\ntype = \"ui_extension\"\nname = \"My checkout extension\"\nhandle = \"checkout-ui\"\n\n[extensions.settings]\n\n[[extensions.settings.fields]]\nkey = \"banner_title\"\ntype = \"single_line_text_field\"\nname = \"Banner title\"\ndescription = \"Enter a title for the banner.\"\n\n[[extensions.settings.fields.validations]]\nname = \"min\"\nvalue = \"5\"\n[[extensions.settings.fields.validations]]\nname = \"max\"\nvalue = \"20\"\n",
+              "language": "toml"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "title": "Error handling",
+    "description": "You can use standard web techniques to handle errors in [checkout UI extensions](/api/checkout-ui-extensions/) but you may need to account for how they run inside of a [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).",
+    "id": "error-handling",
+    "sections": [
+      {
+        "type": "Generic",
+        "anchorLink": "handling-any-error",
+        "title": "Handling any error",
+        "sectionContent": "Add an `unhandledrejection` listener for promise rejections or an `error` listener for other exceptions like Javascript runtime errors or failures to load a resource.",
+        "codeblock": {
+          "title": "Handling any error",
+          "tabs": [
+            {
+              "code": "// For unhandled promise rejections\nself.addEventListener(\n  'unhandledrejection',\n  (error) =&gt; {\n    console.warn(\n      'event unhandledrejection',\n      error,\n    );\n  },\n);\n\n// For other exceptions\nself.addEventListener('error', (error) =&gt; {\n  console.warn('event error', error);\n});\n",
+              "language": "ts"
+            }
+          ]
+        }
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "third-party-libraries",
+        "title": "Third party libraries",
+        "sectionContent": "\nYou can use error reporting libraries like [Bugsnag](https://www.bugsnag.com/) or [Sentry](https://sentry.io/). However, they might require extra configuration because UI extensions run inside of a [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).\n\n> Tip:\n> You must request [network access](/api/checkout-ui-extensions/configuration#network-access) to transmit errors to a third party service.\n"
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "sentry",
+        "title": "Sentry (recommended)",
+        "sectionContent": "\nInitialize Sentry following their [Web Worker guide](https://docs.sentry.io/platforms/javascript/configuration/webworkers/). We recommend disabling the default integrations to be sure it will run within a Web Worker. You'll need to add event listeners manually.\n\nIf you are writing your UI extension in React, you can follow Sentry's [React integration guide](https://docs.sentry.io/platforms/javascript/guides/react/) to get additional context on errors thrown while rendering your components. Integrations like tracing do not currently run in Web Workers ([issue](https://github.com/getsentry/sentry-javascript/issues/5289)).",
+        "codeblock": {
+          "title": "Sentry",
+          "tabs": [
+            {
+              "code": "import {\n  reactExtension,\n  Banner,\n} from '@shopify/ui-extensions-react/checkout';\nimport * as Sentry from '@sentry/browser';\n\nSentry.init({\n  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',\n  defaultIntegrations: false,\n});\n\nself.addEventListener(\n  'unhandledrejection',\n  (error) =&gt; {\n    Sentry.captureException(\n      new Error(error.reason.stack),\n    );\n  },\n);\n\nself.addEventListener('error', (error) =&gt; {\n  Sentry.captureException(\n    new Error(error.reason.stack),\n  );\n});\n\n// Your normal extension code.\nexport default reactExtension(\n  'purchase.checkout.block.render',\n  () =&gt; &lt;Extension /&gt;,\n);\n\nfunction Extension() {\n  return &lt;Banner&gt;Your extension&lt;/Banner&gt;;\n}\n",
+              "language": "ts"
+            }
+          ]
+        }
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "bugsnag",
+        "title": "Bugsnag",
+        "sectionContent": "\nFollow [Bugsnag's documentation](https://docs.bugsnag.com/platforms/javascript/) to install it for your extension. Bugsnag adds event listeners by default so there's no need to add them manually.\n\nIf you use the [CDN version](https://docs.bugsnag.com/platforms/javascript/cdn-guide/), you'll need to add polyfill code (see example) before importing Bugsnag because it tries to access some variables that are not available in Web Workers ([details](https://github.com/bugsnag/bugsnag-js/issues/1506)).\n\nIf you are writing your UI extension in React, you can follow Bugsnag's [React integration guide](https://docs.bugsnag.com/platforms/javascript/legacy/react/) to get additional context on errors thrown while rendering your components.",
+        "codeblock": {
+          "title": "Bugsnag",
+          "tabs": [
+            {
+              "code": "/**\n * The CDN version of Bugsnag requires this polyfill.\n */\n(() =&gt; {\n  const document = {\n    documentElement: {\n      outerHTML: '',\n      createElement: () =&gt; ({}),\n      clientWidth: 0,\n      clientHeight: 0,\n    },\n    addEventListener: () =&gt; {},\n  };\n  const history = {};\n  const window = self;\n  self.window = window;\n  window.document = document;\n  window.history = history;\n})();\n",
+              "language": "ts"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "title": "Targets Overview",
+    "description": "\nA [target](/docs/apps/app-extensions/configuration#targets) represents where your checkout UI extension will appear.\n\nYou register for targets in your [configuration file](/docs/api/checkout-ui-extensions/configuration), and you include a JavaScript function that will run at that location in checkout.\n  ",
+    "id": "extension-targets-overview",
+    "sections": [
+      {
+        "type": "GenericAccordion",
+        "title": "Checkout locations",
+        "anchorLink": "supported-locations",
+        "sectionContent": "Checkout is where buyers go to purchase goods. Checkout consists of the information, shipping, and payment steps in addition to the order summary and Shop Pay. Learn more about building [custom functionality for checkout](/docs/api/checkout-ui-extensions).",
+        "accordionContent": [
+          {
+            "title": "Information",
+            "description": "\nThis is the first step in the checkout process where the buyer enters contact information and a delivery address.\n\nSee [all extensions targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-information.png"
+          },
+          {
+            "title": "Shipping",
+            "description": "\nPoint in checkout where the buyer selects a shipping method.\n\nSee [all extensions targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-shipping.png"
+          },
+          {
+            "title": "Payment",
+            "description": "\nPoint in checkout where the buyer enters their payment information.\n\nSee [all extensions targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-payment.png"
+          },
+          {
+            "title": "Order summary",
+            "description": "\nSummary of the cart contents, discounts, and order totals.\n\nSee [all extensions targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-order-summary.png"
+          },
+          {
+            "title": "Shop Pay",
+            "description": "\nAccelerated checkout where Shopify pre-fills buyer information using their Shop Pay account.\n\nSee [all extensions targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-shop-pay.png"
+          },
+          {
+            "title": "Local Pickup",
+            "description": "\nPoint in checkout where the buyer can select a store location to pick up their purchase.\n\nSee [all extensions targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-local-pickup.png"
+          },
+          {
+            "title": "Pickup Points",
+            "description": "\nPoint in checkout where the buyer can select a pickup point to have their purchase delivered to.\n\nSee [all extensions targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-pickup-points.png"
+          },
+          {
+            "title": "One-page checkout",
+            "description": "\nAll checkout pages (information, shipping, and payment) are combined into a single page with the order summary.\n\nGet started testing extensions on [one-page checkout](/docs/apps/checkout/best-practices/testing-ui-extensions#one-page-checkout).\n",
+            "image": "supported-locations-one-page-checkout.png"
+          }
+        ]
+      },
+      {
+        "type": "GenericAccordion",
+        "title": "Thank you locations",
+        "anchorLink": "supported-typ-locations",
+        "sectionContent": "The thank you page is shown to buyers immediately after a checkout is successfully submitted. Learn more about building for [the thank you page](/docs/apps/checkout/thank-you-order-status).",
+        "accordionContent": [
+          {
+            "title": "Order details",
+            "description": "\nDisplays all order information to buyers.\n\nSee [all thank you page extension targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-thank-you.png"
+          },
+          {
+            "title": "Order summary",
+            "description": "\nSummary of the cart contents, discounts, and order totals.\n\nSee [all thank you page extensions targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-order-summary-thank-you.png"
+          }
+        ]
+      },
+      {
+        "type": "GenericAccordion",
+        "title": "Order status locations",
+        "anchorLink": "supported-osp-locations",
+        "sectionContent": "The order status page is shown to buyers when they return to a completed checkout for order updates. Learn more about building for [the order status page](/docs/apps/checkout/thank-you-order-status).",
+        "accordionContent": [
+          {
+            "title": "Order details",
+            "description": "\nDisplays all order information to buyers.\n\nSee [all order status page extension targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-order-status.png"
+          },
+          {
+            "title": "Order summary",
+            "description": "\nSummary of the cart contents, discounts, and order totals.\n\nSee [all order status page extensions targets](/docs/api/checkout-ui-extensions/targets).\n",
+            "image": "supported-locations-order-summary-order-status.png"
+          }
+        ]
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "static-extension-targets",
+        "title": "Static extension targets",
+        "image": "static-extension-targets.png",
+        "sectionContent": "Static extension targets render immediately before or after most core checkout features such as contact information, shipping methods, and order summary line items. Merchants use the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor) to activate and place the extension in the checkout experience.\n      \n\nWhen a core checkout feature isn't rendered, neither are the static extension targets tied to it. For example, shipping methods aren't shown when customers select the option for store pickup and the UI extensions that load before or after the shipping method aren't rendered.\n      \n\nChoose static extension targets when your content and functionality is closely related to a core checkout feature. An example is a shipping delay notice.\n      ",
+        "sectionCard": [
+          {
+            "name": "Extension targets",
+            "subtitle": "API reference",
+            "url": "/docs/api/checkout-ui-extensions/targets",
+            "type": "blocks"
+          }
+        ]
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "block-extension-targets",
+        "title": "Block extension targets",
+        "sectionContent": "Block extension targets render between core checkout features. Merchants can use the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor) to place the extension in the [checkout](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations), [thank you](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-typ-locations), or [order status](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-osp-locations) pages.\n      \n\nBlock extensions are always rendered, regardless of what other elements of the checkout are present. For example, an extension placed above the shipping address will still render even for digital products which do not require a shipping address.\n\nChoose block extension targets when your content and functionality works independently of a core checkout feature. This is useful for custom content, like a field to capture order notes from the customer.",
+        "image": "block-extension-targets.png",
+        "sectionCard": [
+          {
+            "name": "Extension targets",
+            "subtitle": "API reference",
+            "url": "/docs/api/checkout-ui-extensions/targets",
+            "type": "blocks"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "title": "Checkout UI extensions",
+    "description": "Checkout UI extensions let app developers build custom functionality that merchants can install\n    at defined points in the checkout flow, including product information, shipping, payment,\n    order summary, and Shop Pay.\n    \n\n > Shopify Plus: \n>Checkout UI extensions for the information, shipping and payment step are available only to stores on a [Shopify Plus](https://www.shopify.com/plus) plan.",
+    "id": "checkout-ui-extensions",
+    "image": "/assets/landing-pages/templated-apis/checkout-ui-extensions/checkout-ui.png",
+    "darkImage": "/assets/landing-pages/templated-apis/checkout-ui-extensions/checkout-ui-dark.png",
+    "mobileImage": "/assets/landing-pages/templated-apis/checkout-ui-extensions/checkout-ui-mobile.png",
+    "mobileDarkImage": "/assets/landing-pages/templated-apis/checkout-ui-extensions/checkout-ui-mobile-dark.png",
+    "sections": [
+      {
+        "type": "Generic",
+        "anchorLink": "scaffolding-extension",
+        "title": "Scaffolding an extension",
+        "sectionContent": "Use Shopify CLI to [generate a new extension](/apps/tools/cli/commands#generate-extension) in the directory of your app.",
+        "sectionCard": [
+          {
+            "name": "Getting started video",
+            "subtitle": "Watch",
+            "url": "https://www.youtube.com/watch?v=jr_AIUDUSMw",
+            "type": "youtube"
+          }
+        ],
+        "codeblock": {
+          "title": "Scaffolding",
+          "tabs": [
+            {
+              "title": "npm",
+              "code": "npm init @shopify/app@latest\ncd your-app\nnpm run shopify app generate extension\n",
+              "language": "bash"
+            },
+            {
+              "title": "yarn",
+              "code": "yarn create @shopify/app\ncd your-app\nyarn shopify app generate extension\n",
+              "language": "bash"
+            },
+            {
+              "title": "pnpm",
+              "code": "pnpm create @shopify/app\ncd your-app\npnpm shopify app generate extension\n",
+              "language": "bash"
+            }
+          ]
+        },
+        "initialLanguage": "bash"
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "extension-targets",
+        "title": "Extension Targets",
+        "sectionContent": "Extension targets provide locations where merchants can insert custom content.\n        Static extension targets are tied to core checkout features like contact information, shipping methods, and order summary line items.\n        Block extension targets can be displayed at any point in the checkout process and will always render regardless of which checkout features are available.\n        An example is a field to capture order notes from the customer.\n        \n\nExtension UIs are rendered using [remote UI](https://github.com/Shopify/remote-ui),\n        a fast and secure environment for custom [(non-DOM)](#constraints) UIs.",
+        "sectionCard": [
+          {
+            "name": "Extension targets",
+            "subtitle": "Overview",
+            "url": "/docs/api/checkout-ui-extensions/extension-targets-overview",
+            "type": "blocks"
+          }
+        ],
+        "image": "extension-targets.png",
+        "codeblock": {
+          "title": "Extension targets",
+          "tabs": [
+            {
+              "title": "React",
+              "code": "import {\n  reactExtension,\n  Banner,\n} from '@shopify/ui-extensions-react/checkout';\n\nexport default reactExtension(\n  'purchase.checkout.block.render',\n  () =&gt; &lt;Extension /&gt;,\n);\n\nfunction Extension() {\n  return &lt;Banner&gt;Your extension&lt;/Banner&gt;;\n}\n",
+              "language": "tsx"
+            },
+            {
+              "title": "JS",
+              "code": "import {\n  extension,\n  Banner,\n} from '@shopify/ui-extensions/checkout';\n\nexport default extension(\n  'purchase.checkout.block.render',\n  (root, api) =&gt; {\n    const banner = root.createComponent(\n      Banner,\n      {},\n      'Your extension',\n    );\n    root.appendChild(banner);\n  },\n);\n",
+              "language": "js"
+            }
+          ]
+        },
+        "initialLanguage": "tsx"
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "configuration-file",
+        "title": "Configuration file",
+        "sectionContent": "When you create a checkout UI extension, the `shopify.extension.toml` file is automatically generated in your checkout UI extension directory.  It contains the extension's configuration, which includes the extension name, extension targets, metafields, capabilities, and settings definition.",
+        "sectionCard": [
+          {
+            "name": "Configuration guide",
+            "subtitle": "Learn more",
+            "url": "/docs/api/checkout-ui-extensions/configuration",
+            "type": "gear"
+          }
+        ],
+        "codeblock": {
+          "title": "shopify.extension.toml",
+          "tabs": [
+            {
+              "title": "toml",
+              "code": "api_version = \"2023-07\"\n\n[[extensions]]\ntype = \"ui_extension\"\nname = \"My checkout extension\"\nhandle = \"checkout-ui\"\n\n  [[extensions.targeting]]\n  target = \"purchase.checkout.block.render\"\n  module = \"./Checkout.jsx\"\n\n",
+              "language": "toml"
+            }
+          ]
+        },
+        "initialLanguage": "yaml"
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "extension-apis",
+        "title": "Extension APIs",
+        "sectionContent": "APIs enable checkout UI extensions to get information about the checkout or related objects and to perform actions. For example, you can use the APIs to retrieve what's in customer carts so that you can offer related products. \n\nExtensions use JavaScript to read and write data and call external services, and natively render UIs built using Shopify's checkout components.",
+        "sectionCard": [
+          {
+            "name": "Checkout extensions API",
+            "subtitle": "API reference",
+            "url": "/docs/api/checkout-ui-extensions/apis",
+            "type": "blocks"
+          }
+        ],
+        "codeblock": {
+          "title": "Extension APIs",
+          "tabs": [
+            {
+              "title": "React",
+              "code": "import {\n  reactExtension,\n  useShippingAddress,\n  Banner,\n} from '@shopify/ui-extensions-react/checkout';\n\nexport default reactExtension(\n  'purchase.checkout.delivery-address.render-before',\n  () =&gt; &lt;Extension /&gt;,\n);\n\nfunction Extension() {\n  const {countryCode} = useShippingAddress();\n\n  if (countryCode !== 'CA') {\n    return (\n      &lt;Banner&gt;\n        Sorry, we can only ship to Canada at this\n        time\n      &lt;/Banner&gt;\n    );\n  }\n}\n",
+              "language": "tsx"
+            },
+            {
+              "title": "JS",
+              "code": "import {\n  extension,\n  Banner,\n} from '@shopify/ui-extensions/checkout';\n\nexport default extension(\n  'purchase.checkout.delivery-address.render-before',\n  (root, api) =&gt; {\n    renderApp(root, api);\n\n    api.shippingAddress.subscribe(() =&gt;\n      renderApp(root, api),\n    );\n  },\n);\n\nfunction renderApp(root, api) {\n  const {countryCode} =\n    api.shippingAddress.current;\n\n  // In case of a re-render, remove previous children.\n  for (const child of root.children) {\n    root.removeChild(child);\n  }\n\n  if (countryCode !== 'CA') {\n    const banner = root.createComponent(\n      Banner,\n      {},\n      'Sorry, we can only ship to Canada at this time',\n    );\n    root.appendChild(banner);\n  }\n}\n",
+              "language": "js"
+            }
+          ]
+        },
+        "initialLanguage": "tsx"
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "ui-components",
+        "title": "UI components",
+        "image": "ui-components.gif",
+        "sectionContent": "Checkout UI extensions declare their interface using supported UI components. Shopify renders the UI natively, so it's performant, accessible, and works in all of checkout's supported browsers. \n\nCheckout components are designed to be flexible, enabling you to layer and mix them to create highly-customized app extensions that feel seamless within the checkout experience. All components inherit a merchant's brand settings and the CSS cannot be altered or overridden.",
+        "sectionCard": [
+          {
+            "name": "Component library",
+            "subtitle": "API reference",
+            "url": "/docs/api/checkout-ui-extensions/components",
+            "type": "blocks"
+          },
+          {
+            "name": "Figma UI kit",
+            "subtitle": "UI Reference",
+            "url": "https://www.figma.com/community/file/1121180079120732846",
+            "type": "setting"
+          }
+        ],
+        "codeblock": {
+          "title": "UI components",
+          "tabs": [
+            {
+              "title": "React",
+              "code": "import {\n  reactExtension,\n  BlockStack,\n  InlineStack,\n  Button,\n  Image,\n  Text,\n} from '@shopify/ui-extensions-react/checkout';\n\nexport default reactExtension(\n  'purchase.checkout.block.render',\n  () =&gt; &lt;Extension /&gt;,\n);\n\nfunction Extension() {\n  return (\n    &lt;InlineStack&gt;\n      &lt;Image source=\"/url/for/image\" /&gt;\n      &lt;BlockStack&gt;\n        &lt;Text size=\"large\"&gt;Heading&lt;/Text&gt;\n        &lt;Text size=\"small\"&gt;Description&lt;/Text&gt;\n      &lt;/BlockStack&gt;\n      &lt;Button\n        onPress={() =&gt; {\n          console.log('button was pressed');\n        }}\n      &gt;\n        Button\n      &lt;/Button&gt;\n    &lt;/InlineStack&gt;\n  );\n}\n",
+              "language": "tsx"
+            },
+            {
+              "title": "JS",
+              "code": "import {\n  extension,\n  BlockStack,\n  Button,\n  Image,\n  InlineStack,\n  Text,\n} from '@shopify/ui-extensions/checkout';\n\nexport default extension(\n  'purchase.checkout.block.render',\n  (root, api) =&gt; {\n    const inlineStack = root.createComponent(\n      InlineStack,\n      {},\n      [\n        root.createComponent(Image, {\n          source: '/url/for/image',\n        }),\n        root.createComponent(BlockStack, {}, [\n          root.createComponent(\n            Text,\n            {size: 'large'},\n            'Heading',\n          ),\n          root.createComponent(\n            Text,\n            {size: 'small'},\n            'Description',\n          ),\n        ]),\n        root.createComponent(\n          Button,\n          {\n            onPress: () =&gt; {\n              console.log('button was pressed');\n            },\n          },\n          'Button',\n        ),\n      ],\n    );\n\n    root.appendChild(inlineStack);\n  },\n);\n",
+              "language": "js"
+            }
+          ]
+        },
+        "initialLanguage": "tsx"
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "security",
+        "title": "Security",
+        "sectionContent": "\nCheckout UI extensions are a safe and secure way to customize the appearance and functionality of the checkout page without compromising the security of checkout or customer data.\n- They run in an isolated sandbox, separate from the checkout page and other UI extensions.\n- They don't have access to sensitive payment information or the checkout page itself (HTML or other assets).\n- They are limited to specific UI components and APIs that are exposed by the platform.\n- They have limited access to [global web APIs](https://github.com/Shopify/ui-extensions/blob/unstable/documentation/runtime-environment.md).\n- Apps that wish to access [protected customer data](/docs/apps/store/data-protection/protected-customer-data), must submit an application and are subject to strict security guidelines and review proccesses by Shopify.\n",
+        "sectionNotice": [
+          {
+            "title": "Constraints",
+            "sectionContent": "\nYou can't override the CSS for UI components. The checkout UI will always render the merchant's own branding as shown in the image in the UI components section above.\n\nCheckout UI extensions don't have access to the DOM and can't return DOM nodes. They can't return `<div>` elements, for example. Building an arbitrary tree of HTML and loading additional scripts using script tags are also not supported.\n",
+            "type": "info"
+          }
+        ],
+        "sectionCard": [
+          {
+            "name": "Rendering extensions",
+            "subtitle": "Learn more",
+            "url": "https://shopify.engineering/remote-rendering-ui-extensibility",
+            "type": "tutorial"
+          },
+          {
+            "name": "Checkout styling",
+            "subtitle": "Learn more",
+            "url": "/docs/apps/checkout/styling",
+            "type": "tutorial"
+          }
+        ]
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "troubleshooting",
+        "title": "Troubleshooting",
+        "sectionContent": "Find an end-to-end guide to testing your extensions in [Testing checkout UI extensions](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).\n\nIf you're encountering errors when you run `dev` for an app that contains checkout UI extensions, follow this [troubleshooting guide](/apps/checkout/delivery-instructions/getting-started#troubleshooting).",
+        "sectionCard": [
+          {
+            "name": "Troubleshooting guide",
+            "subtitle": "Learn more",
+            "url": "/apps/checkout/delivery-instructions/getting-started#troubleshooting",
+            "type": "apps"
+          }
+        ]
+      },
+      {
+        "type": "Resource",
+        "anchorLink": "resources",
+        "title": "Resources",
+        "resources": [
+          {
+            "name": "remote-ui",
+            "subtitle": "Learn more about the underlying technology that powers checkout UI extensions.",
+            "url": "https://github.com/Shopify/remote-ui",
+            "type": "gitHub"
+          },
+          {
+            "name": "UX guidelines",
+            "subtitle": "Use our UX guidelines when you're designing your checkout experiences to ensure that they're trustworthy, efficient, and considerate.",
+            "url": "/apps/checkout/checkout-ux-guidelines",
+            "type": "star"
+          },
+          {
+            "name": "Localization",
+            "subtitle": "You can use JavaScript APIs to access translations and localize UI extensions for international merchants and customers.",
+            "url": "/apps/checkout/localize-ui-extensions",
+            "type": "globe"
+          },
+          {
+            "name": "Tutorials",
+            "subtitle": "Check out our tutorials on how to build payment or delivery customizations, product offers, custom banners and more.",
+            "url": "/apps/checkout",
+            "type": "growth"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "title": "API versioning and unified UI extensions",
+    "description": "\nAs of Summer Editions 2023 (July 26), we have introduced some important changes to checkout UI extensions:\n\n- The introduction of API versioning and the [associated API versioning strategy](/docs/api/usage/versioning)\n- Changes to the configuration `toml` file that match the format for other app extensions\n- `extension points` have been renamed to `targets`\n\nFor more details on the above, [please visit our post on the ui-extensions public repository](https://github.com/Shopify/ui-extensions/discussions/1161)\n",
+    "id": "versioning-migration",
+    "sections": [
+      {
+        "type": "Markdown",
+        "anchorLink": "what-changed-in-the-toml-file",
+        "title": "What changed in the toml file",
+        "sectionContent": "\nThe main changes you will need to make will be to your configuration file (`shopify.ui.extension.toml`). We changed a few of the fields you currently use to configure a UI extension:\n\n- `type`, which currently is set to `checkout_ui_extension`, must be updated to `ui_extension`\n- `extension_points` is now `[[extensions.targeting]]` and is expanded to include additional details. Most notably, you will need to provide a `module`, which is a reference to the file in your project that implements the extension. `metafields` that you will query must also now be specified per-extension point\n- a new mandatory field: `api_version`. This field must be a Shopify API version, in the same format you would use for [Shopify's REST and GraphQL APIs](https://shopify.dev/api/usage/versioning). This version will control what extension points, components, and APIs are available to your extension, and will come with the same 1 year (minimum) guarantee as our other APIs. The first public API version for checkout UI extensions was `2023-07`\n- `handle`, which should be set in the nested `extensions` level of your configuration file. This is a unique identifier for your extension, and will be used to reference it from other extensions. We recommend using dash casing for the handle (for example, `my-extension` for an extension named \"My extension\")\n- `shopify.ui.extension.toml` is now `shopify.extension.toml`\n"
+      },
+      {
+        "type": "GenericAccordion",
+        "anchorLink": "converting-the-extension-configuration-file",
+        "title": "Update the configuration file",
+        "sectionContent": "\nFirst, rename your `shopify.ui.extension.toml` file to `shopify.extension.toml`.\n\nNext, update the extension configuration file to the new format. To make it easier for the CLI to detect which extensions are being migrated to the new format, you should have the directory name of the extension match the new `handle` field you provide. We recommend making both the directory name and `handle` fields be the handle-cased version of your extension name (for example, `my-extension` for an extension with `name = \"My extension\"`).\n",
+        "accordionContent": [
+          {
+            "title": "Previous shopify.ui.extension.toml",
+            "description": "",
+            "codeblock": {
+              "title": "Previous shopify.ui.extension.toml",
+              "tabs": [
+                {
+                  "title": "shopify.ui.extension.toml",
+                  "code": "type = \"checkout_ui_extension\"\nname = \"My Extension\"\n\nextension_points = ['Checkout::Dynamic::Render']\n\n[[metafields]]\nnamespace = \"my_namespace\"\nkey = \"my_key\"\n\n[settings]\n[[settings.fields]]\nkey = \"banner_title\"\ntype = \"single_line_text_field\"\nname = \"Banner title\"\ndescription = \"Enter a title for the banner\"\n",
+                  "language": "toml"
+                }
+              ]
+            }
+          },
+          {
+            "title": "New shopify.extension.toml",
+            "description": "",
+            "codeblock": {
+              "title": "New shopify.extension.toml",
+              "tabs": [
+                {
+                  "title": "shopify.extension.toml",
+                  "code": "api_version = \"2023-10\"\n\n[[extensions]]\ntype = \"ui_extension\"\nname = \"My Extension\"\nhandle = \"my-extension\"\n\n[[extensions.targeting]]\nmodule = \"./src/index.ts\"\ntarget = \"purchase.checkout.block.render\"\n\n[[extensions.metafields]]\nnamespace = \"my_namespace\"\nkey = \"my_key\"\n\n[extensions.settings]\n[[extensions.settings.fields]]\nkey = \"banner_title\"\ntype = \"single_line_text_field\"\nname = \"Banner title\"\ndescription = \"Enter a title for the banner\"\n",
+                  "language": "toml"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "GenericAccordion",
+        "anchorLink": "packages",
+        "title": "Update the packages",
+        "sectionContent": "\nWe will be moving to a new set of packages for distributing UI extension APIs — `@shopify/checkout-ui-extensions` and `@shopify/checkout-ui-extensions-react` will be replaced with `@shopify/ui-extensions/checkout` and `@shopify/ui-extensions-react/checkout`. These new packages will allow you to implement extensions for multiple surfaces without requiring multiple dependencies. You'll need to update any import for the existing packages with the new package.\n\nIn your `package.json`, replace any `@shopify/checkout-ui-extensions` package with the `@shopify/ui-extensions` equivalent.\n\nYou will notice that the UI extension packages have a new versioning system. In the new versions, the \"major\" version number is the API version year (e.g., `2023`), the \"minor\" version number is the API version month (e.g., `10` for `2023.10`), and the \"patch\" version number is reserved by Shopify for making bugfixes on the contents of the package (e.g. `.1` for `2023.10.1`). You will need to match the version of the package you install to the API version your extension targets, so that you get access to the types and runtime utilities associated with that API version. We recommend using a version that locks in the major and minor version numbers, and allows the patch version to be updated, like the `2023.10.x` version range shown above.\n\n> Caution:\n> Versions `2023.07.x` and later have a couple breaking changes compared to the `0.27.x` range of the `@shopify/checkout-ui-extensions(-react)` packages. If you want to upgrade to the new API versioning system, but continue to use the APIs you were using before without any changes, we also provide a `2023.4.x` version range that contains the same APIs as the `0.27.x` range of the old packages.\n",
+        "accordionContent": [
+          {
+            "title": "Previous package.json",
+            "description": "",
+            "codeblock": {
+              "title": "Previous package.json",
+              "tabs": [
+                {
+                  "title": "package.json",
+                  "code": "{\n  \"dependencies\": {\n    \"@shopify/checkout-ui-extensions\": \"^0.27.0\",\n    \"@shopify/checkout-ui-extensions-react\": \"^0.27.0\"\n  }\n}\n",
+                  "language": "json"
+                }
+              ]
+            }
+          },
+          {
+            "title": "New package.json",
+            "description": "",
+            "codeblock": {
+              "title": "New package.json",
+              "tabs": [
+                {
+                  "title": "package.json",
+                  "code": "{\n  \"dependencies\": {\n    \"@shopify/ui-extensions\": \"2023.10.x\",\n    \"@shopify/ui-extensions-react\": \"2023.10.x\"\n  }\n}\n",
+                  "language": "json"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "GenericAccordion",
+        "anchorLink": "extension-points",
+        "title": "Update the extension points",
+        "sectionContent": "\nFinally, the new format has a slightly different system for registering your extension target code. The file you list as the `module` for a given extension target **must** export your extension target code as the default export from the module.",
+        "accordionContent": [
+          {
+            "title": "Previous code (JavaScript)",
+            "description": "",
+            "codeblock": {
+              "title": "Previous index.ts",
+              "tabs": [
+                {
+                  "title": "index.ts",
+                  "code": "import {\n  extend,\n  Banner,\n} from '@shopify/checkout-ui-extensions';\n\nextend(\n  'Checkout::Dynamic::Render',\n  (root, {extensionPoint, i18n}) =&gt; {\n    root.appendChild(\n      root.createComponent(\n        Banner,\n        {title: 'My extension'},\n        i18n.translate('welcome', {\n          extensionPoint,\n        }),\n      ),\n    );\n  },\n);\n",
+                  "language": "ts"
+                }
+              ]
+            }
+          },
+          {
+            "title": "New code (JavaScript)",
+            "description": "",
+            "codeblock": {
+              "title": "New index.ts",
+              "tabs": [
+                {
+                  "title": "index.ts",
+                  "code": "import {\n  extension,\n  Banner,\n} from '@shopify/ui-extensions/checkout';\n\nexport default extension(\n  'purchase.checkout.block.render',\n  (root, {extension, i18n}) =&gt; {\n    root.append(\n      root.createComponent(\n        Banner,\n        {title: 'My extension'},\n        i18n.translate('welcome', {\n          target: extension.target,\n        }),\n      ),\n    );\n  },\n);\n",
+                  "language": "ts"
+                }
+              ]
+            }
+          },
+          {
+            "title": "Previous code (React)",
+            "description": "",
+            "codeblock": {
+              "title": "Previous index.tsx",
+              "tabs": [
+                {
+                  "title": "index.tsx",
+                  "code": "import {\n  useApi,\n  render,\n  Banner,\n  useTranslate,\n} from '@shopify/checkout-ui-extensions-react';\n\nrender('Checkout::Dynamic::Render', () =&gt; (\n  &lt;Extension /&gt;\n));\n\nfunction Extension() {\n  const {extensionPoint} = useApi();\n  const translate = useTranslate();\n\n  return (\n    &lt;Banner title=\"luxury-trade-ext\"&gt;\n      {translate('welcome', {extensionPoint})}\n    &lt;/Banner&gt;\n  );\n}\n",
+                  "language": "tsx"
+                }
+              ]
+            }
+          },
+          {
+            "title": "New code (React)",
+            "description": "",
+            "codeblock": {
+              "title": "New index.tsx",
+              "tabs": [
+                {
+                  "title": "index.tsx",
+                  "code": "import {\n  reactExtension,\n  useApi,\n  Banner,\n  useTranslate,\n} from '@shopify/ui-extensions-react/checkout';\n\nexport default reactExtension(\n  'purchase.checkout.block.render',\n  () =&gt; &lt;Extension /&gt;,\n);\n\nfunction Extension() {\n  const {extension} = useApi();\n  const translate = useTranslate();\n\n  return (\n    &lt;Banner title=\"luxury-trade-ext\"&gt;\n      {translate('welcome', {\n        target: extension.target,\n      })}\n    &lt;/Banner&gt;\n  );\n}\n",
+                  "language": "tsx"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "migrate",
+        "title": "Migrate your extensions",
+        "sectionContent": "\nDeploy after applying the above changes to get your extensions migrated.\n> Note:\n> You will need to update your `@shopify/app` and `@shopify/cli` packages to version `3.48.0` or later in order to migrate to the `ui_extensions` package types.\n",
+        "codeblock": {
+          "title": "Deploy",
+          "tabs": [
+            {
+              "title": "Deploy",
+              "code": "❯ yarn deploy\nyarn run v1.22.19\n$ shopify app deploy\n\n╭─ info ───────────────────────────────────────────────────────────────────────────────────────────────╮\n│                                                                                                      │\n│  Extension migrations can't be undone.                                                               │\n│                                                                                                      │\n│  Your \"my-extension\" configuration has been updated. Migrating gives you access to new               │\n│  features and won't impact the end user experience. All previous extension versions will reflect     │\n│  this change.                                                                                        │\n│                                                                                                      │\n╰──────────────────────────────────────────────────────────────────────────────────────────────────────╯\n\n?  Migrate \"my-extension\"?\n\n&gt;  (y) Yes, confirm migration from \"checkout_ui_extension\"\n   (n) No, cancel\n",
+              "language": "plaintext"
+            }
+          ]
+        }
+      },
+      {
+        "type": "Markdown",
+        "anchorLink": "extension-targets-list",
+        "title": "Reference: extension point to extension target",
+        "sectionContent": "\nExtension targets are more flexible and powerful than extension points and they allow to link UI extensions with functions.\n\n| Extension point name  | Extension target name |\n|---|---|\n| Checkout::Actions::RenderBefore | purchase.checkout.actions.render-before |\n| Checkout::CartLineDetails::RenderAfter | purchase.checkout.cart-line-item.render-after |\n| Checkout::CartLines::RenderAfter | purchase.checkout.cart-line-list.render-after |\n| Checkout::Contact::RenderAfter | purchase.checkout.contact.render-after |\n| Checkout::DeliveryAddress::RenderBefore | purchase.checkout.delivery-address.render-before |\n| Checkout::Dynamic::Render | purchase.checkout.block.render |\n| Checkout::GiftCard::Render | purchase.checkout.gift-card.render |\n| Checkout::OrderStatus::CartLineDetails::RenderAfter | customer-account.order-status.cart-line-item.render-after |\n| Checkout::OrderStatus::CartLines::RenderAfter | customer-account.order-status.cart-line-list.render-after |\n| Checkout::OrderStatus::Dynamic::Render | customer-account.order-status.block.render |\n| Checkout::PickupLocations::RenderAfter | purchase.checkout.pickup-location-list.render-after |\n| Checkout::PickupLocations::RenderBefore | purchase.checkout.pickup-location-list.render-before |\n| Checkout::PickupPoints::RenderAfter | purchase.checkout.pickup-point-list.render-after |\n| Checkout::PickupPoints::RenderBefore | purchase.checkout.pickup-point-list.render-before |\n| Checkout::Reductions::RenderAfter | purchase.checkout.reductions.render-after |\n| Checkout::Reductions::RenderBefore | purchase.checkout.reductions.render-before |\n| Checkout::ShippingMethodDetails::RenderAfter | purchase.checkout.shipping-option-item.render-after |\n| Checkout::ShippingMethodDetails::RenderExpanded | purchase.checkout.shipping-option-item.details.render |\n| Checkout::ShippingMethods::RenderAfter | purchase.checkout.shipping-option-list.render-after |\n| Checkout::ShippingMethods::RenderBefore | purchase.checkout.shipping-option-list.render-before |\n| Checkout::ThankYou::CartLineDetails::RenderAfter | purchase.thank-you.cart-line-item.render-after |\n| Checkout::ThankYou::CartLines::RenderAfter | purchase.thank-you.cart-line-list.render-after |\n| Checkout::ThankYou::CustomerInformation::RenderAfter | purchase.thank-you.customer-information.render-after |\n| Checkout::ThankYou::Dynamic::Render | purchase.thank-you.block.render |\n"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
### Background

Related to https://github.com/Shopify/ui-extensions-private/issues/2088. This commits the generated docs to source control so that this associated chron job to open a PR on shopify-dev runs to update the docs.

### Solution

Don't ignore the files, and generate the latest one.

### 🎩

We'll need to tophat with the shopify-dev PR that gets created to ensure this is working as we expect.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
