### PR TITLE
Addresses TypeScript errors blocking dynamic docs generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   },
   "dependencies": {
     "@shopify/generate-docs": "^0.10.9"
+  },
+  "resolutions": {
+    "@types/react": "17.0.2"
   }
 }

--- a/packages/ui-extensions-react/src/surfaces/admin/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/render.tsx
@@ -35,9 +35,13 @@ export function reactExtension<ExtensionTarget extends RenderExtensionTarget>(
     return new Promise((resolve, reject) => {
       try {
         remoteRender(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           <ExtensionApiContext.Provider value={api}>
             {render(api as ApiForRenderExtension<ExtensionTarget>)}
           </ExtensionApiContext.Provider>,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           root,
           () => {
             resolve();

--- a/packages/ui-extensions-react/src/surfaces/admin/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/render.tsx
@@ -35,8 +35,6 @@ export function reactExtension<ExtensionTarget extends RenderExtensionTarget>(
     return new Promise((resolve, reject) => {
       try {
         remoteRender(
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
           <ExtensionApiContext.Provider value={api}>
             {render(api as ApiForRenderExtension<ExtensionTarget>)}
           </ExtensionApiContext.Provider>,

--- a/packages/ui-extensions-react/src/surfaces/checkout/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/render.tsx
@@ -126,7 +126,7 @@ class ErrorBoundary extends Component<PropsWithChildren<{}>, ErrorState> {
       return null;
     }
 
-    return <>{this.props.children}</>;
+    return this.props.children;
   }
 }
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/render.tsx
@@ -44,8 +44,6 @@ export function reactExtension<Target extends RenderExtensionTarget>(
       await new Promise<void>((resolve, reject) => {
         try {
           remoteRender(
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
             <ExtensionApiContext.Provider value={api}>
               <ErrorBoundary>{element}</ErrorBoundary>
             </ExtensionApiContext.Provider>,

--- a/packages/ui-extensions-react/src/surfaces/checkout/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/render.tsx
@@ -44,9 +44,13 @@ export function reactExtension<Target extends RenderExtensionTarget>(
       await new Promise<void>((resolve, reject) => {
         try {
           remoteRender(
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             <ExtensionApiContext.Provider value={api}>
               <ErrorBoundary>{element}</ErrorBoundary>
             </ExtensionApiContext.Provider>,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             root,
             () => {
               resolve();
@@ -122,7 +126,7 @@ class ErrorBoundary extends Component<PropsWithChildren<{}>, ErrorState> {
       return null;
     }
 
-    return this.props.children;
+    return <>{this.props.children}</>;
   }
 }
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/render.tsx
@@ -126,7 +126,7 @@ class ErrorBoundary extends Component<PropsWithChildren<{}>, ErrorState> {
       return null;
     }
 
-    return <>{this.props.children}</>;
+    return this.props.children;
   }
 }
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/render.tsx
@@ -44,8 +44,6 @@ export function reactExtension<Target extends RenderExtensionTarget>(
       await new Promise<void>((resolve, reject) => {
         try {
           remoteRender(
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
             <ExtensionApiContext.Provider value={api}>
               <ErrorBoundary>{element}</ErrorBoundary>
             </ExtensionApiContext.Provider>,

--- a/packages/ui-extensions-react/src/surfaces/customer-account/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/render.tsx
@@ -44,9 +44,13 @@ export function reactExtension<Target extends RenderExtensionTarget>(
       await new Promise<void>((resolve, reject) => {
         try {
           remoteRender(
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             <ExtensionApiContext.Provider value={api}>
               <ErrorBoundary>{element}</ErrorBoundary>
             </ExtensionApiContext.Provider>,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             root,
             () => {
               resolve();
@@ -122,7 +126,7 @@ class ErrorBoundary extends Component<PropsWithChildren<{}>, ErrorState> {
       return null;
     }
 
-    return this.props.children;
+    return <>{this.props.children}</>;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2388,22 +2388,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=17.0.0 <18.0.0":
-  version "17.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.11.tgz#67fcd0ddbf5a0b083a0f94e926c7d63f3b836451"
-  integrity sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==
+"@types/react@*", "@types/react@17.0.2", "@types/react@>=17.0.0 <18.0.0", "@types/react@^18.0.21":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
+  integrity sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^18.0.21":
-  version "18.2.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.14.tgz#fa7a6fecf1ce35ca94e74874f70c56ce88f7a127"
-  integrity sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/resolve@1.17.1":
@@ -2412,11 +2402,6 @@
   integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
-
-"@types/scheduler@*":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
-  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/semver@^6.0.0":
   version "6.2.3"


### PR DESCRIPTION
### Background

The checkout-dev dynamic [docs generation action fails](https://github.com/Shopify/shopify-dev/actions/runs/8696119801/job/23848671756) on the `2023-07` version of `ui-extensions-react` because of TypeScript issues.

The three `render.tsx` files in this version have not been changed in more recent versions, but the action succeeds. 

This PR ignores the TypeScript errors and wraps the return of `children` props in `ErrorBoundary` in a fragment.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
