### PR TITLE
Publish

### DIFF
--- a/packages/web-pixels-extension/package.json
+++ b/packages/web-pixels-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/web-pixels-extension",
   "description": "Provides tools to author Web Pixels extension",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
 - @shopify/web-pixels-extension@1.1.0

### Background

Give merchants/devs access to the customer ID associated with an order, on `checkout_completed`.

Depends on Shopify/web-pixels-manager#601. Related to Shopify/ce-customer-behaviour/issues/4187.

### Solution

As discussed in [the issue](https://github.com/Shopify/ce-customer-behaviour/issues/4187#issuecomment-1955195962), we're adding a new `OrderCustomer` type rather than just a `customerId` field on `Order`. This will allow us to add more customer data in the future, like `ordersCount` without having to prefix everything with `customer`.

We're going with a new `OrderCustomer` rather than the existing `Customer` type to simplify things. Having a full customer profile type inside `Order` raises lots of questions that are hard to answer, like if the order hasn't been created yet but the customer is logged in, what would the right value be for `checkout.order.customer.email`? With `OrderCustomer`, it's simply the customer ID of the customer that placed the order.

### 🎩

Checkout with [this spin instance](https://shop1.shopify.web-pixels-manager-docs-g5am.richard-poirier.us.spin.dev/) and use the console to see events. This will exercise checkout-web for `checkout_started` (no customer id yet).

To tophat the Checkout One TYP, turn on the `redirect_to_checkout_web_thank_you_page` flag [here](https://app.shopify.web-pixels-manager-docs-g5am.richard-poirier.us.spin.dev/services/internal/shops/1/beta_flags)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation: https://github.com/Shopify/shopify-dev/pull/41595
