### PR TITLE
Session navigation scanner toast api examples for pos ui ext docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,12 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
   },
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -1,5 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const generateCodeBlockForActionApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'action-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Action API',
@@ -16,20 +20,21 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  requires:
+    ExtensionTargetType.PosHomeTileRender ||
+    ExtensionTargetType.PosPurchasePostActionMenuItemRender,
   examples: {
     description: 'Examples of using the Action API.',
     examples: [
       {
-        codeblock: generateCodeBlock(
+        codeblock: generateCodeBlockForActionApi(
           'Present a modal from post purchase.',
-          'action-api',
           'present-modal',
         ),
       },
       {
-        codeblock: generateCodeBlock(
+        codeblock: generateCodeBlockForActionApi(
           'Present a modal from smart grid.',
-          'action-api',
           'present-modal-tile',
         ),
       },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -1,9 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
-const functionality = 'cart-api';
 const generateCodeBlockForCartApi = (title: string, fileName: string) =>
-  generateCodeBlock(title, functionality, fileName);
+  generateCodeBlock(title, 'cart-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Cart API',
@@ -20,6 +20,9 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  requires:
+    ExtensionTargetType.PosHomeTileRender ||
+    ExtensionTargetType.PosHomeModalRender,
   examples: {
     description: 'Examples of using the Cart API',
     examples: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -1,6 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
+const generateCodeBlockForConnectivityApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'connectivity-api', fileName);
+
 const data: ReferenceEntityTemplateSchema = {
   name: 'Connectivity API',
   description:
@@ -20,9 +23,8 @@ const data: ReferenceEntityTemplateSchema = {
     description: 'Examples of using the Connectivity API',
     examples: [
       {
-        codeblock: generateCodeBlock(
+        codeblock: generateCodeBlockForConnectivityApi(
           'Subscribe to connectivity changes.',
-          'connectivity-api',
           'subscribable',
         ),
       },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -1,6 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
+const generateCodeBlockForDeviceApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'device-api', fileName);
+
 const data: ReferenceEntityTemplateSchema = {
   name: 'Device API',
   description:
@@ -20,23 +23,20 @@ const data: ReferenceEntityTemplateSchema = {
     description: 'Examples of using the Device API.',
     examples: [
       {
-        codeblock: generateCodeBlock(
+        codeblock: generateCodeBlockForDeviceApi(
           'Retrieve name of the device.',
-          'device-api',
           'name',
         ),
       },
       {
-        codeblock: generateCodeBlock(
+        codeblock: generateCodeBlockForDeviceApi(
           'Retrieve the ID of the device.',
-          'device-api',
           'device-id',
         ),
       },
       {
-        codeblock: generateCodeBlock(
+        codeblock: generateCodeBlockForDeviceApi(
           'Check if device is a tablet.',
-          'device-api',
           'tablet',
         ),
       },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -1,6 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
+const generateCodeBlockForLocaleApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'locale-api', fileName);
+
 const data: ReferenceEntityTemplateSchema = {
   name: 'Locale API',
   description:
@@ -20,9 +23,8 @@ const data: ReferenceEntityTemplateSchema = {
     description: 'Examples of using the Locale API',
     examples: [
       {
-        codeblock: generateCodeBlock(
+        codeblock: generateCodeBlockForLocaleApi(
           'Subscribe to locale changes.',
-          'locale-api',
           'subscribable',
         ),
       },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -1,4 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const generateCodeBlockForNavigationApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'navigation-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Navigation API',
@@ -15,6 +20,33 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  requires: ExtensionTargetType.PosHomeModalRender,
+  examples: {
+    description: 'Examples of using the Navigation API',
+    examples: [
+      {
+        codeblock: generateCodeBlockForNavigationApi(
+          'Navigate between two screens',
+          'two-screen',
+        ),
+      },
+    ],
+    exampleGroups: [
+      {
+        title: 'Navigation actions',
+        examples: [
+          {
+            description:
+              'Navigates to the specified screen. It is important to note that any screens you wish to navigate to must already exist in the Navigator.',
+            codeblock: generateCodeBlockForNavigationApi(
+              'Navigate to a route in current navigation tree',
+              'navigation-tree',
+            ),
+          },
+        ],
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -1,4 +1,5 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Order API',
@@ -6,6 +7,9 @@ const data: ReferenceEntityTemplateSchema = {
     'The Order API provides an extension with data about the current order.',
   isVisualComponent: false,
   type: 'APIs',
+  requires:
+    ExtensionTargetType.PosPurchasePostActionMenuItemRender ||
+    ExtensionTargetType.PosPurchasePostActionRender,
   definitions: [
     {
       title: 'OrderApi',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -1,16 +1,15 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
-const functionality = 'product-search-api';
 const generateCodeBlockForProductSearchApi = (
   title: string,
   fileName: string,
-) => generateCodeBlock(title, functionality, fileName);
+) => generateCodeBlock(title, 'product-search-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ProductSearch API',
   description:
-    'The ProductSearch API gives extensions  access to the native product search and fetching functionality of Shopify POS. The interface provides numerous functions to search for products by query, or to fetch the details of one or more products or product variants.',
+    'The ProductSearch API gives extensions access to the native product search and fetching functionality of Shopify POS. The interface provides numerous functions to search for products by query, or to fetch the details of one or more products or product variants.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -1,4 +1,5 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Scanner API',
@@ -15,6 +16,55 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  examples: {
+    description: 'Examples of receiving updates from the Scanner API',
+    examples: [
+      {
+        codeblock: generateCodeBlock(
+          'Subscribe to scan event updates',
+          'scanner-api',
+          'subscribable-events',
+        ),
+      },
+      {
+        codeblock: generateCodeBlock(
+          'Receiving updates on available scanner sources for the POS',
+          'scanner-api',
+          'subscribable-sources',
+        ),
+      },
+    ],
+    exampleGroups: [
+      {
+        title: 'Hardware scanner example',
+        examples: [
+          {
+            description:
+              'In this example, assuming a physical scanner is connected to the POS, any scans performed when ui extensions are in use will automatically add the product to the cart if the data exists on the shop.',
+            codeblock: generateCodeBlock(
+              'Hardware scanner ',
+              'scanner-api',
+              'hardware-scanner-example',
+            ),
+          },
+        ],
+      },
+      {
+        title: 'Conditional scanner source rendering example',
+        examples: [
+          {
+            description:
+              'There might be situations where a developer needs to conditionally render UI elements based on the available scanning sources of the device on which the extension is installed. For example, an extension could be designed for full-screen camera scanning, but a device like POS GO does not have a camera. In such cases, it would be necessary to avoid rendering the camera scanner component and instead create a UI that supports embedded scanning.',
+            codeblock: generateCodeBlock(
+              'Conditional scanner source rendering example',
+              'scanner-api',
+              'hardware-scanner-example',
+            ),
+          },
+        ],
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -1,5 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const generateCodeBlockForScannerApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'scanner-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Scanner API',
@@ -16,49 +20,41 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  requires: ExtensionTargetType.PosHomeModalRender,
   examples: {
     description: 'Examples of receiving updates from the Scanner API',
     examples: [
       {
-        codeblock: generateCodeBlock(
+        codeblock: generateCodeBlockForScannerApi(
           'Subscribe to scan event updates',
-          'scanner-api',
           'subscribable-events',
         ),
       },
       {
-        codeblock: generateCodeBlock(
-          'Receiving updates on available scanner sources for the POS',
-          'scanner-api',
+        codeblock: generateCodeBlockForScannerApi(
+          'Receiving updates on available scanner sources',
           'subscribable-sources',
         ),
       },
     ],
     exampleGroups: [
       {
-        title: 'Hardware scanner example',
+        title: 'Use cases',
         examples: [
           {
             description:
               'In this example, assuming a physical scanner is connected to the POS, any scans performed when ui extensions are in use will automatically add the product to the cart if the data exists on the shop.',
-            codeblock: generateCodeBlock(
-              'Hardware scanner ',
-              'scanner-api',
+            codeblock: generateCodeBlockForScannerApi(
+              'Hardware scanner example',
               'hardware-scanner-example',
             ),
           },
-        ],
-      },
-      {
-        title: 'Conditional scanner source rendering example',
-        examples: [
           {
             description:
               'There might be situations where a developer needs to conditionally render UI elements based on the available scanning sources of the device on which the extension is installed. For example, an extension could be designed for full-screen camera scanning, but a device like POS GO does not have a camera. In such cases, it would be necessary to avoid rendering the camera scanner component and instead create a UI that supports embedded scanning.',
-            codeblock: generateCodeBlock(
+            codeblock: generateCodeBlockForScannerApi(
               'Conditional scanner source rendering example',
-              'scanner-api',
-              'hardware-scanner-example',
+              'conditional-scanner-example',
             ),
           },
         ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -1,4 +1,8 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateCodeBlockForSessionApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'session-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Session API',
@@ -15,6 +19,17 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  examples: {
+    description: 'Examples of using the Session API',
+    examples: [
+      {
+        codeblock: generateCodeBlockForSessionApi(
+          'Retrieve the current session data',
+          'token',
+        ),
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -1,4 +1,8 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateCodeBlockForToastApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'toast-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Toast API',
@@ -14,6 +18,17 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  examples: {
+    description: 'Examples of using the Toast API',
+    examples: [
+      {
+        codeblock: generateCodeBlockForToastApi(
+          'Display a Toast component from the tile',
+          'show',
+        ),
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/connectivity-api/subscribable.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/connectivity-api/subscribable.tsx
@@ -16,4 +16,4 @@ const SmartGridTile = () => {
   );
 };
 
-reactExtension('pos.home.tile.render', () => <SmartGridTile />);
+export default reactExtension('pos.home.tile.render', () => <SmartGridTile />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/device-api/device-id.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/device-api/device-id.tsx
@@ -17,4 +17,4 @@ const SmartGridTile = () => {
   );
 };
 
-reactExtension('pos.home.tile.render', () => <SmartGridTile />);
+export default reactExtension('pos.home.tile.render', () => <SmartGridTile />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/device-api/name.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/device-api/name.tsx
@@ -17,4 +17,4 @@ const SmartGridTile = () => {
   );
 };
 
-reactExtension('pos.home.tile.render', () => <SmartGridTile />);
+export default reactExtension('pos.home.tile.render', () => <SmartGridTile />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/device-api/tablet.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/device-api/tablet.tsx
@@ -16,4 +16,4 @@ const SmartGridTile = () => {
   );
 };
 
-reactExtension('pos.home.tile.render', () => <SmartGridTile />);
+export default reactExtension('pos.home.tile.render', () => <SmartGridTile />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/navigation-tree.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/navigation-tree.ts
@@ -1,0 +1,22 @@
+// You can navigate to any of these three screens since they all exist within the same Navigator.
+let navigator = root.createComponent(Navigator);
+
+let screenOne = root.createComponent(Screen, {
+  name: 'ScreenOne',
+  title: 'Screen One Title',
+});
+
+let screenTwo = root.createComponent(Screen, {
+  name: 'ScreenTwo',
+  title: 'Screen Two Title',
+});
+
+let screenThree = root.createComponent(Screen, {
+  name: 'ScreenThree',
+  title: 'Screen Three Title',
+});
+
+navigator.appendChild(screenOne);
+navigator.appendChild(screenTwo);
+navigator.appendChild(screenThree);
+root.appendChild(navigator);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/navigation-tree.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/navigation-tree.tsx
@@ -1,0 +1,8 @@
+// You can navigate to any of these three screens since they all exist within the same Navigator.
+return (
+  <Navigator>
+    <Screen name="ScreenOne" title="Screen One Title" />
+    <Screen name="ScreenTwo" title="Screen Two  Title" />
+    <Screen name="ScreenThree" title="Screen Three Title" />
+  </Navigator>
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/two-screen.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/two-screen.ts
@@ -1,0 +1,36 @@
+import {
+  extension,
+  Button,
+  Navigator,
+  Screen,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  let navigator = root.createComponent(Navigator);
+
+  let screenOne = root.createComponent(Screen, {
+    name: 'ScreenOne',
+    title: 'Screen One Title',
+  });
+
+  let screenTwo = root.createComponent(Screen, {
+    name: 'ScreenTwo',
+    title: 'Screen Two Title',
+  });
+
+  let navigateScreenOneBtn = root.createComponent(Button, {
+    title: 'Navigate to Screen One',
+    onPress: () => api.navigation.navigate('ScreenOne'),
+  });
+
+  let navigateScreenTwoBtn = root.createComponent(Button, {
+    title: 'Navigate to Screen Two',
+    onPress: () => api.navigation.navigate('ScreenTwo'),
+  });
+
+  screenOne.appendChild(navigateScreenTwoBtn);
+  screenTwo.appendChild(navigateScreenOneBtn);
+  navigator.appendChild(screenOne);
+  navigator.appendChild(screenTwo);
+  root.appendChild(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/two-screen.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/two-screen.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Navigator,
+  Screen,
+  Button,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+
+  return (
+    <Navigator>
+      <Screen name="ScreenOne" title="Screen One Title">
+        <Button
+          title="Navigate to Screen Two"
+          onPress={() => api.navigation.navigate('ScreenTwo')}
+        />
+      </Screen>
+      <Screen name="ScreenTwo" title="Screen Two Title">
+        <Button
+          title="Navigate to Screen One"
+          onPress={() => api.navigation.navigate('ScreenOne')}
+        />
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => (
+  <SmartGridModal />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/conditional-scanner-example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/conditional-scanner-example.ts
@@ -8,6 +8,34 @@ import {
 } from '@shopify/ui-extensions/point-of-sale';
 
 export default extension('pos.home.modal.render', (root, api) => {
+  const dataText = root.createComponent('Text', {
+    text: 'Scanned data: ',
+  });
+
+  const sourceText = root.createComponent('Text', {
+    text: 'Scanned data source: ',
+  });
+
+  const cameraScanner = root.createComponent(CameraScanner);
+  const stack1 = root.createComponent(Stack, {
+    direction: 'horizontal',
+  });
+  const stack2 = root.createComponent(Stack, {
+    direction: 'vertical',
+    alignment: 'space-evenly',
+  });
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  const navigator = root.createComponent(Navigator);
+
+  screen.append(stack1);
+  navigator.append(screen);
+  root.append(navigator);
+
   api.scanner.scannerDataSubscribable.subscribe((data, source) => {
     dataText.updateProps({
       text: `Scanned data: ${data || ''}`,
@@ -30,34 +58,4 @@ export default extension('pos.home.modal.render', (root, api) => {
       stack1.append(stack2);
     }
   });
-
-  const dataText = root.createComponent('Text', {
-    text: 'Scanned data: ',
-  });
-
-  const sourceText = root.createComponent('Text', {
-    text: 'Scanned data source: ',
-  });
-
-  const cameraScanner = root.createComponent(CameraScanner);
-  const stack1 = root.createComponent(Stack, {
-    direction: 'horizontal',
-    flexChildren: true,
-    flex: 1,
-  });
-  const stack2 = root.createComponent(Stack, {
-    direction: 'vertical',
-    alignment: 'space-evenly',
-  });
-
-  const screen = root.createComponent(Screen, {
-    title: 'Home',
-    name: 'Home',
-  });
-
-  const navigator = root.createComponent(Navigator);
-
-  screen.append(stack1);
-  navigator.append(screen);
-  root.append(navigator);
 });

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/conditional-scanner-example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/conditional-scanner-example.ts
@@ -1,0 +1,63 @@
+import {
+  CameraScanner,
+  Navigator,
+  Screen,
+  Stack,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  api.scanner.scannerDataSubscribable.subscribe((data, source) => {
+    dataText.updateProps({
+      text: `Scanned data: ${data || ''}`,
+    });
+    sourceText.updateProps({
+      text: `Scanned data source: ${source || ''}`,
+    });
+  });
+
+  api.scanner.scannerSourcesSubscribable.subscribe((sources) => {
+    // Clear previous children to avoid duplicate appending
+    stack1.children = [];
+    stack2.children = [];
+
+    if (sources.include('camera')) {
+      stack1.append(cameraScanner);
+    } else {
+      stack2.append(dataText);
+      stack2.append(sourceText);
+      stack1.append(stack2);
+    }
+  });
+
+  const dataText = root.createComponent('Text', {
+    text: 'Scanned data: ',
+  });
+
+  const sourceText = root.createComponent('Text', {
+    text: 'Scanned data source: ',
+  });
+
+  const cameraScanner = root.createComponent(CameraScanner);
+  const stack1 = root.createComponent(Stack, {
+    direction: 'horizontal',
+    flexChildren: true,
+    flex: 1,
+  });
+  const stack2 = root.createComponent(Stack, {
+    direction: 'vertical',
+    alignment: 'space-evenly',
+  });
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  const navigator = root.createComponent(Navigator);
+
+  screen.append(stack1);
+  navigator.append(screen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/conditional-scanner-example.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/conditional-scanner-example.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import {
   CameraScanner,
   Navigator,
@@ -11,18 +11,18 @@ import {
 } from '@shopify/ui-extensions-react/point-of-sale';
 
 const SmartGridModal = () => {
-  const { data, source } = useScannerDataSubscription();
+  const {data, source} = useScannerDataSubscription();
   const availableScanners = useScannerSourcesSubscription();
   const hasCameraScanner = availableScanners.includes('camera');
 
   return (
     <Navigator>
-      <Screen name='Home' title='Home'>
-        <Stack direction='horizontal' flexChildren flex={1}>
+      <Screen name="Home" title="Home">
+        <Stack direction="horizontal">
           {hasCameraScanner ? (
             <CameraScanner />
           ) : (
-            <Stack direction='vertical' alignment='space-evenly'>
+            <Stack direction="vertical" alignment="space-evenly">
               <Text>{`Scanned data: ${data || ''}`}</Text>
               <Text>{`Scanned data source: ${source || ''}`}</Text>
             </Stack>
@@ -33,4 +33,6 @@ const SmartGridModal = () => {
   );
 };
 
-export default reactExtension('pos.home.modal.render', () => <SmartGridModal />);
+export default reactExtension('pos.home.modal.render', () => (
+  <SmartGridModal />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/conditional-scanner-example.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/conditional-scanner-example.tsx
@@ -1,0 +1,36 @@
+import React, {useEffect} from 'react';
+import {
+  CameraScanner,
+  Navigator,
+  Screen,
+  Stack,
+  Text,
+  useScannerDataSubscription,
+  useScannerSourcesSubscription,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  const { data, source } = useScannerDataSubscription();
+  const availableScanners = useScannerSourcesSubscription();
+  const hasCameraScanner = availableScanners.includes('camera');
+
+  return (
+    <Navigator>
+      <Screen name='Home' title='Home'>
+        <Stack direction='horizontal' flexChildren flex={1}>
+          {hasCameraScanner ? (
+            <CameraScanner />
+          ) : (
+            <Stack direction='vertical' alignment='space-evenly'>
+              <Text>{`Scanned data: ${data || ''}`}</Text>
+              <Text>{`Scanned data source: ${source || ''}`}</Text>
+            </Stack>
+          )}
+        </Stack>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => <SmartGridModal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/hardware-scanner-example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/hardware-scanner-example.ts
@@ -1,0 +1,41 @@
+import React, {useEffect} from 'react';
+import {
+  Navigator,
+  Screen,
+  Stack,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  api.scanner.scannerDataSubscribable.subscribe((data) => {
+    if (data) {
+      api.cart.addLineItem(12345678, 1);
+    }
+    text.updateProps({
+      text: `Scanned data: ${data || ''}`,
+    });
+  });
+
+  const text = root.createComponent('Text', {
+    text: 'Scanned data: ',
+  });
+
+  const stack = root.createComponent(Stack, {
+    direction: 'horizontal',
+    flexChildren: true,
+    flex: 1,
+  });
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  const navigator = root.createComponent(Navigator);
+
+  stack.append(text);
+  screen.append(stack);
+  navigator.append(screen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/hardware-scanner-example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/hardware-scanner-example.ts
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import {
   Navigator,
   Screen,
@@ -8,23 +8,12 @@ import {
 } from '@shopify/ui-extensions/point-of-sale';
 
 export default extension('pos.home.modal.render', (root, api) => {
-  api.scanner.scannerDataSubscribable.subscribe((data) => {
-    if (data) {
-      api.cart.addLineItem(12345678, 1);
-    }
-    text.updateProps({
-      text: `Scanned data: ${data || ''}`,
-    });
-  });
-
   const text = root.createComponent('Text', {
     text: 'Scanned data: ',
   });
 
   const stack = root.createComponent(Stack, {
     direction: 'horizontal',
-    flexChildren: true,
-    flex: 1,
   });
 
   const screen = root.createComponent(Screen, {
@@ -38,4 +27,10 @@ export default extension('pos.home.modal.render', (root, api) => {
   screen.append(stack);
   navigator.append(screen);
   root.append(navigator);
+
+  api.scanner.scannerDataSubscribable.subscribe((data) => {
+    text.updateProps({
+      text: `Scanned data: ${data || ''}`,
+    });
+  });
 });

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/hardware-scanner-example.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/hardware-scanner-example.tsx
@@ -1,0 +1,37 @@
+import React, {useEffect} from 'react';
+import {
+  Navigator,
+  Screen,
+  Stack,
+  Text,
+  useScannerDataSubscription,
+  useApi,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+  const {data} = useScannerDataSubscription();
+
+  // Update the cart when a product is scanned.
+  useEffect(() => {
+    const addProductToCart = (data: string | undefined) => {
+      if (data) {
+        api.cart.addLineItem(Number(data), 1);
+      }
+    };
+    addProductToCart(data);
+  }, [data]);
+
+  return (
+    <Navigator>
+      <Screen name="Home" title="Home">
+        <Stack direction="horizontal" flexChildren flex={1}>
+          <Text>{`Scanned data: ${data || ''}`}</Text>
+        </Stack>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => <SmartGridModal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/hardware-scanner-example.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/hardware-scanner-example.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import {
   Navigator,
   Screen,
@@ -13,20 +13,10 @@ const SmartGridModal = () => {
   const api = useApi<'pos.home.modal.render'>();
   const {data} = useScannerDataSubscription();
 
-  // Update the cart when a product is scanned.
-  useEffect(() => {
-    const addProductToCart = (data: string | undefined) => {
-      if (data) {
-        api.cart.addLineItem(Number(data), 1);
-      }
-    };
-    addProductToCart(data);
-  }, [data]);
-
   return (
     <Navigator>
       <Screen name="Home" title="Home">
-        <Stack direction="horizontal" flexChildren flex={1}>
+        <Stack direction="horizontal">
           <Text>{`Scanned data: ${data || ''}`}</Text>
         </Stack>
       </Screen>
@@ -34,4 +24,6 @@ const SmartGridModal = () => {
   );
 };
 
-export default reactExtension('pos.home.modal.render', () => <SmartGridModal />);
+export default reactExtension('pos.home.modal.render', () => (
+  <SmartGridModal />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-events.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-events.ts
@@ -1,0 +1,45 @@
+import {
+  Navigator,
+  Screen,
+  Stack,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  api.scanner.scannerDataSubscribable.subscribe((data, source) => {
+    dataText.updateProps({
+      text: `Scanned data: ${data || ''}`,
+    });
+    sourceText.updateProps({
+      text: `Scanned data source: ${source || ''}`,
+    });
+  });
+
+  const dataText = root.createComponent('Text', {
+    text: 'Scanned data: ',
+  });
+
+  const sourceText = root.createComponent('Text', {
+    text: 'Scanned data source: ',
+  });
+
+  const stack1 = root.createComponent(Stack, {
+    direction: 'horizontal',
+    flexChildren: true,
+    flex: 1,
+  });
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  const navigator = root.createComponent(Navigator);
+
+  stack1.append(dataText);
+  stack1.append(sourceText);
+  screen.append(stack1);
+  navigator.append(screen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-events.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-events.ts
@@ -7,15 +7,6 @@ import {
 } from '@shopify/ui-extensions/point-of-sale';
 
 export default extension('pos.home.modal.render', (root, api) => {
-  api.scanner.scannerDataSubscribable.subscribe((data, source) => {
-    dataText.updateProps({
-      text: `Scanned data: ${data || ''}`,
-    });
-    sourceText.updateProps({
-      text: `Scanned data source: ${source || ''}`,
-    });
-  });
-
   const dataText = root.createComponent('Text', {
     text: 'Scanned data: ',
   });
@@ -26,8 +17,6 @@ export default extension('pos.home.modal.render', (root, api) => {
 
   const stack1 = root.createComponent(Stack, {
     direction: 'horizontal',
-    flexChildren: true,
-    flex: 1,
   });
 
   const screen = root.createComponent(Screen, {
@@ -42,4 +31,13 @@ export default extension('pos.home.modal.render', (root, api) => {
   screen.append(stack1);
   navigator.append(screen);
   root.append(navigator);
+
+  api.scanner.scannerDataSubscribable.subscribe((data, source) => {
+    dataText.updateProps({
+      text: `Scanned data: ${data || ''}`,
+    });
+    sourceText.updateProps({
+      text: `Scanned data source: ${source || ''}`,
+    });
+  });
 });

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-events.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-events.tsx
@@ -1,0 +1,26 @@
+import React, {useEffect} from 'react';
+import {
+  Navigator,
+  Screen,
+  Stack,
+  Text,
+  useScannerDataSubscription,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+
+const SmartGridModal = () => {
+  const {data, source} = useScannerDataSubscription();
+
+  return (
+    <Navigator>
+      <Screen name="Home" title="Home">
+        <Stack direction="horizontal" flexChildren flex={1}>
+          <Text>{`Scanned data: ${data || ''} with ${source || ''}`}</Text>
+        </Stack>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => <SmartGridModal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-events.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-events.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import {
   Navigator,
   Screen,
@@ -8,14 +8,13 @@ import {
   reactExtension,
 } from '@shopify/ui-extensions-react/point-of-sale';
 
-
 const SmartGridModal = () => {
   const {data, source} = useScannerDataSubscription();
 
   return (
     <Navigator>
       <Screen name="Home" title="Home">
-        <Stack direction="horizontal" flexChildren flex={1}>
+        <Stack direction="horizontal">
           <Text>{`Scanned data: ${data || ''} with ${source || ''}`}</Text>
         </Stack>
       </Screen>
@@ -23,4 +22,6 @@ const SmartGridModal = () => {
   );
 };
 
-export default reactExtension('pos.home.modal.render', () => <SmartGridModal />);
+export default reactExtension('pos.home.modal.render', () => (
+  <SmartGridModal />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-sources.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-sources.ts
@@ -7,20 +7,12 @@ import {
 } from '@shopify/ui-extensions/point-of-sale';
 
 export default extension('pos.home.modal.render', (root, api) => {
-  api.scanner.scannerSourcesSubscribable.subscribe((sources) => {
-    scannerSourcesText.updateProps({
-      text: `Available scanner sources: ${sources}`,
-    });
-  });
-
   const scannerSourcesText = root.createComponent('Text', {
     text: 'Available scanner sources: ',
   });
 
   const stack1 = root.createComponent(Stack, {
     direction: 'horizontal',
-    flexChildren: true,
-    flex: 1,
   });
 
   const screen = root.createComponent(Screen, {
@@ -34,4 +26,10 @@ export default extension('pos.home.modal.render', (root, api) => {
   screen.append(stack1);
   navigator.append(screen);
   root.append(navigator);
+
+  api.scanner.scannerSourcesSubscribable.subscribe((sources) => {
+    scannerSourcesText.updateProps({
+      text: `Available scanner sources: ${sources}`,
+    });
+  });
 });

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-sources.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-sources.ts
@@ -1,0 +1,37 @@
+import {
+  Navigator,
+  Screen,
+  Stack,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  api.scanner.scannerSourcesSubscribable.subscribe((sources) => {
+    scannerSourcesText.updateProps({
+      text: `Available scanner sources: ${sources}`,
+    });
+  });
+
+  const scannerSourcesText = root.createComponent('Text', {
+    text: 'Available scanner sources: ',
+  });
+
+  const stack1 = root.createComponent(Stack, {
+    direction: 'horizontal',
+    flexChildren: true,
+    flex: 1,
+  });
+
+  const screen = root.createComponent(Screen, {
+    title: 'Home',
+    name: 'Home',
+  });
+
+  const navigator = root.createComponent(Navigator);
+
+  stack1.append(scannerSourcesText);
+  screen.append(stack1);
+  navigator.append(screen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-sources.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-sources.tsx
@@ -1,0 +1,26 @@
+import React, {useEffect} from 'react';
+import {
+  Navigator,
+  Screen,
+  Stack,
+  Text,
+  useScannerSourcesSubscription,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+
+const SmartGridModal = () => {
+  const scannerSources = useScannerSourcesSubscription();
+
+  return (
+      <Navigator>
+      <Screen name="Home" title="Home">
+        <Stack direction="horizontal" flexChildren flex={1}>
+          <Text>{`Available scanner sources: ${scannerSources}`}</Text>
+        </Stack>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => <SmartGridModal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-sources.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/scanner-api/subscribable-sources.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import {
   Navigator,
   Screen,
@@ -8,14 +8,13 @@ import {
   reactExtension,
 } from '@shopify/ui-extensions-react/point-of-sale';
 
-
 const SmartGridModal = () => {
   const scannerSources = useScannerSourcesSubscription();
 
   return (
-      <Navigator>
+    <Navigator>
       <Screen name="Home" title="Home">
-        <Stack direction="horizontal" flexChildren flex={1}>
+        <Stack direction="horizontal">
           <Text>{`Available scanner sources: ${scannerSources}`}</Text>
         </Stack>
       </Screen>
@@ -23,4 +22,6 @@ const SmartGridModal = () => {
   );
 };
 
-export default reactExtension('pos.home.modal.render', () => <SmartGridModal />);
+export default reactExtension('pos.home.modal.render', () => (
+  <SmartGridModal />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/session-api/token.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/session-api/token.ts
@@ -1,0 +1,39 @@
+import {
+  Screen,
+  Stack,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const {session} = api;
+  const {currentSession, getSessionToken} = session;
+  const {shopId, userId, locationId, staffMemberId} = currentSession;
+
+  const screen = root.createComponent(Screen, {
+    name: 'ScreenOne',
+    title: 'Screen One Title',
+  });
+
+  const currentSessionText = root.createComponent(
+    Text,
+    {},
+    `shopId: ${shopId}, userId: ${userId}, locationId: ${locationId}, staffId: ${staffMemberId}`,
+  );
+  const sessionTokenText = root.createComponent(
+    Text,
+    {},
+    'sessionToken: undefined',
+  );
+
+  getSessionToken().then((newToken) => {
+    sessionTokenText.children.forEach((child) => {
+      sessionTokenText.removeChild(child);
+    });
+    sessionTokenText.appendChild(`sessionToken: ${newToken}`);
+  });
+
+  screen.appendChild(currentSessionText);
+  screen.appendChild(sessionTokenText);
+  root.appendChild(screen);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/session-api/token.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/session-api/token.tsx
@@ -1,0 +1,33 @@
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Screen,
+  Text,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  const {currentSession, getSessionToken} =
+    useApi<'pos.home.modal.render'>().session;
+
+  const {shopId, userId, locationId, staffMemberId} = currentSession;
+  const [sessionToken, setSessionToken] = useState<string>();
+
+  getSessionToken().then((newToken) => {
+    setSessionToken(newToken);
+  });
+
+  return (
+    <Screen name="ScreenOne" title="Screen One Title">
+      <Text>
+        shopId: {shopId}, userId: {userId}, locationId: {locationId}, staffId:
+        {staffMemberId}
+      </Text>
+      <Text>sessionToken: {sessionToken}</Text>
+    </Screen>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => (
+  <SmartGridModal />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/toast-api/show.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/toast-api/show.ts
@@ -1,0 +1,11 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    onPress: () => api.toast.show('Toast content', 5000),
+    enabled: true,
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/toast-api/show.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/toast-api/show.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import {
-  reactExtension,
-  useLocaleSubscription,
-  useApi,
   Tile,
+  useApi,
+  reactExtension,
 } from '@shopify/ui-extensions-react/point-of-sale';
 
 const SmartGridTile = () => {
-  const locale = useLocaleSubscription();
+  const api = useApi<'pos.home.tile.render'>();
 
   return (
     <Tile
-      title='My App'
-      subtitle={locale}
+      title="My App"
+      onPress={() => api.toast.show('Toast content', 5000)}
       enabled
     />
   );

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
@@ -1,0 +1,6 @@
+export enum ExtensionTargetType {
+  PosHomeModalRender = 'pos.home.modal.render',
+  PosHomeTileRender = 'pos.home.tile.render',
+  PosPurchasePostActionMenuItemRender = 'pos.purchase.post.action.menu-item.render',
+  PosPurchasePostActionRender = 'pos.purchase.post.action.render',
+}


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/36279
Resolves https://github.com/Shopify/pos-next-react-native/issues/36288

### Background

This PR adds the examples for navigation, session, scanner, toast apis to the docs. 

Some important changes you can look below at the comments to find more information but
- I added a extension target helper
- You can edit the `required` field for docs to help us clarify which targets are needed for usage
- Updating the formatter file to allow us to have consistent styling for ts and tsx files

### 🎩

- https://shopify-dev.ui-extensions-psgn.victor-chu.us.spin.dev/docs/api/pos-ui-extensions/unstable/apis/navigation-api
- https://shopify-dev.ui-extensions-psgn.victor-chu.us.spin.dev/docs/api/pos-ui-extensions/unstable/apis/session-api
- https://shopify-dev.ui-extensions-psgn.victor-chu.us.spin.dev/docs/api/pos-ui-extensions/unstable/apis/scanner-api
- https://shopify-dev.ui-extensions-psgn.victor-chu.us.spin.dev/docs/api/pos-ui-extensions/unstable/apis/toast-api

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
