### PR TITLE
Add support for "snapit" command

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -1,0 +1,26 @@
+name: Snapit
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  snapit:
+    name: Snapit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+
+      - uses: ./.github/workflows/actions/prepare
+
+      - name: Create snapshot
+        uses: Shopify/snapit@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        with:
+          build_script: yarn build
+          comment_command: /snapit


### PR DESCRIPTION
### Background

This PR adds support for the `/snapit` command to generate snapshot versions of the packages using the [GH action that powers the functionality for Polaris](https://github.com/Shopify/snapit).

See this [WxM post](https://shopify.workplace.com/groups/896033601551400/permalink/1120763079078450/) for additional context.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
