### PR TITLE
Add OrderCustomer to Web Pixels checkout.order object

### DIFF
--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -890,6 +890,13 @@ export const pixelEvents = {
           'An order is a customer’s completed request to purchase one or more products from a shop. An order is created when a customer completes the checkout process.',
       },
       properties: {
+        customer: {
+          ref: 'OrderCustomer',
+          nullable: true,
+          metadata: {
+            description: 'The customer that placed the order.',
+          },
+        },
         id: {
           type: 'string',
           metadata: {
@@ -1088,6 +1095,20 @@ export const pixelEvents = {
           ref: 'MoneyV2',
           metadata: {
             description: 'The total cost of the merchandise line.',
+          },
+        },
+      },
+    },
+    OrderCustomer: {
+      metadata: {
+        description: 'The customer that placed the order.',
+      },
+      properties: {
+        id: {
+          type: 'string',
+          nullable: true,
+          metadata: {
+            description: 'The ID of the customer.',
           },
         },
       },

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -1337,9 +1337,24 @@ export type Name = string;
  */
 export interface Order {
   /**
+   * The customer that placed the order.
+   */
+  customer: OrderCustomer | null;
+
+  /**
    * The ID of the order.
    */
   id: string;
+}
+
+/**
+ * The customer that placed the order.
+ */
+export interface OrderCustomer {
+  /**
+   * The ID of the customer.
+   */
+  id: string | null;
 }
 
 /**

--- a/packages/web-pixels-extension/src/types/index.ts
+++ b/packages/web-pixels-extension/src/types/index.ts
@@ -19,6 +19,7 @@ export type {
   CheckoutLineItem,
   CartCost,
   CartLineCost,
+  OrderCustomer,
   Order,
   MailingAddress,
   ProductVariant,


### PR DESCRIPTION
### Background

Give merchants/devs access to the customer ID associated with an order, on `checkout_completed`.

Depends on Shopify/web-pixels-manager#601. Related to Shopify/ce-customer-behaviour/issues/4187.

### Solution

As discussed in [the issue](https://github.com/Shopify/ce-customer-behaviour/issues/4187#issuecomment-1955195962), we're adding a new `OrderCustomer` type rather than just a `customerId` field on `Order`. This will allow us to add more customer data in the future, like `ordersCount` without having to prefix everything with `customer`.

We're going with a new `OrderCustomer` rather than the existing `Customer` type to simplify things. Having a full customer profile type inside `Order` raises lots of questions that are hard to answer, like if the order hasn't been created yet but the customer is logged in, what would the right value be for `checkout.order.customer.email`? With `OrderCustomer`, it's simply the customer ID of the customer that placed the order.

### 🎩

Checkout with [this spin instance](https://shop1.shopify.web-pixels-manager-docs-g5am.richard-poirier.us.spin.dev/) and use the console to see events. This will exercise checkout-web for `checkout_started` (no customer id yet).

To tophat the Checkout One TYP, turn on the `redirect_to_checkout_web_thank_you_page` flag [here](https://app.shopify.web-pixels-manager-docs-g5am.richard-poirier.us.spin.dev/services/internal/shops/1/beta_flags)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation: https://github.com/Shopify/shopify-dev/pull/41595
