### PR TITLE
Unstable patch for checkout ui extensions

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/checkout/components/Select/Select.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/components/Select/Select.ts
@@ -1,7 +1,5 @@
-import {
-  Select as BaseSelect,
-  SelectOptionProps as BaseSelectOptionProps,
-} from '@shopify/ui-extensions/checkout';
+import type {SelectOptionProps as BaseSelectOptionProps} from '@shopify/ui-extensions/checkout';
+import {Select as BaseSelect} from '@shopify/ui-extensions/checkout';
 import {createRemoteReactComponent} from '@remote-ui/react';
 import type {ReactPropsFromRemoteComponentType} from '@remote-ui/react';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/errors.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/errors.ts
@@ -1,4 +1,4 @@
-import {ExtensionTarget} from '@shopify/ui-extensions/checkout';
+import type {ExtensionTarget} from '@shopify/ui-extensions/checkout';
 
 export class CheckoutUIExtensionError extends Error {
   name = 'CheckoutUIExtensionError';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/api.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/api.ts
@@ -1,5 +1,5 @@
 import {useContext} from 'react';
-import {
+import type {
   RenderExtensionTarget,
   ApiForRenderExtension,
 } from '@shopify/ui-extensions/checkout';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/cart-line-target.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/cart-line-target.ts
@@ -1,4 +1,4 @@
-import {CartLine} from '@shopify/ui-extensions/checkout';
+import type {CartLine} from '@shopify/ui-extensions/checkout';
 
 import {ExtensionHasNoTargetError} from '../errors';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/checkout-token.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/checkout-token.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CheckoutToken,
   RenderExtensionTarget,
 } from '@shopify/ui-extensions/checkout';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/country.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/country.ts
@@ -1,4 +1,7 @@
-import {Country, RenderExtensionTarget} from '@shopify/ui-extensions/checkout';
+import type {
+  Country,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/checkout';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/currency.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/currency.ts
@@ -1,4 +1,7 @@
-import {Currency, RenderExtensionTarget} from '@shopify/ui-extensions/checkout';
+import type {
+  Currency,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/checkout';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/language.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/language.ts
@@ -1,4 +1,7 @@
-import {Language, RenderExtensionTarget} from '@shopify/ui-extensions/checkout';
+import type {
+  Language,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/checkout';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/market.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/market.ts
@@ -1,4 +1,7 @@
-import {Market, RenderExtensionTarget} from '@shopify/ui-extensions/checkout';
+import type {
+  Market,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/checkout';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/metafield.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/metafield.ts
@@ -1,4 +1,4 @@
-import {Metafield} from '@shopify/ui-extensions/checkout';
+import type {Metafield} from '@shopify/ui-extensions/checkout';
 
 import {CheckoutUIExtensionError} from '../errors';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/order.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/order.ts
@@ -1,4 +1,7 @@
-import {Order, RenderExtensionTarget} from '@shopify/ui-extensions/checkout';
+import type {
+  Order,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/checkout';
 
 import {ExtensionHasNoMethodError} from '../errors';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/payment-method.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/payment-method.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   PaymentMethodAttributesResult,
   PaymentMethodAttributesChange,
   PaymentMethodAttribute,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/redeemable.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/redeemable.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   RedeemableChangeResult,
   RedeemableChange,
 } from '@shopify/ui-extensions/checkout';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/session-token.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/session-token.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SessionToken,
   RenderExtensionTarget,
 } from '@shopify/ui-extensions/checkout';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/shipping-option-target.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/shipping-option-target.ts
@@ -1,4 +1,4 @@
-import {ShippingOption} from '@shopify/ui-extensions/checkout';
+import type {ShippingOption} from '@shopify/ui-extensions/checkout';
 import {useMemo} from 'react';
 
 import {ExtensionHasNoTargetError} from '../errors';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/target.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/target.ts
@@ -1,4 +1,4 @@
-import {ExtensionTarget, CartLine} from '@shopify/ui-extensions/checkout';
+import type {ExtensionTarget, CartLine} from '@shopify/ui-extensions/checkout';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/app-metafields.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/app-metafields.test.ts
@@ -1,4 +1,4 @@
-import {Metafield} from '@shopify/ui-extensions/checkout';
+import type {Metafield} from '@shopify/ui-extensions/checkout';
 import {faker} from '@faker-js/faker';
 
 import {useAppMetafields} from '../app-metafields';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/billing-address.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/billing-address.test.ts
@@ -1,4 +1,4 @@
-import {MailingAddress} from '@shopify/ui-extensions/checkout';
+import type {MailingAddress} from '@shopify/ui-extensions/checkout';
 
 import {useBillingAddress} from '../billing-address';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/buyer-identity.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/buyer-identity.test.tsx
@@ -1,4 +1,4 @@
-import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 import {faker} from '@faker-js/faker';
 
 import {ScopeNotGrantedError} from '../../errors';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/cart-line-target.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/cart-line-target.test.ts
@@ -1,4 +1,4 @@
-import {ExtensionTarget, CartLine} from '@shopify/ui-extensions/checkout';
+import type {ExtensionTarget, CartLine} from '@shopify/ui-extensions/checkout';
 
 import {useCartLineTarget} from '../cart-line-target';
 import {ExtensionHasNoTargetError} from '../../errors';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/checkout-settings.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/checkout-settings.test.ts
@@ -1,4 +1,4 @@
-import {CheckoutSettings} from '@shopify/ui-extensions/checkout';
+import type {CheckoutSettings} from '@shopify/ui-extensions/checkout';
 
 import {useCheckoutSettings} from '../checkout-settings';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/country.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/country.test.tsx
@@ -1,4 +1,4 @@
-import {CountryCode} from '@shopify/ui-extensions/checkout';
+import type {CountryCode} from '@shopify/ui-extensions/checkout';
 
 import {useLocalizationCountry} from '../country';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/currency.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/currency.test.tsx
@@ -1,4 +1,4 @@
-import {CurrencyCode} from '@shopify/ui-extensions/checkout';
+import type {CurrencyCode} from '@shopify/ui-extensions/checkout';
 
 import {useCurrency} from '../currency';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/discounts.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/discounts.test.tsx
@@ -1,4 +1,4 @@
-import {
+import type {
   CartDiscountCode,
   CartDiscountAllocation,
 } from '@shopify/ui-extensions/checkout';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/gift-cards.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/gift-cards.test.tsx
@@ -1,4 +1,4 @@
-import {AppliedGiftCard} from '@shopify/ui-extensions/checkout';
+import type {AppliedGiftCard} from '@shopify/ui-extensions/checkout';
 
 import {useAppliedGiftCards} from '../gift-cards';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/metafield.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/metafield.test.tsx
@@ -1,5 +1,5 @@
 import {faker} from '@faker-js/faker';
-import {Metafield} from '@shopify/ui-extensions/checkout';
+import type {Metafield} from '@shopify/ui-extensions/checkout';
 
 import {useMetafield} from '..';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/metafields.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/metafields.test.tsx
@@ -1,5 +1,5 @@
 import {faker} from '@faker-js/faker';
-import {Metafield} from '@shopify/ui-extensions/checkout';
+import type {Metafield} from '@shopify/ui-extensions/checkout';
 
 import {useMetafields} from '..';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/mount.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/mount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {createRender} from '@quilted/react-testing';
-import {
+import type {
   ApiForRenderExtension,
   RenderExtensionTarget,
 } from '@shopify/ui-extensions/checkout';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/payment-method.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/payment-method.test.ts
@@ -1,4 +1,4 @@
-import {ExtensionTarget} from '@shopify/ui-extensions/checkout';
+import type {ExtensionTarget} from '@shopify/ui-extensions/checkout';
 
 import {
   useApplyPaymentMethodAttributesChange,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/payment-options.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/payment-options.test.tsx
@@ -1,4 +1,4 @@
-import {
+import type {
   PaymentOption,
   SelectedPaymentOption,
 } from '@shopify/ui-extensions/checkout';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/redeemable.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/redeemable.test.ts
@@ -1,4 +1,4 @@
-import {ExtensionTarget} from '@shopify/ui-extensions/checkout';
+import type {ExtensionTarget} from '@shopify/ui-extensions/checkout';
 
 import {useApplyRedeemableChange} from '../redeemable';
 import {ExtensionHasNoMethodError} from '../../errors';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/shipping-address.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/shipping-address.test.ts
@@ -1,4 +1,4 @@
-import {MailingAddress} from '@shopify/ui-extensions/checkout';
+import type {MailingAddress} from '@shopify/ui-extensions/checkout';
 
 import {useShippingAddress} from '../shipping-address';
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/shipping-option-target.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/shipping-option-target.test.ts
@@ -1,4 +1,7 @@
-import {ExtensionTarget, ShippingOption} from '@shopify/ui-extensions/checkout';
+import type {
+  ExtensionTarget,
+  ShippingOption,
+} from '@shopify/ui-extensions/checkout';
 
 import {useShippingOptionTarget} from '../shipping-option-target';
 import {ExtensionHasNoTargetError} from '../../errors';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/timezone.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/timezone.ts
@@ -1,4 +1,7 @@
-import {RenderExtensionTarget, Timezone} from '@shopify/ui-extensions/checkout';
+import type {
+  RenderExtensionTarget,
+  Timezone,
+} from '@shopify/ui-extensions/checkout';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/translate.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/translate.ts
@@ -3,7 +3,6 @@ import type {
   RenderExtensionTarget,
   I18nTranslate,
 } from '@shopify/ui-extensions/checkout';
-import type {RemoteComponentType} from '@remote-ui/types';
 
 import {useApi} from './api';
 
@@ -26,7 +25,7 @@ export function useTranslate<
       return translation.map((part, index) => {
         if (isValidElement(part)) {
           // eslint-disable-next-line react/no-array-index-key
-          return cloneElement(part as RemoteComponentType<any>, {key: index});
+          return cloneElement(part, {key: index});
         }
         return part;
       });

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/address.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/address.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getLinksByTag,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/analytics.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/analytics.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/attributes.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/attributes.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   STANDARD_API_PROPERTIES_DESCRIPTION,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-identity.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-identity.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   STANDARD_API_PROPERTIES_DESCRIPTION,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   STANDARD_API_PROPERTIES_DESCRIPTION,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cart-lines.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cart-lines.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   STANDARD_API_PROPERTIES_DESCRIPTION,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/checkout-token.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/checkout-token.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getLinksByTag,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cost.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cost.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getLinksByTag,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/delivery.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/delivery.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getLinksByTag,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/discounts.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/discounts.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   CHECKOUT_API_PROPERTIES_DESCRIPTION,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/extension-meta.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/extension-meta.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getLinksByTag,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/gift-cards.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/gift-cards.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   CHECKOUT_API_PROPERTIES_DESCRIPTION,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/localization.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/localization.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/metafields.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/metafields.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getLinksByTag,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/note.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/note.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   CHECKOUT_API_PROPERTIES_DESCRIPTION,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/order.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/order.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getLinksByTag,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/payment-options.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/payment-options.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getHookExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/query.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/query.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/session-token.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/session-token.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/settings.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/settings.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/shop.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/shop.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getLinksByTag,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/storage.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/storage.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getLinksByTag,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
@@ -1,4 +1,4 @@
-import {CodeTabType, ExampleType, LinkType} from '@shopify/generate-docs';
+import type {CodeTabType, ExampleType, LinkType} from '@shopify/generate-docs';
 
 const examplePath = '../examples';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/hooks/api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/hooks/api.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getHookExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/hooks/extension-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/hooks/extension-api.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getHookExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/hooks/subscription.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/hooks/subscription.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getHookExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/customer-account.order-status.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/customer-account.order-status.block.render.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/customer-account.order-status.cart-line-item.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/customer-account.order-status.cart-line-item.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/customer-account.order-status.cart-line-list.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/customer-account.order-status.cart-line-list.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/customer-account.order-status.customer-information.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/customer-account.order-status.customer-information.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.actions.render-before.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.actions.render-before.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.block.render.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.cart-line-item.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.cart-line-item.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   CHECKOUT_CART_LINE_ITEM_API,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.cart-line-list.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.cart-line-list.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.contact.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.contact.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.delivery-address.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.delivery-address.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.delivery-address.render-before.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.delivery-address.render-before.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.footer.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.footer.render-after.doc.ts
@@ -1,10 +1,13 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.checkout.footer.render-after',
-  description: 'A static extension target that is rendered below the footer.',
+  description: `A static extension target that is rendered below the footer.
+
+  To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading. See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/structure/blockspacer).
+  `,
   defaultExample: getExample('purchase.checkout.footer.render-after/default', [
     'jsx',
     'js',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.header.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.header.render-after.doc.ts
@@ -1,10 +1,13 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.checkout.header.render-after',
-  description: 'A static extension target that is rendered below the header.',
+  description: `A static extension target that is rendered below the header.
+
+  To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading. See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/structure/blockspacer).
+  `,
   defaultExample: getExample('purchase.checkout.header.render-after/default', [
     'jsx',
     'js',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.payment-method-list.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.payment-method-list.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.payment-method-list.render-before.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.payment-method-list.render-before.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.pickup-location-list.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.pickup-location-list.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.pickup-location-list.render-before.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.pickup-location-list.render-before.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.pickup-point-list.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.pickup-point-list.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample, getLinksByTag, PICKUP_POINT_LIST_API} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.pickup-point-list.render-before.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.pickup-point-list.render-before.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample, getLinksByTag, PICKUP_POINT_LIST_API} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.reductions.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.reductions.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample, getLinksByTag, CHECKOUT_API} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.reductions.render-before.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.reductions.render-before.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample, getLinksByTag, CHECKOUT_API} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.shipping-option-item.details.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.shipping-option-item.details.render.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.shipping-option-item.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.shipping-option-item.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.shipping-option-list.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.shipping-option-list.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.shipping-option-list.render-before.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.shipping-option-list.render-before.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
   getExample,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.block.render.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample, getLinksByTag, STANDARD_API} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.cart-line-item.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.cart-line-item.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample, getLinksByTag, CART_LINE_ITEM_API} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.cart-line-list.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.cart-line-list.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample, getLinksByTag, STANDARD_API} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.customer-information.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.customer-information.render-after.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample, getLinksByTag, STANDARD_API} from '../helper.docs';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.footer.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.footer.render-after.doc.ts
@@ -1,11 +1,13 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {STANDARD_API, getExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.thank-you.footer.render-after',
-  description:
-    'A static extension target that is rendered below the footer on the **Thank you** page.',
+  description: `A static extension target that is rendered below the footer on the **Thank you** page.
+
+  To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading. See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/structure/blockspacer).
+  `,
   defaultExample: getExample('purchase.thank-you.footer.render-after/default', [
     'jsx',
     'js',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.header.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.header.render-after.doc.ts
@@ -1,11 +1,13 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {STANDARD_API, getExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.thank-you.header.render-after',
-  description:
-    'A static extension target that is rendered below the header on the **Thank you** page.',
+  description: `A static extension target that is rendered below the header on the **Thank you** page.
+
+  To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading. See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/structure/blockspacer).
+  `,
   defaultExample: getExample('purchase.thank-you.header.render-after/default', [
     'jsx',
     'js',

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/configuration.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/configuration.doc.ts
@@ -1,4 +1,4 @@
-import {LandingTemplateSchema} from '@shopify/generate-docs';
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
 
 // Order of data shape mimics visual structure of page
 // Anything in an array can have multiple objects

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/error-handling.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/error-handling.doc.ts
@@ -1,4 +1,4 @@
-import {LandingTemplateSchema} from '@shopify/generate-docs';
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
 
 const data: LandingTemplateSchema = {
   title: 'Error handling',

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/extension-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/extension-overview.doc.ts
@@ -1,4 +1,4 @@
-import {LandingTemplateSchema} from '@shopify/generate-docs';
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
 
 // Order of data shape mimics visual structure of page
 // Anything in an array can have multiple objects

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
@@ -1,4 +1,4 @@
-import {LandingTemplateSchema} from '@shopify/generate-docs';
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
 
 const data: LandingTemplateSchema = {
   title: 'Checkout UI extensions',

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/versioning-migration.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/versioning-migration.doc.ts
@@ -1,4 +1,4 @@
-import {LandingTemplateSchema} from '@shopify/generate-docs';
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
 
 // Order of data shape mimics visual structure of page
 // Anything in an array can have multiple objects

--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -15,4 +15,9 @@ export type AnyComponentBuilder<ComponentTypes> =
 /**
  * Union of supported API versions
  */
-export type ApiVersion = '2023-04' | '2023-07' | '2023-10' | 'unstable';
+export type ApiVersion =
+  | '2023-04'
+  | '2023-07'
+  | '2023-10'
+  | '2024-01'
+  | 'unstable';

--- a/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
@@ -1,6 +1,6 @@
 import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
-import {CartLine} from '../standard/standard';
+import type {CartLine} from '../standard/standard';
 
 export interface CartLineItemApi {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -1,4 +1,4 @@
-import {Attribute, SellingPlan, MailingAddress} from '../shared';
+import type {Attribute, SellingPlan, MailingAddress} from '../shared';
 
 /**
  * Removes a note

--- a/packages/ui-extensions/src/surfaces/checkout/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/docs.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   StandardApi,
   CheckoutApi,
   CartLineItemApi,

--- a/packages/ui-extensions/src/surfaces/checkout/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/order-status/order-status.ts
@@ -1,4 +1,4 @@
-import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 /**
  * Information about an order that was placed.

--- a/packages/ui-extensions/src/surfaces/checkout/api/payment/payment-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/payment/payment-option-item.ts
@@ -1,4 +1,4 @@
-import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 export type PaymentMethodAttributesResult =
   | PaymentMethodAttributesResultSuccess

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
@@ -1,6 +1,6 @@
 import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
-import {ShippingOption} from '../standard/standard';
+import type {ShippingOption} from '../standard/standard';
 
 export interface ShippingOptionItemApi {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
@@ -1,6 +1,6 @@
-import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
-import {DeliveryGroup} from '../standard/standard';
+import type {DeliveryGroup} from '../standard/standard';
 
 export interface ShippingOptionListApi {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -12,7 +12,7 @@ import type {
   MailingAddress,
 } from '../shared';
 import type {ExtensionTarget} from '../../targets';
-import {ApiVersion} from '../../../../shared';
+import type {ApiVersion} from '../../../../shared';
 
 /**
  * A key-value storage object for the extension.
@@ -73,7 +73,7 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The API version that was set in the extension config file.
    *
-   * @example '2023-04', '2023-07'
+   * @example '2023-04', '2023-07', '2023-10', '2024-01', 'unstable'
    */
   apiVersion: ApiVersion;
 
@@ -787,6 +787,9 @@ export interface Shop {
   name: string;
   /**
    * The primary storefront URL.
+   *
+   * > Caution:
+   * > As of version `2024-04` this value will no longer have a trailing slash.
    */
   storefrontUrl?: string;
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Banner',

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'BlockLayout',

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {MaybeResponsiveConditionalStyle} from '../../style';
+import type {MaybeResponsiveConditionalStyle} from '../../style';
 import type {Rows} from '../shared';
 import type {GridProps} from '../Grid/Grid';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockSpacer/BlockSpacer.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockSpacer/BlockSpacer.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'BlockSpacer',

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample} from '../../helper.docs';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.ts
@@ -10,7 +10,7 @@ import type {
   SpacingProps,
   ViewLikeAccessibilityRole,
 } from '../shared';
-import {MaybeResponsiveConditionalStyle} from '../../style';
+import type {MaybeResponsiveConditionalStyle} from '../../style';
 
 export interface BlockStackProps
   extends Pick<BackgroundProps, 'background'>,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Button/Button.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Button',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/Checkbox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/Checkbox.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample} from '../../helper.docs';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/Checkbox.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/Checkbox.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {DisclosureActivatorProps} from '../shared';
+import type {DisclosureActivatorProps} from '../shared';
 
 export interface CheckboxProps extends DisclosureActivatorProps {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Choice/Choice.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Choice/Choice.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Choice',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Choice/Choice.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Choice/Choice.ts
@@ -1,4 +1,5 @@
-import {createRemoteComponent, RemoteFragment} from '@remote-ui/core';
+import type {RemoteFragment} from '@remote-ui/core';
+import {createRemoteComponent} from '@remote-ui/core';
 
 export interface ChoiceProps {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ChoiceList/ChoiceList.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample} from '../../helper.docs';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/ConsentCheckbox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/ConsentCheckbox.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ConsentCheckbox',

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/ConsentCheckbox.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/ConsentCheckbox.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {CheckboxProps} from '../Checkbox/Checkbox';
+import type {CheckboxProps} from '../Checkbox/Checkbox';
 
 export interface ConsentCheckboxProps extends Omit<CheckboxProps, 'value'> {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/ConsentPhoneField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/ConsentPhoneField.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ConsentPhoneField',

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/ConsentPhoneField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/ConsentPhoneField.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {PhoneFieldProps} from '../PhoneField/PhoneField';
+import type {PhoneFieldProps} from '../PhoneField/PhoneField';
 
 export type ConsentPolicy = 'sms-marketing';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DateField/DateField.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'DateField',

--- a/packages/ui-extensions/src/surfaces/checkout/components/DateField/DateField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DateField/DateField.ts
@@ -1,7 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {DatePickerProps, SelectedDate} from '../DatePicker/DatePicker';
-import {TextFieldProps} from '../TextField/TextField';
+import type {DatePickerProps, SelectedDate} from '../DatePicker/DatePicker';
+import type {TextFieldProps} from '../TextField/TextField';
 
 export interface DateFieldProps
   extends Pick<

--- a/packages/ui-extensions/src/surfaces/checkout/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DatePicker/DatePicker.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'DatePicker',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Disclosure/Disclosure.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Disclosure/Disclosure.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample} from '../../helper.docs';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/Disclosure/Disclosure.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Disclosure/Disclosure.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {MaybeResponsiveConditionalStyle} from '../../style';
+import type {MaybeResponsiveConditionalStyle} from '../../style';
 import type {DisclosureOpen} from '../shared';
 
 export interface DisclosureProps {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Divider/Divider.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Divider',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Form',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Grid',

--- a/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'GridItem',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Heading',

--- a/packages/ui-extensions/src/surfaces/checkout/components/HeadingGroup/HeadingGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/HeadingGroup/HeadingGroup.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'HeadingGroup',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image',

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineLayout/InlineLayout.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineLayout/InlineLayout.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample} from '../../helper.docs';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineSpacer/InlineSpacer.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineSpacer/InlineSpacer.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'InlineSpacer',

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'InlineStack',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Link',

--- a/packages/ui-extensions/src/surfaces/checkout/components/List/List.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/List/List.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'List',

--- a/packages/ui-extensions/src/surfaces/checkout/components/ListItem/ListItem.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ListItem/ListItem.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ListItem',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Map/Map.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Map/Map.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Map',

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapMarker/MapMarker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapMarker/MapMarker.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'MapMarker',

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapPopover/MapPopover.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapPopover/MapPopover.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'MapPopover',

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapPopover/MapPopover.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapPopover/MapPopover.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {IdProps} from '../shared';
+import type {IdProps} from '../shared';
 
 export interface MapPopoverProps extends IdProps {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Modal',

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'PaymentIcon',

--- a/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/PhoneField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/PhoneField.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'PhoneField',

--- a/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/PhoneField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/PhoneField.ts
@@ -1,7 +1,8 @@
-import {createRemoteComponent, RemoteFragment} from '@remote-ui/core';
+import type {RemoteFragment} from '@remote-ui/core';
+import {createRemoteComponent} from '@remote-ui/core';
 
-import {Autocomplete} from '../shared';
-import {IconSource} from '../Icon/Icon';
+import type {Autocomplete} from '../shared';
+import type {IconSource} from '../Icon/Icon';
 
 export interface PhoneFieldProps {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover/Popover.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover/Popover.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Popover',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Pressable',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {MaybeResponsiveConditionalStyle} from '../../style';
+import type {MaybeResponsiveConditionalStyle} from '../../style';
 import type {
   BlockAlignment,
   BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ProductThumbnail',

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.ts
@@ -1,7 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {MaybeConditionalStyle, ResolutionCondition} from '../../style';
-import {Size} from '../shared';
+import type {MaybeConditionalStyle, ResolutionCondition} from '../../style';
+import type {Size} from '../shared';
 
 export interface ProductThumbnailProps {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ScrollView',

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {
+import type {
   BackgroundProps,
   BorderProps,
   CornerProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Select/Select.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Select',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Select/Select.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Select/Select.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {Autocomplete} from '../shared';
+import type {Autocomplete} from '../shared';
 
 export interface SelectOptionProps {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonImage/SkeletonImage.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonImage/SkeletonImage.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample} from '../../helper.docs';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonImage/SkeletonImage.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonImage/SkeletonImage.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {MaybeResponsiveConditionalStyle} from '../../style';
+import type {MaybeResponsiveConditionalStyle} from '../../style';
 import type {IdProps} from '../shared';
 
 export interface SkeletonImageProps extends IdProps {

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonText/SkeletonText.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonText/SkeletonText.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample} from '../../helper.docs';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonTextBlock/SkeletonTextBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonTextBlock/SkeletonTextBlock.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'SkeletonTextBlock',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Spinner',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Stepper/Stepper.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Stepper/Stepper.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Stepper',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Stepper/Stepper.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Stepper/Stepper.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {IconSource} from '../Icon/Icon';
+import type {IconSource} from '../Icon/Icon';
 
 export interface StepperProps {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tag/Tag.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tag/Tag.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Tag',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tag/Tag.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tag/Tag.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {IconSource} from '../Icon/Icon';
+import type {IconSource} from '../Icon/Icon';
 import type {IdProps} from '../shared';
 
 export interface TagProps extends IdProps {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Text/Text.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Text',

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextBlock/TextBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextBlock/TextBlock.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextBlock',

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextField',

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.ts
@@ -1,7 +1,8 @@
-import {createRemoteComponent, RemoteFragment} from '@remote-ui/core';
+import type {RemoteFragment} from '@remote-ui/core';
+import {createRemoteComponent} from '@remote-ui/core';
 
-import {Autocomplete} from '../shared';
-import {IconSource} from '../Icon/Icon';
+import type {Autocomplete} from '../shared';
+import type {IconSource} from '../Icon/Icon';
 
 type Type = 'text' | 'email' | 'number' | 'telephone';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/ToggleButton/ToggleButton.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ToggleButton/ToggleButton.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ToggleButton',

--- a/packages/ui-extensions/src/surfaces/checkout/components/ToggleButtonGroup/ToggleButtonGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ToggleButtonGroup/ToggleButtonGroup.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {getExample} from '../../helper.docs';
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/Tooltip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/Tooltip.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Tooltip',

--- a/packages/ui-extensions/src/surfaces/checkout/components/View/View.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/View/View.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'View',

--- a/packages/ui-extensions/src/surfaces/checkout/components/View/View.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/View/View.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-import {MaybeResponsiveConditionalStyle} from '../../style';
+import type {MaybeResponsiveConditionalStyle} from '../../style';
 import type {
   BackgroundProps,
   BlockAlignment,

--- a/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
@@ -1,6 +1,9 @@
-import {RemoteFragment} from '@remote-ui/core';
+import type {RemoteFragment} from '@remote-ui/core';
 
-import {MaybeConditionalStyle, MaybeResponsiveConditionalStyle} from '../style';
+import type {
+  MaybeConditionalStyle,
+  MaybeResponsiveConditionalStyle,
+} from '../style';
 
 /**
  * A descriptor for selecting the data a field would like to receive during
@@ -20,7 +23,7 @@ export interface Autocomplete {
   field: AutocompleteField;
 }
 
-export type AutocompleteGroup = 'shipping' | 'billing' | 'location';
+export type AutocompleteGroup = 'shipping' | 'billing';
 
 export type AutocompleteField =
   | 'name'
@@ -346,7 +349,7 @@ export interface SpacingProps {
    *
    * - [`base`, `none`] means blockStart and blockEnd paddings are `base`, inlineStart and inlineEnd paddings are `none`
    *
-   * - [`base`, `none`, `loose`, `tight`] means blockStart padding is `base`, inlineEnd padding is `none`, blockEnd padding is `loose` and  blockStart padding is `tight`
+   * - [`base`, `none`, `large200`, `small200`] means blockStart padding is `base`, inlineEnd padding is `none`, blockEnd padding is `large200` and  blockStart padding is `small200`
    */
   padding?: MaybeResponsiveConditionalStyle<MaybeShorthandProperty<Spacing>>;
 }
@@ -500,11 +503,28 @@ export type Size =
 
 export type Spacing =
   | 'none'
-  | 'extraTight'
-  | 'tight'
+  | 'small500'
+  | 'small400'
+  | 'small300'
+  | 'small200'
+  | 'small100'
   | 'base'
-  | 'loose'
-  | 'extraLoose';
+  | 'large100'
+  | 'large200'
+  | 'large300'
+  | 'large400'
+  | 'large500'
+  | SpacingDeprecated;
+
+/** @deprecated These values are deprecated and will eventually be removed.
+ * Use the new values.
+ *
+ * `extraTight`: `small400`
+ * `tight`: `small200`
+ * `loose`: `large200`
+ * `extraLoose`: `large500`
+ */
+export type SpacingDeprecated = 'extraTight' | 'tight' | 'loose' | 'extraLoose';
 
 export type Alignment = 'start' | 'center' | 'end';
 export type InlineAlignment = 'start' | 'center' | 'end';

--- a/packages/ui-extensions/src/surfaces/checkout/helper.docs.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/helper.docs.ts
@@ -1,4 +1,4 @@
-import {CodeTabType, ExampleType} from '@shopify/generate-docs';
+import type {CodeTabType, ExampleType} from '@shopify/generate-docs';
 
 const examplePath = '../../../../../docs/surfaces/checkout/reference/examples';
 

--- a/packages/ui-extensions/src/surfaces/checkout/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/shared.ts
@@ -1,6 +1,6 @@
 import type {ComponentsBuilder, AnyComponentBuilder} from '../../shared';
 
-type ComponentTypes = typeof import('./components');
+import type * as ComponentsModule from './components';
 
-export type Components = ComponentsBuilder<ComponentTypes>;
-export type AnyComponent = AnyComponentBuilder<ComponentTypes>;
+export type Components = ComponentsBuilder<typeof ComponentsModule>;
+export type AnyComponent = AnyComponentBuilder<typeof ComponentsModule>;

--- a/packages/ui-extensions/src/surfaces/checkout/style/style.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/style/style.doc.ts
@@ -1,4 +1,4 @@
-import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'StyleHelper',

--- a/packages/ui-extensions/src/surfaces/checkout/style/style.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/style/style.ts
@@ -1,5 +1,5 @@
 import {memoize} from './memoize';
-import {
+import type {
   Conditions,
   ConditionalStyle,
   BaseConditions,


### PR DESCRIPTION
### Background

This PR adds import type optimizations and updated documentation for the change to the `storefrontUrl` format. These changes are pulled from the `checkout-web` private package.

```
/**
   * The primary storefront URL.
   *
   * > Caution:
   * > As of version `2024-04` this value will no longer have a trailing slash.
   */
  storefrontUrl?: string;
```

In addition, this PR fixes a bug where the `2024-01` version was not included as a valid string for the `ApiVersion` type. This will be patched for `2024.1.x` as well in another PR.

### Solution

Follows the instructions outlines in [this vault doc](https://vault.shopify.io/teams/2083/pages/Extension-Libraries~gkKh.md).

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
