### PR TITLE
update CameraScannerBannerProps to use BannerProps

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "1.6.0-rc.1",
+  "version": "1.6.0-rc.2",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/retail-ui-extensions": "1.6.0-rc.1",
+    "@shopify/retail-ui-extensions": "1.6.0-rc.2",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/retail-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify Point of Sale",
-  "version": "1.6.0-rc.1",
+  "version": "1.6.0-rc.2",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/retail-ui-extensions/src/components/CameraScanner/CameraScanner.ts
+++ b/packages/retail-ui-extensions/src/components/CameraScanner/CameraScanner.ts
@@ -1,18 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
+import {BannerProps} from '../Banner';
 
-export type BannerType =
-  | 'Success'
-  | 'Warning'
-  | 'Error'
-  | 'Info'
-  | 'Critical'
-  | 'Default';
-
-export interface CameraScannerBannerProps {
-  title: string;
-  variant?: BannerType;
-  visible?: boolean;
-}
+export type CameraScannerBannerProps = Pick<
+  BannerProps,
+  'title' | 'variant' | 'visible'
+>;
 
 export interface CameraScannerProps {
   bannerProps?: CameraScannerBannerProps;

--- a/packages/retail-ui-extensions/src/components/CameraScanner/index.ts
+++ b/packages/retail-ui-extensions/src/components/CameraScanner/index.ts
@@ -1,6 +1,5 @@
 export type {
   CameraScannerProps,
   CameraScannerBannerProps,
-  BannerType,
 } from './CameraScanner';
 export {CameraScanner} from './CameraScanner';

--- a/packages/retail-ui-extensions/src/components/index.ts
+++ b/packages/retail-ui-extensions/src/components/index.ts
@@ -61,7 +61,6 @@ export {CameraScanner} from './CameraScanner';
 export type {
   CameraScannerProps,
   CameraScannerBannerProps,
-  BannerType,
 } from './CameraScanner';
 
 export {Badge} from './Badge';

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -148,7 +148,6 @@ export type {
   ScreenProps,
   ScreenPresentationProps,
   SecondaryActionProps,
-  BannerType,
   CameraScannerBannerProps,
 } from './components';
 


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/pos-next-react-native/issues/28204

From @NathanJolly 's [suggestions](https://github.com/Shopify/ui-extensions/pull/1626/files#r1440567589), I've gone ahead and removed the `BannerType` definitions and instead to use `BannerProps`.

Also bumped the version to `1.6.0-rc.2`

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
