### PR TITLE
Unstable Release (checkout) for address-autocomplete.suggest

### DIFF
--- a/.changeset/yellow-lions-behave.md
+++ b/.changeset/yellow-lions-behave.md
@@ -1,0 +1,7 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+- Adds `purchase.address-autocomplete.suggest` extension target
+- Adds the `primaryAction` and `secondaryAction` to the `Sheet` component

--- a/packages/ui-extensions-react/src/surfaces/checkout/components/Sheet/Sheet.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/components/Sheet/Sheet.ts
@@ -4,4 +4,6 @@ import type {ReactPropsFromRemoteComponentType} from '@remote-ui/react';
 
 export type SheetProps = ReactPropsFromRemoteComponentType<typeof BaseSheet>;
 
-export const Sheet = createRemoteReactComponent(BaseSheet);
+export const Sheet = createRemoteReactComponent(BaseSheet, {
+  fragmentProps: ['primaryAction', 'secondaryAction'],
+});

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.address-autocomplete.suggest/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.address-autocomplete.suggest/default.example.ts
@@ -1,0 +1,30 @@
+import {extension} from '@shopify/ui-extensions/checkout';
+
+export default extension(
+  'purchase.address-autocomplete.suggest',
+  async (api) => {
+    const {
+      signal,
+      target: {value, field},
+    } = api;
+
+    const suggestions =
+      await fetchAddressAutocompleteSuggestions(
+        value,
+        signal,
+      );
+
+    async function fetchAddressAutocompleteSuggestions(
+      value,
+      signal,
+    ) {
+      const response = await fetch(
+        `https://myapp.com/api?query=${value}&field=${field}`,
+        {signal},
+      );
+      return response.json();
+    }
+
+    return {suggestions};
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
@@ -597,6 +597,13 @@ const CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION = {
   type: 'CustomerAccountStandardApi',
 };
 
+const ADDRESS_AUTOCOMPLETE_STANDARD_API_DEFINITION = {
+  title: 'AddressAutocompleteStandardApi',
+  description:
+    'The base API object provided to this and other `purchase.address-autocomplete` extension targets.',
+  type: 'AddressAutocompleteStandardApi',
+};
+
 const CART_LINE_ITEM_API_DEFINITION = {
   title: 'CartLineItemApi',
   description:

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
@@ -98,6 +98,7 @@ export function getExamples(
     ...createExample(
       'customer-account.order-status.customer-information.render-after/default',
     ),
+    ...createExample('purchase.address-autocomplete.suggest/default'),
     ...createExample('purchase.cart-line-item.line-components.render/default'),
     ...createExample('purchase.checkout.actions.render-before/default'),
     ...createExample('purchase.checkout.block.render/default'),
@@ -604,6 +605,20 @@ const ADDRESS_AUTOCOMPLETE_STANDARD_API_DEFINITION = {
   type: 'AddressAutocompleteStandardApi',
 };
 
+const ADDRESS_AUTOCOMPLETE_SUGGEST_API_DEFINITION = {
+  title: 'AddressAutocompleteSuggestApi',
+  description:
+    'The API object provided to the `purchase.address-autocomplete.suggest` extension target.',
+  type: 'AddressAutocompleteSuggestApi',
+};
+
+const ADDRESS_AUTOCOMPLETE_SUGGEST_API_OUTPUT_DEFINITION = {
+  title: 'AddressAutocompleteSuggestApiOutput',
+  description:
+    'The API object returned by the `purchase.address-autocomplete.suggest` extension target.',
+  type: 'AddressAutocompleteSuggestApiOutput',
+};
+
 const CART_LINE_ITEM_API_DEFINITION = {
   title: 'CartLineItemApi',
   description:
@@ -674,6 +689,15 @@ export const STANDARD_API = {
 
 export const CHECKOUT_API = {
   definitions: [CHECKOUT_API_DEFINITION, STANDARD_API_DEFINITION],
+  ...COMMON_API,
+};
+
+export const ADDRESS_AUTOCOMPLETE_SUGGEST_API = {
+  definitions: [
+    ADDRESS_AUTOCOMPLETE_SUGGEST_API_DEFINITION,
+    ADDRESS_AUTOCOMPLETE_SUGGEST_API_OUTPUT_DEFINITION,
+    ADDRESS_AUTOCOMPLETE_STANDARD_API_DEFINITION,
+  ],
   ...COMMON_API,
 };
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.address-autocomplete.suggest.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.address-autocomplete.suggest.doc.ts
@@ -1,0 +1,24 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {
+  ADDRESS_AUTOCOMPLETE_SUGGEST_API,
+  getExample,
+  getLinksByTag,
+} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'purchase.address-autocomplete.suggest',
+  description: `
+  An extension target used to provide address autocomplete suggestions. It accepts input and must return address suggestions.
+
+  > Caution: This target does not support rendering UI components.
+  `,
+  subCategory: 'Utility',
+  defaultExample: getExample('purchase.address-autocomplete.suggest/default', [
+    'js',
+  ]),
+  related: getLinksByTag('targets'),
+  ...ADDRESS_AUTOCOMPLETE_SUGGEST_API,
+};
+
+export default data;

--- a/packages/ui-extensions/src/extension.ts
+++ b/packages/ui-extensions/src/extension.ts
@@ -44,5 +44,5 @@ export interface RenderExtensionWithRemoteRoot<
 }
 
 export interface RunnableExtension<Api, Output> {
-  (api: Api): Output | Promise<Output>;
+  (api: Api): Output;
 }

--- a/packages/ui-extensions/src/surfaces/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout.ts
@@ -140,9 +140,14 @@ export type {PickupLocationItemApi} from './checkout/api/pickup/pickup-location-
 export type {ShippingOptionItemApi} from './checkout/api/shipping/shipping-option-item';
 export type {ShippingOptionListApi} from './checkout/api/shipping/shipping-option-list';
 export type {
-  AddressAutocompleteSuggestion,
   AddressAutocompleteSuggestApi,
+  AddressAutocompleteSuggestApiOutput,
+  AddressAutocompleteFormatSuggestionApi,
+  AddressAutocompleteFormatSuggestionApiOutput,
+  AddressAutocompleteSuggestion,
 } from './checkout/api/address-autocomplete/address-autocomplete';
+
+export type {AddressAutocompleteStandardApi} from './checkout/api/address-autocomplete/standard';
 
 export type {
   PaymentMethodAttributesResult,

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/address-autocomplete.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/address-autocomplete.ts
@@ -1,6 +1,18 @@
 import type {MailingAddress} from '../shared';
 
 export interface AddressAutocompleteSuggestApi {
+  /**
+   * The signal that the extension should listen to for cancellation requests.
+   *
+   * If the signal is aborted, the extension should cancel any ongoing requests.
+   * The signal will be aborted either when the buyer navigates away from the
+   * address field or when the debounced query value changes.
+   *
+   * Pass this signal to any asynchronous operations that need to be cancelled,
+   * like `fetch`.
+   */
+  signal: AbortSignal;
+
   target: {
     /**
      * The input that the user has typed so far into the address field.
@@ -14,15 +26,10 @@ export interface AddressAutocompleteSuggestApi {
      *
      * @example "address1"
      */
-    field: AutocompleteAddress;
-
-    /**
-     * An AbortSignal that may be used to cancel in-flight network requests.
-     * This signal is sent when the buyer has stopped interacting with the address field.
-     */
-    signal: AbortSignal;
+    field: Extract<keyof MailingAddress, 'address1' | 'zip'>;
   };
 }
+
 export interface AddressAutocompleteSuggestion {
   /**
    * The human-readable autocomplete suggestion text. This text is
@@ -30,7 +37,7 @@ export interface AddressAutocompleteSuggestion {
    *
    * @example "123 Main St, Toronto, ON, CA"
    */
-  description: string;
+  label: string;
 
   /**
    * Optional.
@@ -66,13 +73,20 @@ export interface AddressAutocompleteSuggestion {
 
 interface MatchedSubstring {
   /**
-   * The start location of the matched substring in the suggestion description text.
+   * The start location of the matched substring in the suggestion label text.
    */
   offset: number;
   /**
-   * The length of the matched substring in the suggestion description text.
+   * The length of the matched substring in the suggestion label text.
    */
   length: number;
+}
+
+export interface AddressAutocompleteSuggestApiOutput {
+  /**
+   * An array of address autocomplete suggestions to show to the buyer.
+   */
+  suggestions: AddressAutocompleteSuggestion[];
 }
 
 /**
@@ -85,3 +99,19 @@ type AutocompleteAddress = Partial<
     'address1' | 'address2' | 'city' | 'provinceCode' | 'zip' | 'countryCode'
   >
 >;
+
+export interface AddressAutocompleteFormatSuggestionApi {
+  /**
+   * The selected autocomplete suggestion that the buyer selected during checkout.
+   */
+  target: {
+    selectedSuggestion: AddressAutocompleteSuggestion;
+  };
+}
+
+export interface AddressAutocompleteFormatSuggestionApiOutput {
+  /**
+   * The formatted address that will be used to populate the native address fields.
+   */
+  formattedAddress: AutocompleteAddress;
+}

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/address-autocomplete.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/address-autocomplete.ts
@@ -13,21 +13,28 @@ export interface AddressAutocompleteSuggestApi {
    */
   signal: AbortSignal;
 
-  target: {
-    /**
-     * The input that the user has typed so far into the address field.
-     *
-     * @example "123 M"
-     */
-    value: string;
+  /**
+   * The current state of the address field that the buyer is interacting with.
+   *
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   */
+  target: Target;
+}
 
-    /**
-     * The address field that the buyer is interacting with.
-     *
-     * @example "address1"
-     */
-    field: Extract<keyof MailingAddress, 'address1' | 'zip'>;
-  };
+interface Target {
+  /**
+   * The current value of the `field` the buyer is interacting with.
+   *
+   * @example "123 M"
+   */
+  value: string;
+
+  /**
+   * The `MailingAddress` field that the buyer is interacting with.
+   *
+   * @example "address1"
+   */
+  field: 'address1' | 'zip';
 }
 
 export interface AddressAutocompleteSuggestion {
@@ -93,13 +100,11 @@ export interface AddressAutocompleteSuggestApiOutput {
  * A partial mailing address with only fields relevant to address autocomplete.
  * All fields are optional
  */
-type AutocompleteAddress = Partial<
-  Pick<
+interface AutocompleteAddress
+  extends Pick<
     MailingAddress,
     'address1' | 'address2' | 'city' | 'provinceCode' | 'zip' | 'countryCode'
-  >
->;
-
+  > {}
 export interface AddressAutocompleteFormatSuggestionApi {
   /**
    * The selected autocomplete suggestion that the buyer selected during checkout.

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
@@ -1,0 +1,268 @@
+import type {
+  Analytics,
+  Capability,
+  CheckoutToken,
+  Country,
+  Currency,
+  Editor,
+  ExtensionSettings,
+  I18n,
+  Language,
+  Market,
+  Metafield,
+  SessionToken,
+  Shop,
+  Storage,
+  Version,
+} from '../standard/standard';
+import type {Attribute, MailingAddress} from '../shared';
+import type {
+  ApiVersion,
+  GraphQLError,
+  StorefrontApiVersion,
+  Timezone,
+} from '../../../../shared';
+
+export interface AddressAutocompleteStandardApi<
+  Target extends
+    | 'purchase.address-autocomplete.suggest'
+    | 'purchase.address-autocomplete.format-suggestion',
+> {
+  /**
+   * Methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
+   */
+  analytics: Analytics;
+
+  /**
+   * Custom attributes left by the customer to the merchant, either in their cart or during checkout.
+   */
+  attributes: Attribute[] | undefined;
+
+  /**
+   * The proposed buyer billing address. The address updates when the field is
+   * committed (on change) rather than every keystroke.
+   *
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   */
+  billingAddress?: MailingAddress | undefined;
+
+  /**
+   * A stable id that represents the current checkout.
+   *
+   * Matches the `token` field in the [WebPixel checkout payload](https://shopify.dev/docs/api/pixels/customer-events#checkout)
+   * and the `checkout_token` field in the [Admin REST API Order resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object).
+   */
+  checkoutToken: CheckoutToken | undefined;
+
+  /**
+   * Meta information about the extension.
+   */
+  extension: Extension<Target>;
+
+  /**
+   * Utilities for translating content and formatting values according to the current
+   * [`localization`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization)
+   * of the checkout.
+   *
+   * See [localization examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#examples)
+   * for more information.
+   */
+  i18n: I18n;
+
+  /**
+   * Details about the location, language, and currency of the buyer. For utilities to easily
+   * format and translate content based on these details, you can use the
+   * [`i18n`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-i18n)
+   * object instead.
+   */
+  localization: Localization;
+
+  /**
+   * The metafields that apply to the current checkout.
+   *
+   * Metafields are stored locally on the client and are applied to the order object after the checkout completes.
+   *
+   * These metafields are shared by all extensions running on checkout, and
+   * persist for as long as the customer is working on this checkout.
+   *
+   * Once the order is created, you can query these metafields using the
+   * [GraphQL Admin API](https://shopify.dev/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)
+   */
+  metafields: Metafield[];
+
+  /**
+   * Used to query the Storefront GraphQL API with a prefetched token.
+   *
+   * See [storefront api access examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/storefront-api) for more information.
+   */
+  query: <Data = unknown, Variables = Record<string, unknown>>(
+    query: string,
+    options?: {variables?: Variables; version?: StorefrontApiVersion},
+  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;
+
+  /**
+   * Provides access to session tokens, which can be used to verify token claims on your app's server.
+   *
+   * See [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/session-token) for more information.
+   */
+  sessionToken: SessionToken;
+
+  /**
+   * The settings matching the settings definition written in the
+   * [`shopify.extension.toml`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration) file.
+   *
+   *  See [settings examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/settings) for more information.
+   *
+   * > Note: When an extension is being installed in the editor, the settings will be empty
+   */
+  settings: ExtensionSettings;
+
+  /**
+   * The proposed buyer shipping address. During the information step,
+   * the address updates when the field is committed (on change) rather than every keystroke.
+   * An address value is only present if delivery is required. Otherwise, the subscribable value is undefined.
+   *
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   */
+  shippingAddress?: MailingAddress | undefined;
+
+  /** Shop where the checkout is taking place. */
+  shop: Shop;
+
+  /**
+   * Key-value storage for the extension.
+   * Uses `localStorage` and should persist across the buyer's current checkout session.
+   * However, data persistence isn't guaranteed and storage is reset when the buyer starts a new checkout.
+   *
+   * Data is shared across all activated extension targets of this extension. In versions `<=2023-07`,
+   * each activated extension target had its own storage.
+   */
+  storage: Storage;
+
+  /**
+   * The runner version being used for the extension.
+   *
+   * @example 'unstable'
+   */
+  version: Version;
+}
+
+interface Extension<
+  Target extends
+    | 'purchase.address-autocomplete.suggest'
+    | 'purchase.address-autocomplete.format-suggestion',
+> {
+  /**
+   * The API version that was set in the extension config file.
+   *
+   * @example '2023-07', '2023-10', '2024-01', '2024-04', 'unstable'
+   */
+  apiVersion: ApiVersion;
+
+  /**
+   * The allowed capabilities of the extension, defined
+   * in your [shopify.extension.toml](https://shopify.dev/docs/api/checkout-ui-extensions/configuration) file.
+   *
+   * * [`api_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.
+   *
+   * * [`network_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.
+   *
+   * * [`block_progress`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a buyer's progress and the merchant has allowed this blocking behavior.
+   *
+   * * [`collect_buyer_consent.sms_marketing`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect buyer consent for SMS marketing.
+   *
+   * * [`collect_buyer_consent.customer_privacy`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register buyer consent decisions that will be honored on Shopify-managed services.
+   */
+  capabilities: Capability[];
+
+  /**
+   * Information about the editor where the extension is being rendered.
+   *
+   * The value is undefined if the extension is not running in an editor.
+   */
+  editor?: Editor;
+
+  /**
+   * Whether your extension is currently rendered to the screen.
+   *
+   * Shopify might render your extension before it's visible in the UI,
+   * typically to pre-render extensions that will appear on a later step of the
+   * checkout.
+   *
+   * Your extension might also continue to run after the buyer has navigated away
+   * from where it was rendered. The extension continues running so that
+   * your extension is immediately available to render if the buyer navigates back.
+   *
+   * If the extension is not capable of rendering UI components, this value will always be false.
+   */
+  rendered: boolean;
+
+  /**
+   * The URL to the script that started the extension target.
+   */
+  scriptUrl: string;
+  /**
+   * The identifier that specifies where in Shopify’s UI your code is being
+   * injected. This will be one of the targets you have included in your
+   * extension’s configuration file.
+   *
+   * @example 'purchase.checkout.block.render'
+   * @see https://shopify.dev/docs/api/checkout-ui-extensions/unstable/extension-targets-overview
+   * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
+   */
+  target: Target;
+
+  /**
+   * The published version of the running extension target.
+   *
+   * For unpublished extensions, the value is `undefined`.
+   *
+   * @example 3.0.10
+   */
+  version?: string;
+}
+
+interface Localization {
+  /**
+   * The currency that the buyer sees for money amounts in the checkout.
+   */
+  currency: Currency;
+
+  /**
+   * The buyer’s time zone.
+   */
+  timezone: Timezone;
+
+  /**
+   * The language the buyer sees in the checkout.
+   */
+  language: Language;
+
+  /**
+   * This is the buyer's language, as supported by the extension.
+   * If the buyer's actual language is not supported by the extension,
+   * this is the fallback locale used for translations.
+   *
+   * For example, if the buyer's language is 'fr-CA' but your extension
+   * only supports translations for 'fr', then the `isoCode` for this
+   * language is 'fr'. If your extension does not provide french
+   * translations at all, this value is the default locale for your
+   * extension (that is, the one matching your .default.json file).
+   */
+  extensionLanguage: Language;
+
+  /**
+   * The country context of the checkout. This value carries over from the
+   * context of the cart, where it was used to contextualize the storefront
+   * experience. The value is undefined if unknown.
+   */
+  country: Country | undefined;
+
+  /**
+   * The [market](https://shopify.dev/docs/apps/markets) context of the
+   * checkout. This value carries over from the context of the cart, where it
+   * was used to contextualize the storefront experience. The value is undefined
+   * if unknown.
+   */
+  market: Market | undefined;
+}

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -295,7 +295,7 @@ export interface GiftCardRemoveChange {
   type: 'removeGiftCard';
 
   /**
-   * Gift card code.
+   * The full gift card code, or the last four digits of the code.
    */
   code: string;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1718,6 +1718,25 @@ export interface DeliveryGroupDetails extends DeliveryGroup {
   targetedCartLines: CartLine[];
 }
 
+export interface AllowedProcessing {
+  /**
+   * Can collect customer analytics about how the shop was used and interactions made on the shop.
+   */
+  analytics: boolean;
+  /**
+   * Can collect customer preference for marketing, attribution and targeted advertising from the merchant.
+   */
+  marketing: boolean;
+  /**
+   * Can collect customer preferences such as language, currency, size, and more.
+   */
+  preferences: boolean;
+  /**
+   * Can collect customer preference for sharing data with third parties, usually for behavioral advertising.
+   */
+  saleOfData: boolean;
+}
+
 export interface VisitorConsent {
   /**
    * Visitor consents to recording data to understand how customers interact with the site.
@@ -1768,8 +1787,12 @@ export interface CustomerPrivacyRegion {
 
 export interface CustomerPrivacy {
   /**
+   * An object containing flags for each consent property denoting whether they can be processed based on visitor consent, merchant configuration, and user location.
+   */
+  allowedProcessing: AllowedProcessing;
+  /**
    * An object containing the customer's current privacy consent settings.
-   *
+   * *
    * @example `true` — the customer has actively granted consent, `false` — the customer has actively denied consent, or `undefined` — the customer has not yet made a decision.
    */
   visitorConsent: VisitorConsent;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.ts
@@ -13,6 +13,7 @@ export type IconSource =
   | 'camera'
   | 'caretDown'
   | 'cart'
+  | 'categories'
   | 'checkmark'
   | 'chevronLeft'
   | 'chevronRight'

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.ts
@@ -1,3 +1,4 @@
+import type {RemoteFragment} from '@remote-ui/core';
 import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
@@ -45,6 +46,15 @@ export interface SheetProps extends IdProps {
 
   /** Callback fired when the sheet is closed. */
   onHide?(): void;
+
+  /**
+   * The primary action to perform, provided as a `Button` component.
+   */
+  primaryAction?: RemoteFragment;
+  /**
+   * The secondary action to perform, provided as a `Button` component.
+   */
+  secondaryAction?: RemoteFragment;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -1,6 +1,9 @@
 import type {
-  AddressAutocompleteSuggestion,
   AddressAutocompleteSuggestApi,
+  AddressAutocompleteSuggestApiOutput,
+  AddressAutocompleteFormatSuggestionApi,
+  AddressAutocompleteFormatSuggestionApiOutput,
+  AddressAutocompleteStandardApi,
 } from '../checkout';
 
 import type {CartLineItemApi} from './api/cart-line/cart-line-item';
@@ -727,8 +730,19 @@ export interface RunnableExtensionTargets {
    * @experimental
    */
   'purchase.address-autocomplete.suggest': RunnableExtension<
-    AddressAutocompleteSuggestApi,
-    AddressAutocompleteSuggestion[]
+    AddressAutocompleteStandardApi<'purchase.address-autocomplete.suggest'> &
+      AddressAutocompleteSuggestApi,
+    AddressAutocompleteSuggestApiOutput
+  >;
+  /**
+   * An extension target used to provide address autocomplete format suggestions. It does not support rendering UI components.
+   * @private
+   * @experimental
+   */
+  'purchase.address-autocomplete.format-suggestion': RunnableExtension<
+    AddressAutocompleteStandardApi<'purchase.address-autocomplete.format-suggestion'> &
+      AddressAutocompleteFormatSuggestionApi,
+    AddressAutocompleteFormatSuggestionApiOutput
   >;
 }
 
@@ -762,7 +776,7 @@ export type ArgumentsForExtension<Target extends keyof ExtensionTargets> =
  * For RenderExtensionTargets, this API type is the second argument to
  * the callback for that extension target.
  *
- * For RunnableExtensionTargets, this API type if the only argument to
+ * For RunnableExtensionTargets, this API type is the only argument to
  * the callback for that extension target.
  */
 export type ApiForExtension<Target extends ExtensionTarget> =

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -726,8 +726,6 @@ export interface RenderExtensionTargets {
 export interface RunnableExtensionTargets {
   /**
    * An extension target used to provide address autocomplete suggestions. It does not support rendering UI components.
-   * @private
-   * @experimental
    */
   'purchase.address-autocomplete.suggest': RunnableExtension<
     AddressAutocompleteStandardApi<'purchase.address-autocomplete.suggest'> &


### PR DESCRIPTION
### Background
This PR will update `unstable` packages with the latest changes

### Solution
generated by running `pnpm prepare-package-release`

### 🎩 
tophatted on my prod store with the snapshot and an address-autocomplete extension.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
