### PR TITLE
Remove order confirmation API from `customer-account.order-status.block.render`

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -278,8 +278,7 @@ export interface ExtensionTargets {
    * @deprecated Use `customer-account.order-status.block.render` from `@shopify/ui-extension/customer-account` instead.
    */
   'customer-account.order-status.block.render': RenderExtension<
-    OrderConfirmationApi &
-      OrderStatusApi &
+    OrderStatusApi &
       CustomerAccountStandardApi<'customer-account.order-status.block.render'>,
     AnyComponent
   >;


### PR DESCRIPTION
This removes the Order Confirmation API from `customer-account.order-status.block.render` as it was mistakenly added. This has also been updated here Shopify/checkout-web/pull/30834