### PR TITLE
Re-add example code def for header/footer targets

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.footer.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.footer.render-after.doc.ts
@@ -10,6 +10,10 @@ const data: ReferenceEntityTemplateSchema = {
   > To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading.
   > See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/components/structure/blockspacer).
   `,
+  defaultExample: getExample('purchase.checkout.footer.render-after/default', [
+    'jsx',
+    'js',
+  ]),
   subCategory: 'Footer',
   related: getLinksByTag('targets'),
   ...CHECKOUT_API,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.footer.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.footer.render-after.doc.ts
@@ -10,6 +10,10 @@ const data: ReferenceEntityTemplateSchema = {
   > To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading.
   > See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/components/structure/blockspacer).
   `,
+  defaultExample: getExample('purchase.thank-you.footer.render-after/default', [
+    'jsx',
+    'js',
+  ]),
   subCategory: 'Footer',
   related: getLinksByTag('targets'),
   ...STANDARD_API,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.header.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.header.render-after.doc.ts
@@ -10,6 +10,10 @@ const data: ReferenceEntityTemplateSchema = {
   > To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading.
   > See: [Spinner](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/spinner), [SkeletonText](https://shopify.dev/docs/api/checkout-ui-extensions/components/feedback/skeletontext), or [BlockSpacer](https://shopify.dev/docs/api/checkout-ui-extensions/components/structure/blockspacer).
   `,
+  defaultExample: getExample('purchase.thank-you.header.render-after/default', [
+    'jsx',
+    'js',
+  ]),
   subCategory: 'Header',
   related: getLinksByTag('targets'),
   ...STANDARD_API,


### PR DESCRIPTION
### Background

Default code examples for these header/footer targets were accidentally removed in the latest 2024.1.1 patch. This will add them back. This does not require a package release since this is only documentation related.

### Solution

Re-add the missing default code.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
