### PR TITLE
Retail/1.6/add paginated variant search

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "1.6.0-rc.2",
+  "version": "1.6.0-rc.3",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/retail-ui-extensions": "1.6.0-rc.2",
+    "@shopify/retail-ui-extensions": "1.6.0-rc.3",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/retail-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify Point of Sale",
-  "version": "1.6.0-rc.2",
+  "version": "1.6.0-rc.3",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/retail-ui-extensions/src/extension-api/product-search-api/product-search-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/product-search-api/product-search-api.ts
@@ -12,21 +12,27 @@ export type ProductSortType =
   | 'ALPHABETICAL_Z_TO_A';
 
 /**
- * Parameters for using the searchProducts function.
+ * Base interface for pagination.
  */
-export interface ProductSearchParams {
+export interface PaginationParams {
+  /**
+   * Specifies the number of results to be returned in this page. The maximum number of items that will be returned is 50.
+   */
+  first?: number;
+  /**
+   * Specifies the page cursor. Items after this cursor will be returned.
+   */
+  afterCursor?: string;
+}
+
+/**
+ * Interface for product search
+ */
+export interface ProductSearchParams extends PaginationParams {
   /**
    * The search term to be used to search for POS products.
    */
   queryString?: string;
-  /**
-   * Specifies the number of results to be returned in this page of products. The maximum number of products that will be returned is 50.
-   */
-  first?: number;
-  /**
-   * Specifies the page cursor. Products after this cursor will be returned.
-   */
-  afterCursor?: string;
   /**
    * Specifies the order in which products should be sorted. When a `queryString` is provided, sortType will not have any effect, as the results will be returned in order by relevance to the `queryString`.
    */
@@ -73,6 +79,14 @@ export interface ProductSearchApiContent {
   fetchProductVariantsWithProductId(
     productId: number,
   ): Promise<ProductVariant[]>;
+
+  /** Fetches a page of product variants associated with a product.
+   * @param paginationParams The parameters for pagination.
+   */
+  fetchPaginatedProductVariantsWithProductId(
+    productId: number,
+    paginationParams: PaginationParams,
+  ): Promise<PaginatedResult<ProductVariant>>;
 }
 
 /**


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/pos-next-react-native/issues/30069

### Solution

This PR adds the function `fetchPaginatedProductVariantsWithProductId` to the ProductSearch API.

