### PR TITLE
Update Badge Props & Expose Sheet component in customer account surface

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/shared-checkout-components.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/shared-checkout-components.ts
@@ -87,6 +87,8 @@ export {
   Select,
   type SelectProps,
   type SelectOptionProps,
+  Sheet,
+  type SheetProps,
   SkeletonImage,
   type SkeletonImageProps,
   SkeletonText,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Badge/Badge.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 import type {Size, VisibilityProps} from '../shared';
+import {IconSource} from '../Icon/Icon';
 
 type Tone = 'default' | 'critical' | 'subdued';
 
@@ -23,6 +24,16 @@ export interface BadgeProps extends VisibilityProps {
    * it will be passed as `aria-label` to underlying element and announced to buyers using assistive technologies.
    */
   accessibilityLabel?: string;
+  /**
+   * The name of the icon to be displayed in the badge.
+   */
+  icon?: IconSource;
+  /**
+   * The position of the icon in relation to the text.
+   *
+   * @default 'start'
+   */
+  iconPosition?: 'start' | 'end';
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/customer-account/components/shared-checkout-components.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/shared-checkout-components.ts
@@ -87,6 +87,8 @@ export {
   Select,
   type SelectProps,
   type SelectOptionProps,
+  Sheet,
+  type SheetProps,
   SkeletonImage,
   type SkeletonImageProps,
   SkeletonText,


### PR DESCRIPTION
### Background

1. Update `Badge` props to expose `icon` & `iconPosition` as defined in api design
2. Expose `Sheet` component in Customer Accounts

Related PR in customer Accounts: https://github.com/Shopify/customer-account-web/pull/4113
Dev Docs PR: https://github.com/Shopify/shopify-dev/pull/42291

### Solution

N/A

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
