### PR TITLE
feat: Tooltip

### DIFF
--- a/.changeset/lazy-chairs-join.md
+++ b/.changeset/lazy-chairs-join.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+Add tooltip component and update Button and Text with interestTarget API

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Tooltip/Tooltip.ts
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Tooltip/Tooltip.ts
@@ -1,0 +1,5 @@
+import {Thumbnail as BaseThumbnail} from '@shopify/ui-extensions/admin';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const Thumbnail = createRemoteReactComponent(BaseThumbnail);
+export type {ThumbnailProps} from '@shopify/ui-extensions/admin';

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Tooltip/examples/basic-tooltip.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Tooltip/examples/basic-tooltip.example.tsx
@@ -1,0 +1,14 @@
+import {render, Tooltip} from '@shopify/ui-extensions-react/admin';
+
+render('Playground', () => <App />);
+
+function App() {
+  return (
+    <>
+      <Button interestTarget="tooltip-1">tooltip-1</Button>
+      <Tooltip id="tooltip-1">
+        <Text>Tooltip Content</Text>
+      </Tooltip>
+    </>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.ts
@@ -37,6 +37,11 @@ interface CommonProps {
   lang?: string;
 
   /**
+   * The ID of the tooltip that is intended to display as a result of a hover interaction on this element.
+   */
+  interestTarget?: string;
+
+  /**
    * Callback when a link is pressed. If `href` is set,
    * it will execute the callback and then navigate to the location specified by `href`.
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/Text.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/Text.ts
@@ -36,6 +36,11 @@ export interface TextProps {
   fontStyle?: FontStyle;
 
   /**
+   * The ID of the tooltip that is intended to display as a result of a hover interaction on this element.
+   */
+  interestTarget?: string;
+
+  /**
    * Provide semantic meaning to content and improve support for assistive technologies.
    * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip/README.md
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip/README.md
@@ -1,0 +1,3 @@
+# Tooltip
+
+Tooltips are floating labels that briefly explain the function of a user interface element. They must be specified inside the `interestTarget` prop of an activator component. Currently, activator components are `Button` and `Text`.

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip/Tooltip.docs.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip/Tooltip.docs.ts
@@ -1,0 +1,57 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Tooltip',
+  description:
+    'Tooltips are floating labels that briefly explain the function of a user interface element. They must be specified inside the `interestTarget` prop of an activator component. Currently, activator components are `Button` and `Text`.',
+  requires: '',
+  thumbnail: 'tooltip-thumbnail.png',
+  isVisualComponent: true,
+  type: '',
+  definitions: [
+    {
+      title: 'TooltipProps',
+      description: '',
+      type: 'TooltipProps',
+    },
+  ],
+  category: 'Components',
+  subCategory: 'Overlays',
+  defaultExample: {
+    image: 'tooltip-default.png',
+    codeblock: {
+      title: 'Basic Tooltip',
+      tabs: [
+        {
+          title: 'React',
+          code: '../../../../../../ui-extensions-react/src/surfaces/checkout/components/Tooltip/examples/basic-tooltip.example.tsx',
+          language: 'tsx',
+        },
+        {
+          title: 'JS',
+          code: './examples/basic-tooltip.example.ts',
+          language: 'js',
+        },
+      ],
+    },
+  },
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best Practices',
+      sectionContent:
+        'Use tooltips if:\n\n- It’s used for showing information only.\n\n- The information contained in it should be helpful but not vital to the user experience.\n\n- The information can be written in a sentence.',
+    },
+  ],
+  related: [
+    {
+      name: 'Button',
+      subtitle: 'Component',
+      url: 'button',
+      type: 'component',
+    },
+  ],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip/Tooltip.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip/Tooltip.ts
@@ -1,0 +1,13 @@
+import {createRemoteComponent} from '@remote-ui/core';
+import type {GlobalProps} from '../shared';
+
+export interface TooltipProps extends GlobalProps {
+  children?: any;
+}
+
+/**
+ * Tooltips are floating labels that briefly explain the function of a user interface element. They must be specified inside the `interestTarget` prop of an activator component. Currently, activator components are `Button` and `Text`.
+ */
+export const Tooltip = createRemoteComponent<'Tooltip', TooltipProps>(
+  'Tooltip',
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip/examples/basic-Tooltip.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip/examples/basic-Tooltip.example.ts
@@ -1,0 +1,16 @@
+import {Button, extend, Tooltip, Text} from '@shopify/ui-extensions/admin';
+
+extend('Playground', (root) => {
+  const button = root.createComponent(Button, {
+    interestTarget: "tooltip-1"
+  }, 'Tooltip 1');
+  const tooltip = root.createComponent(Tooltip, {
+    id: 'tooltip-1',
+  }, 
+    root.createComponent(Text, {}, 'Tooltip Content'),
+  );
+
+  root.appendChild(button);
+  root.appendChild(tooltip);
+  root.mount();
+});


### PR DESCRIPTION
### Background

Adds the Tooltip component

This also updates the Text and Button interfaces to include `interestTarget` which triggers the tooltip

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have updated relevant documentation
