### PR TITLE
export requireLogin  doc type

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -43,6 +43,9 @@ export interface Docs_OrderStatus_AddressApi
 export interface Docs_OrderStatus_ShopApi
   extends Pick<OrderStatusApi<any>, 'shop'> {}
 
+export interface Docs_OrderStatus_RequireLoginApi
+  extends Pick<OrderStatusApi<any>, 'requireLogin'> {}
+
 export interface Docs_OrderStatus_CartLinesApi
   extends Pick<OrderStatusApi<any>, 'lines'> {}
 


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/65925
export requireLogin  doc type so that we can use it in dev docs

customer account web side PR: https://github.com/Shopify/customer-account-web/pull/3887 

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

https://shopify-dev.doc.brian-shen.us.spin.dev/docs/api/customer-account-ui-extensions/unstable/apis/order-status-api/require-login

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
