### PR TITLE
Publish `@shopify/web-pixels-extension@1.0.0`

### DIFF
--- a/packages/web-pixels-extension/package.json
+++ b/packages/web-pixels-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/web-pixels-extension",
   "description": "Provides tools to author Web Pixels extension",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Publishing a new version of the `@shopify/web-pixels-extension` package
 - @shopify/web-pixels-extension@1.0.0

### Background
Closes https://github.com/Shopify/ce-customer-behaviour/issues/4213
Bump the version and publish the changes done in https://github.com/Shopify/ui-extensions/pull/1725

### Solution
Went through the normal version bump process outlined [here](https://github.com/Shopify/web-pixels-manager/blob/main/help-docs/updating-events.md#updating-ui-extensions)

A major version felt appropriate, since we are removing something, but definitely up for changing if people feel differently.

### 🎩

Tag is at: https://github.com/Shopify/ui-extensions/releases/tag/%40shopify%2Fweb-pixels-extension%401.0.0

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
