### PR TITLE
drop runExtension support for customer account ui extension

### DIFF
--- a/.changeset/lucky-beds-care.md
+++ b/.changeset/lucky-beds-care.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Drop runExtension support for customer account ui extension

--- a/packages/ui-extensions/src/surfaces/customer-account/extension.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/extension.ts
@@ -19,7 +19,3 @@ export const extension =
  * @deprecated This is deprecated, use `extension` instead.
  */
 export const extend = extension;
-
-export interface RunExtension<Api, Return> {
-  (api: Api): Promise<Return>;
-}

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -2,7 +2,7 @@ import {AnyComponent} from '../checkout/shared';
 
 import {CartLineItemApi} from './api/cart-line/cart-line-item';
 import type {OrderStatusApi} from './api/order-status/order-status';
-import type {RenderExtension, RunExtension} from './extension';
+import type {RenderExtension} from './extension';
 import {
   StandardApi,
   FullExtensionNavigation,
@@ -102,17 +102,9 @@ export interface CustomerAccountExtensionTargets {
       FullPageApi,
     AllComponents
   >;
-  'CustomerAccount::Returns::Initiate': RunExtension<
-    StandardApi<'CustomerAccount::Returns::Initiate'> & {orderId: string},
-    void
-  >;
   'CustomerAccount::KitchenSink': RenderExtension<
     StandardApi<'CustomerAccount::KitchenSink'> & {name: string},
     AllComponents
-  >;
-  'CustomerAccount::KitchenSinkRun': RunExtension<
-    StandardApi<'CustomerAccount::KitchenSinkRun'> & {name: string},
-    string
   >;
   'customer-account.order-index.block.render': RenderExtension<
     StandardApi<'customer-account.order-index.block.render'>,
@@ -273,29 +265,6 @@ export interface ActionExtensionApi {
 export type ApiForExtension<Target extends keyof ExtensionTargets> =
   ExtractedApiFromExtension<ExtensionTargets[Target]>;
 
-type ExtractedApiFromRunExtension<T> = T extends RunExtension<
-  infer Api,
-  unknown
->
-  ? Api
-  : never;
-
 type ExtractedApiFromExtension<T> = T extends RenderExtension<any, any>
   ? ExtractedApiFromRenderExtension<T>
-  : T extends RunExtension<any, any>
-  ? ExtractedApiFromRunExtension<T>
   : never;
-
-/**
- * A union type containing all extension targets that follow the pattern of
- * accepting an `api` argument, and using those arguments to run code that does not render anything, but instead return
- * a value or execute a side effect.
- */
-export type RunExtensionTarget = {
-  [Target in keyof ExtensionTargets]: ExtensionTargets[Target] extends RunExtension<
-    any,
-    any
-  >
-    ? Target
-    : never;
-}[keyof ExtensionTargets];


### PR DESCRIPTION
### Background

Part of step 4 ( have to do it in ui-extension  side as well ) of this ticket https://github.com/Shopify/core-issues/issues/63160

Please also review customer account web side PR: https://github.com/Shopify/customer-account-web/pull/3701 

1. customer account repo: support render customer-account.order.action.menu-item.render if it is within return extension https://github.com/Shopify/customer-account-web/pull/3679 
2. return repo: add an customer-account.order.action.menu-item.render  target extension and remove the CustomerAccount::Returns::Initiate target extension  ( after step 1 is deployed ) https://github.com/Shopify/buyer-returns/pull/372 
3. customer account repo: remove requestReturn logic  https://github.com/Shopify/customer-account-web/pull/3699 
4. customer account repo: remove the legacy CustomerAccount::Returns::Initiate 
     - customer account web side:  https://github.com/Shopify/customer-account-web/pull/3701 
     - ui extension side https://github.com/Shopify/ui-extensions/pull/1658
5. customer account repo and return repo: once soft auth customer account api is supported, move the whether to render request return logic to return app 
6. drop the support for CustomerAccount::Returns::Initiate in core https://github.com/Shopify/shopify/blob/f646c61cdfe69b47ed1c9a82eff8d29eb866c7e0/components/apps/app/services/apps/models/ui_extension/schema/groups/customer_account_ui.rb

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

See tophat of this ticket https://github.com/Shopify/customer-account-web/pull/3701 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
