### PR TITLE
Update order status with processedAt type for customer account surface 

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -1200,6 +1200,11 @@ export interface Order {
    */
   cancelledAt?: string;
   /**
+   * The date and time when the order was processed.
+   * Processing happens after the checkout has completed, and indicates that the order is available in the admin.
+   */
+  processedAt?: string;
+  /**
    * A randomly generated alpha-numeric identifier for the order.
    * For orders created in 2024 and onwards, the number will always be present. For orders created before that date, the number might not be present.
    */


### PR DESCRIPTION
This PR adds the `Order` `processedAt` type to `unstable` for the customer-account surface.
The corresponding PR for passing this attribute to the Order API can be found [here](https://github.com/Shopify/customer-account-web/pull/4430).

### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
