### PR TITLE
Revert "Sunset `PriceOverride` discount type"

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
@@ -17,10 +17,14 @@ export interface CartApi {
 
 /**
  * @deprecated
- * Code discounts are only supported at the Cart level.
+ * PriceOverride is no longer supported. Code discounts are only supported at the Cart level.
  * Please migrate to using CartDiscountType and LineItemDiscountType as soon as possible.
  */
-export type DiscountType = 'Percentage' | 'FixedAmount' | 'Code';
+export type DiscountType =
+  | 'Percentage'
+  | 'FixedAmount'
+  | 'PriceOverride'
+  | 'Code';
 
 export type CartDiscountType = 'Percentage' | 'FixedAmount' | 'Code';
 


### PR DESCRIPTION
Reverts Shopify/ui-extensions#1485