### PR TITLE
[UI Components]: Adding updated figma link to `2023-04`

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
@@ -162,7 +162,7 @@ const data: LandingTemplateSchema = {
         {
           name: 'Figma UI kit',
           subtitle: 'UI Reference',
-          url: 'https://www.figma.com/community/file/1121180079120732846',
+          url: 'https://www.figma.com/community/file/1304881365343613949/checkout-and-account-components',
           type: 'setting',
         },
       ],


### PR DESCRIPTION
### Background

- We updated our figma community files and the links changed, and since we removed the old ones they were leading to an 404 page.

### Solution

- Talking to UX, the new link will not be updated to a different one in future releases.

### 🎩

- https://shopify-dev.figma-links-update.igor-deoliveiramartins.us.spin.dev/docs/api/checkout-ui-extensions

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation