### PR TITLE
Add missing point-of-sale entry to loom config

### DIFF
--- a/packages/ui-extensions-react/loom.config.ts
+++ b/packages/ui-extensions-react/loom.config.ts
@@ -6,6 +6,7 @@ export default createPackage((pkg) => {
   pkg.entry({root: './src/index.ts'});
   pkg.entry({name: 'checkout', root: './src/surfaces/checkout.ts'});
   pkg.entry({name: 'admin', root: './src/surfaces/admin.ts'});
+  pkg.entry({name: 'point-of-sale', root: './src/surfaces/point-of-sale.ts'});
   pkg.entry({
     name: 'customer-account',
     root: './src/surfaces/customer-account.ts',


### PR DESCRIPTION
### Background

When we migrated over point-of-sale code to unified package we forgot to include an entry in the loom config for react package. Lack of this entry causes a module resolution error when the package is used in the POS UI extension app:

```
✘ [ERROR] Could not resolve "@shopify/ui-extensions-react/point-of-sale"
```

### Solution

Adding missing entry to the loom config generates necessary `esnext`, `js` and `mjs` needed to correctly resolve the module inside UI extension apps.

### 🎩

- on this branch you can `cd packages/ui-extensions-react`
- install generated tarball in UI extension app that is using components from `@shopify/ui-extensions-react/point-of-sale` package
- run `yarn dev`
- verify that the build doesn't throw `✘ [ERROR] Could not resolve "@shopify/ui-extensions-react/point-of-sale"`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
