### PR TITLE
Add extension targets pages for pos-ui-extensions

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.sh
@@ -26,6 +26,7 @@ build_exit=$?
 
 # Remove .doc.js files
 find ./ -name '*.doc*.js' -exec rm -r {} \;
+find ./ -wholename '*/point-of-sale/reference/helpers/*.js' -exec rm -r {} \;
 
 if [ $build_exit -ne 0 ]; then
   fail_and_exit $build_exit

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/action.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/action.ts
@@ -1,0 +1,23 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.purchase.post.action.render', (root) => {
+  const navigator = root.createComponent(Navigator);
+  const screen = root.createComponent(Screen, {
+    name: 'HelloWorld',
+    title: 'Hello World!',
+  });
+  const scrollView = root.createComponent(ScrollView);
+  const text = root.createComponent(Text);
+
+  text.append('Welcome to the extension!');
+  scrollView.append(text);
+  screen.append(scrollView);
+  navigator.append(screen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/action.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/action.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { Text, Screen, ScrollView, Navigator, reactExtension } from '@shopify/ui-extensions-react/point-of-sale'
+
+const Modal = () => {
+  return (
+    <Navigator>
+      <Screen name="HelloWorld" title="Hello World!">
+        <ScrollView>
+          <Text>Welcome to the extension!</Text>
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.purchase.post.action.render', () => <Modal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/action.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/action.tsx
@@ -5,7 +5,7 @@ import { Text, Screen, ScrollView, Navigator, reactExtension } from '@shopify/ui
 const Modal = () => {
   return (
     <Navigator>
-      <Screen name="HelloWorld" title="Hello World!">
+      <Screen name='HelloWorld' title='Hello World!'>
         <ScrollView>
           <Text>Welcome to the extension!</Text>
         </ScrollView>

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/menu-item.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/menu-item.ts
@@ -1,0 +1,15 @@
+import {ActionItem, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.purchase.post.action.menu-item.render',
+  (root, api) => {
+    const actionItem = root.createComponent(ActionItem, {
+      onPress: () => api.action.presentModal(),
+      enabled: true,
+    });
+
+    console.log(JSON.stringify(api));
+
+    root.append(actionItem);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/menu-item.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/menu-item.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { reactExtension, ActionItem, useApi } from '@shopify/ui-extensions-react/point-of-sale';
+
+const ActionItemComponent = () => {
+    const api = useApi();
+    return <ActionItem enabled onPress={() => api.action.presentModal()}/>
+}
+
+export default reactExtension('pos.purchase.post.action.menu-item.render', () => <ActionItemComponent />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/modal.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/modal.ts
@@ -1,0 +1,23 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root) => {
+  const navigator = root.createComponent(Navigator);
+  const screen = root.createComponent(Screen, {
+    name: 'HelloWorld',
+    title: 'Hello World!',
+  });
+  const scrollView = root.createComponent(ScrollView);
+  const text = root.createComponent(Text);
+
+  text.append('Welcome to the extension!');
+  scrollView.append(text);
+  screen.append(scrollView);
+  navigator.append(screen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/modal.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/modal.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { Text, Screen, ScrollView, Navigator, reactExtension } from '@shopify/ui-extensions-react/point-of-sale'
+
+const Modal = () => {
+  return (
+    <Navigator>
+      <Screen name="HelloWorld" title="Hello World!">
+        <ScrollView>
+          <Text>Welcome to the extension!</Text>
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/modal.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/modal.tsx
@@ -5,7 +5,7 @@ import { Text, Screen, ScrollView, Navigator, reactExtension } from '@shopify/ui
 const Modal = () => {
   return (
     <Navigator>
-      <Screen name="HelloWorld" title="Hello World!">
+      <Screen name='HelloWorld' title='Hello World!'>
         <ScrollView>
           <Text>Welcome to the extension!</Text>
         </ScrollView>

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/tile.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/tile.ts
@@ -1,0 +1,12 @@
+import {extension, Tile} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My app',
+    subtitle: 'SmartGrid vanilla-js Extension',
+    onPress: () => api.action.presentModal(),
+    enabled: true,
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/tile.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/tile.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { Tile, reactExtension, useApi } from '@shopify/ui-extensions-react/point-of-sale'
+
+const TileComponent = () => {
+  const api = useApi()
+  return (
+    <Tile
+      title="My app"
+      subtitle="SmartGrid react Extension"
+      onPress={() => {
+        api.action.presentModal()
+      }}
+      enabled
+    />
+  )
+}
+
+export default reactExtension('pos.home.tile.render', () => {
+  return <TileComponent />
+})

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/tile.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/tile.tsx
@@ -6,8 +6,8 @@ const TileComponent = () => {
   const api = useApi()
   return (
     <Tile
-      title="My app"
-      subtitle="SmartGrid react Extension"
+      title='My app'
+      subtitle='SmartGrid react Extension'
       onPress={() => {
         api.action.presentModal()
       }}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.modal.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.modal.render.doc.ts
@@ -1,0 +1,23 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'pos.home.modal.render',
+  description:
+    'A full-screen extension target that renders when a `pos.home.tile.render` target calls for it',
+  defaultExample: {
+    codeblock: generateCodeBlock('Modal', 'targets', 'modal'),
+  },
+  category: 'Targets',
+  subCategory: 'Smart grid',
+  isVisualComponent: false,
+  related: [
+    {
+      name: 'pos.home.tile.render',
+      url: '/docs/api/pos-ui-extensions/targets/pos-home-tile-render',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.tile.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.tile.render.doc.ts
@@ -1,0 +1,22 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'pos.home.tile.render',
+  description: 'A static extension target that renders as a smart grid tile',
+  defaultExample: {
+    codeblock: generateCodeBlock('Tile', 'targets', 'tile'),
+  },
+  category: 'Targets',
+  subCategory: 'Smart grid',
+  isVisualComponent: false,
+  related: [
+    {
+      name: 'pos.home.modal.render',
+      url: '/docs/api/pos-ui-extensions/targets/pos-home-modal-render',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.menu-item.render.doc.ts
@@ -1,0 +1,23 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'pos.purchase.post.action.menu-item.render',
+  description:
+    'A static extension target that renders as a menu item on the post-purchase screen',
+  defaultExample: {
+    codeblock: generateCodeBlock('Menu item', 'targets', 'menu-item'),
+  },
+  category: 'Targets',
+  subCategory: 'Post-purchase',
+  isVisualComponent: false,
+  related: [
+    {
+      name: 'pos.purchase.post.action.render',
+      url: '/docs/api/pos-ui-extensions/targets/pos-purchase-post-action-render',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.render.doc.ts
@@ -1,0 +1,23 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'pos.purchase.post.action.render',
+  description:
+    'A full-screen extension target that renders when a `pos.purchase.post.action.menu-item.render` target calls for it',
+  defaultExample: {
+    codeblock: generateCodeBlock('Action', 'targets', 'action'),
+  },
+  category: 'Targets',
+  subCategory: 'Post-purchase',
+  isVisualComponent: false,
+  related: [
+    {
+      name: 'pos.purchase.post.action.menu-item.render',
+      url: '/docs/api/pos-ui-extensions/targets/pos-purchase-post-action-menu-item-render',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/extension-targets.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/extension-targets.doc.ts
@@ -1,0 +1,68 @@
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
+
+const data: LandingTemplateSchema = {
+  title: 'Targets overview',
+  description: `
+A [target](/docs/apps/app-extensions/configuration#targets) represents where your POS UI extension will appear.
+`,
+  id: 'extension-targets-overview',
+  image: '/assets/landing-pages/templated-apis/hero.png',
+  darkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  tabletImage: '/assets/landing-pages/templated-apis/hero.png',
+  tabletDarkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  mobileImage: '/assets/landing-pages/templated-apis/hero.png',
+  mobileDarkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  sections: [
+    {
+      type: 'GenericAccordion',
+      title: 'Smart grid',
+      anchorLink: 'smart-grid',
+      sectionContent:
+        'The smart grid. Learn more about [the smart grid](/docs/apps/pos#home-screen).',
+      accordionContent: [
+        {
+          title: 'Tile',
+          description: `
+Displays a tile on the smart grid.
+
+Review [all extension targets](/docs/api/pos-ui-extensions/targets).
+`,
+        },
+        {
+          title: 'Modal',
+          description: `
+Displays a modal when a tile is tapped.
+
+Review [all extension targets](/docs/api/pos-ui-extensions/targets).
+`,
+        },
+      ],
+    },
+    {
+      type: 'GenericAccordion',
+      title: 'Post-purchase',
+      anchorLink: 'post-purchase',
+      sectionContent: 'The post-purchase screen',
+      accordionContent: [
+        {
+          title: 'Menu item',
+          description: `
+Displays a menu item on the post-purchase screen.
+
+Review [all extension targets](/docs/api/pos-ui-extensions/targets).
+`,
+        },
+        {
+          title: 'Action',
+          description: `
+Displays a modal when a menu item is tapped.
+
+Review [all extension targets](/docs/api/pos-ui-extensions/targets).
+`,
+        },
+      ],
+    },
+  ],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pos-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pos-overview.doc.ts
@@ -23,7 +23,7 @@ const data: LandingTemplateSchema = {
         {
           subtitle: 'Extension targets',
           name: 'View all available extension targets',
-          url: '/docs/api/admin-extensions/components',
+          url: '/docs/api/pos-ui-extensions/targets',
           type: 'pickaxe-1',
         },
         {


### PR DESCRIPTION
### Background

Closes https://github.com/Shopify/pos-next-react-native/issues/36431

### Solution

This adds the extension target pages in the same method as checkout. It adds the following pages: 
https://shopify-dev.ui-extensions-70k7.nathan-oliveira.us.spin.dev/docs/api/pos-ui-extensions/unstable/extension-targets-overview
https://shopify-dev.ui-extensions-70k7.nathan-oliveira.us.spin.dev/docs/api/pos-ui-extensions/unstable/targets

As well as the four pages you can navigate to from there.

### 🎩

Compare the new pages linked above with how checkout does it:
https://shopify-dev.ui-extensions-70k7.nathan-oliveira.us.spin.dev/docs/api/checkout-ui-extensions/unstable/extension-targets-overview
https://shopify-dev.ui-extensions-70k7.nathan-oliveira.us.spin.dev/docs/api/checkout-ui-extensions/unstable/targets

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
