### PR TITLE
add timeline-event target and TimelineEvent component

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/TimelineEvent/TimelineEvent.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/TimelineEvent/TimelineEvent.ts
@@ -1,0 +1,11 @@
+import {TimelineEvent as BaseTimelineEvent} from '@shopify/ui-extensions/customer-account';
+import {
+  createRemoteReactComponent,
+  ReactPropsFromRemoteComponentType,
+} from '@remote-ui/react';
+
+export type TimelineEventProps = ReactPropsFromRemoteComponentType<
+  typeof BaseTimelineEvent
+>;
+
+export const TimelineEvent = createRemoteReactComponent(BaseTimelineEvent);

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/TimelineEvent/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/TimelineEvent/index.ts
@@ -1,0 +1,2 @@
+export {TimelineEvent} from './TimelineEvent';
+export type {TimelineEventProps} from './TimelineEvent';

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/index.ts
@@ -1,6 +1,7 @@
 export * from './Card';
 export * from './CustomerAccountAction';
 export * from './Page';
+export * from './TimelineEvent';
 /* @internal */
 export * from './PolicyModal';
 export * from './ResourceItem';

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -99,6 +99,14 @@ export interface FulfillmentApi {
   fulfillmentId: string;
 }
 
+export interface TimelineEventApi {
+  /**
+   * Optionnal Id of a single fulfillment.
+   * An undefined value represents unfulfilled items.
+   */
+  fulfillmentId?: string;
+}
+
 export interface ReturnApi {
   /**
    * Id of a single return.

--- a/packages/ui-extensions/src/surfaces/customer-account/components/TimelineEvent/TimelineEvent.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/TimelineEvent/TimelineEvent.ts
@@ -1,0 +1,30 @@
+import {createRemoteComponent} from '@remote-ui/core';
+import type {IconSource} from '../shared-checkout-components';
+
+export interface TimelineEventProps {
+  /**
+   * Specifies which icon to display.
+   * Check the list of available icons [here](/docs/api/checkout-ui-extensions/components/media/icon#icons).
+   */
+  statusIcon: IconSource;
+  /**
+   * Sets the title of the TimelineEvent.
+   */
+  title: string;
+  /**
+   * Sets the description of the TimelineEvent.
+   * It's only visible when the event is the first one.
+   */
+  description: string;
+  /**
+   * Sets the date of the TimelineEvent.
+   * Format must be YYYY-MM-DD.
+   * The timeline will be ordered by this date.
+   */
+  eventTime: string;
+}
+
+export const TimelineEvent = createRemoteComponent<
+  'TimelineEvent',
+  TimelineEventProps
+>('TimelineEvent');

--- a/packages/ui-extensions/src/surfaces/customer-account/components/TimelineEvent/index.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/TimelineEvent/index.ts
@@ -1,0 +1,2 @@
+export {TimelineEvent} from './TimelineEvent';
+export type {TimelineEventProps} from './TimelineEvent';

--- a/packages/ui-extensions/src/surfaces/customer-account/components/index.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/index.ts
@@ -1,6 +1,7 @@
 export * from './Card';
 export * from './CustomerAccountAction';
 export * from './Page';
+export * from './TimelineEvent';
 /* @internal */
 export * from './PolicyModal';
 export * from './ResourceItem';

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -9,6 +9,7 @@ import {
   CompanyLocationApi,
   OrderApi,
   FulfillmentApi,
+  TimelineEventApi,
   ReturnApi,
 } from './api/standard-api/standard-api';
 
@@ -75,6 +76,13 @@ export interface OrderStatusExtensionTargets {
   'customer-account.order-status.unfulfilled-items.render-after': RenderExtension<
     OrderStatusApi<'customer-account.order-status.unfulfilled-items.render-after'> &
       StandardApi<'customer-account.order-status.unfulfilled-items.render-after'>,
+    AnyComponent
+  >;
+
+  'customer-account.order-status.timeline-event.render': RenderExtension<
+    OrderStatusApi<'customer-account.order-status.timeline-event.render'> &
+      StandardApi<'customer-account.order-status.timeline-event.render'> &
+      TimelineEventApi,
     AnyComponent
   >;
   'customer-account.order-status.payment-details.render-after': RenderExtension<


### PR DESCRIPTION
### Background

We want to expose a new extension target in New Customer Account that will allow partners to inject timeline events in each fulfillment timeline within the order details page.

Part of https://github.com/Shopify/core-issues/issues/63454

### Solution

I used `customer-account.order-status.fulfillment-details.render-after` as a source of inspiration.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
