### PR TITLE
Finish links to other pages on pos overview page

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/pos-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/pos-overview.doc.ts
@@ -4,7 +4,7 @@ const data: LandingTemplateSchema = {
   title: 'POS UI extensions',
   description: `The UI Extensions library enables individuals to build extensions that use interface elements and behaviors that mirror the look and feel of the POS retail experience. These elements render natively, providing the performance and accessibility inherent to a native app. POS UI extensions are available for the smart grid.
   > Tip:
-  > Shopify constantly works on adding new features to POS UI extensions. You can visit the [changelog](/docs/api/pos-extensions/ui-extensions-reference/versions) to make sure you're using the latest version of POS UI extensions.
+  > Shopify constantly works on adding new features to POS UI extensions. You can visit the [changelog](/docs/api/pos-ui-extensions/versions) to make sure you're using the latest version of POS UI extensions.
   `,
   id: 'pos-ui-extensions',
   image: '/assets/landing-pages/templated-apis/hero.png',
@@ -22,27 +22,21 @@ const data: LandingTemplateSchema = {
       sectionCard: [
         {
           subtitle: 'Extension targets',
-          name: 'View all available extension targets',
+          name: 'See all available extension targets',
           url: '/docs/api/pos-ui-extensions/targets',
           type: 'pickaxe-1',
         },
         {
           subtitle: 'APIs',
-          name: 'See all accessible APIs',
-          url: '/docs/api/admin-extensions/components',
+          name: 'See all available APIs',
+          url: '/docs/api/pos-ui-extensions/apis',
           type: 'pickaxe-2',
         },
         {
           subtitle: 'Components',
-          name: 'Explore all available components',
-          url: '/docs/api/admin-extensions/api/extension-targets',
+          name: 'See all available components',
+          url: '/docs/api/pos-ui-extensions/components',
           type: 'blocks',
-        },
-        {
-          subtitle: 'Figma UI Kit',
-          name: 'Use the Figma UI kit to design your extension.',
-          url: '/apps/checkout/checkout-ux-guidelines',
-          type: 'star',
         },
       ],
     },
@@ -57,6 +51,12 @@ const data: LandingTemplateSchema = {
           subtitle: 'Set up your development environment',
           url: '/docs/api/pos-ui-extensions/getting-started',
           type: 'blocks',
+        },
+        {
+          subtitle: 'Figma UI Kit',
+          name: 'Use the Figma UI kit to design your extension.',
+          url: 'https://www.figma.com/community/file/1255225508400961281',
+          type: 'star',
         },
       ],
     },


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/pos-next-react-native/issues/36277

### Solution

This updates the placeholder links on the overview page. All links should point to new docs now.

### 🎩

https://shopify-dev.ui-extensions-70k7.nathan-oliveira.us.spin.dev/docs/api/pos-ui-extensions

Click the links and make sure they all go to the right places.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
