### PR TITLE
Update Docs_ResourceItem_Button_Action to add `appearance` prop

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -111,7 +111,7 @@ export interface Docs_ResourceItem_Button_Action
     | 'loadingLabel'
     | 'disabled'
     | 'accessibilityLabel'
-    | 'kind'
+    | 'appearance'
   > {}
 
 export interface Docs_OrderActionMenu_Button


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/temp-project-mover-Archetypically-20250312121459/issues/61

### Solution

Remove `kind` from packages/ui-extensions/src/surfaces/customer-account/api/docs.ts > `Docs_ResourceItem_Button_Action`
### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
