### PR TITLE
updated list component docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/List.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/List.doc.ts
@@ -15,6 +15,36 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Components',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'guidelines',
+      title: 'Guidelines',
+      sectionContent: `
+List items have a wide variety of use cases:
+
+- To display and link to an object | Examples: an item in the cart, a customer in the customer list
+- To display information | Examples: the payment breakdown in an order, staff contact information
+- To display a menu item | Examples: an item on the first page of settings, an item in “More actions”
+- To display a setting
+- To display an action related to other items in the section
+- To show a selectable option | Example: one filter option
+- To display an external link
+    `,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'content-guidelines',
+      title: 'Content Guidelines',
+      sectionContent: `
+Subtitles:
+
+- Each subtitle should have a different piece of information. Don't use dashes to display more than one type of information on the same line.
+- Subtitles should be shown in order of relevance.
+- If you're showing the results of the form, the label should be the form field title and the subtitle should be the information the merchant entered.
+    `,
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.ts
@@ -10,8 +10,19 @@ export type BadgeVariant =
 export type BadgeStatus = 'empty' | 'partial' | 'complete';
 
 export interface BadgeProps {
+  /**
+   * The text displayed inside the badge.
+   */
   text: string;
+
+  /**
+   * The appearance and function of the badge.
+   */
   variant: BadgeVariant;
+
+  /**
+   * A circle icon on the badge.
+   */
   status?: BadgeStatus;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/List/List.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/List/List.ts
@@ -3,12 +3,26 @@ import {BadgeProps} from '../Badge/Badge';
 import {ColorType} from '../Text/Text';
 
 export interface ToggleSwitch {
+  /**
+   * Whether or not the toggle switch is on or off.
+   */
   value?: boolean;
+
+  /**
+   * Whether or not the toggle switch is disabled.
+   */
   disabled?: boolean;
 }
 
 export interface SubtitleType {
+  /**
+   * The subtitles to display beneath the main label.
+   */
   content: string;
+
+  /**
+   * Property used to modify the subtitle appearance.
+   */
   color?: ColorType;
 }
 
@@ -23,7 +37,7 @@ export interface ListRowLeftSide {
    * The subtitles to display beneath the main label. Up to 3 subtitles can be displayed.
    * Subtitles can optionally be configured with colors by passing an object with a `content` and `color` properties.
    */
-  subtitle?: readonly [ListRowSubtitle, ListRowSubtitle?, ListRowSubtitle?];
+  subtitle?: [ListRowSubtitle, ListRowSubtitle?, ListRowSubtitle?];
   /**
    * @deprecated
    * badge will be removed in version 2.0.0 in favor of badges.
@@ -87,7 +101,7 @@ export interface ListProps {
    */
   title?: string;
   /**
-   * A header component for the list
+   * A header component for the list.
    */
   listHeaderComponent?: RemoteFragment;
   /**


### PR DESCRIPTION
closes https://github.com/Shopify/pos-next-react-native/issues/36295
### Background

- Updates List component docs primarily nested props like `BadgeProps`, `SubtitleType`, and `Badge(s)`.

https://github.com/Shopify/ui-extensions/assets/81783308/8946d23a-a11f-4635-afcd-4e72f3037b5c

### Solution

- Edited `List.ts` and `Badge.ts` to add descriptions to referenced Props.
- Added subsections with generic sections to the page for Guidelines and ContentGuidelines sections.
### 🎩

- Visit [THIS SPINSTANCE](https://shopify-dev.ui-extensions-90tx.marco-yip.us.spin.dev/docs/api/pos-ui-extensions/unstable/components/list)
- Compare it with the [old docs](https://shopify.dev/docs/api/pos-extensions/ui-extensions-reference/components/list).
- Read through the List component docs, ensuring you click through the sub-props that are commonly nested within the main props like `data`.
- Take note of formatting and layout.
- Anything else that is expected for component docs.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
