### PR TITLE
Adds POS to ui-extension exports

### DIFF
--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -20,6 +20,9 @@
       ],
       "customer-account": [
         "./build/ts/surfaces/customer-account.d.ts"
+      ],
+      "point-of-sale": [
+        "./build/ts/surfaces/point-of-sale.d.ts"
       ]
     }
   },
@@ -47,6 +50,12 @@
       "esnext": "./build/esnext/surfaces/customer-account.esnext",
       "import": "./build/esm/surfaces/customer-account.mjs",
       "require": "./build/cjs/surfaces/customer-account.js"
+    },
+    "./point-of-sale": {
+      "types": "./build/ts/surfaces/point-of-sale.d.ts",
+      "esnext": "./build/esnext/surfaces/point-of-sale.esnext",
+      "import": "./build/esm/surfaces/point-of-sale.mjs",
+      "require": "./build/cjs/surfaces/point-of-sale.js"
     }
   },
   "license": "MIT",


### PR DESCRIPTION
### Background

Forgot to include this commit in the last PR. This makes it so we can import pos components as `@shopify/ui-extensions/point-of-sale`

Right now we are aligned on point-of-sale, but there's a good chance we might change it to pos before we ship any official version. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
