### PR TITLE
[UI components]: Update style helper docs for unstable

### DIFF
--- a/.changeset/sharp-houses-rest.md
+++ b/.changeset/sharp-houses-rest.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add docs fixes for the conditional style Style type

--- a/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
@@ -381,10 +381,32 @@ export type AccessibilityRole =
   /** Used to strip the semantic meaning of an element, but leave the visual styling intact. */
   | 'presentation';
 
-export type NonPresentationalAccessibilityRole = Exclude<
-  AccessibilityRole,
-  'decorative' | 'presentation'
->;
+export type NonPresentationalAccessibilityRole =
+  /** Used to indicate the primary content. */
+  | 'main'
+  /** Used to indicate the component is a header. */
+  | 'header'
+  /** Used to display information such as copyright information, navigation links, and privacy statements. */
+  | 'footer'
+  /** Used to indicate a generic section. */
+  | 'section'
+  /** Used to designate a supporting section that relates to the main content. */
+  | 'complementary'
+  /** Used to identify major groups of links used for navigating. */
+  | 'navigation'
+  /** Used to identify a list of ordered items. */
+  | 'orderedList'
+  /** Used to identify an item inside a list of items. */
+  | 'listItem'
+  /** Used to identify a list of unordered items. */
+  | 'unorderedList'
+  /** Used to indicates the component acts as a divider that separates and distinguishes sections of content. */
+  | 'separator'
+  /** Used to define a live region containing advisory information for the user that is not important enough to be an alert. */
+  | 'status'
+  /** Used for important, and usually time-sensitive, information. */
+  | 'alert';
+
 export type ViewLikeAccessibilityRole =
   | NonPresentationalAccessibilityRole
   | [NonPresentationalAccessibilityRole, NonPresentationalAccessibilityRole];

--- a/packages/ui-extensions/src/surfaces/checkout/style/style.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/style/style.ts
@@ -1,5 +1,11 @@
 import {memoize} from './memoize';
-import {Conditions, ConditionalStyle, BaseConditions} from './types';
+import {
+  Conditions,
+  ConditionalStyle,
+  BaseConditions,
+  StylesConditions,
+  StylesConditionalStyle,
+} from './types';
 import {isEqual} from './isEqual';
 
 const MAX_CACHE_SIZE = 50;
@@ -80,9 +86,30 @@ const when: WhenFunction = function when<
   ) as WhenReturnType<T, TContext, AcceptedConditions>;
 };
 
+// This interface is only used to provide documentation for the Style helper.
+// It is not used in the implementation.
 export interface DocsStyle {
-  default: <T>(defaultValue: T) => ConditionalStyle<T>;
-  when: <T>(conditions: Conditions, value: T) => ConditionalStyle<T>;
+  /**
+   * Sets an optional default value to use when no other condition is met.
+   *
+   * @param defaultValue The default value
+   * @returns The chainable condition style
+   */
+  default: <T>(defaultValue: T) => StylesConditionalStyle<T>;
+  /**
+   * Adjusts the style based on different conditions. All conditions, expressed
+   * as a literal object, must be met for the associated value to be applied.
+   *
+   * The `when` method can be chained together to build more complex styles.
+   *
+   * @param conditions The condition(s)
+   * @param value The conditional value that can be applied if the conditions are met
+   * @returns The chainable condition style
+   */
+  when: <T>(
+    conditions: StylesConditions,
+    value: T,
+  ) => StylesConditionalStyle<T>;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/style/types.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/style/types.ts
@@ -26,6 +26,57 @@ export type BaseConditions = AtLeastOne<
   DefaultConditions & ResolutionCondition
 >;
 
+// This interface is only used to provide documentation for the Style helper.
+// It is not used in the implementation.
+export interface StylesBaseConditions {
+  viewportInlineSize?: {min: 'small' | 'medium' | 'large'};
+  hover?: true;
+  focus?: true;
+  resolution?: 1 | 1.3 | 1.5 | 2 | 2.6 | 3 | 3.5 | 4;
+}
+
+// This interface is only used to provide documentation for the Style helper.
+// It is not used in the implementation.
+export interface StylesConditions {
+  viewportInlineSize?: {min: 'small' | 'medium' | 'large'};
+  hover?: true;
+  focus?: true;
+}
+
+// This interface is only used to provide documentation for the Style helper.
+// It is not used in the implementation.
+export interface StylesConditionalValue<
+  T,
+  AcceptedConditions extends StylesBaseConditions = StylesBaseConditions,
+> {
+  /**
+   * The conditions that must be met for the value to be applied. At least one
+   * condition must be specified.
+   */
+  conditions: AcceptedConditions;
+  /**
+   * The value that will be applied if the conditions are met.
+   */
+  value: T;
+}
+
+// This interface is only used to provide documentation for the Style helper.
+// It is not used in the implementation.
+export interface StylesConditionalStyle<
+  T,
+  AcceptedConditions extends StylesBaseConditions = StylesBaseConditions,
+> {
+  /**
+   * The default value applied when none of the conditional values
+   * specified in `conditionals` are met.
+   */
+  default?: T;
+  /**
+   * An array of conditional values.
+   */
+  conditionals: StylesConditionalValue<T, AcceptedConditions>[];
+}
+
 export interface ConditionalValue<
   T,
   AcceptedConditions extends BaseConditions = Conditions,
@@ -66,7 +117,6 @@ export type MaybeConditionalStyle<
   AcceptedConditions extends BaseConditions = Conditions,
 > = T | ConditionalStyle<T, AcceptedConditions>;
 
-export type MaybeResponsiveConditionalStyle<T> = MaybeConditionalStyle<
-  T,
-  ViewportSizeCondition
->;
+export type MaybeResponsiveConditionalStyle<T> =
+  | T
+  | ConditionalStyle<T, ViewportSizeCondition>;


### PR DESCRIPTION
### What problem are you trying to solve? 💡

complete https://github.com/Shopify/checkout-web/issues/23677 fix, that wasn't included in all versions

### How are you solving it? 🛠️

- For `NonPresentationalAccessibilityRole` I took JF's suggestion and just duplicated a bit of code since generate-docs cannot handle `Exclude` property right, and to avoid future errors I opted to not use Pick property as well.
- For conditional styles I end up simplifying some of the types along with @ncardeli, and created a simplified version for docs only, that way we were able to avoid the infinite loop when trying to access the property on the docs.

### Tophat 🎩

#### Spin Instance 🌀

https://shopify-dev.conditional-styles-doc-fixes.igor-deoliveiramartins.us.spin.dev/docs/api/checkout-ui-extensions

Before
<img width="665" alt="Screenshot 2023-12-06 at 11 16 01 AM" src="https://github.com/Shopify/checkout-web/assets/12087916/44761e72-05ea-4b66-9e39-c7b88f2883d7">
<img width="648" alt="Screenshot 2023-12-06 at 11 18 32 AM" src="https://github.com/Shopify/checkout-web/assets/12087916/9408fff5-a546-4744-a2ee-555234d91d13">



After
<img width="631" alt="Screenshot 2024-01-15 at 12 00 15 PM" src="https://github.com/Shopify/ui-extensions/assets/12087916/f318b9e5-5989-4af3-842c-64877e39d52c">

<img width="651" alt="Screenshot 2023-12-06 at 11 19 04 AM" src="https://github.com/Shopify/checkout-web/assets/12087916/fb3e7a56-22fb-484e-af1d-315f95e59f10">
-8ad4-d909d41d3da3">

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation