### PR TITLE
Add selling_plan_allocation to Web Pixels checkout.line_item object

### DIFF
--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -1488,6 +1488,40 @@ export const pixelEvents = {
         },
       },
     },
+    MouseEventData: {
+      metadata: {
+        description: 'An object that contains data about a mouse event',
+      },
+      properties: {
+        element: {
+          ref: 'GenericElement',
+        },
+        screenX: {
+          type: 'int32',
+        },
+        screenY: {
+          type: 'int32',
+        },
+        pageX: {
+          type: 'int32',
+        },
+        pageY: {
+          type: 'int32',
+        },
+        offsetX: {
+          type: 'int32',
+        },
+        offsetY: {
+          type: 'int32',
+        },
+        movementX: {
+          type: 'int32',
+        },
+        movementY: {
+          type: 'int32',
+        },
+      },
+    },
     CustomData: {
       metadata: {
         description:
@@ -2269,11 +2303,7 @@ export const pixelEvents = {
           ref: 'Timestamp',
         },
         data: {
-          properties: {
-            element: {
-              ref: 'GenericElement',
-            },
-          },
+          ref: 'MouseEventData',
         },
       },
     },

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -138,17 +138,13 @@ export interface PixelEventsCheckoutStarted {
   type: EventType.Standard;
 }
 
-export interface PixelEventsClickedData {
-  element: GenericElement;
-}
-
 /**
  * The `clicked` event logs an instance where any element on the page has been
  * clicked
  */
 export interface PixelEventsClicked {
   clientId: ClientId;
-  data: PixelEventsClickedData;
+  data: MouseEventData;
   id: Id;
 
   /**
@@ -1358,6 +1354,21 @@ export interface MoneyV2 {
    * standard codes.
    */
   currencyCode: string;
+}
+
+/**
+ * An object that contains data about a mouse event
+ */
+export interface MouseEventData {
+  element: GenericElement;
+  movementX: number;
+  movementY: number;
+  offsetX: number;
+  offsetY: number;
+  pageX: number;
+  pageY: number;
+  screenX: number;
+  screenY: number;
 }
 
 /**

--- a/packages/web-pixels-extension/src/types/WebPixelsManager.ts
+++ b/packages/web-pixels-extension/src/types/WebPixelsManager.ts
@@ -11,7 +11,7 @@ export type SchemaVersion = 'v1';
 
 export type PixelEventName = keyof PixelEvents;
 
-type EventNameOfType<T extends EventType> = {
+export type EventNameOfType<T extends EventType> = {
   [K in PixelEventName]: PixelEvents[K] extends {type: T} ? K : never;
 }[PixelEventName];
 


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/ce-customer-behaviour/issues/3991. Depends on https://github.com/Shopify/web-pixels-manager/pull/739

### Solution

- Discussed the potential schema heavily in Slack. Essentially, we want to limit the amount of fields we add to avoid adding maintenance and avoid having to load unnecessary fields onto every single checkout. This schema includes the bare minimum merchants are requesting/need. 
- A handful of fields that are in the liquid schema could not be populated given the fields that are already being requested in the API calls. We don't want to add to these api calls because that would decrease performance / increase latency on checkout. This is summarized [here](https://github.com/Shopify/ce-customer-behaviour/issues/3991#issuecomment-2105247309).

### 🎩
https://shop1.shopify.selling-plan3.aashna-narang.us.spin.dev/checkouts/cn/Z2NwLXVzLWNlbnRyYWwxOjAxSFlLNzdZTTZOTVE0WlRaWTRENlg5NDdZ/
<img width="1915" alt="Screenshot 2024-05-23 at 2 29 43 PM" src="https://github.com/Shopify/ui-extensions/assets/105367204/9ee58c92-8766-4cd8-8973-a9ad9936b203">


### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
