### PR TITLE
Retail: Add PaginationParams to exported types

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -25,6 +25,7 @@ export type {
 export type {OrderAPIContent, OrderApi} from './api/order-api/order-api';
 
 export type {
+  PaginationParams,
   ProductSortType,
   ProductSearchParams,
   ProductSearchApi,


### PR DESCRIPTION
### Background

This export was missing.

### Solution

Add it.

### 🎩

`yalc` this onto your POS and verify that the type can be imported: https://github.com/Shopify/pos-next-react-native/blob/deb616f6c3668a84e64bf1d883529e5e969e05ce/src/components/UIExtensions/versions/unstable/api/useProductSearchApi.ts#L2

If you're unsure how to `yalc` this, you can use this script: https://github.com/Shopify/pos-next-react-native/pull/34077

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
