### PR TITLE
Added new functionality for combined cart discounts

### DIFF
--- a/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
+++ b/packages/retail-ui-extensions/src/extension-api/cart-api/cart-api.ts
@@ -49,8 +49,18 @@ export interface CartApiContent {
     amount?: string,
   ): Promise<void>;
 
+  /** Add a code discount to the cart
+   * @param code the code for the discount to add to the cart
+   */
+  addCartCodeDiscount(code: string): Promise<void>;
+
   /** Remove the cart discount */
   removeCartDiscount(): Promise<void>;
+
+  /** Remove all cart and line item discounts
+   * @param disableAutomaticDiscounts Whether or not automatic discounts should be enabled after removing the discounts.
+   */
+  removeAllDiscounts(disableAutomaticDiscounts: boolean): Promise<void>;
 
   /** Clear the cart */
   clearCart(): Promise<void>;

--- a/packages/retail-ui-extensions/src/extension-api/types/cart.ts
+++ b/packages/retail-ui-extensions/src/extension-api/types/cart.ts
@@ -6,6 +6,7 @@ export interface Cart {
   grandTotal: string;
   note?: string;
   cartDiscount?: Discount;
+  cartDiscounts: Discount[];
   customer?: Customer;
   lineItems: LineItem[];
   properties: Record<string, string>;


### PR DESCRIPTION
### Background

POS is going to be supporting combined cart discounts. This PR brings in some functions, as well as a new property called `cartDiscounts: Discounts[]` to support this feature. 

### Solution

Partners are now going to be able to take advantage of this feature. Since regular manual discounts are still limited to only one discount per cart, but code discounts are not, in order to simplify the logic we are going to be separating the two functions. 

We are also providing new functions to remove discounts in a batch call, or remove a specific discount code.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
