### PR TITLE
Suppress TS Error on Global Type in Retail UI Extensions

### DIFF
--- a/packages/retail-ui-extensions/src/globals.ts
+++ b/packages/retail-ui-extensions/src/globals.ts
@@ -10,6 +10,9 @@ export interface ShopifyGlobal {
 
 declare global {
   interface WorkerGlobalScope {
+    // conflicts with build/ts/globals.d.ts
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     readonly shopify: ShopifyGlobal;
   }
 }


### PR DESCRIPTION
### Background

This is a second attempt at a fix for this error when doing TS type checking in POS UI Extensions:
```
node_modules/@shopify/retail-ui-extensions/src/globals.ts:13:14 - error TS2717: Subsequent property declarations must have the same type.  Property 'shopify' must be of type 'ShopifyGlobal', but here has type 'ShopifyGlobal'.

13     readonly shopify: ShopifyGlobal;
                ~~~~~~~

  node_modules/@shopify/retail-ui-extensions/build/ts/globals.d.ts:8:18
    8         readonly shopify: ShopifyGlobal;
                       ~~~~~~~
    'shopify' was also declared here.
```

We attempted a fix in https://github.com/Shopify/ui-extensions/pull/999, but it was reverted because it caused other issues.

### Solution
The solution is simply suppressing any TS errors from this line, to avoid a duplicate declaration error. I see that this was done in a similar part of the code: https://github.com/Shopify/ui-extensions/blob/unstable/packages/ui-extensions/src/surfaces/checkout/globals.ts#L15

### 🎩
We're already "patching" this library with this fix in our repository (DM me for link), so you can see TS running and passing there.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
