### PR TITLE
[Unstable] add buyer journey api to unstable

### DIFF
--- a/.changeset/nine-laws-switch.md
+++ b/.changeset/nine-laws-switch.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+Adds `buyerJourney.steps`, `buyerJourney.activeStep`, and their associated react hooks to the checkout surface API.

--- a/packages/ui-extensions-react/src/surfaces/checkout.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout.ts
@@ -263,6 +263,8 @@ export {
   useBuyerJourney,
   useBuyerJourneyIntercept,
   useBuyerJourneyCompleted,
+  useBuyerJourneyActiveStep,
+  useBuyerJourneySteps,
 } from './checkout/hooks/buyer-journey';
 export {useCheckoutSettings} from './checkout/hooks/checkout-settings';
 export {useMetafield} from './checkout/hooks/metafield';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/buyer-journey.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/buyer-journey.ts
@@ -3,6 +3,7 @@ import type {
   RenderExtensionTarget,
   Interceptor,
   BuyerJourney,
+  BuyerJourneyStep,
 } from '@shopify/ui-extensions/checkout';
 
 import {ExtensionHasNoMethodError} from '../errors';
@@ -75,4 +76,39 @@ export function useBuyerJourneyIntercept<
       teardownPromise.then((teardown) => teardown()).catch(() => {});
     };
   }, [api.buyerJourney]);
