### PR TITLE
updates Customer Privacy API to replace hasCollectedConsent flag

### DIFF
--- a/.changeset/thin-feet-wait.md
+++ b/.changeset/thin-feet-wait.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Replaces hasCollectedConsent with shouldShowBanner and adds saleOfDataRegion flag to Customer Privacy API.

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1700,13 +1700,17 @@ export type ApplyTrackingConsentChangeType = (
 
 export interface CustomerPrivacy {
   /**
-   * Whether the customer has previously given consent.
-   */
-  hasCollectedConsent: boolean;
-  /**
    * An object containing the customer's current cookie consent settings.
    */
   visitorConsent: VisitorConsent;
+  /**
+   * Whether a consent banner should be displayed.
+   */
+  shouldShowBanner: boolean;
+  /**
+   * Whether the visitor is in a region requiring data sale opt-outs.
+   */
+  saleOfDataRegion: boolean;
 }
 
 export type TrackingConsentChangeResult =


### PR DESCRIPTION
### Background

Resolves [#30593](https://github.com/Shopify/checkout-web/issues/30593) and updates the `ui-extensions` package to include changes made as part of [30337](https://github.com/Shopify/checkout-web/issues/30337).

Docs will be updated as a follow-up in [#30592](https://github.com/Shopify/checkout-web/issues/30592).

This PR updates the Customer Privacy API flags, replacing `hasCollectedConsent` with `shouldShowBanner` and adding `saleOfDataRegion`. The two new flags are set to the return values of the [consent-tracking-api package](https://github.com/Shopify/consent-tracking-api) methods of the same name.

### Solution

This update makes the checkout version of the API more consistent with the storefront implementation and provides more useful flags to extensions so they can a) know when to render a "sale of data" checkbox/switch and b) use the package logic that takes enabled regions into account.

### 🎩

<img width="687" alt="image" src="https://github.com/Shopify/ui-extensions/assets/100380574/afdfb4a2-2b75-460e-b534-b8cd1620525b">

- [ ] Navigate to the [Updated docs](https://shopify-dev.checkout-web-api-docs-3bsr.rick-caplan.us.spin.dev/docs/api/checkout-ui-extensions/unstable/apis/customer-privacy)
- [ ] click on the "CustomerPrivacy" type to show the details and confirm the interface matches the code, including comment text

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
