### PR TITLE
2024-04: clarify `Image.source` description

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/checkout/components/Image/examples/basic-image.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/components/Image/examples/basic-image.example.tsx
@@ -10,6 +10,6 @@ export default reactExtension(
 
 function Extension() {
   return (
-    <Image source="https://shopify.dev/assets/api/checkout-extensions/checkout/components/image-example-code.png" />
+    <Image source="https://cdn.shopify.com/YOUR_IMAGE_HERE" />
   );
 }

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.ts
@@ -17,7 +17,7 @@ import type {
 
 export interface ImageProps extends BorderProps, CornerProps, IdProps {
   /**
-   * The URL or path to the image. Supports the `resolution` and `viewportInlineSize` conditional styles only.
+   * The URL of the image. Supports the `resolution` and `viewportInlineSize` conditional styles only.
    */
   source: Required<
     MaybeConditionalStyle<

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image/examples/basic-image.example.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image/examples/basic-image.example.ts
@@ -2,8 +2,7 @@ import {extension, Image} from '@shopify/ui-extensions/checkout';
 
 export default extension('purchase.checkout.block.render', (root) => {
   const image = root.createComponent(Image, {
-    source:
-      'https://shopify.dev/assets/api/checkout-extensions/checkout/components/image-example-code.png',
+    source: 'https://cdn.shopify.com/YOUR_IMAGE_HERE',
   });
 
   root.appendChild(image);


### PR DESCRIPTION
### Background
Part of https://github.com/Shopify/checkout-web/issues/31776. Updates the docs for the `2024-04` stable release. 

There is [another PR](https://github.com/Shopify/ui-extensions/pull/1863) in this repo to update the `unstable` channel docs.

A follow up to https://github.com/Shopify/checkout-web/pull/31805
