### PR TITLE
added overlay to Page and ResourceItem props

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -83,6 +83,7 @@ export interface Docs_Page_Button_PrimaryAction
   extends Pick<
     ButtonProps,
     | 'onPress'
+    | 'overlay'
     | 'to'
     | 'loading'
     | 'loadingLabel'
@@ -101,6 +102,7 @@ export interface Docs_ResourceItem_Button_Action
   extends Pick<
     ButtonProps,
     | 'onPress'
+    | 'overlay'
     | 'to'
     | 'loading'
     | 'loadingLabel'


### PR DESCRIPTION
### Background

Updating docs for Docs_Page_Button_PrimaryAction and Docs_ResourceItem_Button_Action to include overlay prop

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

[ResourceItem ButtonProps action](https://shopify-dev.overlay-docs.joe-keohan.eu.spin.dev/docs/api/customer-account-ui-extensions/unstable/components/resourceitem#buttonprops%20action)
[Page ButtonProps PrimaryAction](https://shopify-dev.overlay-docs.joe-keohan.eu.spin.dev/docs/api/customer-account-ui-extensions/unstable/components/page#buttonprops%20primaryaction)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
