### PR TITLE
Add shop object to web pixels init data

### DIFF
--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -177,6 +177,9 @@ export const pixelEvents = {
           nullable: true,
           ref: 'Cart',
         },
+        shop: {
+          ref: 'Shop',
+        },
         checkout: {
           nullable: true,
           ref: 'Checkout',
@@ -1261,6 +1264,53 @@ export const pixelEvents = {
           metadata: {
             description:
               'The name of the payment provider used for the transaction.',
+          },
+        },
+      },
+    },
+    Shop: {
+      metadata: {
+        description:
+          'The shop represents information about the store, such as the store name and currency.',
+      },
+      properties: {
+        name: {
+          type: 'string',
+          metadata: {
+            description: 'The shop’s name.',
+          },
+        },
+        paymentSettings: {
+          metadata: {
+            description: 'Settings related to payments.',
+          },
+          properties: {
+            currencyCode: {
+              type: 'string',
+              metadata: {
+                description:
+                  'The three-letter code for the shop’s primary currency.',
+              },
+            },
+          },
+        },
+        myshopifyDomain: {
+          type: 'string',
+          metadata: {
+            description: 'The shop’s myshopify.com domain.',
+          },
+        },
+        storefrontUrl: {
+          type: 'string',
+          nullable: true,
+          metadata: {
+            description: 'The shop’s primary storefront URL.',
+          },
+        },
+        countryCode: {
+          type: 'string',
+          metadata: {
+            description: 'The shop’s country code.',
           },
         },
       },

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -1165,6 +1165,7 @@ export interface InitData {
   checkout: Checkout | null;
   customer: Customer | null;
   productVariants: ProductVariant[] | null;
+  shop: Shop;
 }
 
 /**
@@ -1503,6 +1504,47 @@ export interface ShippingRate {
    * Price of this shipping rate.
    */
   price: MoneyV2;
+}
+
+/**
+ * Settings related to payments.
+ */
+export interface ShopPaymentSettings {
+  /**
+   * The three-letter code for the shop’s primary currency.
+   */
+  currencyCode: string;
+}
+
+/**
+ * The shop represents information about the store, such as the store name and
+ * currency.
+ */
+export interface Shop {
+  /**
+   * The shop’s country code.
+   */
+  countryCode: string;
+
+  /**
+   * The shop’s myshopify.com domain.
+   */
+  myshopifyDomain: string;
+
+  /**
+   * The shop’s name.
+   */
+  name: string;
+
+  /**
+   * Settings related to payments.
+   */
+  paymentSettings: ShopPaymentSettings;
+
+  /**
+   * The shop’s primary storefront URL.
+   */
+  storefrontUrl: string | null;
 }
 
 /**

--- a/packages/web-pixels-extension/src/types/RegisterInit.ts
+++ b/packages/web-pixels-extension/src/types/RegisterInit.ts
@@ -1,6 +1,7 @@
 import type {
   Context,
   Cart,
+  Shop,
   Checkout,
   Customer,
   ProductVariant,
@@ -12,6 +13,7 @@ export interface RegisterInit {
   data: {
     customer: Partial<Customer> | null;
     cart: Partial<Cart> | null;
+    shop: Shop;
   };
 }
 
@@ -19,6 +21,7 @@ export interface RegisterInit {
 export interface InitData {
   customer?: Customer;
   cart?: Cart;
+  shop: Shop;
   checkout?: Checkout;
   productVariants?: ProductVariant[];
 }

--- a/packages/web-pixels-extension/src/types/index.ts
+++ b/packages/web-pixels-extension/src/types/index.ts
@@ -7,6 +7,7 @@ export type {
   Browser,
   Context,
   Cart,
+  Shop,
   CartLine,
   Customer,
   DiscountApplication,


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/ce-customer-behaviour/issues/4875. Depends on https://github.com/Shopify/web-pixels-manager/pull/690

### Solution

Code has been auto-generated from running `yarn schema:all` on branch with changes in web-pixels-manager repo (see PR listed above)

### 🎩

https://shop1.shopify.shop-object-next-v6.james-calverley.us.spin.dev/

- view product/collection on SFR or begin a checkout
- inspect console and ensure that the `shop` object is included within `init.data`
<img width="600" alt="Screenshot 2024-05-14 at 12 59 47 PM" src="https://github.com/Shopify/ui-extensions/assets/90476041/59712b03-4f5f-43b0-906c-4ace82331569">

### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
