### PR TITLE
adds useCustomerPrivacy hook and updates Sheet and Customer Privacy examples

### DIFF
--- a/.changeset/happy-kings-shop.md
+++ b/.changeset/happy-kings-shop.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+- Adds `useCustomerPrivacy` hook.

--- a/packages/ui-extensions-react/src/surfaces/checkout.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout.ts
@@ -338,3 +338,4 @@ export {useDeliveryGroups} from './checkout/hooks/delivery-groups';
 export {useDeliveryGroup} from './checkout/hooks/delivery-group';
 export {useDeliveryGroupTarget} from './checkout/hooks/delivery-group-target';
 export {useCheckoutToken} from './checkout/hooks/checkout-token';
+export {useCustomerPrivacy} from './checkout/hooks/customer-privacy';

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/customer-privacy.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/customer-privacy.ts
@@ -1,0 +1,17 @@
+import type {
+  CustomerPrivacy,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/checkout';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+/**
+ * Returns the current customer privacy settings and metadata and
+ * re-renders your component if the customer privacy settings change.
+ */
+export function useCustomerPrivacy<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): CustomerPrivacy {
+  return useSubscription(useApi<Target>().customerPrivacy);
+}

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/customer-privacy.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/customer-privacy.test.ts
@@ -1,0 +1,38 @@
+import type {CustomerPrivacy} from '@shopify/ui-extensions/checkout';
+
+import {useCustomerPrivacy} from '../customer-privacy';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useCustomerPrivacy', () => {
+  it('returns customer privacy settings and data from the API', () => {
+    const customerPrivacyValue: CustomerPrivacy = {
+      allowedProcessing: {
+        marketing: true,
+        analytics: true,
+        preferences: false,
+        saleOfData: false,
+      },
+      metafields: [{key: 'test-key', value: 'test-value'}],
+      saleOfDataRegion: true,
+      shouldShowBanner: true,
+      region: {
+        countryCode: 'CA',
+        provinceCode: 'ON',
+      },
+      visitorConsent: {
+        marketing: true,
+        analytics: true,
+      },
+    };
+
+    const extensionApi = {
+      customerPrivacy:
+        createMockStatefulRemoteSubscribable(customerPrivacyValue),
+    };
+
+    const {value} = mount.hook(() => useCustomerPrivacy(), {extensionApi});
+
+    expect(value).toMatchObject(customerPrivacyValue);
+  });
+});

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/customer-privacy.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/customer-privacy.doc.ts
@@ -23,7 +23,23 @@ const data: ReferenceEntityTemplateSchema = {
         'The base API object provided to `purchase` extension targets.',
       type: 'Docs_Standard_CustomerPrivacyApi',
     },
+    {
+      title: 'useCustomerPrivacy',
+      description:
+        'Returns the current customer privacy settings and metadata and re-renders your component if the customer privacy settings change.',
+      type: 'UseCustomerPrivacyGeneratedType',
+    },
   ],
