### PR TITLE
Add page for pos-ui-extensions for server communication

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/server-communication/modal.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/server-communication/modal.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+
+import { Screen, useApi, reactExtension, Text } from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+
+  const [authenticated, setAuthenticated] = useState<number>();
+  const [error, setError] = useState<string>();
+  const [sessionToken, setSessionToken] = useState<string>();
+
+  useEffect(() => {
+    api.session.getSessionToken().then((token) => {
+      setSessionToken(token);
+      fetch('https://YOUR_DEVELOPMENT_SERVER/api/extensions/test', {
+        method: 'GET',
+        mode: 'cors',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      })
+        .then((response) => setAuthenticated(response.status))
+        .catch(setError);
+    });
+  }, []);
+
+  return (
+    <Screen name='Home' title='Authentication example'>
+      <Text>Token: {sessionToken}</Text>
+      <Text>Authenticated: {authenticated}</Text>
+      <Text>Error: {error}</Text>
+    </Screen>
+  );
+}
+
+export default reactExtension('pos.home.modal.render', () => {
+  return <SmartGridModal />
+})

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/server-communication/tile.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/server-communication/tile.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { Tile, useApi, reactExtension } from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile
+      title='Example extension'
+      enabled
+      onPress={api.action.presentModal}
+    />
+  );
+};
+
+export default reactExtension('pos.home.tile.render', () => {
+  return <SmartGridTile />
+})

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/server-communication.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/server-communication.doc.ts
@@ -1,0 +1,65 @@
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
+
+const examplePath = '../examples/server-communication';
+
+const data: LandingTemplateSchema = {
+  title: 'Communicate with a server',
+  description:
+    'Learn how to fetch data from your development server to your POS UI extension.',
+  id: 'server-communication',
+  image: '/assets/landing-pages/templated-apis/hero.png',
+  darkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  tabletImage: '/assets/landing-pages/templated-apis/hero.png',
+  tabletDarkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  mobileImage: '/assets/landing-pages/templated-apis/hero.png',
+  mobileDarkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  sections: [
+    {
+      type: 'Generic',
+      anchorLink: 'authenticating',
+      title: 'Authenticating with a development server',
+      sectionContent: `
+Often, an extension running on a simulator or a device will need to communicate with a development server running on a local machine. One solution is to use the [session API](/docs/api/pos-ui-extensions/apis/session-api) to get session tokens, and to pass these tokens to your development servers for [authentication](/docs/apps/auth/session-tokens/getting-started) using the [shopify_app gem](https://github.com/Shopify/shopify-api-ruby).
+      `,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'cors',
+      title: 'CORS considerations',
+      sectionContent: `Requests originating from an extension will be of origin **cdn.shopify.com**. Your server needs to allow requests from this origin.`,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'https',
+      title: 'HTTPS requirement',
+      sectionContent: `
+Shopify POS will refuse to fetch any non-HTTPS requests. Therefore, you must find a way to host your development server where it serves HTTPS requests. For example, a standard rails server will run on \`localhost:3000\`. Attempting to access this server from an Android emulator using \`10.0.2.2:3000\` will fail. One strategy is to use [Cloudflare Quick Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/do-more-with-tunnels/trycloudflare/), which provide an HTTPS URL to connect.
+      `,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'example-extension',
+      title: 'Example extension',
+      codeblock: {
+        title: 'Example extension',
+        tabs: [
+          {
+            title: 'Tile',
+            code: `${examplePath}/tile.tsx`,
+            language: 'tsx',
+          },
+          {
+            title: 'Modal',
+            code: `${examplePath}/modal.tsx`,
+            language: 'tsx',
+          },
+        ],
+      },
+      sectionContent: `
+Here is an example extension that presents a Smart Grid tile. When tapped, the tile will present a modal that uses the Session API to get a session token, and then fetches a test endpoint on the development server.
+      `,
+    },
+  ],
+};
+
+export default data;


### PR DESCRIPTION
### Background

Closes https://github.com/Shopify/pos-next-react-native/issues/36270

### Solution

This adds the page for communicating with servers

### 🎩

Old: https://shopify.dev/docs/apps/pos/ui-extensions/authentication
New: https://shopify-dev.ui-extensions-70k7.nathan-oliveira.us.spin.dev/docs/api/pos-ui-extensions/unstable/server-communication

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
