### PR TITLE
Improve incorrect hook usage messaging

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/api.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/api.ts
@@ -24,7 +24,7 @@ export function useApi<
 
   if (api == null) {
     throw new CheckoutUIExtensionError(
-      'You can only call this hook when running as a UI extension.',
+      'You can only call this hook when running as a checkout UI extension.',
     );
   }
 

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/api.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/api.test.tsx
@@ -23,7 +23,7 @@ describe('useApi', () => {
     };
 
     await expect(runner).rejects.toThrow(
-      'You can only call this hook when running as a UI extension.',
+      'You can only call this hook when running as a checkout UI extension.',
     );
   });
 });

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/api.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/api.ts
@@ -24,7 +24,7 @@ export function useApi<
 
   if (api == null) {
     throw new CustomerAccountUIExtensionError(
-      'You can only call this hook when running as a UI extension.',
+      'You can only call this hook when running as a customer account UI extension.',
     );
   }
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/api.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/api.test.tsx
@@ -25,7 +25,7 @@ describe('useApi', () => {
     };
 
     await expect(runner).rejects.toThrow(
-      'You can only call this hook when running as a UI extension.',
+      'You can only call this hook when running as a customer account UI extension.',
     );
   });
 });

--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/hooks/api.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/hooks/api.ts
@@ -24,7 +24,7 @@ export function useApi<
 
   if (api == null) {
     throw new PosUIExtensionError(
-      'You can only call this hook when running as a UI extension.',
+      'You can only call this hook when running as a point of sale UI extension.',
     );
   }
 


### PR DESCRIPTION
### Background

If a partner builds a `checkout` UI extension for the Thank You Page and inadvertently uses a React hook from `customer-account`, they will get an error stating "_You can only call this hook when running as a UI extension_". In this case, it is running within a UI extension, but its not the right surface. Let's make the message more targeted.

> **Note**: The core reason why this doesn't work is because the hooks rely on a react extension context which is established by the `import { reactExtension} from '@shopify/ui-extensions-react/{surface}`. Hooks must be exported from the same surface as `reactExtension`. This is by design.

Implements improvement done for [checkout UI extensions](https://github.com/Shopify/checkout-web/pull/33723) to other surfaces.

### Solution

Establish that the hooks must be called from the specific type of UI extension rather than just a "UI extension".

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
