### PR TITLE
Added examples for all cart functions

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -1,4 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const functionality = 'cart-api';
+const generateCodeBlockForCartApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, functionality, fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Cart API',
@@ -15,6 +20,149 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  examples: {
+    description: 'Examples of using the Cart API',
+    examples: [
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Subscribe to cart changes.',
+          'subscribable',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Apply a cart level discount',
+          'apply-cart-discount',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Apply a cart level discount code',
+          'apply-cart-code-discount',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Remove all the discounts on the cart and line items',
+          'remove-all-discounts',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Set a custom discount on a line item',
+          'set-line-item-discount',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Set a custom discount on multiple line items',
+          'bulk-set-line-item-discounts',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Remove a discount on a line item',
+          'remove-line-item-discount',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Clear the entire cart',
+          'clear-cart',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Set the customer in the cart',
+          'set-customer',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Remove the customer in the cart',
+          'remove-customer',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Add a custom sale to the cart',
+          'add-custom-sale',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Add a line item to the cart',
+          'add-line-item',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Remove a line item from the cart',
+          'remove-line-item',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Add custom properties to the cart',
+          'add-cart-properties',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Remove custom properties from the cart',
+          'remove-cart-properties',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Add custom properties to a line item',
+          'add-line-item-properties',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Add custom properties to multiple line items',
+          'bulk-add-line-item-properties',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Remove custom properties from a line item',
+          'remove-line-item-properties',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Set an attributed staff member on the cart',
+          'set-attributed-staff',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Set an attributed staff member on a line item',
+          'set-attributed-staff-to-line-item',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Add an address to the customer in the cart',
+          'add-address',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Delete an address corresponding to an ID',
+          'delete-address',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Set the default address of the customer in the cart',
+          'update-default-address',
+        ),
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/action-api/present-modal.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/action-api/present-modal.ts
@@ -5,27 +5,23 @@ import {
   extension,
 } from '@shopify/ui-extensions/point-of-sale';
 
-export default extension(
-  'pos.purchase.post.action.render',
-  (root, api) => {
-    const button = root.createComponent(Button, {
-      onPress: () => {
-        console.log('Button pressed');
-      },
-      title: 'Button test',
-    });
+export default extension('pos.purchase.post.action.render', (root, api) => {
+  const button = root.createComponent(Button, {
+    onPress: () => {
+      api.action.presentModal();
+    },
+    title: 'Button test',
+  });
 
-    const screen = root.createComponent(Screen, {
-      title: 'Post-Purchase Title',
-      name: 'Post-Purchase Name',
-    });
+  const screen = root.createComponent(Screen, {
+    title: 'Post-Purchase Title',
+    name: 'Post-Purchase Name',
+  });
 
-    screen.append(button);
+  screen.append(button);
 
-    const navigator =
-      root.createComponent(Navigator);
-    navigator.append(screen);
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
 
-    root.append(navigator);
-  },
-);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-address.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-address.ts
@@ -1,0 +1,21 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.addAddress({
+        address1: '123456 Main Street',
+        city: 'Ottawa',
+        province: 'Ontario',
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'Canada',
+      });
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-address.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-address.tsx
@@ -1,0 +1,32 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.addAddress({
+        address1: '123456 Main Street', 
+        city: 'Ottawa', 
+        province: 'Ontario',
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'Canada'
+      })}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-cart-properties.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-cart-properties.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart action',
+    enabled: true,
+    onPress: () => {
+      api.cart.addCartProperties({Engraving: 'John Doe'});
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-cart-properties.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-cart-properties.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.addCartProperties({Engraving: 'John Doe'})}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-custom-sale.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-custom-sale.ts
@@ -1,0 +1,19 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.addCustomSale({
+        title: 'New product',
+        quantity: 1,
+        price: '10.00',
+        taxable: true,
+      });
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-custom-sale.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-custom-sale.tsx
@@ -1,0 +1,30 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.addCustomSale({
+        title: 'New product',
+        quantity: 1,
+        price: '10.00',
+        taxable: true,
+      })}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-properties.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-properties.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.addLineItemProperties('aa-1234567', {Engraving: 'John Doe'});
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-properties.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-properties.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.addLineItemProperties('aa-1234567', {Engraving: 'John Doe'})}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.addLineItem(12345678, 1);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.addLineItem(12345678, 1)}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/apply-cart-code-discount.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/apply-cart-code-discount.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.addCartCodeDiscount('SUMMER_2024');
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/apply-cart-code-discount.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/apply-cart-code-discount.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.addCartCodeDiscount('SUMMER_2024')} 
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/apply-cart-discount.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/apply-cart-discount.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.applyCartDiscount('Percentage', 'Summer discount', '10');
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/apply-cart-discount.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/apply-cart-discount.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.applyCartDiscount('Percentage', 'Summer discount', '10')}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/bulk-add-line-item-properties.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/bulk-add-line-item-properties.ts
@@ -1,0 +1,17 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.bulkAddLineItemProperties([
+        {lineItemUuid: 'aa-1234567', properties: {Engraving: 'John Doe'}},
+        {lineItemUuid: 'bb-001234567', properties: {Engraving: 'Jane Doe'}},
+      ]);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/bulk-add-line-item-properties.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/bulk-add-line-item-properties.tsx
@@ -1,0 +1,28 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.bulkAddLineItemProperties([
+        {lineItemUuid: 'aa-1234567', properties: {Engraving: 'John Doe'}},
+        {lineItemUuid: 'bb-001234567', properties: {Engraving: 'Jane Doe'}}
+      ])}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/bulk-set-line-item-discounts.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/bulk-set-line-item-discounts.ts
@@ -1,0 +1,31 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.bulkSetLineItemDiscounts([
+        {
+          lineItemUuid: 'aa-1234567',
+          lineItemDiscount: {
+            title: 'Summer 2024',
+            amount: '10',
+            type: 'Percentage',
+          },
+        },
+        {
+          lineItemUuid: 'bb-1234567',
+          lineItemDiscount: {
+            title: 'Shorts sale',
+            amount: '15',
+            type: 'FixedAmount',
+          },
+        },
+      ]);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/bulk-set-line-item-discounts.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/bulk-set-line-item-discounts.tsx
@@ -1,0 +1,42 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.bulkSetLineItemDiscounts([
+        {
+          lineItemUuid: 'aa-1234567',
+          lineItemDiscount: {
+            title: 'Summer 2024',
+            amount: '10',
+            type: 'Percentage',
+          },
+        },
+        {
+          lineItemUuid: 'bb-1234567',
+          lineItemDiscount: {
+            title: 'Shorts sale',
+            amount: '15',
+            type: 'FixedAmount',
+          },
+        },
+      ])}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/clear-cart.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/clear-cart.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.clearCart();
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/clear-cart.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/clear-cart.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.clearCart()}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/delete-address.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/delete-address.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.deleteAddress(123456);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/delete-address.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/delete-address.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.deleteAddress(123456)}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-all-discounts.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-all-discounts.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.removeAllDiscounts(true);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-all-discounts.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-all-discounts.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.removeAllDiscounts(true)}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-cart-discount.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-cart-discount.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.removeCartDiscount();
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-cart-discount.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-cart-discount.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.removeCartDiscount()}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-cart-properties.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-cart-properties.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.removeCartProperties(['Engraving']);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-cart-properties.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-cart-properties.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.removeCartProperties(['Engraving'])}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-customer.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-customer.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.removeCustomer();
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-customer.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-customer.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.removeCustomer()}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-discount.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-discount.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.removeLineItemDiscount('aa-1234567');
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-discount.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-discount.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.removeLineItemDiscount('aa-1234567')}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-properties.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-properties.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.removeLineItemProperties('aa-1234567', ['Engraving']);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-properties.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-properties.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.removeLineItemProperties('aa-1234567', ['Engraving'])}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.removeLineItem('aa-1234567');
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.removeLineItem('aa-1234567')}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-attributed-staff-to-line-item.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-attributed-staff-to-line-item.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.setAttributedStaffToLineItem(123456, 'aa-1234567');
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-attributed-staff-to-line-item.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-attributed-staff-to-line-item.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.setAttributedStaffToLineItem(123456, 'aa-1234567')}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-attributed-staff.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-attributed-staff.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.setAttributedStaff(123456);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-attributed-staff.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-attributed-staff.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.setAttributedStaff(123456)}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-customer.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-customer.ts
@@ -1,0 +1,16 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.setCustomer({
+        id: 1,
+      });
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-customer.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-customer.tsx
@@ -1,0 +1,27 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.setCustomer({
+        id: 1,
+      })}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-line-item-discount.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-line-item-discount.ts
@@ -1,0 +1,19 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.setLineItemDiscount(
+        'aa-1234567',
+        'Percentage',
+        'Summer discount',
+        '10',
+      );
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-line-item-discount.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/set-line-item-discount.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.setLineItemDiscount('aa-1234567', 'Percentage', 'Summer discount', '10')}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/subscribable.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/subscribable.ts
@@ -1,0 +1,17 @@
+import {Cart, Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: `${api.cart.subscribable.initial.lineItems.length} line items in cart`,
+    enabled: true,
+  });
+
+  api.cart.subscribable.subscribe((newCart: Cart) => {
+    tile.updateProps({
+      subtitle: `${newCart.lineItems.length > 0} line items in cart`,
+    });
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/subscribable.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/subscribable.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile,
+  useCartSubscription
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const cart = useCartSubscription();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle={`${cart.lineItems.length} line items in cart`} 
+      enabled
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/update-default-address.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/update-default-address.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.updateDefaultAddress(123456);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/update-default-address.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/update-default-address.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title="My App" 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.updateDefaultAddress(123456)}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/helpers/generateCodeBlock.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/helpers/generateCodeBlock.ts
@@ -1,0 +1,21 @@
+export const generateCodeBlock = (
+  title: string,
+  functionality: string,
+  filename: string,
+) => {
+  return {
+    title,
+    tabs: [
+      {
+        title: 'React',
+        code: `../examples/${functionality}/${filename}.tsx`,
+        language: 'tsx',
+      },
+      {
+        title: 'TS',
+        code: `../examples/${functionality}/${filename}.ts`,
+        language: 'ts',
+      },
+    ],
+  };
+};


### PR DESCRIPTION
Fixes https://github.com/Shopify/pos-next-react-native/issues/36273

### Background

This PR adds examples for all the cart API functions. 

### Solution

I chose to bunch them by functionality, as opposed to the way they are listed in the cart api contents interface. Maybe we should edit that order.

### 🎩

https://shopify-dev.ui-extensions-7t4u.jeansebastien-goupil.us.spin.dev/docs/api/pos-ui-extensions/unstable/apis/cart-api

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
