### PR TITLE
Added OrderApi to targets

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -22,7 +22,7 @@ export type {
   NavigationApi,
 } from './api/navigation-api/navigation-api';
 
-export type {OrderAPIContent, Order} from './api/order-api/order-api';
+export type {OrderAPIContent, OrderApi} from './api/order-api/order-api';
 
 export type {
   ProductSortType,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.tsx
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.tsx
@@ -1,14 +1,14 @@
 /**
  * Interface to access the order
  */
-export interface OrderAPIContent {
-  order: Order;
+export interface OrderApi {
+  order: OrderAPIContent;
 }
 
 /**
  * Interface for Order details
  */
-export interface Order {
+export interface OrderAPIContent {
   /**
    * The unique identifier for the order
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -1,6 +1,6 @@
 import {StandardApi} from './api/standard/standard-api';
 // eslint-disable-next-line import/no-deprecated
-import {SmartGridApi, NavigationApi, ScannerApi} from './api';
+import {SmartGridApi, NavigationApi, ScannerApi, OrderApi} from './api';
 import {RenderExtension} from './extension';
 import type {Components} from './shared';
 import {AnyComponentBuilder} from '../../shared';
@@ -21,11 +21,13 @@ export interface ExtensionTargets {
     BasicComponents
   >;
   'pos.purchase.post.action.render': RenderExtension<
-    StandardApi<'pos.purchase.post.action.render'> & ActionApi,
+    StandardApi<'pos.purchase.post.action.render'> & OrderApi,
     BasicComponents
   >;
   'pos.purchase.post.action.menu-item.render': RenderExtension<
-    StandardApi<'pos.purchase.post.action.menu-item.render'>,
+    StandardApi<'pos.purchase.post.action.menu-item.render'> &
+      ActionApi &
+      OrderApi,
     ActionComponents
   >;
 }


### PR DESCRIPTION
### Background

This adds OrderApi to the new targets, and moves ActionApi to the correct target. I also swapped the names in the Order file because they interface names were inverted, and added the Api suffix to the Order interface, since that's the pattern with the other APIs ( just a small detail that we missed when reviewing that original PR).

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
