### PR TITLE
removes redundant Capability type and uses checkout interface in customer account

### DIFF
--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -1,5 +1,7 @@
 import type {RemoteComponentType} from '@remote-ui/core';
 
+export type {Capability} from './surfaces/checkout/api/standard/standard';
+
 export type ComponentsBuilder<ComponentTypes> = {
   [K in keyof ComponentTypes]: ComponentTypes[K] extends RemoteComponentType<
     any,

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -3,6 +3,7 @@ import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 import type {
   ApiVersion,
+  Capability,
   CurrencyCode,
   Timezone,
   CountryCode,
@@ -12,6 +13,7 @@ import type {
 
 export {
   ApiVersion,
+  Capability,
   CurrencyCode,
   Timezone,
   CountryCode,
@@ -138,17 +140,6 @@ export interface I18n {
 }
 
 /**
- * The capabilities an extension has access to.
- *
- * * [`api_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.
- *
- * * [`network_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.
- *
- * * [`block_progress`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a buyer's progress and the merchant has allowed this blocking behavior.
- */
-export type Capability = 'api_access' | 'network_access' | 'block_progress';
-
-/**
  * Meta information about an extension target.
  */
 export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
@@ -160,14 +151,17 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
   apiVersion: ApiVersion;
 
   /**
-   * The allowed capabilities of the extension, defined
-   * in your [shopify.ui.extension.toml](https://shopify.dev/docs/api/checkout-ui-extensions/configuration) file.
+   * The capabilities an extension has access to.
    *
    * * [`api_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.
    *
    * * [`network_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.
    *
    * * [`block_progress`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a buyer's progress and the merchant has allowed this blocking behavior.
+   *
+   * * [`collect_buyer_consent.sms_marketing`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect buyer consent for SMS marketing.
+   *
+   * * [`collect_buyer_consent.customer_privacy`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register buyer consent decisions that will be honored on Shopify-managed services.
    */
   capabilities: StatefulRemoteSubscribable<Capability[]>;
 


### PR DESCRIPTION
### Background

This PR replaces the redundant `Capability` type in customer account with the type maintained in the checkout surface.

### Solution

We have been maintaining two `Capability` types, causing the instance in customer account to fall out of sync with checkout. This change allows us to maintain the capabilities in one type.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
