### PR TITLE
957/add expanded block targets

### DIFF
--- a/.changeset/famous-pillows-work.md
+++ b/.changeset/famous-pillows-work.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+Add new block extension targets: collection, draft-order, abandoned-checkout, and product-variant

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   "editor.formatOnSave": true,
   "eslint.enable": true,
   "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/targets-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/targets-overview.doc.ts
@@ -123,9 +123,24 @@ You register targets in your \`shopify.extension.toml\` and inside the Javascrip
         'Admin block extensions appear on resource detail pages throughout the admin. Learn more about [admin blocks](/docs/apps/admin/admin-actions-and-blocks#admin-blocks).',
       sectionSubContent: [
         {
+          title: 'Abandoned checkout details',
+          sectionContent:
+            'This page shows information about a single abandoned checkout. The `admin.abandoned-checkout-details.block.render` target is available on this page.',
+        },
+        {
+          title: 'Collection details',
+          sectionContent:
+            'This page shows information about a single collection. The `admin.collection-details.block.render` target is available on this page.',
+        },
+        {
           title: 'Customer details',
           sectionContent:
             'This page shows information about a single customer. The `admin.customer-details.block.render` target is available on this page.',
+        },
+        {
+          title: 'Draft order details',
+          sectionContent:
+            'This page shows information about a single draft order. The `admin.draft-order-details.block.render` target is available on this page.',
         },
         {
           title: 'Order details',
@@ -136,6 +151,11 @@ You register targets in your \`shopify.extension.toml\` and inside the Javascrip
           title: 'Product details',
           sectionContent:
             'This page shows information about a single product. The `admin.product-details.block.render` target is available on this page.',
+        },
+        {
+          title: 'Product variant details',
+          sectionContent:
+            'This page shows information about a single product variant. The `admin.product-variant-details.block.render` target is available on this page.',
         },
       ],
     },

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/targets-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/targets-overview.doc.ts
@@ -19,24 +19,19 @@ You register targets in your \`shopify.extension.toml\` and inside the Javascrip
         'Admin action extensions appear on resource pages throughout the admin. Learn more about [admin actions](/docs/apps/admin/admin-actions-and-blocks#admin-actions).',
       sectionSubContent: [
         {
-          title: 'Product details',
+          title: 'Abandoned checkout details',
           sectionContent:
-            'This page shows information about a single product. The `admin.product-details.action.render` target is available on this page.',
+            'This page shows information about a single abandoned checkout. The `admin.abandoned-checkout-details.action.render` target is available on this page.',
         },
         {
-          title: 'Product variant details',
+          title: 'Collection details',
           sectionContent:
-            'This page shows information about a single product variant. The `admin.product-variant-details.action.render` target is available on this page.',
+            'This page shows information about a single collection. The `admin.collection-details.action.render` target is available on this page.',
         },
         {
-          title: 'Product index',
+          title: 'Collection index',
           sectionContent:
-            'This page shows a table of multiple products. The `admin.product-index.action.render` target is available on this page.',
-        },
-        {
-          title: 'Product index selection',
-          sectionContent:
-            'This page shows a table of multiple products. The `admin.product-index.selection-action.render` target is available on this page.',
+            'This page shows a table of multiple collections. The `admin.collection-index.action.render` target is available on this page.',
         },
         {
           title: 'Customer details',
@@ -47,6 +42,36 @@ You register targets in your \`shopify.extension.toml\` and inside the Javascrip
           title: 'Customer index',
           sectionContent:
             'This page shows a table of multiple customers. The `admin.customer-index.action.render` and `admin.customer-index.selection-action.render` targets are available on this page.',
+        },
+        {
+          title: 'Customer segment details',
+          sectionContent:
+            'This page shows information about a single customer segment. The `admin.customer-segment-details.action.render` target is available on this page.',
+        },
+        {
+          title: 'Discount details',
+          sectionContent:
+            'This page shows information about a single discount. The `admin.discount-details.action.render` target is available on this page.',
+        },
+        {
+          title: 'Discount index',
+          sectionContent:
+            'This page shows a table of multiple discounts. The `admin.discount-index.action.render` target is available on this page.',
+        },
+        {
+          title: 'Draft order details',
+          sectionContent:
+            'This page shows information about a single draft order. The `admin.draft-order-details.action.render` target is available on this page.',
+        },
+        {
+          title: 'Draft order index',
+          sectionContent:
+            'This page shows a table of multiple draft orders. The `admin.draft-order-index.action.render` target is available on this page.',
+        },
+        {
+          title: 'Draft order index selection',
+          sectionContent:
+            'This page shows a table of multiple draft orders. The `admin.draft-order-index.selection-action.render` target is available on this page.',
         },
         {
           title: 'Order details',
@@ -69,49 +94,24 @@ You register targets in your \`shopify.extension.toml\` and inside the Javascrip
             'This page shows a table of multiple orders. The `admin.order-index.selection-action.render` target is available on this page.',
         },
         {
-          title: 'Collection details',
+          title: 'Product details',
           sectionContent:
-            'This page shows information about a single collection. The `admin.collection-details.action.render` target is available on this page.',
+            'This page shows information about a single product. The `admin.product-details.action.render` target is available on this page.',
         },
         {
-          title: 'Collection index',
+          title: 'Product index',
           sectionContent:
-            'This page shows a table of multiple collections. The `admin.collection-index.action.render` target is available on this page.',
+            'This page shows a table of multiple products. The `admin.product-index.action.render` target is available on this page.',
         },
         {
-          title: 'Draft order details',
+          title: 'Product index selection',
           sectionContent:
-            'This page shows information about a single draft order. The `admin.draft-order-details.action.render` target is available on this page.',
+            'This page shows a table of multiple products. The `admin.product-index.selection-action.render` target is available on this page.',
         },
         {
-          title: 'Draft order index',
+          title: 'Product variant details',
           sectionContent:
-            'This page shows a table of multiple draft orders. The `admin.draft-order-index.action.render` target is available on this page.',
-        },
-        {
-          title: 'Draft order index selection',
-          sectionContent:
-            'This page shows a table of multiple draft orders. The `admin.draft-order-index.selection-action.render` target is available on this page.',
-        },
-        {
-          title: 'Discount details',
-          sectionContent:
-            'This page shows information about a single discount. The `admin.discount-details.action.render` target is available on this page.',
-        },
-        {
-          title: 'Discount index',
-          sectionContent:
-            'This page shows a table of multiple discounts. The `admin.discount-index.action.render` target is available on this page.',
-        },
-        {
-          title: 'Abandoned checkout details',
-          sectionContent:
-            'This page shows information about a single abandoned checkout. The `admin.abandoned-checkout-details.action.render` target is available on this page.',
-        },
-        {
-          title: 'Customer segment details',
-          sectionContent:
-            'This page shows information about a single customer segment. The `admin.customer-segment-details.action.render` target is available on this page.',
+            'This page shows information about a single product variant. The `admin.product-variant-details.action.render` target is available on this page.',
         },
       ],
     },
@@ -123,9 +123,9 @@ You register targets in your \`shopify.extension.toml\` and inside the Javascrip
         'Admin block extensions appear on resource detail pages throughout the admin. Learn more about [admin blocks](/docs/apps/admin/admin-actions-and-blocks#admin-blocks).',
       sectionSubContent: [
         {
-          title: 'Product details',
+          title: 'Customer details',
           sectionContent:
-            'This page shows information about a single product. The `admin.product-details.block.render` target is available on this page.',
+            'This page shows information about a single customer. The `admin.customer-details.block.render` target is available on this page.',
         },
         {
           title: 'Order details',
@@ -133,9 +133,9 @@ You register targets in your \`shopify.extension.toml\` and inside the Javascrip
             'This page shows information about a single order. The `admin.order-details.block.render` target is available on this page.',
         },
         {
-          title: 'Customer details',
+          title: 'Product details',
           sectionContent:
-            'This page shows information about a single customer. The `admin.customer-details.block.render` target is available on this page.',
+            'This page shows information about a single product. The `admin.product-details.block.render` target is available on this page.',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -71,7 +71,7 @@ export interface ExtensionTargets {
 
   // Blocks
   /**
-   * Renders an Admin Block in the product details page.
+   * Renders an admin block in the product details page.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -81,7 +81,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Block in the order details page.
+   * Renders an admin block in the order details page.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -91,7 +91,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Block in the customer details page.
+   * Renders an admin block in the customer details page.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -101,7 +101,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Block in the collection details page.
+   * Renders an admin block in the collection details page.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -111,7 +111,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Block in the draft order details page.
+   * Renders an admin block in the draft order details page.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -121,7 +121,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Block in the abandoned checkout details page.
+   * Renders an admin block in the abandoned checkout details page.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
@@ -131,7 +131,7 @@ export interface ExtensionTargets {
   >;
 
   /**
-   * Renders an Admin Block in the product variant details page.
+   * Renders an admin block in the product variant details page.
    *
    * See the [list of available components](/docs/api/admin-extensions/components).
    */

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -100,6 +100,46 @@ export interface ExtensionTargets {
     AllComponents
   >;
 
+  /**
+   * Renders an Admin Block in the collection details page.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.collection-details.block.render': RenderExtension<
+    BlockExtensionApi<'admin.collection-details.block.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Block in the draft order details page.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.draft-order-details.block.render': RenderExtension<
+    BlockExtensionApi<'admin.draft-order-details.block.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Block in the abandoned checkout details page.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.abandoned-checkout-details.block.render': RenderExtension<
+    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,
+    AllComponents
+  >;
+
+  /**
+   * Renders an Admin Block in the product variant details page.
+   *
+   * See the [list of available components](/docs/api/admin-extensions/components).
+   */
+  'admin.product-variant-details.block.render': RenderExtension<
+    BlockExtensionApi<'admin.product-variant-details.block.render'>,
+    AllComponents
+  >;
+
   // Actions
   /**
    * Renders an admin action extension in the product details page. Open this extension from the "More Actions" menu.


### PR DESCRIPTION
### Background

closes https://github.com/Shopify/app-ui/issues/957

Adds collection, draft-order, abandoned-checkout, and product-variant block targets 

### Solution

Follow existing pattern.

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
