### PR TITLE
Add a constellation for building dev docs

### DIFF
--- a/.spin/constellation.yml
+++ b/.spin/constellation.yml
@@ -1,0 +1,5 @@
+schema: v1
+extend: shopify-dev
+repos:
+  - ui-extensions:
+      branch: unstable


### PR DESCRIPTION
### Background

After [this PR](https://github.com/Shopify/ui-extensions/pull/1686), we can build our ui-extensions docs in spin. But first we need a constellation to use :)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
