### PR TITLE
Add metafields to `PickupLocationOption`

### DIFF
--- a/.changeset/lovely-pots-scream.md
+++ b/.changeset/lovely-pots-scream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add metafields to PickupLocationOption

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1648,6 +1648,11 @@ export interface PickupLocationOption extends DeliveryOptionBase {
    * The location details of the pickup location.
    */
   location: PickupLocation;
+
+  /**
+   * The metafields associated with this delivery option.
+   */
+  metafields?: Metafield[];
 }
 
 interface PickupLocation {


### PR DESCRIPTION
### Background

Metafields were added to `PickupLocationOption`.

### Solution

Adds types for metafields in `PickupLocationOption`.

### 🎩

https://shopify-dev.checkout-web-api-docs-53fq.alessandro-dalgrande.us.spin.dev/docs/api/checkout-ui-extensions/unstable/apis/delivery

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
