### PR TITLE
Adds support for async react renders for admin extensions

### DIFF
--- a/.changeset/warm-spiders-smell.md
+++ b/.changeset/warm-spiders-smell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-react': patch
+---
+
+Adds support for async render functions for Admin extensions

--- a/packages/ui-extensions-react/src/surfaces/admin/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/render.tsx
@@ -25,18 +25,22 @@ import {ExtensionApiContext} from './context';
  */
 export function reactExtension<ExtensionTarget extends RenderExtensionTarget>(
   target: ExtensionTarget,
-  render: (api: ApiForRenderExtension<ExtensionTarget>) => ReactElement<any>,
+  render: (
+    api: ApiForRenderExtension<ExtensionTarget>,
+  ) => Promise<ReactElement<any>> | ReactElement<any>,
 ): ExtensionTargets[ExtensionTarget] {
   // TypeScript can’t infer the type of the callback because it’s a big union
   // type. To get around it, we’ll just fake like we are rendering the
   // Playground extension, since all render extensions have the same general
   // shape (`RenderExtension`).
-  return extension<'Playground'>(target as any, (root, api) => {
-    return new Promise((resolve, reject) => {
+  return extension<'Playground'>(target as any, async (root, api) => {
+    const element = await render(api as ApiForRenderExtension<ExtensionTarget>);
+
+    await new Promise<void>((resolve, reject) => {
       try {
         remoteRender(
           <ExtensionApiContext.Provider value={api}>
-            {render(api as ApiForRenderExtension<ExtensionTarget>)}
+            {element}
           </ExtensionApiContext.Provider>,
           root,
           () => {


### PR DESCRIPTION
### Background
As per [this comment](https://github.com/Shopify/ui-api-design/issues/227#issuecomment-1900860778) in https://github.com/Shopify/ui-api-design/issues/227 we want to lift where an extension can fetch data to the extension callback

### Solution
This solution mirrors the [implementation from checkout ](https://github.com/Shopify/ui-extensions/blob/unstable/packages/ui-extensions-react/src/surfaces/checkout/render.tsx#L44-L62).

### 🎩
You can try out my spin instance which has both async and sync rendering react and js extensions, lemme know if my dev server isn't running.
https://admin.web.arbok.thomas-marcucci.us.spin.dev/store/development-store-1/products/2

Otherwise if you want to test it on your own:
`spin up checkout-ui-extension-dev`
`git clone git@github.com:Shopify/ui-extensions.git`
`cd` into `ui-extensions/packages/ui-extensions` and `yarn link`
`cd` into `ui-extensions/packages/ui-extensions-react` and `yarn link`
`cd` into `ui-extensions` root and `yarn build`

create an app and generate an admin block extension
`cd` into your extension's folder and `yarn link @shopify/ui-extensions` and `yarn link @shopify/ui-extensions-react`
change the render function in your extension to be be async
```
export default reactExtension(TARGET, async (api) => {
  return <App />;
});
```
Now `yarn dev` and open up the extension preview. It should work as normal. ~~If you throw an exception it should show in the extension's place.~~ If you throw an exception in the render, it should be swallowed and the extension will render its default version (extension name as title and empty content).

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
