### PR TITLE
Migrate to isospin 2

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,5 @@
+name: ui-extensions
+
+up:
+  - node:
+      version: v20.10.0


### PR DESCRIPTION
### Background

Web Pixels API is still on branch `main` and we've migrated to isospin version 2, but this repo was only migrated on the `unstable` branch.

### Solution

Added the missing `dev.yml` based on the `unstable` version of that same file.

### 🎩

Checkout the branch locally and spin an instance on branch `main`.

```
spin up .spin/constellation.yml --metadata isospin_version=2 -c ui-extensions.branch=main
```

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
