### PR TITLE
expose authenticated account related hooks

### DIFF
--- a/.changeset/purple-weeks-doubt.md
+++ b/.changeset/purple-weeks-doubt.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-react': patch
+'@shopify/ui-extensions': patch
+---
+
+expose authenticated account related hooks

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/index.ts
@@ -35,3 +35,7 @@ export {useOrder} from './order';
 export {useAppliedGiftCards} from './gift-cards';
 export {useNavigationCurrentEntry} from './live-navigation';
 export {useNavigation} from './navigation';
+export {
+  useAuthenticatedAccountCustomer,
+  useAuthenticatedAccountPurchasingCompany,
+} from './authenticated-account';


### PR DESCRIPTION
### Background

expose authenticated account related hooks


### 🎩

With the local package, we can get the hook correctly. 

<img width="1938" alt="Screenshot 2024-01-29 at 12 29 03" src="https://github.com/Shopify/ui-extensions/assets/12724940/e976b033-c243-4322-b584-75028582cfb9">

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
