### PR TITLE
add requireLogin for customer account order status api

### DIFF
--- a/.changeset/nine-points-deny.md
+++ b/.changeset/nine-points-deny.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+add requireLogin for CA order status api

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -347,6 +347,11 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
    * @example 'unstable'
    */
   version: Version;
+
+  /**
+   * The requireLogin() method triggers login if the customer is viewing pre-authenticated Order Status Page.
+   */
+  requireLogin: () => Promise<void>;
 }
 
 export interface OrderStatusBuyerIdentity {


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/65428 

Add requireLogin for customer account order status api

customer account web side PR: https://github.com/Shopify/customer-account-web/pull/3779 


### 🎩

Please see tophat in this PR: customer account web side PR: https://github.com/Shopify/customer-account-web/pull/3779  

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
