### PR TITLE
adds missing changesets for 2024-04 checkout

### DIFF
--- a/.changeset/clever-ways-fold.md
+++ b/.changeset/clever-ways-fold.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+Introduces a new `Sheet` component. It is designed to be used on top of other elements in a user interface and is typically bound to the bottom of the page.

--- a/.changeset/eight-seahorses-relate.md
+++ b/.changeset/eight-seahorses-relate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-react': patch
+---
+
+The `useDeliveryGroup()` react hook in the checkout surface no longer throws an exception if the delivery group is undefined.


### PR DESCRIPTION
### Background

Adds missing changesets for 2024-04 checkout. This corresponds to a [PR that was previously merged](https://github.com/Shopify/ui-extensions/pull/1852).

