### PR TITLE
moving sessionToken into standardApi

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/session-token.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/session-token.ts
@@ -1,5 +1,5 @@
 import {
-  RenderOrderStatusExtensionTarget,
+  RenderExtensionTarget,
   SessionToken,
 } from '@shopify/ui-extensions/customer-account';
 
@@ -10,7 +10,7 @@ import {ExtensionHasNoFieldError} from '../errors';
  * Provides access to session tokens, which can be used to verify token claims on your app's server.
  */
 export function useSessionToken<
-  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
 >(): SessionToken {
   const api = useApi<Target>();
   const extensionTarget = api.extension.target;

--- a/packages/ui-extensions/src/surfaces/customer-account/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api.ts
@@ -9,7 +9,6 @@ export type {
   Product,
   ProductVariant,
   SelectedOption,
-  SessionToken,
   Money,
   Shop,
   Version,
@@ -67,6 +66,7 @@ export type {
   PurchasingCompany,
   Company,
   Customer,
+  SessionToken,
 } from './api/shared';
 
 export type {CartLineItemApi} from './api/cart-line/cart-line-item';

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -31,9 +31,6 @@ export interface Docs_OrderStatus_GiftCardsApi
 export interface Docs_OrderStatus_NoteApi
   extends Pick<OrderStatusApi<any>, 'note'> {}
 
-export interface Docs_OrderStatus_SessionTokenApi
-  extends Pick<OrderStatusApi<any>, 'sessionToken'> {}
-
 export interface Docs_OrderStatus_SettingsApi
   extends Pick<OrderStatusApi<any>, 'settings'> {}
 
@@ -66,6 +63,9 @@ export interface Docs_Standard_VersionApi
 
 export interface Docs_Standard_LocalizationApi
   extends Pick<StandardApi<any>, 'localization' | 'i18n'> {}
+
+export interface Docs_Standard_SessionTokenApi
+  extends Pick<StandardApi<any>, 'sessionToken'> {}
 
 export interface Docs_Standard_StorageApi
   extends Pick<StandardApi<any>, 'storage'> {}

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -306,13 +306,6 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
   order: StatefulRemoteSubscribable<Order | undefined>;
 
   /**
-   * Provides access to session tokens, which can be used to verify token claims on your app's server.
-   *
-   * See [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#example-session-token) for more information.
-   */
-  sessionToken: SessionToken;
-
-  /**
    * id that represents the checkout used to create the order.
    *
    * Matches the `token` field in the [WebPixel checkout payload](https://shopify.dev/docs/api/pixels/customer-events#checkout)
@@ -354,16 +347,6 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
    * @example 'unstable'
    */
   version: Version;
-}
-
-export interface SessionToken {
-  /**
-   * Requests a session token that hasn't expired. You should call this method every
-   * time you need to make a request to your backend in order to get a valid token.
-   * This method will return cached tokens when possible, so you don’t need to worry
-   * about storing these tokens yourself.
-   */
-  get(): Promise<string>;
 }
 
 export interface OrderStatusBuyerIdentity {

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -1208,3 +1208,13 @@ export interface Ui {
     close(overlayId: string): void;
   };
 }
+
+export interface SessionToken {
+  /**
+   * Requests a session token that hasn't expired. You should call this method every
+   * time you need to make a request to your backend in order to get a valid token.
+   * This method will return cached tokens when possible, so you don’t need to worry
+   * about storing these tokens yourself.
+   */
+  get(): Promise<string>;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -7,6 +7,7 @@ import {
   GraphQLError,
   StorefrontApiVersion,
   Ui,
+  SessionToken,
 } from '../shared';
 
 import type {ExtensionTarget} from '../../targets';
@@ -77,6 +78,13 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * Key-value storage for the extension target.
    */
   storage: Storage;
+
+  /**
+   * Provides access to session tokens, which can be used to verify token claims on your app's server.
+   *
+   * See [session token examples](https://shopify.dev/docs/api/customer-account-ui-extensions/apis/session-token#examples) for more information.
+   */
+  sessionToken: SessionToken;
 
   /**
    * Methods to interact with the extension's UI.


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/63163

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation https://github.com/Shopify/customer-account-web/pull/3416
