### PR TITLE
Add debugging doc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/debugging.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/debugging.doc.ts
@@ -13,8 +13,8 @@ const data: LandingTemplateSchema = {
   sections: [
     {
       type: 'Generic',
-      anchorLink: `overview`,
-      title: `Overview`,
+      anchorLink: 'overview',
+      title: 'Overview',
       sectionContent: `
 APIs and components will report if they receive parameters of an unexpected type. For further debugging, you can use \`console.log\` to print any additional information in the console.
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/debugging.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/debugging.doc.ts
@@ -1,0 +1,66 @@
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
+
+const data: LandingTemplateSchema = {
+  title: 'Debugging',
+  description: 'Discover how you can debug your POS UI Extensions.',
+  id: 'debugging',
+  image: '/assets/landing-pages/templated-apis/hero.png',
+  darkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  tabletImage: '/assets/landing-pages/templated-apis/hero.png',
+  tabletDarkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  mobileImage: '/assets/landing-pages/templated-apis/hero.png',
+  mobileDarkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  sections: [
+    {
+      type: 'Generic',
+      anchorLink: `overview`,
+      title: `Overview`,
+      sectionContent: `
+APIs and components will report if they receive parameters of an unexpected type. For further debugging, you can use \`console.log\` to print any additional information in the console.
+
+### APIs
+If an API receives an incorrect parameter, it won't attempt to perform the action and it will \`throw\` an error instead. This error can be viewed either by implementing a \`try/catch\` block or by using the Chrome console.
+
+### Components
+
+If a component is given an incorrect parameter, the extension will be replaced with a non-descriptive user interface that indicates an issue has occurred. In case the extension is running locally, the developer will also see the exact error displayed as a toast message.
+
+**In the future we plan to modify this behavior to display the error in the Chrome console instead, aligning with the API approach.**`,
+    },
+    {
+      type: 'Generic',
+      anchorLink: `using-chrome-console`,
+      title: `Using Chrome console`,
+      sectionContent: `
+This section covers how to view POS UI Extension logs and errors.
+
+> Note:
+> Due to certain iOS security limitations, debugging is currently only possible with an Android device or an Android studio emulator.
+
+### Requirements
+
+- The extension needs to be running on a [development store](/docs/apps/tools/development-stores) in the POS app. Debugging is only available on development stores. You can create a development store from the Partner Portal, or you can use an existing development store for debugging purposes.
+![Development store](/assets/api/pos/debug-development-store.png)
+- You've set up an Android Studio emulator, or you have an Android device available with the POS app installed. If you use an Android device, you can follow the [Chrome developer documentation](https://developer.chrome.com/docs/devtools/remote-debugging/) to set up a device for debugging purposes.
+
+### Steps
+
+You can debug your POS UI Extension by following these steps:
+
+1. Connect the Android device to your computer or launch the Android emulator.
+2. Make sure the POS UI Extension is running on the POS app.
+3. Using Google Chrome, navigate to <a href=chrome://inspect>chrome://inspect</a>.
+4. The UI Extension sandbox should appear on the list as "Shopify UI Extensions Internal"
+5. Click the inspect button. This should open a DevTools window, where you will be able to interact with the console, and view \`console.log\` statements in your code along with inspecting the network activity.
+
+### Demo
+
+The following demo shows ow to debug a POS UI Extension by leveraging tools such as the Console and Network available in Google Chrome. The example extension code has \`console.log\` statements when the SmartGrid tile is pressed to open modal and also to log the remote fetch response.
+
+![Debugging demo](/assets/api/pos/debug-ui-extension.gif)
+`,
+    },
+  ],
+};
+
+export default data;


### PR DESCRIPTION
Closes https://github.com/Shopify/pos-next-react-native/issues/36271

### Background

- Creates Static page for debugging.


https://github.com/Shopify/ui-extensions/assets/81783308/a7c0f668-39a0-4563-af08-359eafabfd19

### Solution

- Utilizing a generic component  in a logical and readable way that is consistent with other static pages, and the original debugging page.

### 🎩

- Visit [THIS SPINSTANCE](https://shopify-dev.ui-extensions-90tx.marco-yip.us.spin.dev/docs/api/pos-ui-extensions/unstable/debugging)
- Compare it with the [old docs](https://shopify.dev/docs/apps/pos/ui-extensions/debugging)
- Click through the debugging sections
- Take note of formatting, word choices, and layout

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
