### PR TITLE
Added buyer_accepts_sms_marketing to wpm

### DIFF
--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -541,6 +541,13 @@ export const pixelEvents = {
               "Indicates whether the customer has consented to be sent marketing material via email. This property is only available if you've [upgraded to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-upgrade).",
           },
         },
+        buyerAcceptsSMSMarketing: {
+          type: 'boolean',
+          metadata: {
+            description:
+              "Indicates whether the customer has consented to be sent marketing material via SMS. This property is only available if you've [upgraded to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-upgrade).",
+          },
+        },
         currencyCode: {
           type: 'string',
           metadata: {

--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -541,7 +541,7 @@ export const pixelEvents = {
               "Indicates whether the customer has consented to be sent marketing material via email. This property is only available if you've [upgraded to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-upgrade).",
           },
         },
-        buyerAcceptsSMSMarketing: {
+        buyerAcceptsSmsMarketing: {
           type: 'boolean',
           metadata: {
             description:

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -792,7 +792,7 @@ export interface Checkout {
    * to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-
    * settings/checkout-extensibility/checkout-upgrade).
    */
-  buyerAcceptsSMSMarketing: boolean;
+  buyerAcceptsSmsMarketing: boolean;
 
   /**
    * The three-letter code that represents the currency, for example, USD.

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -787,6 +787,14 @@ export interface Checkout {
   buyerAcceptsEmailMarketing: boolean;
 
   /**
+   * Indicates whether the customer has consented to be sent marketing
+   * material via SMS. This property is only available if you've [upgraded
+   * to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-
+   * settings/checkout-extensibility/checkout-upgrade).
+   */
+  buyerAcceptsSMSMarketing: boolean;
+
+  /**
    * The three-letter code that represents the currency, for example, USD.
    * Supported codes include standard ISO 4217 codes, legacy codes, and non-
    * standard codes.


### PR DESCRIPTION
### Background

## Context

EPIC: https://github.com/Shopify/ce-customer-behaviour/issues/4868
ISSUE: https://github.com/Shopify/ce-customer-behaviour/issues/4869 

All PRs:
- https://github.com/Shopify/web-pixels-manager/pull/735
- https://github.com/Shopify/ui-extensions/pull/1969
- https://github.com/Shopify/checkout-web/pull/34002
### Solution

Adding buyer accepts sms marketing as generated from wpm
### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
