### PR TITLE
Add staticPage for pos-ui-extensions migration

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/code-changes.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/code-changes.ts
@@ -1,0 +1,28 @@
+// Before
+import {extend, Tile} from '@shopify/retail-ui-extensions';
+
+extend('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My app',
+    subtitle: 'SmartGrid Extension',
+    onPress: () => api.smartGrid.presentModal(),
+    enabled: true,
+  });
+
+  root.append(tile);
+  root.mount();
+});
+
+// After
+import {extension, Tile} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My app',
+    subtitle: 'SmartGrid Extension',
+    onPress: () => api.action.presentModal(),
+    enabled: true,
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/code-changes.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/code-changes.tsx
@@ -1,0 +1,39 @@
+// Before
+import React from 'react'
+import { Tile, useApi, render } from '@shopify/retail-ui-extensions-react'
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>()
+  return (
+    <Tile
+      title="My app"
+      subtitle="SmartGrid Extension"
+      onPress={() => {
+        api.smartGrid.presentModal()
+      }}
+      enabled
+    />
+  )
+}
+
+render('pos.home.tile.render', () => <SmartGridTile />)
+
+// After
+import React from 'react'
+import { Tile, useApi, reactExtension } from '@shopify/ui-extensions-react/point-of-sale'
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>()
+  return (
+    <Tile
+      title="My app"
+      subtitle="SmartGrid Extension"
+      onPress={() => {
+        api.action.presentModal()
+      }}
+      enabled
+    />
+  )
+}
+
+export default reactExtension('pos.home.tile.render', () => <SmartGridTile />)

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.npm.bash
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.npm.bash
@@ -1,0 +1,10 @@
+# 1. Remove the old packages
+npm uninstall @shopify/retail-ui-extensions*
+
+# 2. Upgrade React
+npm update react@^18.2.0
+npm update @types/react@^18.2.0
+
+# 3. Install the new packages
+npm install @shopify/ui-extensions@2024.4
+npm install @shopify/ui-extensions-react@2024.4

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.yarn.bash
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.yarn.bash
@@ -1,0 +1,10 @@
+# 1. Remove the old packages
+yarn remove @shopify/retail-ui-extensions*
+
+# 2. Upgrade React
+yarn upgrade react@^18.2.0
+yarn upgrade @types/react@^18.2.0
+
+# 3. Install the new packages
+yarn add @shopify/ui-extensions@2024.4
+yarn add @shopify/ui-extensions-react@2024.4

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/shopify.extension.toml
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/shopify.extension.toml
@@ -1,0 +1,15 @@
+api_version = "2024-04"
+
+[[extensions]]
+type = "ui_extension"
+name = "my-tutorial-extension"
+handle = "my-tutorial-extension"
+description = "Tutorial extension!"
+
+[[extensions.targeting]]
+module = "./src/Tile.tsx"
+target = "pos.home.tile.render"
+
+[[extensions.targeting]]
+module = "./src/Modal.tsx"
+target = "pos.home.modal.render"

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/migrating.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/migrating.doc.ts
@@ -1,0 +1,100 @@
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../../reference/helpers/generateCodeBlock';
+
+const examplePath = '../examples/migrating';
+
+const data: LandingTemplateSchema = {
+  title: 'Migrating',
+  description:
+    'Migrate your POS UI Extension to use the latest unified ui-extension package.',
+  id: 'migrating',
+  image: '/assets/landing-pages/templated-apis/hero.png',
+  darkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  tabletImage: '/assets/landing-pages/templated-apis/hero.png',
+  tabletDarkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  mobileImage: '/assets/landing-pages/templated-apis/hero.png',
+  mobileDarkImage: '/assets/landing-pages/templated-apis/hero-dark.png',
+  sections: [
+    {
+      type: 'Generic',
+      anchorLink: 'overview',
+      title: 'Overview',
+      sectionContent: `
+POS UI Extensions are moving to the newer \`@shopify/ui-extensions\` package, shared with [Checkout UI Extensions](https://shopify.dev/docs/api/checkout-ui-extensions) and [Admin UI Extensions](https://shopify.dev/docs/api/admin-extensions). This will allow your extensions to use the same package regardless of the surface they extend, and for a single extension to implement multiple targets across different surfaces of Shopify more easily.
+
+\`@shopify/retail-ui-extensions\` and \`@shopify/retail-ui-extensions-react\` are deprecated. They are now maintained as part of \`@shopify/ui-extensions\` and \`@shopify/ui-extensions-react\`. This guide explains how to migrate from the old packages to the new ones.
+
+Aside from these migration steps, \`@shopify/ui-extensions@2024.4\` is backwards compatible with \`@shopify/retail-ui-extensions@1.7.0\`.
+      `,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'setup',
+      title: 'Setup',
+      codeblock: {
+        title: 'Setup',
+        tabs: [
+          {
+            title: 'yarn',
+            code: `${examplePath}/setup.yarn.bash`,
+            language: 'bash',
+          },
+          {
+            title: 'npm',
+            code: `${examplePath}/setup.npm.bash`,
+            language: 'bash',
+          },
+        ],
+      },
+      sectionContent: `
+1. Navigate to your \`package.json\` in the directory of your UI Extension. You'll need to remove \`@shopify/retail-ui-extensions\` or \`@shopify/retail-ui-extensions-react\` (whichever you're using).
+2. If you use React, replace your version of \`react\` and \`@types/react\` (if you use typescript) with version 18 and up. \`@shopify/ui-extensions-react\` does not support any version prior to React 18.
+3. Next you'll need to add the new dependencies, \`@shopify/ui-extensions\` or \`@shopify/ui-extensions-react\`. Currently we support \`2024.4\`. If you are using the \`@shopify/ui-extensions-react\` package, you will also need to install \`@shopify/ui-extensions\`.
+      `,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'code-changes',
+      title: 'Code changes',
+      codeblock: generateCodeBlock('Code changes', 'migrating', 'code-changes'),
+      sectionContent: `
+1. Replace imports from \`@shopify/retail-ui-extensions\` with \`@shopify/ui-extensions/point-of-sale\`. Replace imports from \`@shopify/retail-ui-extensions-react\` with \`@shopify/ui-extensions-react/point-of-sale\`.
+2. Replace calls to \`extend\` with \`extension\` and replace calls to \`render\` with \`reactExtension\`. Move each call to \`extension\` and \`reactExtension\` to individual files, and export them with an \`export default\` statement.
+     `,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'configuration',
+      title: 'Configuration',
+      codeblock: {
+        tabs: [
+          {
+            title: 'shopify.extension.toml',
+            code: `${examplePath}/shopify.extension.toml`,
+            language: 'toml',
+          },
+        ],
+        title: 'Configuration',
+      },
+      sectionContent: `
+Migrate your \`shopify.extension.toml\` file to reflect the [new syntax](https://shopify.dev/docs/apps/structure/app-extensions/configuration#how-it-works).
+- Specify which \`api_version\` you are using at the top of the file (above \`[[extensions]]\`). This will let POS know which version of the \`ui-extensions\` package you're using.
+
+> Note:
+> \`api_version\` needs to be declared in a \`yyyy-mm\` format. If you are using \`@shopify/ui-extensions\` version \`2024.4\` for example, you must declare your \`api_version\` as 2024-04. The patch is irrelevant to \`api_version\`.
+
+- Declare each extension target and file path in \`shopify.extension.toml\`
+      `,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'validation',
+      title: 'Validation',
+      sectionContent: `
+Validate your migration by running \`yarn dev\` or \`npm run dev\`
+`,
+    },
+  ],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -18,7 +18,7 @@ const data: LandingTemplateSchema = {
       title: '1.7.0',
       sectionNotice: [
         {
-          sectionContent: `This is the final version using the \`retail-ui-extensions(-react)\` package. Please see the migration guide for more information.`,
+          sectionContent: `This is the final version using the \`retail-ui-extensions(-react)\` package. Please see the [migration guide](/docs/api/pos-ui-extensions/migrating) for more information.`,
           title: 'Note',
           type: 'Info',
         },


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/pos-next-react-native/issues/36822

### Solution

This adds the migration guide that was hiding in the beta pages.

### 🎩

Old: https://shopify.dev/beta/pos-extension-migration
New: https://shopify-dev.ui-extensions-70k7.nathan-oliveira.us.spin.dev/docs/api/pos-ui-extensions/unstable/migrating

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
