### PR TITLE
Publish buyer accepts email marketing

### DIFF
--- a/packages/web-pixels-extension/package.json
+++ b/packages/web-pixels-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/web-pixels-extension",
   "description": "Provides tools to author Web Pixels extension",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
### Background
EPIC: https://github.com/Shopify/ce-customer-behaviour/issues/4868
ISSUE: https://github.com/Shopify/ce-customer-behaviour/issues/4869


This PR requires the following PRs to be approved before shipping:

https://github.com/Shopify/web-pixels-manager/pull/719
https://github.com/Shopify/ui-extensions/pull/1938
https://github.com/Shopify/checkout-web/pull/33728
https://github.com/Shopify/shopify-dev/pull/44084
Publish changes from https://github.com/Shopify/ui-extensions/pull/1938

### Solution

bumping the wpm version to publish the new buyerAceceptsEmailMarketing field

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
