### PR TITLE
Redefine types for validations in a way that works for doc generation

### DIFF
--- a/.changeset/little-seals-punch.md
+++ b/.changeset/little-seals-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Redefine types for validations in a way that works for doc generation

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/launch-options.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/launch-options.ts
@@ -1,20 +1,34 @@
-import {Metafield} from './metafields';
+interface Metafield {
+  description?: string;
+  id: string;
+  namespace: string;
+  key: string;
+  value: string;
+  type: string;
+}
 
+interface Validation {
+  /**
+   * the validation's gid when active in a shop
+   */
+  id: string;
+  /**
+   * the metafields owned by the validation
+   */
+  metafields: Metafield[];
+}
+
+interface ShopifyFunction {
+  /**
+   * the validation function's unique identifier
+   */
+  id: string;
+}
+
+/**
+ * The object that exposes the validation with its settings.
+ */
 export interface ValidationData {
-  validation?: {
-    /**
-     * the validation's gid when active in a shop
-     */
-    id: string;
-    /**
-     * the metafields owned by the validation
-     */
-    metafields: Metafield[];
-  };
-  shopifyFunction: {
-    /**
-     * the validation function's unique identifier
-     */
-    id: string;
-  };
+  validation?: Validation;
+  shopifyFunction: ShopifyFunction;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/metafields.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/metafields.ts
@@ -45,15 +45,6 @@ const supportedDefinitionTypes = [
 
 export type SupportedDefinitionType = typeof supportedDefinitionTypes[number];
 
-export interface Metafield {
-  description?: string;
-  id: string;
-  namespace: string;
-  key: string;
-  value: string;
-  type: string;
-}
-
 interface MetafieldUpdateChange {
   type: 'updateMetafield';
   key: string;
@@ -80,6 +71,6 @@ type MetafieldChangeResult =
   | MetafieldChangeSuccess
   | MetafieldChangeResultError;
 
-export interface ApplyMetafieldChange {
-  (change: MetafieldChange): Promise<MetafieldChangeResult>;
-}
+export type ApplyMetafieldChange = (
+  change: MetafieldChange,
+) => Promise<MetafieldChangeResult>;

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -1,0 +1,25 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Validation Settings API',
+  description:
+    'This API is available Validation Settings extensions. Refer to the [tutorial](/docs/apps/checkout/validation/create-complex-validation-rules) for more information. Note that the [`FunctionSettings`](/docs/api/admin-extensions/components/forms/functionsettings) component is required to build Validation Settings extensions.',
+  isVisualComponent: false,
+  type: 'API',
+  definitions: [
+    {
+      title: 'applyMetafieldChange',
+      description: 'Applies a change to the validation settings.',
+      type: 'ApplyMetafieldChange',
+    },
+    {
+      title: 'data',
+      description: 'The object that exposes the validation with its settings.',
+      type: 'ValidationData',
+    },
+  ],
+  category: 'API',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.ts
@@ -7,6 +7,9 @@ import {ValidationData} from './launch-options';
 export interface ValidationSettingsApi<
   ExtensionTarget extends AnyExtensionTarget,
 > extends StandardApi<ExtensionTarget> {
+  /**
+   * Applies a change to the validation settings.
+   */
   applyMetafieldChange: ApplyMetafieldChange;
   data: ValidationData;
 }


### PR DESCRIPTION
### Background

Types were not getting generated which hindered use of the new Cart and Checkout Validation settings in Admin UI extensions.

### Solution

Refactored types so that they can be included in the generated docs.

### 🎩

[ask for internal link]

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
