### PR TITLE
Validation settings Admin UI Extension target

### DIFF
--- a/.changeset/tall-ladybugs-join.md
+++ b/.changeset/tall-ladybugs-join.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+adds definitions for validation settings admin extension target

--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -7,3 +7,4 @@ export type {BlockExtensionApi} from './api/block/block';
 export type {ProductDetailsConfigurationApi} from './api/product-configuration/product-details-configuration';
 export type {ProductVariantDetailsConfigurationApi} from './api/product-configuration/product-variant-details-configuration';
 export type {OrderRoutingRuleApi} from './api/order-routing-rule/order-routing-rule';
+export type {ValidationSettingsApi} from './api/checkout-rules/validation-settings';

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/launch-options.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/launch-options.ts
@@ -1,0 +1,14 @@
+export interface ValidationData {
+  validation?: {
+    /**
+     * the validation's gid when active in a shop
+     */
+    id: string;
+  };
+  shopifyFunction: {
+    /**
+     * the validation's unique identifier
+     */
+    uuid: string;
+  };
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/metafields.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/metafields.ts
@@ -1,0 +1,76 @@
+const supportedDefinitionTypes = [
+  'boolean',
+  'collection_reference',
+  'color',
+  'date',
+  'date_time',
+  'dimension',
+  'file_reference',
+  'json',
+  'metaobject_reference',
+  'mixed_reference',
+  'money',
+  'multi_line_text_field',
+  'number_decimal',
+  'number_integer',
+  'page_reference',
+  'product_reference',
+  'rating',
+  'rich_text_field',
+  'single_line_text_field',
+  'product_taxonomy_value_reference',
+  'url',
+  'variant_reference',
+  'volume',
+  'weight',
+  'list.collection_reference',
+  'list.color',
+  'list.date',
+  'list.date_time',
+  'list.dimension',
+  'list.file_reference',
+  'list.metaobject_reference',
+  'list.mixed_reference',
+  'list.number_decimal',
+  'list.number_integer',
+  'list.page_reference',
+  'list.product_reference',
+  'list.rating',
+  'list.single_line_text_field',
+  'list.url',
+  'list.variant_reference',
+  'list.volume',
+  'list.weight',
+] as const;
+
+export type SupportedDefinitionType = typeof supportedDefinitionTypes[number];
+
+interface MetafieldUpdateChange {
+  type: 'updateMetafield';
+  key: string;
+  namespace?: string;
+  value: string | number;
+  valueType?: SupportedDefinitionType;
+}
+
+interface MetafieldRemoveChange {
+  type: 'removeMetafield';
+  key: string;
+  namespace: string;
+}
+
+type MetafieldChange = MetafieldUpdateChange | MetafieldRemoveChange;
+interface MetafieldChangeResultError {
+  type: 'error';
+  message: string;
+}
+interface MetafieldChangeSuccess {
+  type: 'success';
+}
+type MetafieldChangeResult =
+  | MetafieldChangeSuccess
+  | MetafieldChangeResultError;
+
+export interface ApplyMetafieldChange {
+  (change: MetafieldChange): Promise<MetafieldChangeResult>;
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.ts
@@ -1,0 +1,12 @@
+import type {StandardApi} from '../standard/standard';
+import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+
+import {ApplyMetafieldChange} from './metafields';
+import {ValidationData} from './launch-options';
+
+export interface ValidationSettingsApi<
+  ExtensionTarget extends AnyExtensionTarget,
+> extends StandardApi<ExtensionTarget> {
+  applyMetafieldChange: ApplyMetafieldChange;
+  data: ValidationData;
+}

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -9,6 +9,7 @@ import type {
   ProductDetailsConfigurationApi,
   ProductVariantDetailsConfigurationApi,
   OrderRoutingRuleApi,
+  ValidationSettingsApi,
 } from './api';
 import {AnyComponentBuilder} from '../../shared';
 
@@ -233,6 +234,16 @@ export interface ExtensionTargets {
   >;
   'admin.settings.order-routing-rule.render': RenderExtension<
     OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders Validation Settings within a given validation's add and edit views.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.settings.validation.render': RenderExtension<
+    ValidationSettingsApi<'admin.settings.validation.render'>,
     AllComponents
   >;
 }


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/checkout-web/issues/18126

spec'ed here https://github.com/Shopify/ui-api-design/pull/197

_tl;dr: a task-specific extension target that configures only validation functions._



### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
