### PR TITLE
exporting authenticated account hooks

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/index.ts
@@ -33,3 +33,7 @@ export {useExtensionEditor} from './extension-editor';
 export {useDiscountAllocations, useDiscountCodes} from './discounts';
 export {useOrder} from './order';
 export {useAppliedGiftCards} from './gift-cards';
+export {
+  useAuthenticatedAccountCustomer,
+  useAuthenticatedAccountPurchasingCompany,
+} from './authenticated-account';


### PR DESCRIPTION
### Background

The hooks in `packages/ui-extensions-react/src/surfaces/customer-account/hooks/authenticated-account.ts` were not being exported in the corresponding index file so this PR resolves that

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
