### PR TITLE
add new extension targets for action extensions everywhere

### DIFF
--- a/.changeset/tidy-coins-retire.md
+++ b/.changeset/tidy-coins-retire.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+add new targets for action extensions

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -171,6 +171,87 @@ export interface ExtensionTargets {
     AllComponents
   >;
 
+  /**
+   * Renders an Admin Action in the discount index page. Open this extension from the "More Actions" menu.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.discount-index.action.render': RenderExtension<
+    ActionExtensionApi<'admin.discount-index.action.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Action in the collection details page. Open this extension from the "More Actions" menu.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.collection-details.action.render': RenderExtension<
+    ActionExtensionApi<'admin.collection-details.action.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Action in the collection index page. Open this extension from the "More Actions" menu.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.collection-index.action.render': RenderExtension<
+    ActionExtensionApi<'admin.collection-index.action.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Action in the abandonded checkout page. Open this extension from the "More Actions" menu.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.abandoned-checkout-details.action.render': RenderExtension<
+    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Action in the product variant details page. Open this extension from the "More Actions" menu.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.variant-details.action.render': RenderExtension<
+    ActionExtensionApi<'admin.variant-details.action.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Action in the draft order details page. Open this extension from the "More Actions" menu.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.draft-order-details.action.render': RenderExtension<
+    ActionExtensionApi<'admin.draft-order-details.action.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Action in the draft orders page. Open this extension from the "More Actions" menu.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.draft-order-index.action.render': RenderExtension<
+    ActionExtensionApi<'admin.draft-order-index.action.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Action in the order fulfilled card. Open this extension from the "3-dot" menu inside the order fulfilled card.
+   * Note: This extension will only be visible in orders which were fulfilled by the same app as the extension.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.order-fulfilled-card.action.render': RenderExtension<
+    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,
+    AllComponents
+  >;
+
   // Bulk Actions
 
   /**
@@ -200,6 +281,16 @@ export interface ExtensionTargets {
    */
   'admin.customer-index.selection-action.render': RenderExtension<
     ActionExtensionApi<'admin.customer-index.selection-action.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Action in the draft order page when multiple resources are selected. Open this extension from the "3-dot" menu.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.draft-order-index.selection-action.render': RenderExtension<
+    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,
     AllComponents
   >;
 

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -216,8 +216,8 @@ export interface ExtensionTargets {
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
-  'admin.variant-details.action.render': RenderExtension<
-    ActionExtensionApi<'admin.variant-details.action.render'>,
+  'admin.product-variant-details.action.render': RenderExtension<
+    ActionExtensionApi<'admin.product-variant-details.action.render'>,
     AllComponents
   >;
 

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -102,7 +102,7 @@ export interface ExtensionTargets {
 
   // Actions
   /**
-   * Renders an admin action in the product details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the product details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -112,7 +112,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the order details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the order details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -122,7 +122,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the customer details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the customer details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -132,7 +132,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the customer segment details page. Open this extension from the "Use segment" button.
+   * Renders an admin action extension in the customer segment details page. Open this extension from the "Use segment" button.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -142,7 +142,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the product index page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the product index page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -152,7 +152,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the order index page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the order index page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -162,7 +162,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the customer index page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the customer index page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -172,7 +172,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the discount index page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the discount index page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -182,7 +182,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the collection details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the collection details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -192,7 +192,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the collection index page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the collection index page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -202,7 +202,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the abandonded checkout page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the abandonded checkout page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -212,7 +212,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the product variant details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the product variant details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -222,7 +222,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the draft order details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the draft order details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -232,7 +232,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the draft orders page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the draft orders page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -242,7 +242,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the discount details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action extension in the discount details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -252,7 +252,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the order fulfilled card. Open this extension from the "3-dot" menu inside the order fulfilled card.
+   * Renders an admin action extension in the order fulfilled card. Open this extension from the "3-dot" menu inside the order fulfilled card.
    * Note: This extension will only be visible on orders which were fulfilled by your app.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
@@ -265,7 +265,7 @@ export interface ExtensionTargets {
   // Bulk Actions
 
   /**
-   * Renders an admin action in the product index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
+   * Renders an admin action extension in the product index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -275,7 +275,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the order index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
+   * Renders an admin action extension in the order index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -285,7 +285,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the customer index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
+   * Renders an admin action extension in the customer index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -295,7 +295,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an admin action in the draft order page when multiple resources are selected. Open this extension from the "3-dot" menu.
+   * Renders an admin action extension in the draft order page when multiple resources are selected. Open this extension from the "3-dot" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -253,7 +253,7 @@ export interface ExtensionTargets {
 
   /**
    * Renders an admin action in the order fulfilled card. Open this extension from the "3-dot" menu inside the order fulfilled card.
-   * Note: This extension will only be visible in orders which were fulfilled by the same app as the extension.
+   * Note: This extension will only be visible on orders which were fulfilled by your app.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -242,6 +242,16 @@ export interface ExtensionTargets {
   >;
 
   /**
+   * Renders an Admin Action in the discount details page. Open this extension from the "More Actions" menu.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.discount-details.action.render': RenderExtension<
+    ActionExtensionApi<'admin.discount-details.action.render'>,
+    AllComponents
+  >;
+
+  /**
    * Renders an Admin Action in the order fulfilled card. Open this extension from the "3-dot" menu inside the order fulfilled card.
    * Note: This extension will only be visible in orders which were fulfilled by the same app as the extension.
    *

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -102,7 +102,7 @@ export interface ExtensionTargets {
 
   // Actions
   /**
-   * Renders an Admin Action in the product details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the product details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -112,7 +112,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the order details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the order details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -122,7 +122,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the customer details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the customer details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -132,7 +132,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the customer segment details page. Open this extension from the "Use segment" button.
+   * Renders an admin action in the customer segment details page. Open this extension from the "Use segment" button.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -142,7 +142,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the product index page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the product index page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -152,7 +152,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the order index page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the order index page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -162,7 +162,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the customer index page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the customer index page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -172,7 +172,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the discount index page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the discount index page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -182,7 +182,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the collection details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the collection details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -192,7 +192,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the collection index page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the collection index page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -202,7 +202,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the abandonded checkout page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the abandonded checkout page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -212,7 +212,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the product variant details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the product variant details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -222,7 +222,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the draft order details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the draft order details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -232,7 +232,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the draft orders page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the draft orders page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -242,7 +242,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the discount details page. Open this extension from the "More Actions" menu.
+   * Renders an admin action in the discount details page. Open this extension from the "More Actions" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -252,7 +252,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the order fulfilled card. Open this extension from the "3-dot" menu inside the order fulfilled card.
+   * Renders an admin action in the order fulfilled card. Open this extension from the "3-dot" menu inside the order fulfilled card.
    * Note: This extension will only be visible in orders which were fulfilled by the same app as the extension.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
@@ -265,7 +265,7 @@ export interface ExtensionTargets {
   // Bulk Actions
 
   /**
-   * Renders an Admin Action in the product index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
+   * Renders an admin action in the product index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -275,7 +275,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the order index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
+   * Renders an admin action in the order index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -285,7 +285,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the customer index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
+   * Renders an admin action in the customer index page when multiple resources are selected. Open this extension from the "More Actions"  menu of the resource list. The resource ids are available to this extension at runtime.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -295,7 +295,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Action in the draft order page when multiple resources are selected. Open this extension from the "3-dot" menu.
+   * Renders an admin action in the draft order page when multiple resources are selected. Open this extension from the "3-dot" menu.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */


### PR DESCRIPTION
closes https://github.com/Shopify/app-ui/issues/835

https://shopify-dev.ui-extensions-026v.josh-white.us.spin.dev/docs/api/admin-extensions/unstable/api/extension-targets

Adding type definitions for the [new extension targets being added](https://github.com/Shopify/app-ui/issues/834). 

Targets being added: 

- [x] Order details fulfilled card (weird) 
- [x] Draft orders overview
- [x] Draft order details
- [x] Draft orders bulk selection
- [x] Variants details
- [ ] Variants bulk selection (being deleted) 
- [x] Collections overview
- [x] Collection details
- [x] Abandoned checkout details
- [x] Discount overview
- [x] Discount details (in progress) 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
