### PR TITLE
deprecating Tile and creating the ActionItem interface

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
@@ -1,3 +1,5 @@
+export {ActionMenuItem} from './components/Actiontem/ActionItem';
+export type {ActionItem} from './components/Actiontem/ActionItem';
 export {Badge} from './components/Badge/Badge';
 export type {BadgeProps, BadgeVariant} from './components/Badge/Badge';
 export {Banner} from './components/Banner/Banner';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Actiontem/ActionItem.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Actiontem/ActionItem.ts
@@ -1,0 +1,14 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+export interface ActionItem {
+  title: string;
+  subtitle?: string;
+  enabled?: boolean;
+  onPress: () => void;
+  badgeValue: number;
+  destructive?: boolean;
+}
+
+export const ActionMenuItem = createRemoteComponent<'ActionItem', ActionItem>(
+  'ActionItem',
+);

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.ts
@@ -1,5 +1,8 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/*
+ * @deprecated This is deprecated, use `ActionItem` instead.
+ */
 export interface TileProps {
   title: string;
   subtitle?: string;


### PR DESCRIPTION
### Background

Resolves part of https://github.com/Shopify/pos-next-react-native/issues/31843

The new UI Extension architecture will introduce a generic component called `ActionItem`, which can be manifested as a Tile or list row. 

🎩


### Checklist

~~- [ ] I have :tophat:'d these changes~~
~~- [ ] I have updated relevant documentation~~