+}
+
+/**
+ * Returns all possible steps a buyer can take to complete the checkout. These steps may vary depending on the type of checkout or the shop's configuration.
+ */
+export function useBuyerJourneySteps<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): BuyerJourneyStep[] {
+  const api = useApi<Target>();
+
+  if (!('buyerJourney' in api) || !api.buyerJourney) {
+    throw new ExtensionHasNoMethodError('buyerJourney', api.extension.target);
+  }
+
+  return useSubscription(api.buyerJourney.steps);
+}
+
+/**
+ * Returns the buyer journey step that the buyer is currently on.
+ */
+export function useBuyerJourneyActiveStep<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): BuyerJourneyStep | undefined {
+  const api = useApi<Target>();
+
+  if (!('buyerJourney' in api) || !api.buyerJourney) {
+    throw new ExtensionHasNoMethodError('buyerJourney', api.extension.target);
+  }
+
+  const steps = useSubscription(api.buyerJourney.steps);
+  const activeStep = useSubscription(api.buyerJourney.activeStep);
+
+  return activeStep
+    ? steps.find(({handle}) => handle === activeStep.handle)
+    : undefined;
 }

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/buyer-journey.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/buyer-journey.test.ts
@@ -1,0 +1,250 @@
+import {ExtensionHasNoMethodError} from '../../errors';
+import {
+  useBuyerJourney,
+  useBuyerJourneyActiveStep,
+  useBuyerJourneyCompleted,
+  useBuyerJourneyIntercept,
+  useBuyerJourneySteps,
+} from '../buyer-journey';
+
+import {createMockStatefulRemoteSubscribable, mount} from './mount';
+
+describe('buyerJourney Hooks', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    jest.mocked(console.error).mockRestore();
+  });
+
+  describe('useBuyerJourneySteps()', () => {
+    it('raises an exception when buyerJourney api is not available', () => {
+      expect(() => {
+        mount.hook(() => useBuyerJourneySteps(), {
+          extensionApi: {
+            buyerJourney: undefined,
+            extension: {
+              target: 'purchase.checkout.header.render-after',
+            },
+          },
+        });
+      }).toThrow(ExtensionHasNoMethodError);
+    });
+
+    it('returns the list of steps from the buyerJourney.steps subscribable', () => {
+      const steps = [
+        {
+          handle: 'information' as const,
+          label: 'Information',
+          disabled: false,
+          to: 'shopify:checkout/information',
+        },
+        {
+          handle: 'shipping' as const,
+          label: 'Shipping',
+          disabled: false,
+          to: 'shopify:checkout/shipping',
+        },
+        {
+          handle: 'payment' as const,
+          label: 'Payment',
+          disabled: false,
+          to: 'shopify:checkout/payment',
+        },
+      ];
+
+      const hook = mount.hook(() => useBuyerJourneySteps(), {
+        extensionApi: {
+          buyerJourney: {
+            steps: createMockStatefulRemoteSubscribable(steps),
+          },
+          extension: {
+            target: 'purchase.checkout.header.render-after',
+          },
+        },
+      });
+
+      expect(hook.current).toStrictEqual(steps);
+    });
+  });
+
+  describe('useBuyerJourneyActiveStep()', () => {
+    it('raises an exception when buyerJourney api is not available', () => {
+      expect(() => {
+        mount.hook(() => useBuyerJourneyActiveStep(), {
+          extensionApi: {
+            buyerJourney: undefined,
+            extension: {
+              target: 'purchase.checkout.header.render-after',
+            },
+          },
+        });
+      }).toThrow(ExtensionHasNoMethodError);
+    });
+
+    it('returns the step that matches the activeStep.handle', () => {
+      const activeStepHandle = 'information' as const;
+      const steps = [
+        {
+          handle: activeStepHandle,
+          label: 'Information',
+          disabled: false,
+          to: 'shopify:checkout/information',
+        },
+        {
+          handle: 'shipping' as const,
+          label: 'Shipping',
+          disabled: false,
+          to: 'shopify:checkout/shipping',
+        },
+        {
+          handle: 'payment' as const,
+          label: 'Payment',
+          disabled: false,
+          to: 'shopify:checkout/payment',
+        },
+      ];
+
+      const hook = mount.hook(() => useBuyerJourneyActiveStep(), {
+        extensionApi: {
+          buyerJourney: {
+            steps: createMockStatefulRemoteSubscribable(steps),
+            activeStep: createMockStatefulRemoteSubscribable({
+              handle: activeStepHandle,
+            }),
+          },
+          extension: {
+            target: 'purchase.checkout.header.render-after',
+          },
+        },
+      });
+
+      expect(hook.current).toStrictEqual(steps[0]);
+    });
+
+    it('returns undefined if no step matches the active step handle', () => {
+      const step = {
+        handle: 'information' as const,
+        label: 'Information',
+        disabled: false,
+        to: 'shopify:checkout/information',
+      };
+
+      const hook = mount.hook(() => useBuyerJourneyActiveStep(), {
+        extensionApi: {
+          buyerJourney: {
+            steps: createMockStatefulRemoteSubscribable([step]),
+            activeStep: createMockStatefulRemoteSubscribable({
+              handle: 'payment',
+            }),
+          },
+          extension: {
+            target: 'purchase.checkout.header.render-after',
+          },
+        },
+      });
+
+      expect(hook.current).toBeUndefined();
+    });
+  });
+
+  describe('useBuyerJourney()', () => {
+    it('raises an exception when buyerJourney api is not available', () => {
+      expect(() => {
+        mount.hook(() => useBuyerJourney(), {
+          extensionApi: {
+            extension: {
+              target: 'purchase.checkout.header.render-after',
+            },
+          },
+        });
+      }).toThrow(ExtensionHasNoMethodError);
+    });
+
+    it('returns the buyer journey when the api is available', () => {
+      const hook = mount.hook(() => useBuyerJourney(), {
+        extensionApi: {
+          buyerJourney: {},
+          extension: {
+            target: 'purchase.checkout.header.render-after',
+          },
+        },
+      });
+
+      expect(hook.current).toStrictEqual({});
+    });
+  });
+
+  describe('useBuyerJourneyCompleted()', () => {
+    it('raises an exception when buyerJourney api is not available', () => {
+      expect(() => {
+        mount.hook(() => useBuyerJourneyCompleted(), {
+          extensionApi: {
+            extension: {
+              target: 'purchase.checkout.header.render-after',
+            },
+          },
+        });
+      }).toThrow(ExtensionHasNoMethodError);
+    });
+
+    it.each([true, false])(
+      'returns the buyer journey completed value: %s',
+      (completed) => {
+        const hook = mount.hook(() => useBuyerJourneyCompleted(), {
+          extensionApi: {
+            buyerJourney: {
+              completed: createMockStatefulRemoteSubscribable(completed),
+            },
+            extension: {
+              target: 'purchase.checkout.header.render-after',
+            },
+          },
+        });
+
+        expect(hook.current).toStrictEqual(completed);
+      },
+    );
+  });
+
+  describe('useBuyerJourneyIntercept()', () => {
+    it('raises an exception when buyerJourney api is not available', () => {
+      expect(() => {
+        mount.hook(
+          () =>
+            useBuyerJourneyIntercept(() => ({
+              behavior: 'allow',
+            })),
+          {
+            extensionApi: {
+              extension: {
+                target: 'purchase.checkout.header.render-after',
+              },
+            },
+          },
+        );
+      }).toThrow(ExtensionHasNoMethodError);
+    });
+
+    it('calls the interceptor function', () => {
+      const mockIntercept = jest.fn(() =>
+        Promise.resolve({behavior: 'allow'} as const),
+      );
+
+      mount.hook(() => useBuyerJourneyIntercept(mockIntercept), {
+        extensionApi: {
+          buyerJourney: {
+            intercept: (cb: () => void) => cb(),
+          },
+          extension: {
+            target: 'purchase.checkout.header.render-after',
+          },
+        },
+      });
+
+      expect(mockIntercept).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
@@ -41,6 +41,20 @@ const data: ReferenceEntityTemplateSchema = {
       `,
       type: 'UseBuyerJourneyInterceptGeneratedType',
     },
+    {
+      title: 'useBuyerJourneySteps',
+      description: `
+        Returns all possible steps a buyer can take to complete the checkout. These steps may vary depending on the type of checkout or the shop's configuration.
+      `,
+      type: 'UseBuyerJourneyStepsGeneratedType',
+    },
+    {
+      title: 'useBuyerJourneyActiveStep',
+      description: `
+        Returns the buyer journey step that the buyer is currently on.
+      `,
+      type: 'UseBuyerJourneyActiveStepGeneratedType',
+    },
   ],
   defaultExample: getExample('buyer-journey-intercept/target-native-field', [
     'jsx',

--- a/packages/ui-extensions/src/surfaces/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout.ts
@@ -2,6 +2,7 @@ export type {
   ApiVersion,
   BuyerIdentity,
   BuyerJourney,
+  BuyerJourneyStep,
   Capability,
   CartCost,
   CartMetafield,

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -432,6 +432,68 @@ export interface BuyerJourney {
    * For example, when viewing the **Order status** page after submitting payment, the buyer will have completed their order.
    */
   completed: StatefulRemoteSubscribable<boolean>;
+  /**
+   * All possible steps a buyer can take to complete the checkout. These steps may vary depending on the type of checkout or the shop's configuration.
+   */
+  steps: StatefulRemoteSubscribable<BuyerJourneyStep[]>;
+  /**
+   * What step of checkout the buyer is currently on.
+   */
+  activeStep: StatefulRemoteSubscribable<BuyerJourneyStepReference | undefined>;
+}
+
+/**
+ * | handle  | Description  |
+ * |---|---|
+ * | `cart`  |  The cart page.  |
+ * | `checkout`  |  A one-page checkout, including Shop Pay.  |
+ * | `information`  |  The contact information step of a three-page checkout.  |
+ * | `shipping`  |  The shipping step of a three-page checkout.  |
+ * | `payment`  |  The payment step of a three-page checkout.  |
+ * | `review`  |  The step after payment where the buyer confirms the purchase. Not all shops are configured to have a review step.  |
+ * | `thank-you`  |  The page displayed after the purchase, thanking the buyer.  |
+ * | `unknown` |  An unknown step in the buyer journey.  |
+ */
+type BuyerJourneyStepHandle =
+  | 'cart'
+  | 'checkout'
+  | 'information'
+  | 'shipping'
+  | 'payment'
+  | 'review'
+  | 'thank-you'
+  | 'unknown';
+
+/**
+ * What step of checkout the buyer is currently on.
+ */
+interface BuyerJourneyStepReference {
+  /**
+   * The handle that uniquely identifies the buyer journey step.
+   */
+  handle: BuyerJourneyStepHandle;
+}
+
+export interface BuyerJourneyStep {
+  /**
+   * The handle that uniquely identifies the buyer journey step.
+   */
+  handle: BuyerJourneyStepHandle;
+  /**
+   * The localized label of the buyer journey step.
+   */
+  label: string;
+  /**
+   * The url of the buyer journey step. This property leverages the `shopify:` protocol
+   * E.g. `shopify:cart` or `shopify:checkout/information`.
+   */
+  to: string;
+  /**
+   * The disabled state of the buyer journey step. This value will be true if the buyer has not reached the step yet.
+   *
+   * For example, if the buyer has not reached the `shipping` step yet, `shipping` would be disabled.
+   */
+  disabled: boolean;
 }
 
 export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {


### PR DESCRIPTION
### Background

This PR syncs the latest content for the buyer journey and some small changes pending in checkout-web. 

Original issue with PRs linked https://github.com/Shopify/checkout-web/issues/29336

### Solution

Ran `yarn prepare-package-release`

### 🎩

Tophatted with local extension by syncing the files over to my local app. 

Both activeStep and steps are defined from using the hook
<img width="667" alt="Screenshot 2024-02-26 at 5 01 16 PM" src="https://github.com/Shopify/ui-extensions/assets/10457708/5713a832-c54a-4586-a202-4bc1e3b31e5d">



### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
