### PR TITLE
update remote-ui-links 2023-10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ The types in this package allow us to represent additional details about the tar
 - What **UI Components** are available to be rendered, and what properties those UI components accept
 - What **imperative APIs** are provided by the host application, for reading and writing data relevant to the extension
 
-UI extensions are built on an open source project called, [remote-ui](https://github.com/Shopify/remote-ui), which allows them to render native UI elements while being safely sandboxed. If you want to learn more, we’ve written a [technical explanation of how extensions work under the hood](./documentation/how-extensions-work.md).
+UI extensions are built on an open source project called, [remote-ui](https://github.com/Shopify/remote-dom/tree/remote-ui), which allows them to render native UI elements while being safely sandboxed. If you want to learn more, we’ve written a [technical explanation of how extensions work under the hood](./documentation/how-extensions-work.md).

--- a/documentation/how-extensions-work.md
+++ b/documentation/how-extensions-work.md
@@ -2,9 +2,9 @@
 
 ## Open-source core
 
-The underlying technology for UI Extensions is [remote-ui](https://github.com/Shopify/remote-ui), an open source technology built by Shopify. remote-ui provides the basic [message passing](https://github.com/Shopify/remote-ui/tree/main/packages/rpc) system that is used by UI Extensions to communicate with the “host” application they are extending. remote-ui also provides the [component model](https://github.com/Shopify/remote-ui/tree/main/packages/core) extensions use to describe their UI. If you are familiar with building for the web, remote-ui is very similar to the DOM — it gives you a programmatic model for defining UI components and attaching UI to the screen.
+The underlying technology for UI Extensions is [remote-ui](https://github.com/Shopify/remote-dom/tree/remote-ui), an open source technology built by Shopify. remote-ui provides the basic [message passing](https://github.com/Shopify/remote-dom/tree/remote-ui/packages/rpc) system that is used by UI Extensions to communicate with the “host” application they are extending. remote-ui also provides the [component model](https://github.com/Shopify/remote-dom/tree/remote-ui/packages/core) extensions use to describe their UI. If you are familiar with building for the web, remote-ui is very similar to the DOM — it gives you a programmatic model for defining UI components and attaching UI to the screen.
 
-In addition to the basic message passing and component model, remote-ui offers integrations for frameworks like [React](https://github.com/Shopify/remote-ui/tree/main/packages/react) and [Vue](https://github.com/Shopify/remote-ui/tree/main/packages/vue). These integrations are used by UI Extensions to provide framework-specific bindings, allowing developers to use UI frameworks they are already familiar with.
+In addition to the basic message passing and component model, remote-ui offers integrations for frameworks like [React](https://github.com/Shopify/remote-dom/tree/remote-ui/packages/react) and [Vue](https://github.com/Shopify/remote-dom/tree/remote-ui/packages/vue). These integrations are used by UI Extensions to provide framework-specific bindings, allowing developers to use UI frameworks they are already familiar with.
 
 ## Components
 

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
@@ -60,7 +60,7 @@ const data: LandingTemplateSchema = {
         Static extension targets are tied to core checkout features like contact information, shipping methods, and order summary line items.
         Block extension targets can be displayed at any point in the checkout process and will always render regardless of which checkout features are available.
         An example is a field to capture order notes from the customer.
-        \n\nExtension UIs are rendered using [remote UI](https://github.com/Shopify/remote-ui),
+        \n\nExtension UIs are rendered using [remote UI](https://github.com/Shopify/remote-dom/tree/remote-ui),
         a fast and secure environment for custom [(non-DOM)](#constraints) UIs.`,
       sectionCard: [
         {

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -230,7 +230,7 @@ export type ArgumentsForExtension<ID extends keyof ExtensionTargets> =
 
 /**
  * A union type containing all of the extension targets that follow the pattern of
- * accepting a [`@remote-ui/core` `RemoteRoot`](https://github.com/Shopify/remote-ui/tree/main/packages/core)
+ * accepting a [`@remote-ui/core` `RemoteRoot`](https://github.com/Shopify/remote-dom/tree/remote-ui/packages/core)
  * and an additional `api` argument, and using those arguments to render
  * UI.
  */

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -680,7 +680,7 @@ export type ArgumentsForExtension<Target extends keyof ExtensionTargets> =
 
 /**
  * A union type containing all of the extension targets that follow the pattern of
- * accepting a [`@remote-ui/core` `RemoteRoot`](https://github.com/Shopify/remote-ui/tree/main/packages/core)
+ * accepting a [`@remote-ui/core` `RemoteRoot`](https://github.com/Shopify/remote-dom/tree/remote-ui/packages/core)
  * and an additional `api` argument, and using those arguments to render
  * UI.
  */

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -68,7 +68,7 @@ export type ArgumentsForExtension<Target extends keyof ExtensionTargets> =
 
 /**
  * A union type containing all of the extension targets that follow the pattern of
- * accepting a [`@remote-ui/core` `RemoteRoot`](https://github.com/Shopify/remote-ui/tree/main/packages/core)
+ * accepting a [`@remote-ui/core` `RemoteRoot`](https://github.com/Shopify/remote-dom/tree/remote-ui/packages/core)
  * and an additional `api` argument, and using those arguments to render
  * UI.
  */


### PR DESCRIPTION
### Background

Renaming `remote-ui` links and applying this change to previous stable versions.

See change in unstable: https://github.com/Shopify/ui-extensions/pull/1800

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