+  defaultExample: getExample('customer-privacy/default', ['jsx', 'js']),
+  examples: {
+    description: '',
+    examples: [
+      getExample('customer-privacy/sheet-consent-banner-with-form', [
+        'jsx',
+        'js',
+      ]),
+    ],
+  },
   related: getLinksByTag('apis'),
 };
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/default.example.ts
@@ -1,0 +1,48 @@
+import {
+  extension,
+  Text,
+} from '@shopify/ui-extensions/checkout';
+
+// 1. Choose an extension target
+export default extension(
+  'purchase.checkout.block.render',
+  (root, {customerPrivacy}) => {
+    const {
+      visitorConsent: {
+        analytics,
+        marketing,
+        preferences,
+        saleOfData,
+      },
+    } = customerPrivacy.current;
+
+    // 2. Use consent values
+    console.log('initialValues');
+    console.log('analytics', analytics);
+    console.log('marketing', marketing);
+    console.log('preferences', preferences);
+    console.log('saleOfData', saleOfData);
+
+    // 3. Update component state when customerPrivacy changes
+    customerPrivacy.subscribe((value) => {
+      if (!value) {
+        return;
+      }
+
+      const {
+        visitorConsent: {
+          analytics,
+          marketing,
+          preferences,
+          saleOfData,
+        },
+      } = value;
+
+      console.log('updatedValues');
+      console.log('analytics', analytics);
+      console.log('marketing', marketing);
+      console.log('preferences', preferences);
+      console.log('saleOfData', saleOfData);
+    });
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/default.example.tsx
@@ -1,0 +1,29 @@
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useCustomerPrivacy,
+} from '@shopify/ui-extensions-react/checkout';
+
+// 1. Choose an extension target
+export default reactExtension(
+  'purchase.checkout.block.render',
+  () => <Extension />,
+);
+
+function Extension() {
+  // 2. Subscribe to customer privacy consent values
+  const {
+    visitorConsent: {
+      analytics,
+      marketing,
+      preferences,
+      saleOfData,
+    },
+  } = useCustomerPrivacy();
+
+  // 3. Use consent values
+  console.log('analytics', analytics);
+  console.log('marketing', marketing);
+  console.log('preferences', preferences);
+  console.log('saleOfData', saleOfData);
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/sheet-consent-banner-with-form.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/sheet-consent-banner-with-form.example.ts
@@ -1,0 +1,298 @@
+import {
+  BlockStack,
+  Button,
+  Checkbox,
+  extension,
+  Form,
+  Grid,
+  Link,
+  Modal,
+  Sheet,
+  TextBlock,
+} from '@shopify/ui-extensions/checkout';
+import type {VisitorConsent} from '@shopify/ui-extensions/checkout';
+// 1. Choose an extension target
+export default extension(
+  'purchase.checkout.footer.render-after',
+  (
+    root,
+    {
+      applyTrackingConsentChange,
+      customerPrivacy,
+      ui,
+    },
+  ) => {
+    const sheetId = 'sheet-consent';
+    const modalId = 'modal-consent';
+
+    let showBanner =
+      customerPrivacy.current.shouldShowBanner;
+
+    const formValues: VisitorConsent = {
+      analytics: undefined,
+      marketing: undefined,
+      preferences: undefined,
+      saleOfData: undefined,
+    };
+
+    // 2. Subscribe to customer privacy consent values and update component state when customerPrivacy changes
+    customerPrivacy.subscribe((value) => {
+      if (!value) {
+        return;
+      }
+
+      showBanner = value.shouldShowBanner;
+
+      const {
+        visitorConsent: {
+          analytics,
+          marketing,
+          preferences,
+          saleOfData,
+        },
+      } = value;
+
+      formValues.analytics =
+        value.visitorConsent.analytics;
+      formValues.marketing =
+        value.visitorConsent.marketing;
+      formValues.preferences =
+        value.visitorConsent.preferences;
+      formValues.saleOfData =
+        value.visitorConsent.saleOfData;
+
+      analyticsCheckbox.updateProps({
+        checked: analytics,
+      });
+      marketingCheckbox.updateProps({
+        checked: marketing,
+      });
+      preferencesCheckbox.updateProps({
+        checked: preferences,
+      });
+      saleOfDataCheckbox.updateProps({
+        checked: saleOfData,
+      });
+    });
+
+    // 3. Set up event handlers
+    const handleConsentChange = async (
+      visitorConsent?: VisitorConsent,
+    ) => {
+      const result =
+        await applyTrackingConsentChange({
+          ...(visitorConsent
+            ? visitorConsent
+            : formValues),
+          type: 'changeVisitorConsent',
+        });
+
+      // Check if operation was successful
+      if (result.type === 'success') {
+        ui.overlay.close(modalId);
+        ui.overlay.close(sheetId);
+      } else {
+        // Handle failure case here
+      }
+    };
+
+    // 4. Create consent preferences form
+    const analyticsCheckbox =
+      root.createComponent(
+        Checkbox,
+        {
+          checked: formValues.analytics,
+          onChange: (checked: boolean) => {
+            formValues.analytics = checked;
+          },
+        },
+        'Analytics',
+      );
+
+    const marketingCheckbox =
+      root.createComponent(
+        Checkbox,
+        {
+          checked: formValues.marketing,
+          onChange: (checked: boolean) => {
+            formValues.marketing = checked;
+          },
+        },
+        'Marketing',
+      );
+
+    const preferencesCheckbox =
+      root.createComponent(
+        Checkbox,
+        {
+          checked: formValues.preferences,
+          onChange: (checked: boolean) => {
+            formValues.preferences = checked;
+          },
+        },
+        'Preferences',
+      );
+
+    const saleOfDataCheckbox =
+      root.createComponent(
+        Checkbox,
+        {
+          checked: formValues.saleOfData,
+          onChange: (checked: boolean) => {
+            formValues.saleOfData = checked;
+          },
+        },
+        'Sale of data',
+      );
+
+    const consentFormSubmitButton =
+      root.createComponent(
+        Button,
+        {accessibilityRole: 'submit'},
+        'Save',
+      );
+
+    const consentForm = root.createComponent(
+      Form,
+      {
+        onSubmit: () => handleConsentChange(),
+      },
+    );
+
+    const consentFormBlockStack =
+      root.createComponent(BlockStack);
+
+    const consentFormGrid = root.createComponent(
+      Grid,
+      {
+        spacing: 'base',
+      },
+    );
+
+    consentFormGrid.appendChild(
+      analyticsCheckbox,
+    );
+    consentFormGrid.appendChild(
+      marketingCheckbox,
+    );
+    consentFormGrid.appendChild(
+      preferencesCheckbox,
+    );
+    consentFormGrid.appendChild(
+      saleOfDataCheckbox,
+    );
+    consentFormGrid.appendChild(
+      consentFormSubmitButton,
+    );
+
+    consentFormBlockStack.appendChild(
+      consentFormGrid,
+    );
+    consentFormBlockStack.appendChild(
+      consentFormSubmitButton,
+    );
+    consentForm.appendChild(
+      consentFormBlockStack,
+    );
+
+    // 5. Create modal to display consent form
+    const modalFragment = root.createFragment();
+
+    const modal = root.createComponent(
+      Modal,
+      {
+        id: modalId,
+        padding: true,
+      },
+      [consentForm],
+    );
+
+    modalFragment.appendChild(modal);
+
+    const declineButton = root.createComponent(
+      Button,
+      {
+        kind: 'secondary',
+        onPress: () =>
+          handleConsentChange({
+            analytics: false,
+            marketing: false,
+            preferences: false,
+            saleOfData: false,
+          }),
+      },
+      'I decline',
+    );
+
+    const acceptButton = root.createComponent(
+      Button,
+      {
+        kind: 'secondary',
+        onPress: () =>
+          handleConsentChange({
+            analytics: true,
+            marketing: true,
+            preferences: true,
+            saleOfData: true,
+          }),
+      },
+      'I agree',
+    );
+
+    const settingsButton = root.createComponent(
+      Button,
+      {
+        kind: 'plain',
+        overlay: modalFragment,
+      },
+      'Settings',
+    );
+
+    const primaryActionFragment =
+      root.createFragment();
+
+    primaryActionFragment.appendChild(
+      declineButton,
+    );
+    primaryActionFragment.appendChild(
+      acceptButton,
+    );
+
+    const secondaryActionFragment =
+      root.createFragment();
+
+    secondaryActionFragment.appendChild(
+      settingsButton,
+    );
+
+    // 6. Create sheet to display privacy consent banner
+    const sheet = root.createComponent(
+      Sheet,
+      {
+        id: sheetId,
+        defaultOpen: showBanner,
+        accessibilityLabel:
+          'A sheet that collects privacy consent preferences',
+        primaryAction: primaryActionFragment,
+        secondaryAction: secondaryActionFragment,
+      },
+      [
+        root.createComponent(
+          TextBlock,
+          undefined,
+          [
+            'This website uses cookies to ensure you get the best experience on our website test.',
+            ' ',
+            root.createComponent(
+              Link,
+              undefined,
+              'Privacy Policy',
+            ),
+          ],
+        ),
+      ],
+    );
+
+    root.appendChild(sheet);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/sheet-consent-banner-with-form.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/sheet-consent-banner-with-form.example.tsx
@@ -1,0 +1,191 @@
+import {useState} from 'react';
+import {
+  reactExtension,
+  BlockStack,
+  Button,
+  Checkbox,
+  Form,
+  Grid,
+  Link,
+  Modal,
+  Sheet,
+  TextBlock,
+  useApi,
+  useCustomerPrivacy,
+} from '@shopify/ui-extensions-react/checkout';
+
+import type {VisitorConsent} from '@shopify/ui-extensions/checkout';
+
+export default reactExtension(
+  'purchase.checkout.footer.render-after',
+  () => <Extension />,
+);
+
+function Extension() {
+  const {applyTrackingConsentChange, ui} =
+    useApi();
+
+  const {
+    shouldShowBanner,
+    visitorConsent: {
+      analytics,
+      marketing,
+      preferences,
+      saleOfData,
+    },
+  } = useCustomerPrivacy();
+
+  const [
+    consentFormValues,
+    setConsentFormValues,
+  ] = useState({
+    analytics,
+    marketing,
+    preferences,
+    saleOfData,
+  });
+
+  const sheetId = 'sheet-consent';
+  const modalId = 'modal-consent';
+
+  const getCheckboxOnChangeHandler = (
+    key: string,
+  ) => {
+    return function (checked: boolean) {
+      setConsentFormValues({
+        ...consentFormValues,
+        [key]: checked,
+      });
+    };
+  };
+
+  const handleConsentChange = async (
+    visitorConsent?: VisitorConsent,
+  ) => {
+    try {
+      const result =
+        await applyTrackingConsentChange({
+          ...(visitorConsent
+            ? visitorConsent
+            : consentFormValues),
+          type: 'changeVisitorConsent',
+        });
+
+      // Check if operation was successful
+      if (result.type === 'success') {
+        ui.overlay.close(modalId);
+        ui.overlay.close(sheetId);
+      } else {
+        // Handle failure case here
+      }
+    } catch (error) {
+      // Handle error case here
+    }
+  };
+
+  const consentFormMarkup = (
+    <Form onSubmit={handleConsentChange}>
+      <BlockStack>
+        <Grid spacing="base">
+          <Checkbox
+            id="marketing"
+            checked={consentFormValues.marketing}
+            onChange={getCheckboxOnChangeHandler(
+              'marketing',
+            )}
+          >
+            Marketing
+          </Checkbox>
+          <Checkbox
+            id="analytics"
+            checked={consentFormValues.analytics}
+            onChange={getCheckboxOnChangeHandler(
+              'analytics',
+            )}
+          >
+            Analytics
+          </Checkbox>
+          <Checkbox
+            id="preferences"
+            checked={
+              consentFormValues.preferences
+            }
+            onChange={getCheckboxOnChangeHandler(
+              'preferences',
+            )}
+          >
+            Preferences
+          </Checkbox>
+          <Checkbox
+            id="saleOfData"
+            checked={consentFormValues.saleOfData}
+            onChange={getCheckboxOnChangeHandler(
+              'saleOfData',
+            )}
+          >
+            Sale of data
+          </Checkbox>
+        </Grid>
+        <Button accessibilityRole="submit">
+          Save
+        </Button>
+      </BlockStack>
+    </Form>
+  );
+
+  return (
+    <Sheet
+      id={sheetId}
+      accessibilityLabel="A sheet that collects privacy consent preferences"
+      defaultOpen={shouldShowBanner}
+      primaryAction={
+        <>
+          <Button
+            kind="secondary"
+            onPress={() =>
+              handleConsentChange({
+                analytics: false,
+                marketing: false,
+                preferences: false,
+                saleOfData: false,
+              })
+            }
+          >
+            I decline
+          </Button>
+          <Button
+            kind="secondary"
+            onPress={() =>
+              handleConsentChange({
+                analytics: true,
+                marketing: true,
+                preferences: true,
+                saleOfData: true,
+              })
+            }
+          >
+            I agree
+          </Button>
+        </>
+      }
+      secondaryAction={
+        <Button
+          kind="plain"
+          overlay={
+            <Modal id={modalId} padding>
+              {consentFormMarkup}
+            </Modal>
+          }
+        >
+          Settings
+        </Button>
+      }
+    >
+      <TextBlock>
+        This website uses cookies to ensure you
+        get the best experience on our website.{' '}
+        <Link>Privacy Policy</Link>
+      </TextBlock>
+    </Sheet>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/sheet-consent.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/sheet-consent.example.ts
@@ -16,104 +16,117 @@ export default extension(
       ui,
     },
   ) => {
-    const primaryFragment = root.createFragment();
-    const secondaryFragment =
-      root.createFragment();
-    const handleConsentChange = async ({
-      analytics,
-      marketing,
-      preferences,
-      saleOfData,
-    }) => {
-      try {
-        const result =
-          await applyTrackingConsentChange({
-            type: 'changeVisitorConsent',
-            analytics,
-            marketing,
-            preferences,
-            saleOfData,
-          });
+    customerPrivacy.subscribe(
+      ({shouldShowBanner}) => {
+        const primaryFragment =
+          root.createFragment();
+        const secondaryFragment =
+          root.createFragment();
+        const handleConsentChange = async ({
+          analytics,
+          marketing,
+          preferences,
+          saleOfData,
+        }) => {
+          try {
+            const result =
+              await applyTrackingConsentChange({
+                type: 'changeVisitorConsent',
+                analytics,
+                marketing,
+                preferences,
+                saleOfData,
+              });
 
-        // Check if operation was successful
-        if (result) {
-          ui.overlay.close(sheetId);
-        } else {
-          // Handle failure case here
-        }
-      } catch (error) {
-        // Handle error case here
-      }
-    };
+            // Check if operation was successful
+            if (result) {
+              ui.overlay.close(sheetId);
+            } else {
+              // Handle failure case here
+            }
+          } catch (error) {
+            // Handle error case here
+          }
+        };
 
-    const declineButton = root.createComponent(
-      Button,
-      {
-        kind: 'secondary',
-        onPress: () =>
-          handleConsentChange({
-            analytics: false,
-            marketing: false,
-            preferences: false,
-            saleOfData: false,
-          }),
-      },
-      'I decline',
-    );
+        const declineButton =
+          root.createComponent(
+            Button,
+            {
+              kind: 'secondary',
+              onPress: () =>
+                handleConsentChange({
+                  analytics: false,
+                  marketing: false,
+                  preferences: false,
+                  saleOfData: false,
+                }),
+            },
+            'I decline',
+          );
 
-    const agreeButton = root.createComponent(
-      Button,
-      {
-        kind: 'secondary',
-        onPress: () =>
-          handleConsentChange({
-            analytics: true,
-            marketing: true,
-            preferences: true,
-            saleOfData: true,
-          }),
-      },
-      'I agree',
-    );
+        const agreeButton = root.createComponent(
+          Button,
+          {
+            kind: 'secondary',
+            onPress: () =>
+              handleConsentChange({
+                analytics: true,
+                marketing: true,
+                preferences: true,
+                saleOfData: true,
+              }),
+          },
+          'I agree',
+        );
 
-    const settingsButton = root.createComponent(
-      Button,
-      {
-        kind: 'secondary',
-      },
-      'Settings',
-    );
+        const settingsButton =
+          root.createComponent(
+            Button,
+            {
+              kind: 'secondary',
+            },
+            'Settings',
+          );
 
-    primaryFragment.appendChild(declineButton);
-    primaryFragment.appendChild(agreeButton);
-    secondaryFragment.appendChild(settingsButton);
+        primaryFragment.appendChild(
+          declineButton,
+        );
+        primaryFragment.appendChild(agreeButton);
+        secondaryFragment.appendChild(
+          settingsButton,
+        );
 
-    const sheetId = 'sheet-consent';
-    const sheet = root.createComponent(Sheet, {
-      id: sheetId,
-      heading: 'We value your privacy',
-      accessibilityLabel:
-        'A sheet that collects privacy consent preferences',
-      defaultOpen:
-        customerPrivacy.current.shouldShowBanner,
-      primaryAction: primaryFragment,
-      secondaryAction: secondaryFragment,
-    });
+        const sheetId = 'sheet-consent';
+        const sheet = root.createComponent(
+          Sheet,
+          {
+            id: sheetId,
+            heading: 'We value your privacy',
+            accessibilityLabel:
+              'A sheet that collects privacy consent preferences',
+            defaultOpen: shouldShowBanner,
+            primaryAction: primaryFragment,
+            secondaryAction: secondaryFragment,
+          },
+        );
 
-    const textBlock = root.createComponent(
-      TextBlock,
-      null,
-      [
-        'We and our partners use cookies and other technologies to improve your experience, measure performance, and tailor marketing. Details in our ',
-        root.createComponent(
-          Link,
+        const textBlock = root.createComponent(
+          TextBlock,
           null,
-          'Privacy Policy',
-        ),
-      ],
-    );
+          [
+            'We and our partners use cookies and other technologies to improve your experience, measure performance, and tailor marketing. Details in our ',
+            root.createComponent(
+              Link,
+              null,
+              'Privacy Policy',
+            ),
+          ],
+        );
 
-    sheet.appendChild(textBlock);
-    root.appendChild(sheet);
+        sheet.appendChild(textBlock);
+        root.appendChild(sheet);
+      },
+    );
   },
 );

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/sheet-consent.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/sheet-consent.example.tsx
@@ -5,6 +5,7 @@ import {
   Sheet,
   TextBlock,
   useApi,
+  useCustomerPrivacy,
 } from '@shopify/ui-extensions-react/checkout';
 
 export default reactExtension(
@@ -13,11 +14,10 @@ export default reactExtension(
 );
 
 function Extension() {
-  const {
-    applyTrackingConsentChange,
-    customerPrivacy,
-    ui,
-  } = useApi();
+  const {applyTrackingConsentChange, ui} =
+    useApi();
+
+  const {shouldShowBanner} = useCustomerPrivacy();
 
   const sheetId = 'sheet-consent';
 
@@ -38,7 +38,7 @@ function Extension() {
         });
 
       // Check if operation was successful
-      if (result) {
+      if (result.type === 'success') {
         ui.overlay.close(sheetId);
       } else {
         // Handle failure case here
@@ -53,13 +53,14 @@ function Extension() {
       id={sheetId}
       heading="We value your privacy"
       accessibilityLabel="A sheet that collects privacy consent preferences"
-      defaultOpen={customerPrivacy.current.shouldShowBanner}
+      defaultOpen={shouldShowBanner}
       primaryAction={
         <>
           <Button
             kind="secondary"
             onPress={() =>
               handleConsentChange({
+                // values derived from local form state
                 analytics: false,
                 marketing: false,
                 preferences: false,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/sheet-description-preferences.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/sheet-description-preferences.example.tsx
@@ -5,7 +5,7 @@ import {
   Link,
   Sheet,
   TextBlock,
-  useApi,
+  useCustomerPrivacy,
 } from '@shopify/ui-extensions-react/checkout';
 
 export default reactExtension(
@@ -14,7 +14,7 @@ export default reactExtension(
 );
 
 function Extension() {
-  const {customerPrivacy} = useApi();
+  const {shouldShowBanner} = useCustomerPrivacy();
 
   const sheetId = 'sheet-consent';
 
@@ -22,7 +22,7 @@ function Extension() {
     <Sheet
       id={sheetId}
       accessibilityLabel="A sheet that collects privacy consent preferences"
-      defaultOpen={customerPrivacy.current.shouldShowBanner}
+      defaultOpen={shouldShowBanner}
       primaryAction={
         <>
           <Button

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/sheet-icon-button-preferences.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/sheet-icon-button-preferences.example.tsx
@@ -5,7 +5,7 @@ import {
   Icon,
   Sheet,
   TextBlock,
-  useApi,
+  useCustomerPrivacy,
 } from '@shopify/ui-extensions-react/checkout';
 
 export default reactExtension(
@@ -14,13 +14,13 @@ export default reactExtension(
 );
 
 function Extension() {
-  const {customerPrivacy} = useApi();
+  const {shouldShowBanner} = useCustomerPrivacy();
 
   return (
     <Sheet
       accessibilityLabel="A sheet that collects privacy consent preferences"
       heading="We value your privacy"
-      defaultOpen={customerPrivacy.current.shouldShowBanner}
+      defaultOpen={shouldShowBanner}
       primaryAction={
         <>
           <Button

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/sheet-layout-content.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/sheet-layout-content.example.tsx
@@ -6,7 +6,7 @@ import {
   InlineLayout,
   Sheet,
   TextBlock,
-  useApi,
+  useCustomerPrivacy,
 } from '@shopify/ui-extensions-react/checkout';
 
 export default reactExtension(
@@ -15,12 +15,12 @@ export default reactExtension(
 );
 
 function Extension() {
-  const {customerPrivacy} = useApi();
+  const {shouldShowBanner} = useCustomerPrivacy();
 
   return (
     <Sheet
       accessibilityLabel="A sheet that collects privacy consent preferences"
-      defaultOpen={customerPrivacy.current.shouldShowBanner}
+      defaultOpen={shouldShowBanner}
       primaryAction={
         <>
           <Button

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
@@ -401,6 +401,25 @@ Ensure your extension can access the Storefront API via the [\`api_access\` capa
         tabs: getExtensionCodeTabs('payments/use-selected-payment-options'),
       },
     },
+    'customer-privacy/default': {
+      description: '',
+      codeblock: {
+        title: 'Read Customer Privacy',
+        tabs: getExtensionCodeTabs('customer-privacy/default'),
+      },
+    },
+    'customer-privacy/sheet-consent-banner-with-form': {
+      description: `
+You can apply changes to customer consent by using the \`applyTrackingConsentChanges\` API.
+
+> Note: Requires the [\`customer_privacy\` capability](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/configuration#collect-buyer-consent) to be set to \`true\`.`,
+      codeblock: {
+        title: 'Use a Sheet to manage customer privacy consent',
+        tabs: getExtensionCodeTabs(
+          'customer-privacy/sheet-consent-banner-with-form',
+        ),
+      },
+    },
     subscription: {
       description: '',
       codeblock: {

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1763,7 +1763,7 @@ export interface TrackingConsentMetafield {
    */
   key: string;
   /**
-   * The information to be stored as metadata. If the value is `null`, the metafield will be deleted.
+   * The information to be stored as metadata.
    *
    * @example 'any string', '', or a stringified JSON object
    */


### PR DESCRIPTION
### Background

This PR introduces examples for the Customer Privacy API, adds the `useCustomerPrivacy` hook, and optimizes the `Sheet` component examples.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

[Sheet examples](https://shopify-dev.rc-package-patches.rick-caplan.us.spin.dev/docs/api/checkout-ui-extensions/unstable/components/overlays/sheet#examples)

[Customer Privacy API examples](https://shopify-dev.rc-package-patches.rick-caplan.us.spin.dev/docs/api/checkout-ui-extensions/unstable/apis/customer-privacy#examples)

[useCustomerPrivacy hook](https://shopify-dev.rc-package-patches.rick-caplan.us.spin.dev/docs/api/checkout-ui-extensions/unstable/apis/customer-privacy#useCustomerPrivacy)

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
