### PR TITLE
Added examples for product search docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -1,4 +1,11 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const functionality = 'product-search-api';
+const generateCodeBlockForProductSearchApi = (
+  title: string,
+  fileName: string,
+) => generateCodeBlock(title, functionality, fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ProductSearch API',
@@ -15,6 +22,47 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  examples: {
+    description: 'Examples of using the Cart API',
+    examples: [
+      {
+        codeblock: generateCodeBlockForProductSearchApi(
+          'Search for products with a search bar',
+          'search-products',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForProductSearchApi(
+          'Fetch a specific product with a product ID',
+          'fetch-product-with-id',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForProductSearchApi(
+          'Fetch multiple products by specifying product IDs',
+          'fetch-products-with-ids',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForProductSearchApi(
+          'Fetch a specific product variant with a variant ID',
+          'fetch-product-variant-with-id',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForProductSearchApi(
+          'Fetch multiple product variants by specifying variant IDs',
+          'fetch-product-variants-with-ids',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForProductSearchApi(
+          'Fetch a page of product variants with a specific product ID',
+          'fetch-paginated-product-variants-with-product-id',
+        ),
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-paginated-product-variants-with-product-id.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-paginated-product-variants-with-product-id.ts
@@ -1,0 +1,51 @@
+import {
+  SearchBar,
+  Screen,
+  Navigator,
+  extension,
+  ListRow,
+  List,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const list = root.createComponent(List, {
+    imageDisplayStrategy: 'always',
+    data: [],
+  });
+
+  const fetchProductVariants = async () => {
+    const results =
+      await api.productSearch.fetchPaginatedProductVariantsWithProductId(1, {
+        first: 10,
+      });
+    const data = results.items.map((variant): ListRow => {
+      return {
+        id: String(variant.id),
+        leftSide: {
+          label: variant.title,
+          image: {
+            source: variant.image,
+          },
+        },
+      };
+    });
+
+    console.log('Cursor for next page: ', results.lastCursor);
+
+    list.updateProps({data});
+  };
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  screen.append(list);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
+
+  root.append(navigator);
+
+  fetchProductVariants();
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-paginated-product-variants-with-product-id.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-paginated-product-variants-with-product-id.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react'
+
+import { Screen, List, Navigator, reactExtension, SearchBar, useApi, ListRow } from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+  const [data, setData] = useState<ListRow[]>([]);
+
+  useEffect(() => {
+    const fetchProductVariants = async () => {
+      const results = await api.productSearch.fetchPaginatedProductVariantsWithProductId(1, {first: 10});
+      const data = results.items.map((variant): ListRow => {
+        return {
+          id: String(variant.id),
+          leftSide: {
+            label: variant.title,
+            image: {
+              source: variant.image
+            }
+          }
+        }
+      })
+  
+      console.log('Cursor for next page: ', results.lastCursor);
+      setData(data)
+    }
+
+    fetchProductVariants();
+  }, []);
+
+  return (
+    <Navigator>
+      <Screen name="HelloWorld" title="Hello World!">
+        <List
+          imageDisplayStrategy='always'
+          data={data}
+        />
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-variant-with-id.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-variant-with-id.ts
@@ -1,0 +1,47 @@
+import {
+  SearchBar,
+  Screen,
+  Navigator,
+  extension,
+  ListRow,
+  List,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const list = root.createComponent(List, {
+    imageDisplayStrategy: 'always',
+    data: [],
+  });
+
+  const fetchProductVariant = async () => {
+    const resultProductVariant =
+      await api.productSearch.fetchProductVariantWithId(1);
+    if (resultProductVariant) {
+      const listItem = {
+        id: String(resultProductVariant.id),
+        leftSide: {
+          label: resultProductVariant.title,
+          image: {
+            source: resultProductVariant.image,
+          },
+        },
+      };
+
+      list.updateProps({data: [listItem]});
+    }
+  };
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  screen.append(list);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
+
+  root.append(navigator);
+
+  fetchProductVariant();
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-variant-with-id.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-variant-with-id.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react'
+
+import { Screen, List, Navigator, reactExtension, SearchBar, useApi, ListRow } from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+  const [data, setData] = useState<ListRow[]>([]);
+
+  useEffect(() => {
+    const fetchProductVariant = async () => {
+      const resultProductVariant = await api.productSearch.fetchProductVariantWithId(1);
+  
+      if (resultProductVariant) { 
+        const listItem = {
+          id: String(resultProductVariant.id),
+          leftSide: {
+            label: resultProductVariant.title,
+            image: {
+              source: resultProductVariant.image
+            }
+          }
+        }
+        setData([listItem])
+      }
+    }
+
+    fetchProductVariant();
+  }, []);
+
+  return (
+    <Navigator>
+      <Screen name="HelloWorld" title="Hello World!">
+        <List
+          imageDisplayStrategy='always'
+          data={data}
+        />
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-variants-with-ids.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-variants-with-ids.ts
@@ -1,0 +1,50 @@
+import {
+  SearchBar,
+  Screen,
+  Navigator,
+  extension,
+  ListRow,
+  List,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const list = root.createComponent(List, {
+    imageDisplayStrategy: 'always',
+    data: [],
+  });
+
+  const fetchProductVariants = async () => {
+    const results = await api.productSearch.fetchProductVariantsWithIds([
+      1, 2, 3, 4,
+    ]);
+    const data = results.fetchedResources.map((variant): ListRow => {
+      return {
+        id: String(variant.id),
+        leftSide: {
+          label: variant.title,
+          image: {
+            source: variant.image,
+          },
+        },
+      };
+    });
+
+    console.log('IDs not found: ', results.idsForResourcesNotFound);
+
+    list.updateProps({data});
+  };
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  screen.append(list);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
+
+  root.append(navigator);
+
+  fetchProductVariants();
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-variants-with-ids.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-variants-with-ids.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react'
+
+import { Screen, List, Navigator, reactExtension, SearchBar, useApi, ListRow } from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+  const [data, setData] = useState<ListRow[]>([]);
+
+  useEffect(() => {
+    const fetchProductVariants = async () => {
+      const results = await api.productSearch.fetchProductVariantsWithIds([1, 2, 3]);
+      const data = results.fetchedResources.map((variant): ListRow => {
+        return {
+          id: String(variant.id),
+          leftSide: {
+            label: variant.title,
+            image: {
+              source: variant.image
+            }
+          }
+        }
+      })
+
+      console.log('IDs not found: ', results.idsForResourcesNotFound);
+  
+      setData(data)
+    }
+
+    fetchProductVariants();
+  }, []);
+
+  return (
+    <Navigator>
+      <Screen name="HelloWorld" title="Hello World!">
+        <List
+          imageDisplayStrategy='always'
+          data={data}
+        />
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-with-id.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-with-id.ts
@@ -1,0 +1,46 @@
+import {
+  SearchBar,
+  Screen,
+  Navigator,
+  extension,
+  ListRow,
+  List,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const list = root.createComponent(List, {
+    imageDisplayStrategy: 'always',
+    data: [],
+  });
+
+  const fetchProduct = async () => {
+    const resultProduct = await api.productSearch.fetchProductWithId(1);
+    if (resultProduct) {
+      const listItem = {
+        id: String(resultProduct.id),
+        leftSide: {
+          label: resultProduct.title,
+          image: {
+            source: resultProduct.featuredImage,
+          },
+        },
+      };
+
+      list.updateProps({data: [listItem]});
+    }
+  };
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  screen.append(list);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
+
+  root.append(navigator);
+
+  fetchProduct();
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-with-id.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-product-with-id.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react'
+
+import { Screen, List, Navigator, reactExtension, SearchBar, useApi, ListRow } from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+  const [data, setData] = useState<ListRow[]>([]);
+
+  useEffect(() => {
+    const fetchProduct = async () => {
+      const resultProduct = await api.productSearch.fetchProductWithId(1)
+  
+      if (resultProduct) { 
+        const listItem = {
+          id: String(resultProduct.id),
+          leftSide: {
+            label: resultProduct.title,
+            image: {
+              source: resultProduct.featuredImage
+            }
+          }
+        }
+        setData([listItem])
+      }
+    }
+
+    fetchProduct();
+  }, []);
+
+  return (
+    <Navigator>
+      <Screen name="HelloWorld" title="Hello World!">
+        <List
+          imageDisplayStrategy='always'
+          data={data}
+        />
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-products-with-ids.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-products-with-ids.ts
@@ -1,0 +1,48 @@
+import {
+  SearchBar,
+  Screen,
+  Navigator,
+  extension,
+  ListRow,
+  List,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const list = root.createComponent(List, {
+    imageDisplayStrategy: 'always',
+    data: [],
+  });
+
+  const fetchProducts = async () => {
+    const results = await api.productSearch.fetchProductsWithIds([1, 2, 3, 4]);
+    const data = results.fetchedResources.map((product): ListRow => {
+      return {
+        id: String(product.id),
+        leftSide: {
+          label: product.title,
+          image: {
+            source: product.featuredImage,
+          },
+        },
+      };
+    });
+
+    console.log('IDs not found: ', results.idsForResourcesNotFound);
+
+    list.updateProps({data});
+  };
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  screen.append(list);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
+
+  root.append(navigator);
+
+  fetchProducts();
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-products-with-ids.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/fetch-products-with-ids.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react'
+
+import { Screen, List, Navigator, reactExtension, SearchBar, useApi, ListRow } from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+  const [data, setData] = useState<ListRow[]>([]);
+
+  useEffect(() => {
+    const fetchProducts = async () => {
+      const results = await api.productSearch.fetchProductsWithIds([1, 2, 3]);
+      const data = results.fetchedResources.map((product): ListRow => {
+        return {
+          id: String(product.id),
+          leftSide: {
+            label: product.title,
+            image: {
+              source: product.featuredImage
+            }
+          }
+        }
+      })
+
+      console.log('IDs not found: ', results.idsForResourcesNotFound);
+  
+      setData(data)
+    }
+
+    fetchProducts();
+  }, []);
+
+  return (
+    <Navigator>
+      <Screen name="HelloWorld" title="Hello World!">
+        <List
+          imageDisplayStrategy='always'
+          data={data}
+        />
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/search-products.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/search-products.ts
@@ -1,0 +1,56 @@
+import {
+  SearchBar,
+  Screen,
+  Navigator,
+  extension,
+  ListRow,
+  List,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const list = root.createComponent(List, {
+    imageDisplayStrategy: 'always',
+    data: [],
+  });
+
+  const search = async (queryString?: string) => {
+    const results = await api.productSearch.searchProducts({queryString});
+    const data = results.items.map((product): ListRow => {
+      return {
+        id: String(product.id),
+        leftSide: {
+          label: product.title,
+          image: {
+            source: product.featuredImage,
+          },
+        },
+      };
+    });
+
+    list.updateProps({data});
+  };
+
+  const searchBar = root.createFragment();
+
+  searchBar.append(
+    root.createComponent(SearchBar, {
+      placeholder: 'Search products',
+      onTextChange: search,
+      onSearch: search,
+    }),
+  );
+
+  list.updateProps({listHeaderComponent: searchBar});
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  screen.append(list);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
+
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/search-products.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-search-api/search-products.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+
+import { Screen, List, Navigator, reactExtension, SearchBar, useApi, ListRow } from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+  const [data, setData] = useState<ListRow[]>([]);
+
+  const search = async (queryString?: string) => {
+    const results = await api.productSearch.searchProducts({queryString})
+    const data = results.items.map((product): ListRow => {
+      return {
+        id: String(product.id),
+        leftSide: {
+          label: product.title,
+          image: {
+            source: product.featuredImage
+          }
+        }
+      }
+    })
+
+    setData(data)
+  }
+
+  return (
+    <Navigator>
+      <Screen name="HelloWorld" title="Hello World!">
+        <List
+          listHeaderComponent={<SearchBar 
+            placeholder='Search products'
+            onTextChange={search}
+            onSearch={search}
+          />}
+        imageDisplayStrategy='always'
+        data={data}
+        />
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/36281

### Background

This adds fully functional code examples for most functions in the product search api. 

### Solution

I left out the example for fetchProductVariantsWithProductId, because we are recommending that devs use the paginated version of that function which has an example. However, in my testing process I discovered that this function is also broken, we'll need to look into why it's not working.

### 🎩

Spin link: https://shopify-dev.ui-extensions-7t4u.jeansebastien-goupil.us.spin.dev/docs/api/pos-ui-extensions/unstable/apis/productsearch-api#example-fetch-multiple-product-variants-by-specifying-variant-ids

I tophatted every example in the documentation by copy pasting the code snippets into an extension that I was running on my physical device. Did a run through on the React ones and then a run through on the TS ones. 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
