### PR TITLE
jkv/build docs copy to shopify dev if dir exists

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -40,9 +40,8 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
-if [ -n "$SPIN" ]; then
-  if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
-
+# Copy the generated docs to shopify-dev
+if [ -d ~/src/github.com/Shopify/shopify-dev ]; then
     mkdir -p ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
     cp ./$DOCS_PATH/generated/* ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
     # Replace 'unstable' with the exact API version in relative doc links
@@ -57,10 +56,11 @@ if [ -n "$SPIN" ]; then
 
     cd ~/src/github.com/Shopify/shopify-dev
 
+  if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/checkout-ui-extensions"
   else
-    echo "If you include shopify-dev in your Spin constellation, this will automatically copy ./$DOCS_PATH/generated to shopify-dev"
+    echo "If you include shopify-dev in your Spin constellation, we can generate a preview link for the docs!"
   fi
 else
-  echo "Not copying docs to shopify-dev because we're not in Spin"
+  echo "Not copying docs to shopify-dev because it was not found at ~/src/github.com/Shopify/shopify-dev."
 fi

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -41,20 +41,18 @@ if [ $sed_exit -ne 0 ]; then
 fi
 
 # Copy the generated docs to shopify-dev
-if [ -d ~/src/github.com/Shopify/shopify-dev ]; then
-    mkdir -p ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
-    cp ./$DOCS_PATH/generated/* ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
+if [ -d ../../../shopify-dev ]; then
+    mkdir -p ../../../shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
+    cp ./$DOCS_PATH/generated/* ../../../shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
     # Replace 'unstable' with the exact API version in relative doc links
     sed -i \
       "s/\/docs\/api\/checkout-ui-extensions\/unstable/\/docs\/api\/checkout-ui-extensions\/$API_VERSION/gi" \
-      ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/generated_docs_data.json
+      ../../../shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/generated_docs_data.json
     sed_exit=$?
     if [ $sed_exit -ne 0 ]; then
       fail_and_exit $sed_exit
     fi
-    rsync -a --delete ./$DOCS_PATH/screenshots/ ~/src/github.com/Shopify/shopify-dev/app/assets/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
-
-    cd ~/src/github.com/Shopify/shopify-dev
+    rsync -a --delete ./$DOCS_PATH/screenshots/ ../../../shopify-dev/app/assets/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
 
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/checkout-ui-extensions"
@@ -62,5 +60,5 @@ if [ -d ~/src/github.com/Shopify/shopify-dev ]; then
     echo "If you include shopify-dev in your Spin constellation, we can generate a preview link for the docs!"
   fi
 else
-  echo "Not copying docs to shopify-dev because it was not found at ~/src/github.com/Shopify/shopify-dev."
+  echo "Not copying docs to shopify-dev because it was not found at ../../../shopify-dev."
 fi


### PR DESCRIPTION
### Background

This is the same change to the doc gen script already in this PR https://github.com/Shopify/checkout-web/pull/30152.

### Solution
Use relative paths for generating docs for shopify-dev.


### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
