### PR TITLE
Add SectionHeader to point-of-sale

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
@@ -100,3 +100,5 @@ export type {TimePickerProps} from './components/TimePicker/TimePicker';
 export type {BaseTextFieldProps} from './components/shared/BaseTextField';
 export type {AutoCapitalizationType} from './components/shared/auto-capitalization-type';
 export type {InputAction, InputProps} from './components/shared/InputField';
+export {SectionHeader} from './components/SectionHeader/SectionHeader';
+export type {SectionHeaderProps} from './components/SectionHeader/SectionHeader';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
@@ -1,0 +1,34 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+export interface SectionHeaderProps {
+  /**
+   * Title to be displayed.
+   */
+  title: string;
+  /**
+   * Action button to be displayed. The SectionHeader must have a `title` for `action` to work.
+   */
+  action?: {
+    /**
+     * Label for the action button.
+     */
+    label: string;
+    /**
+     * Function to handle action button press.
+     */
+    onPress: () => void;
+    /**
+     * Whether or not the action button is disabled.
+     */
+    disabled?: boolean;
+  };
+  /**
+   * Whether or not the divider line under the SectionHeader should be hidden.
+   */
+  hideDivider?: boolean;
+}
+
+export const SectionHeader = createRemoteComponent<
+  'SectionHeader',
+  SectionHeaderProps
+>('SectionHeader');


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-for-retail/issues/438

### Background

Add new `SectionHeader` component so that the PFR component can be exposed in POS UI extensions.

### Solution

Add `SectionHeader.ts` based on a subset of the [component interface in PFR](https://github.com/Shopify/polaris-for-retail/blob/main/src/components/List/components/SectionHeader.tsx#L29) (i.e. without list-specific props).

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
~- [ ] I have updated relevant documentation~
