### PR TITLE
Retail/1.6/add paginated variant search

### DIFF
--- a/packages/retail-ui-extensions-react/package.json
+++ b/packages/retail-ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/retail-ui-extensions-react",
-  "version": "1.6.0-rc.3",
+  "version": "1.6.0-rc.4",
   "description": "React bindings for @shopify/retail-ui-extensions",
   "publishConfig": {
     "access": "public",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@remote-ui/react": "4.5.x",
-    "@shopify/retail-ui-extensions": "1.6.0-rc.3",
+    "@shopify/retail-ui-extensions": "1.6.0-rc.4",
     "@types/react": ">=17.0.0 <18.0.0"
   },
   "peerDependencies": {

--- a/packages/retail-ui-extensions/package.json
+++ b/packages/retail-ui-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/retail-ui-extensions",
   "description": "The API for UI Extensions that run in Shopify Point of Sale",
-  "version": "1.6.0-rc.3",
+  "version": "1.6.0-rc.4",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/retail-ui-extensions/src/extension-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/index.ts
@@ -19,6 +19,7 @@ export type {StandardApi} from './standard-api';
 export type {SessionApiContent, SessionApi} from './session-api';
 export type {ShowToastOptions, ToastApiContent, ToastApi} from './toast-api';
 export type {
+  PaginationParams,
   ProductSearchApi,
   ProductSearchApiContent,
   ProductSortType,

--- a/packages/retail-ui-extensions/src/extension-api/product-search-api/index.ts
+++ b/packages/retail-ui-extensions/src/extension-api/product-search-api/index.ts
@@ -1,4 +1,5 @@
 export type {
+  PaginationParams,
   ProductSearchApi,
   ProductSearchApiContent,
   ProductSortType,

--- a/packages/retail-ui-extensions/src/index.ts
+++ b/packages/retail-ui-extensions/src/index.ts
@@ -36,6 +36,7 @@ export type {
   Discount,
   MultipleResourceResult,
   PaginatedResult,
+  PaginationParams,
   Product,
   ProductOption,
   ProductVariant,


### PR DESCRIPTION
### Background

Had to import this from `@shopify/retail-ui-extensions-v1.6/build/ts/extension-api/product-search-api/product-search-api`

### Solution

Now it can be imported from `@shopify/retail-ui-extensions-v1.6`

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
