### PR TITLE
Add fragmentProps to point-of-sale ui-extensions-react List

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/components/List/List.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/components/List/List.ts
@@ -1,4 +1,6 @@
 import {List as BaseList} from '@shopify/ui-extensions/point-of-sale';
 import {createRemoteReactComponent} from '@remote-ui/react';
 
-export const List = createRemoteReactComponent(BaseList);
+export const List = createRemoteReactComponent(BaseList, {
+  fragmentProps: ['listHeaderComponent'],
+});


### PR DESCRIPTION
### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

Similar to ui-extensions/checkout [`Link`](https://github.com/Shopify/ui-extensions/blob/unstable/packages/ui-extensions-react/src/surfaces/checkout/components/Link/Link.ts#L8)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
