### PR TITLE
Fix shopifyFunction type for Checkout Rules

### DIFF
--- a/.changeset/new-lobsters-invent.md
+++ b/.changeset/new-lobsters-invent.md
@@ -2,4 +2,4 @@
 '@shopify/ui-extensions': patch
 ---
 
-Fix type of shopifyFunction in launch options for Checkout rules
+Updates the `shopifyFunction` type to use `id` rather than `uuid` for Checkout rules.

--- a/.changeset/new-lobsters-invent.md
+++ b/.changeset/new-lobsters-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Fix type of shopifyFunction in launch options for Checkout rules

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/launch-options.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/launch-options.ts
@@ -7,8 +7,8 @@ export interface ValidationData {
   };
   shopifyFunction: {
     /**
-     * the validation's unique identifier
+     * the validation function's unique identifier
      */
-    uuid: string;
+    id: string;
   };
 }


### PR DESCRIPTION
### Background

We've released the wrong type on the function ID.

### Solution

Fixing the attribute name from `uuid` to `id`.
