### PR TITLE
Typ osp naming UI extensions 2023 07

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/buyer-journey.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/buyer-journey.ts
@@ -31,7 +31,7 @@ export function useBuyerJourney<
 /**
  * Returns true if the buyer completed submitting their order.
  *
- * For example, when viewing the order status page after submitting payment, the buyer will have completed their order.
+ * For example, when viewing the **Order status** page after submitting payment, the buyer will have completed their order.
  */
 export function useBuyerJourneyCompleted<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/order-status.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/order-status.doc.ts
@@ -5,9 +5,9 @@ import {getExample, getLinksByTag} from '../helper.docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'OrderStatusApi',
   overviewPreviewDescription:
-    'The API provided to extension targets on the order status page.',
+    'The API provided to extension targets on the **Order status** page.',
   description: `
-This API object is provided to extensions registered for the extension targets that appear exclusively on the order status page.
+This API object is provided to extensions registered for the extension targets that appear exclusively on the **Order status** page.
 
 It extends the [StandardApi](/docs/api/checkout-ui-extensions/apis/standardapi) and provides access to an order object.
 `,

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/extension-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/extension-overview.doc.ts
@@ -141,14 +141,14 @@ Get started testing extensions on [one-page checkout](/docs/apps/checkout/best-p
       title: 'Thank you locations',
       anchorLink: 'supported-typ-locations',
       sectionContent:
-        'The thank you page is shown to buyers immediately after a checkout is successfully submitted. Learn more about building for [the thank you page](/docs/apps/checkout/thank-you-order-status).',
+        'The **Thank you** page is shown to buyers immediately after a checkout is successfully submitted. Learn more about building for [the **Thank you** page](/docs/apps/checkout/thank-you-order-status).',
       accordionContent: [
         {
           title: 'Order details',
           description: `
 Displays all order information to buyers.
 
-See [all thank you page extension targets](/docs/api/checkout-ui-extensions/apis/extensiontargets).
+Review [all **Thank you** page extension targets](/docs/api/checkout-ui-extensions/apis/extensiontargets).
 `,
           image: 'supported-locations-thank-you.png',
         },
@@ -157,7 +157,7 @@ See [all thank you page extension targets](/docs/api/checkout-ui-extensions/apis
           description: `
 Summary of the cart contents, discounts, and order totals.
 
-See [all thank you page extensions targets](/docs/api/checkout-ui-extensions/apis/extensiontargets).
+Review [all **Thank you** page extensions targets](/docs/api/checkout-ui-extensions/apis/extensiontargets).
 `,
           image: 'supported-locations-order-summary-thank-you.png',
         },

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/extension-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/extension-overview.doc.ts
@@ -168,14 +168,14 @@ Review [all **Thank you** page extensions targets](/docs/api/checkout-ui-extensi
       title: 'Order status locations',
       anchorLink: 'supported-osp-locations',
       sectionContent:
-        'The order status page is shown to buyers when they return to a completed checkout for order updates. Learn more about building for [the order status page](/docs/apps/checkout/thank-you-order-status).',
+        'The **Order status** page is shown to buyers when they return to a completed checkout for order updates. Learn more about building for [the **Order status** page](/docs/apps/checkout/thank-you-order-status).',
       accordionContent: [
         {
           title: 'Order details',
           description: `
 Displays all order information to buyers.
 
-See [all order status page extension targets](/docs/api/checkout-ui-extensions/apis/extensiontargets).
+Review [all **Order status** page extension targets](/docs/api/checkout-ui-extensions/apis/extensiontargets).
 `,
           image: 'supported-locations-order-status.png',
         },
@@ -184,7 +184,7 @@ See [all order status page extension targets](/docs/api/checkout-ui-extensions/a
           description: `
 Summary of the cart contents, discounts, and order totals.
 
-See [all order status page extensions targets](/docs/api/checkout-ui-extensions/apis/extensiontargets).
+Review [all **Order status** page extensions targets](/docs/api/checkout-ui-extensions/apis/extensiontargets).
 `,
           image: 'supported-locations-order-summary-order-status.png',
         },

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -413,7 +413,7 @@ export interface BuyerJourney {
   /**
    * This subscribable value will be true if the buyer completed submitting their order.
    *
-   * For example, when viewing the order status page after submitting payment, the buyer will have completed their order.
+   * For example, when viewing the **Order status** page after submitting payment, the buyer will have completed their order.
    */
   completed: StatefulRemoteSubscribable<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -253,7 +253,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the Order Status Page.
+   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the **Order status** page.
    * Unlike static extension targets, dynamic extension targets render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
@@ -266,7 +266,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the Order Status Page.
+   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the **Order status** page.
    * Unlike static extension targets, dynamic extension targets render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
@@ -282,7 +282,7 @@ export interface ExtensionTargets {
   >;
   /**
    * A static extension target that renders on every line item, inside the details
-   * under the line item properties element on the Order Status Page.
+   * under the line item properties element on the **Order status** page.
    */
   'customer-account.order-status.cart-line-item.render-after': RenderExtension<
     CartLineItemApi &
@@ -292,7 +292,7 @@ export interface ExtensionTargets {
   >;
   /**
    * A static extension target that renders on every line item, inside the details
-   * under the line item properties element on the Order Status Page.
+   * under the line item properties element on the **Order status** page.
    *
    * @deprecated Use `customer-account.order-status.cart-line-item.render-after` instead.
    */
@@ -303,7 +303,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after all line items on the Order Status page.
+   * A static extension target that is rendered after all line items on the **Order status** page.
    */
   'customer-account.order-status.cart-line-list.render-after': RenderExtension<
     OrderStatusApi &
@@ -311,7 +311,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after all line items on the Order Status page.
+   * A static extension target that is rendered after all line items on the **Order status** page.
    *
    * @deprecated Use `customer-account.order-status.cart-line-list.render-after` instead.
    */
@@ -321,7 +321,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after a purchase below the customer information on the Order Status page.
+   * A static extension target that is rendered after a purchase below the customer information on the **Order status** page.
    */
   'customer-account.order-status.customer-information.render-after': RenderExtension<
     OrderStatusApi &
@@ -329,7 +329,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after a purchase below the customer information on the Order Status page.
+   * A static extension target that is rendered after a purchase below the customer information on the **Order status** page.
    *
    * @deprecated Use `customer-account.order-status.customer-information.render-after` instead.
    */

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -174,7 +174,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the Thank You Page.
+   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the **Thank you** page.
    * Unlike static extension targets, dynamic extension targets render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
@@ -187,7 +187,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the Thank You Page.
+   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the **Thank you** page.
    * Unlike static extension targets, dynamic extension targets render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
@@ -202,7 +202,7 @@ export interface ExtensionTargets {
   >;
   /**
    * A static extension target that renders on every line item, inside the details
-   * under the line item properties element on the Thank You Page.
+   * under the line item properties element on the **Thank you** page.
    */
   'purchase.thank-you.cart-line-item.render-after': RenderExtension<
     CartLineItemApi &
@@ -211,7 +211,7 @@ export interface ExtensionTargets {
   >;
   /**
    * A static extension target that renders on every line item, inside the details
-   * under the line item properties element on the Thank You Page.
+   * under the line item properties element on the **Thank you** page.
    *
    * @deprecated Use `purchase.thank-you.cart-line-item.render-after` instead.
    */
@@ -221,14 +221,14 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after all line items on the Thank You page.
+   * A static extension target that is rendered after all line items on the **Thank you** page.
    */
   'purchase.thank-you.cart-line-list.render-after': RenderExtension<
     StandardApi<'purchase.thank-you.cart-line-list.render-after'>,
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after all line items on the Thank You page.
+   * A static extension target that is rendered after all line items on the **Thank you** page.
    *
    * @deprecated Use `purchase.thank-you.cart-line-list.render-after` instead.
    */
@@ -237,14 +237,14 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after a purchase below the customer information on the Thank You page.
+   * A static extension target that is rendered after a purchase below the customer information on the **Thank you** page.
    */
   'purchase.thank-you.customer-information.render-after': RenderExtension<
     StandardApi<'purchase.thank-you.customer-information.render-after'>,
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after a purchase below the customer information on the Thank You page.
+   * A static extension target that is rendered after a purchase below the customer information on the **Thank you** page.
    *
    * @deprecated Use `purchase.thank-you.customer-information.render-after` instead.
    */

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -14,7 +14,7 @@ import type {RenderExtension} from './extension';
  */
 export interface ExtensionTargets {
   /**
-   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the Order Status Page.
+   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the **Order status** page.
    * Unlike static extension targets, dynamic extension targets render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
@@ -27,7 +27,7 @@ export interface ExtensionTargets {
   >;
   /**
    * A static extension target that renders on every line item, inside the details
-   * under the line item properties element on the Order Status Page.
+   * under the line item properties element on the **Order status** page.
    */
   'customer-account.order-status.cart-line-item.render-after': RenderExtension<
     CartLineItemApi &
@@ -35,14 +35,14 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after all line items on the Order Status page.
+   * A static extension target that is rendered after all line items on the **Order status** page.
    */
   'customer-account.order-status.cart-line-list.render-after': RenderExtension<
     OrderStatusApi<'customer-account.order-status.cart-line-list.render-after'>,
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after a purchase below the customer information on the Order Status page.
+   * A static extension target that is rendered after a purchase below the customer information on the **Order status** page.
    */
   'customer-account.order-status.customer-information.render-after': RenderExtension<
     OrderStatusApi<'customer-account.order-status.cart-line-list.render-after'>,


### PR DESCRIPTION
### Background

Partial fix for https://github.com/Shopify/shopify-dev/issues/38918

### Solution

- **Thank you** page
- **Order status** page

### 🎩

🌀: https://shopify-dev.checkout-web-api-docs-ugwx.ren-chaturvedi.us.spin.dev/docs/api/checkout-ui-extensions/2023-10/extension-targets-overview#supported-osp-locations (for e.g.)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation