### PR TITLE
Fix broken hyperlink for `selectedPaymentOptions`

### DIFF
--- a/.changeset/eight-scissors-fix.md
+++ b/.changeset/eight-scissors-fix.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Fix broken hyperlink for selectedPaymentOptions


### PR DESCRIPTION
Fix a broken hyperlink for `selectedPaymentOptions` for ver. 2024-01

https://github.com/Shopify/temp-project-mover-megswim-20250326195306/issues/482