### PR TITLE
Add `listHeaderComponent` to retail-ui-extensions ListProps

### DIFF
--- a/packages/retail-ui-extensions/src/components/List/List.ts
+++ b/packages/retail-ui-extensions/src/components/List/List.ts
@@ -1,4 +1,4 @@
-import {createRemoteComponent} from '@remote-ui/core';
+import {RemoteFragment, createRemoteComponent} from '@remote-ui/core';
 import {BadgeProps} from '../Badge';
 import {ColorType} from '../Text';
 
@@ -86,6 +86,10 @@ export interface ListProps {
    * A large display title at the top of the `List`.
    */
   title?: string;
+  /**
+   * A header component for the list
+   */
+  listHeaderComponent?: RemoteFragment;
   /**
    * The array of `ListRow` which will be converted into rows for this list.
    */


### PR DESCRIPTION
### Background

The `ListHeaderComponent` prop will be exposed in the POS UI extensions `List` component so it needs to be added to `ListProps`.

### Solution

Add `listHeaderComponent` to `ListProps`, similar to [Choice.ts](https://github.com/Shopify/ui-extensions/blob/unstable/packages/ui-extensions/src/surfaces/checkout/components/Choice/Choice.ts)

Change duplicated for `unstable` in #1751 

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
