### PR TITLE
Typ osp naming UI extensions 2023 10

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/buyer-journey.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/buyer-journey.ts
@@ -31,7 +31,7 @@ export function useBuyerJourney<
 /**
  * Returns true if the buyer completed submitting their order.
  *
- * For example, when viewing the order status page after submitting payment, the buyer will have completed their order.
+ * For example, when viewing the **Order status** page after submitting payment, the buyer will have completed their order.
  */
 export function useBuyerJourneyCompleted<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.block.render.doc.ts
@@ -4,7 +4,7 @@ import {getExample, getLinksByTag, STANDARD_API} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.thank-you.block.render',
-  description: `A [block extension target](/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the Thank You Page. Unlike static extension targets, block extension targets render where the merchant sets them using the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
+  description: `A [block extension target](/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the **Thank you** page. Unlike static extension targets, block extension targets render where the merchant sets them using the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
 
   The [supported locations](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations) for block extension targets can be previewed during development by [using a URL parameter](/docs/apps/checkout/best-practices/testing-ui-extensions#block-extension-targets).`,
   subCategory: 'Block',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.cart-line-item.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.cart-line-item.render-after.doc.ts
@@ -5,7 +5,7 @@ import {getExample, getLinksByTag, CART_LINE_ITEM_API} from '../helper.docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.thank-you.cart-line-item.render-after',
   description:
-    'A static extension target that renders on every line item, inside the details under the line item properties element on the Thank You Page.',
+    'A static extension target that renders on every line item, inside the details under the line item properties element on the **Thank you** page.',
   defaultExample: getExample(
     'purchase.thank-you.cart-line-item.render-after/default',
     ['jsx', 'js'],

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.cart-line-list.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.cart-line-list.render-after.doc.ts
@@ -5,7 +5,7 @@ import {getExample, getLinksByTag, STANDARD_API} from '../helper.docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.thank-you.cart-line-list.render-after',
   description:
-    'A static extension target that is rendered after all line items on the Thank You page.',
+    'A static extension target that is rendered after all line items on the **Thank you** page.',
   subCategory: 'Order Summary',
   defaultExample: getExample(
     'purchase.thank-you.cart-line-list.render-after/default',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.customer-information.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.customer-information.render-after.doc.ts
@@ -5,7 +5,7 @@ import {getExample, getLinksByTag, STANDARD_API} from '../helper.docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.thank-you.customer-information.render-after',
   description:
-    'A static extension target that is rendered after a purchase below the customer information on the Thank You page.',
+    'A static extension target that is rendered after a purchase below the customer information on the **Thank you** page.',
   subCategory: 'Information',
   defaultExample: getExample(
     'purchase.thank-you.customer-information.render-after/default',

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/extension-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/extension-overview.doc.ts
@@ -129,14 +129,14 @@ See [all thank you page extensions targets](/docs/api/checkout-ui-extensions/tar
       title: 'Order status locations',
       anchorLink: 'supported-osp-locations',
       sectionContent:
-        'The order status page is shown to buyers when they return to a completed checkout for order updates. Learn more about building for [the order status page](/docs/apps/checkout/thank-you-order-status).',
+        'The **Order status** page is shown to buyers when they return to a completed checkout for order updates. Learn more about building for [the **Order status** page](/docs/apps/checkout/thank-you-order-status).',
       accordionContent: [
         {
           title: 'Order details',
           description: `
 Displays all order information to buyers.
 
-See [all order status page extension targets](/docs/api/checkout-ui-extensions/targets).
+Review [all **Order status** page extension targets](/docs/api/checkout-ui-extensions/targets).
 `,
           image: 'supported-locations-order-status.png',
         },
@@ -145,7 +145,7 @@ See [all order status page extension targets](/docs/api/checkout-ui-extensions/t
           description: `
 Summary of the cart contents, discounts, and order totals.
 
-See [all order status page extensions targets](/docs/api/checkout-ui-extensions/targets).
+Review [all **Order status** page extensions targets](/docs/api/checkout-ui-extensions/targets).
 `,
           image: 'supported-locations-order-summary-order-status.png',
         },
@@ -176,7 +176,7 @@ See [all order status page extensions targets](/docs/api/checkout-ui-extensions/
       type: 'Generic',
       anchorLink: 'block-extension-targets',
       title: 'Block extension targets',
-      sectionContent: `Block extension targets render between core checkout features. Merchants can use the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor) to place the extension in the [checkout](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations), [thank you](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-typ-locations), or [order status](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-osp-locations) pages.
+      sectionContent: `Block extension targets render between core checkout features. Merchants can use the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor) to place the extension in the [checkout](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations), [thank you](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-typ-locations), or [**Order status**](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-osp-locations) pages.
       \n\nBlock extensions are always rendered, regardless of what other elements of the checkout are present. For example, an extension placed above the shipping address will still render even for digital products which do not require a shipping address.\n\nChoose block extension targets when your content and functionality works independently of a core checkout feature. This is useful for custom content, like a field to capture order notes from the customer.`,
       image: 'block-extension-targets.png',
       sectionCard: [

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/extension-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/extension-overview.doc.ts
@@ -102,14 +102,14 @@ Get started testing extensions on [one-page checkout](/docs/apps/checkout/best-p
       title: 'Thank you locations',
       anchorLink: 'supported-typ-locations',
       sectionContent:
-        'The thank you page is shown to buyers immediately after a checkout is successfully submitted. Learn more about building for [the thank you page](/docs/apps/checkout/thank-you-order-status).',
+        'The **Thank you** page is shown to buyers immediately after a checkout is successfully submitted. Learn more about building for [the **Thank you** page](/docs/apps/checkout/thank-you-order-status).',
       accordionContent: [
         {
           title: 'Order details',
           description: `
 Displays all order information to buyers.
 
-See [all thank you page extension targets](/docs/api/checkout-ui-extensions/targets).
+Review [all **Thank you** page extension targets](/docs/api/checkout-ui-extensions/targets).
 `,
           image: 'supported-locations-thank-you.png',
         },
@@ -118,7 +118,7 @@ See [all thank you page extension targets](/docs/api/checkout-ui-extensions/targ
           description: `
 Summary of the cart contents, discounts, and order totals.
 
-See [all thank you page extensions targets](/docs/api/checkout-ui-extensions/targets).
+Review [all **Thank you** page extensions targets](/docs/api/checkout-ui-extensions/targets).
 `,
           image: 'supported-locations-order-summary-thank-you.png',
         },
@@ -176,7 +176,7 @@ Review [all **Order status** page extensions targets](/docs/api/checkout-ui-exte
       type: 'Generic',
       anchorLink: 'block-extension-targets',
       title: 'Block extension targets',
-      sectionContent: `Block extension targets render between core checkout features. Merchants can use the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor) to place the extension in the [checkout](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations), [thank you](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-typ-locations), or [**Order status**](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-osp-locations) pages.
+      sectionContent: `Block extension targets render between core checkout features. Merchants can use the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor) to place the extension in the [checkout](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations), [**Thank you**](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-typ-locations), or [**Order status**](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-osp-locations) pages.
       \n\nBlock extensions are always rendered, regardless of what other elements of the checkout are present. For example, an extension placed above the shipping address will still render even for digital products which do not require a shipping address.\n\nChoose block extension targets when your content and functionality works independently of a core checkout feature. This is useful for custom content, like a field to capture order notes from the customer.`,
       image: 'block-extension-targets.png',
       sectionCard: [

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -424,7 +424,7 @@ export interface BuyerJourney {
   /**
    * This subscribable value will be true if the buyer completed submitting their order.
    *
-   * For example, when viewing the order status page after submitting payment, the buyer will have completed their order.
+   * For example, when viewing the **Order status** page after submitting payment, the buyer will have completed their order.
    */
   completed: StatefulRemoteSubscribable<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -261,7 +261,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A [block extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the Order Status Page.
+   * A [block extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the **Order status** page.
    * Unlike static extension targets, block extension targets render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
@@ -276,7 +276,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A [block extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the Order Status Page.
+   * A [block extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the **Order status** page.
    * Unlike static extension targets, block extension targets render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
@@ -292,7 +292,7 @@ export interface ExtensionTargets {
   >;
   /**
    * A static extension target that renders on every line item, inside the details
-   * under the line item properties element on the Order Status Page.
+   * under the line item properties element on the **Order status** page.
    *
    * @deprecated Use `customer-account.order-status.cart-line-item.render-after` from `@shopify/ui-extension/customer-account` instead.
    */
@@ -304,7 +304,7 @@ export interface ExtensionTargets {
   >;
   /**
    * A static extension target that renders on every line item, inside the details
-   * under the line item properties element on the Order Status Page.
+   * under the line item properties element on the **Order status** page.
    *
    * @deprecated Use `customer-account.order-status.cart-line-item.render-after` instead.
    */
@@ -315,7 +315,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after all line items on the Order Status page.
+   * A static extension target that is rendered after all line items on the **Order status** page.
    *
    * @deprecated Use `customer-account.order-status.cart-line-list.render-after` from `@shopify/ui-extension/customer-account` instead.
    */
@@ -325,7 +325,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after all line items on the Order Status page.
+   * A static extension target that is rendered after all line items on the **Order status** page.
    *
    * @deprecated Use `customer-account.order-status.cart-line-list.render-after` from `@shopify/ui-extension/customer-account` instead.
    */
@@ -335,7 +335,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after a purchase below the customer information on the Order Status page.
+   * A static extension target that is rendered after a purchase below the customer information on the **Order status** page.
    *
    * @deprecated Use `customer-account.order-status.customer-information.render-after` from `@shopify/ui-extension/customer-account` instead.
    */
@@ -345,7 +345,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after a purchase below the customer information on the Order Status page.
+   * A static extension target that is rendered after a purchase below the customer information on the **Order status** page.
    *
    * @deprecated Use `customer-account.order-status.customer-information.render-after` from `@shopify/ui-extension/customer-account` instead.
    */

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -182,7 +182,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A [block extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the Thank You Page.
+   * A [block extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the **Thank you** page.
    * Unlike static extension targets, block extension targets render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
@@ -195,7 +195,7 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A [block extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the Thank You Page.
+   * A [block extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the **Thank you** page.
    * Unlike static extension targets, block extension targets render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
@@ -210,7 +210,7 @@ export interface ExtensionTargets {
   >;
   /**
    * A static extension target that renders on every line item, inside the details
-   * under the line item properties element on the Thank You Page.
+   * under the line item properties element on the **Thank you** page.
    */
   'purchase.thank-you.cart-line-item.render-after': RenderExtension<
     CartLineItemApi &
@@ -219,7 +219,7 @@ export interface ExtensionTargets {
   >;
   /**
    * A static extension target that renders on every line item, inside the details
-   * under the line item properties element on the Thank You Page.
+   * under the line item properties element on the **Thank you** page.
    *
    * @deprecated Use `purchase.thank-you.cart-line-item.render-after` instead.
    */
@@ -229,14 +229,14 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after all line items on the Thank You page.
+   * A static extension target that is rendered after all line items on the **Thank you** page.
    */
   'purchase.thank-you.cart-line-list.render-after': RenderExtension<
     StandardApi<'purchase.thank-you.cart-line-list.render-after'>,
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after all line items on the Thank You page.
+   * A static extension target that is rendered after all line items on the **Thank you** page.
    *
    * @deprecated Use `purchase.thank-you.cart-line-list.render-after` instead.
    */
@@ -245,14 +245,14 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after a purchase below the customer information on the Thank You page.
+   * A static extension target that is rendered after a purchase below the customer information on the **Thank you** page.
    */
   'purchase.thank-you.customer-information.render-after': RenderExtension<
     StandardApi<'purchase.thank-you.customer-information.render-after'>,
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after a purchase below the customer information on the Thank You page.
+   * A static extension target that is rendered after a purchase below the customer information on the **Thank you** page.
    *
    * @deprecated Use `purchase.thank-you.customer-information.render-after` instead.
    */

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -14,7 +14,7 @@ import type {RenderExtension} from './extension';
  */
 export interface ExtensionTargets {
   /**
-   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the Order Status Page.
+   * A [dynamic extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview#dynamic-extension-targets) that renders exclusively on the **Order status** page.
    * Unlike static extension targets, dynamic extension targets render where the merchant
    * sets them using the [checkout editor](https://shopify.dev/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).
    *
@@ -27,7 +27,7 @@ export interface ExtensionTargets {
   >;
   /**
    * A static extension target that renders on every line item, inside the details
-   * under the line item properties element on the Order Status Page.
+   * under the line item properties element on the **Order status** page.
    */
   'customer-account.order-status.cart-line-item.render-after': RenderExtension<
     CartLineItemApi &
@@ -35,14 +35,14 @@ export interface ExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after all line items on the Order Status page.
+   * A static extension target that is rendered after all line items on the **Order status** page.
    */
   'customer-account.order-status.cart-line-list.render-after': RenderExtension<
     OrderStatusApi<'customer-account.order-status.cart-line-list.render-after'>,
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered after a purchase below the customer information on the Order Status page.
+   * A static extension target that is rendered after a purchase below the customer information on the **Order status** page.
    */
   'customer-account.order-status.customer-information.render-after': RenderExtension<
     OrderStatusApi<'customer-account.order-status.cart-line-list.render-after'>,


### PR DESCRIPTION
### Background

Partial fix for https://github.com/Shopify/shopify-dev/issues/38918

### Solution

- **Thank you** page
- **Order status** page

### 🎩

🌀: https://shopify-dev.checkout-web-api-docs-ugwx.ren-chaturvedi.us.spin.dev/docs/api/checkout-ui-extensions/extension-targets-overview#supported-osp-locations (for e.g.)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation