### PR TITLE
Add `ActionItem` to point-of-sale surface in react package

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/components.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/components.ts
@@ -1,3 +1,4 @@
+export {ActionItem} from './components/ActionItem/ActionItem';
 export {Badge} from './components/Badge/Badge';
 export {Banner} from './components/Banner/Banner';
 export {Button} from './components/Button/Button';

--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/components/ActionItem/ActionItem.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/components/ActionItem/ActionItem.ts
@@ -1,0 +1,4 @@
+import {ActionItem as BaseActionItem} from '@shopify/ui-extensions/point-of-sale';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const ActionItem = createRemoteReactComponent(BaseActionItem);


### PR DESCRIPTION
### Background

Adds a missing component to react package that is based off this work: https://github.com/Shopify/ui-extensions/pull/1743

### Solution

Just adding missing code

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
