### PR TITLE
January patch 2024-01

### DIFF
--- a/.changeset/loud-houses-press.md
+++ b/.changeset/loud-houses-press.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Adds 2024-01 as a valid `ApiVersion` type value.

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.footer.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.footer.render-after.doc.ts
@@ -4,11 +4,12 @@ import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.checkout.footer.render-after',
-  description: 'A static extension target that is rendered below the footer.',
-  defaultExample: getExample('purchase.checkout.footer.render-after/default', [
-    'jsx',
-    'js',
-  ]),
+  description: `A static extension target that is rendered below the footer.
+
+  > Tip:
+  > To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading.
+  > See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/structure/blockspacer).
+  `,
   subCategory: 'Footer',
   related: getLinksByTag('targets'),
   ...CHECKOUT_API,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.header.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.header.render-after.doc.ts
@@ -4,7 +4,12 @@ import {CHECKOUT_API, getExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.checkout.header.render-after',
-  description: 'A static extension target that is rendered below the header.',
+  description: `A static extension target that is rendered below the header.
+
+  > Tip:
+  > To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading.
+  > See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/structure/blockspacer).
+  `,
   defaultExample: getExample('purchase.checkout.header.render-after/default', [
     'jsx',
     'js',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.footer.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.footer.render-after.doc.ts
@@ -4,12 +4,12 @@ import {STANDARD_API, getExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.thank-you.footer.render-after',
-  description:
-    'A static extension target that is rendered below the footer on the **Thank you** page.',
-  defaultExample: getExample('purchase.thank-you.footer.render-after/default', [
-    'jsx',
-    'js',
-  ]),
+  description: `A static extension target that is rendered below the footer on the **Thank you** page.
+
+  > Tip:
+  > To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading.
+  > See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/structure/blockspacer).
+  `,
   subCategory: 'Footer',
   related: getLinksByTag('targets'),
   ...STANDARD_API,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.header.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.header.render-after.doc.ts
@@ -4,12 +4,12 @@ import {STANDARD_API, getExample, getLinksByTag} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.thank-you.header.render-after',
-  description:
-    'A static extension target that is rendered below the header on the **Thank you** page.',
-  defaultExample: getExample('purchase.thank-you.header.render-after/default', [
-    'jsx',
-    'js',
-  ]),
+  description: `A static extension target that is rendered below the header on the **Thank you** page.
+
+  > Tip:
+  > To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading.
+  > See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/structure/blockspacer).
+  `,
   subCategory: 'Header',
   related: getLinksByTag('targets'),
   ...STANDARD_API,

--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -15,4 +15,9 @@ export type AnyComponentBuilder<ComponentTypes> =
 /**
  * Union of supported API versions
  */
-export type ApiVersion = '2023-04' | '2023-07' | '2023-10' | 'unstable';
+export type ApiVersion =
+  | '2023-04'
+  | '2023-07'
+  | '2023-10'
+  | '2024-01'
+  | 'unstable';

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -73,7 +73,7 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The API version that was set in the extension config file.
    *
-   * @example '2023-04', '2023-07'
+   * @example '2023-04', '2023-07', '2023-10', '2024-01', 'unstable'
    */
   apiVersion: ApiVersion;
 


### PR DESCRIPTION
### Background
Cherry-picks a few changes that were recently [patched in unstable](https://github.com/Shopify/ui-extensions/pull/1663)

- Adds 2024-01 as a valid `ApiVersion` type value
- Adds a note on accounting for layout shift when using header/footer extension targets

### Solution

Cherry pick the changes that should applied to the 2024-01 stable version.


### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
