### PR TITLE
chore: update GitHub templates to reference new packages

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -6,7 +6,7 @@ labels: 'enhancement'
 
 ## Please list the related package(s)
 
-<!-- e.g. checkout-ui-extensions, admin-ui-extensions-react -->
+<!-- e.g. @shopify/ui-extensions-react/checkout, @shopify/ui-extensions-react/admin -->
 
 ## If this related to specific APIs or components, please list them here
 

--- a/.github/ISSUE_TEMPLATE/issue-report.md
+++ b/.github/ISSUE_TEMPLATE/issue-report.md
@@ -8,7 +8,7 @@ labels: 'bug'
 
 ## Please list the package(s) involved in the issue, and include the version you are using
 
-<!-- e.g. checkout-ui-extensions V0.10.1, admin-ui-extensions-react V0.11.0 -->
+<!-- e.g. @shopify/ui-extensions-react/checkout v2023.10.0, @shopify/ui-extensions-react/admin unstable -->
 
 ## Describe the bug
 


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/app-ui/issues/581

We noticed the issue and feature request templates aren't using the new package names.

### Solution

Update the templates to make prioritizing issues easier.

### 🎩

- ...

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
