### PR TITLE
Publish `@shopify/web-pixels-extension@0.5.0`

### DIFF
--- a/packages/web-pixels-extension/package.json
+++ b/packages/web-pixels-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/web-pixels-extension",
   "description": "Provides tools to author Web Pixels extension",
-  "version": "0.4.22",
+  "version": "0.5.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
### Background
Closes https://github.com/Shopify/ce-customer-behaviour/issues/3379
Bumps the version and publishes the changes done in https://github.com/Shopify/ui-extensions/pull/1691

### Solution
Went through the normal version bump process outlined [here](https://github.com/Shopify/web-pixels-manager/blob/main/help-docs/updating-events.md#updating-ui-extensions)

A minor version felt appropriate, but happy to do a patch instead if people would prefer.

### 🎩

Tag is at: https://github.com/Shopify/ui-extensions/releases/tag/%40shopify%2Fweb-pixels-extension%400.5.0

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
