### PR TITLE
Update ValidationData to include metafields

### DIFF
--- a/.changeset/breezy-bikes-brush.md
+++ b/.changeset/breezy-bikes-brush.md
@@ -2,4 +2,4 @@
 '@shopify/ui-extensions': patch
 ---
 
-Update ValidationData to include metafields
+Update the `ValidationData` type to include `metafields`.

--- a/.changeset/breezy-bikes-brush.md
+++ b/.changeset/breezy-bikes-brush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Update ValidationData to include metafields

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -122,6 +122,7 @@ const data: LandingTemplateSchema = {
         {
           name: "Direct API can't be used to manage storefront access tokens.",
           subtitle: 'Note',
+          url: '/docs/api/admin-extensions#direct-api-access',
           type: 'information',
         },
         {

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/launch-options.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/launch-options.ts
@@ -1,9 +1,15 @@
+import {Metafield} from './metafields';
+
 export interface ValidationData {
   validation?: {
     /**
      * the validation's gid when active in a shop
      */
     id: string;
+    /**
+     * the metafields owned by the validation
+     */
+    metafields: Metafield[];
   };
   shopifyFunction: {
     /**

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/metafields.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/metafields.ts
@@ -45,6 +45,15 @@ const supportedDefinitionTypes = [
 
 export type SupportedDefinitionType = typeof supportedDefinitionTypes[number];
 
+export interface Metafield {
+  description?: string;
+  id: string;
+  namespace: string;
+  key: string;
+  value: string;
+  type: string;
+}
+
 interface MetafieldUpdateChange {
   type: 'updateMetafield';
   key: string;


### PR DESCRIPTION
### Background

Instead of using Direct API to load the validation with its metafields inside an Admin UI extension to build the configuration experience, which involves adding an extra `fetch` call and soon an additional app access scope to be able to read those metafields, we're simplifying the experience.

### Solution

We are now exposing metafields in the type of the Admin UI extensions registration callback `api` parameter, following the release of the implementation that makes them available.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
