### PR TITLE
Add fragmentProps to retail-ui-extensions-react List

### DIFF
--- a/packages/retail-ui-extensions-react/src/components/List/List.ts
+++ b/packages/retail-ui-extensions-react/src/components/List/List.ts
@@ -3,4 +3,6 @@ import {createRemoteReactComponent} from '@remote-ui/react';
 
 export type {ListProps} from '@shopify/retail-ui-extensions';
 
-export const List = createRemoteReactComponent(BaseList);
+export const List = createRemoteReactComponent(BaseList, {
+  fragmentProps: ['listHeaderComponent'],
+});


### PR DESCRIPTION
### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

Similar to ui-extensions/checkout [`Link`](https://github.com/Shopify/ui-extensions/blob/unstable/packages/ui-extensions-react/src/surfaces/checkout/components/Link/Link.ts#L8)

Change to `unstable` made in #1764 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
