### PR TITLE
[Patch 2024-04] Support Address Autocomplete Extension Targets

### DIFF
--- a/.changeset/rich-years-smash.md
+++ b/.changeset/rich-years-smash.md
@@ -1,0 +1,8 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Adds support for the following extension targets:
+
+- `purchase.address-autocomplete.suggest`: An extension target that provides address autocomplete suggestions for address forms at checkout. Suggestions are presented to customers for delivery, billing, and pickup point addresses.
+- `purchase.address-autocomplete.format-suggestion`: An extension target that formats the selected address suggestion provided by a `purchase.address-autocomplete.suggest` target. This formatted address is used to auto-populate the fields of the address form.

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.address-autocomplete.format-suggestion/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.address-autocomplete.format-suggestion/default.example.ts
@@ -1,0 +1,33 @@
+import {extension} from '@shopify/ui-extensions/checkout';
+
+export default extension(
+  'purchase.address-autocomplete.format-suggestion',
+  async ({target}) => {
+    // 1. Use the suggestion the buyer selected
+    const {selectedSuggestion} = target;
+
+    // 2. Fetch the address parts to format the address
+    const {
+      address1,
+      address2,
+      city,
+      zip,
+      provinceCode,
+      countryCode,
+    } = await fetch(
+      `https://myapp.com/api/fetch-address?id=${selectedSuggestion.id}`,
+    );
+
+    // 3. Return a formatted address
+    return {
+      formattedAddress: {
+        address1,
+        address2,
+        city,
+        zip,
+        provinceCode,
+        countryCode,
+      },
+    };
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.address-autocomplete.suggest/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.address-autocomplete.suggest/default.example.ts
@@ -1,0 +1,39 @@
+import {extension} from '@shopify/ui-extensions/checkout';
+
+export default extension(
+  'purchase.address-autocomplete.suggest',
+  async ({signal, target}) => {
+    // 1. Use the query term the buyer entered
+    const {field, value} = target;
+
+    // 2. Fetch address suggestions
+    const response = await fetch(
+      `https://myapp.com/api/address-suggestions?query=${value}&field=${field}`,
+      {signal},
+    );
+
+    // 3. Map response data to expected format
+    const {data} = await response.json();
+    const suggestions = data.map((suggestion) => {
+      return {
+        id: suggestion.id,
+        label: suggestion.label,
+        matchedSubstrings:
+          suggestion.matchedSubstrings,
+        formattedAddress: {
+          address1: suggestion.address1,
+          address2: suggestion.address2,
+          city: suggestion.city,
+          zip: suggestion.zip,
+          provinceCode: suggestion.provinceCode,
+          countryCode: suggestion.countryCode,
+        },
+      };
+    });
+
+    // 4. Return up to five address suggestions
+    return {
+      suggestions: suggestions.slice(0, 5),
+    };
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
@@ -98,6 +98,8 @@ export function getExamples(
     ...createExample(
       'customer-account.order-status.customer-information.render-after/default',
     ),
+    ...createExample('purchase.address-autocomplete.suggest/default'),
+    ...createExample('purchase.address-autocomplete.format-suggestion/default'),
     ...createExample('purchase.cart-line-item.line-components.render/default'),
     ...createExample('purchase.checkout.actions.render-before/default'),
     ...createExample('purchase.checkout.block.render/default'),
@@ -548,7 +550,7 @@ const links: Record<string, LinkType[]> = {
 /**
  * Returns an array of `LinkType` that can be used as related links on an entity.
  * This uses a tag structure to allow you to group links together.
- * You can optinally exclude a specific type of link from the results
+ * You can optionally exclude a specific type of link from the results
  */
 export function getLinksByTag(
   name: string,
@@ -614,6 +616,41 @@ const CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION = {
   description:
     'The base API object provided to this and other `customer-account` extension targets.',
   type: 'CustomerAccountStandardApi',
+};
+
+const ADDRESS_AUTOCOMPLETE_STANDARD_API_DEFINITION = {
+  title: 'AddressAutocompleteStandardApi',
+  description:
+    'The base API object provided to this and other `purchase.address-autocomplete` extension targets.',
+  type: 'AddressAutocompleteStandardApi',
+};
+
+const ADDRESS_AUTOCOMPLETE_SUGGEST_API_DEFINITION = {
+  title: 'AddressAutocompleteSuggestApi',
+  description:
+    'The API object provided to the `purchase.address-autocomplete.suggest` extension target.',
+  type: 'AddressAutocompleteSuggestApi',
+};
+
+const ADDRESS_AUTOCOMPLETE_SUGGEST_OUTPUT_DEFINITION = {
+  title: 'AddressAutocompleteSuggestOutput',
+  description:
+    'The object expected to be returned by the `purchase.address-autocomplete.suggest` extension target.',
+  type: 'AddressAutocompleteSuggestOutput',
+};
+
+const ADDRESS_AUTOCOMPLETE_FORMAT_SUGGESTION_API_DEFINITION = {
+  title: 'AddressAutocompleteFormatSuggestionApi',
+  description:
+    'The API object provided to the `purchase.address-autocomplete.format-suggestion` extension target.',
+  type: 'AddressAutocompleteFormatSuggestionApi',
+};
+
+const ADDRESS_AUTOCOMPLETE_FORMAT_SUGGESTION_OUTPUT_DEFINITION = {
+  title: 'AddressAutocompleteFormatSuggestionOutput',
+  description:
+    'The object expected to be returned by the `purchase.address-autocomplete.format-suggestion` extension target.',
+  type: 'AddressAutocompleteFormatSuggestionOutput',
 };
 
 const CART_LINE_ITEM_API_DEFINITION = {
@@ -686,6 +723,24 @@ export const STANDARD_API = {
 
 export const CHECKOUT_API = {
   definitions: [CHECKOUT_API_DEFINITION, STANDARD_API_DEFINITION],
+  ...COMMON_API,
+};
+
+export const ADDRESS_AUTOCOMPLETE_SUGGEST_API = {
+  definitions: [
+    ADDRESS_AUTOCOMPLETE_SUGGEST_API_DEFINITION,
+    ADDRESS_AUTOCOMPLETE_SUGGEST_OUTPUT_DEFINITION,
+    ADDRESS_AUTOCOMPLETE_STANDARD_API_DEFINITION,
+  ],
+  ...COMMON_API,
+};
+
+export const ADDRESS_AUTOCOMPLETE_FORMAT_SUGGESTION_API = {
+  definitions: [
+    ADDRESS_AUTOCOMPLETE_FORMAT_SUGGESTION_API_DEFINITION,
+    ADDRESS_AUTOCOMPLETE_FORMAT_SUGGESTION_OUTPUT_DEFINITION,
+    ADDRESS_AUTOCOMPLETE_STANDARD_API_DEFINITION,
+  ],
   ...COMMON_API,
 };
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.address-autocomplete.format-suggestion.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.address-autocomplete.format-suggestion.doc.ts
@@ -1,0 +1,35 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {
+  ADDRESS_AUTOCOMPLETE_FORMAT_SUGGESTION_API,
+  getExample,
+  getLinksByTag,
+} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'purchase.address-autocomplete.format-suggestion',
+  description: `
+  An extension target that formats the selected address suggestion provided by a [\`purchase.address-autocomplete.suggest\`](/docs/api/checkout-ui-extensions/unstable/targets/address/purchase-address-autocomplete-suggest) target. This formatted address is used to auto-populate the fields of the address form.
+
+  It must return a [\`formattedAddress\`](/docs/api/checkout-ui-extensions/unstable/targets/address/purchase-address-autocomplete-format-suggestion#addressautocompleteformatsuggestionoutput-propertydetail-formattedaddress).
+
+  > Caution:
+  > This extension target is only necessary if the corresponding [\`purchase.address-autocomplete.suggest\`](/docs/api/checkout-ui-extensions/unstable/targets/address/purchase-address-autocomplete-suggest) target does not provide a \`formattedAddress\` for the suggestions. If a formatted address is provided with each suggestion, then this target will not be called.
+  >
+  > If the [\`purchase.address-autocomplete.suggest\`](/docs/api/checkout-ui-extensions/unstable/targets/address/purchase-address-autocomplete-suggest) target is not implemented, then this target will not work.
+
+  > Note:
+  > - This target does not support rendering UI components.
+  > - This extension can only be developed as a JavaScript extension using the \`ui-extensions\` library.
+  > - The [app extension configuration](/docs/apps/app-extensions/configuration) \`shopify.extension.toml\` file is shared between this extension target and [\`purchase.address-autocomplete.suggest\`](/docs/api/checkout-ui-extensions/unstable/targets/address/purchase-address-autocomplete-suggest). This includes extension settings specified in the configuration file.
+  `,
+  subCategory: 'Address',
+  defaultExample: getExample(
+    'purchase.address-autocomplete.format-suggestion/default',
+    ['js'],
+  ),
+  related: getLinksByTag('targets', 'Tutorials'),
+  ...ADDRESS_AUTOCOMPLETE_FORMAT_SUGGESTION_API,
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.address-autocomplete.suggest.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.address-autocomplete.suggest.doc.ts
@@ -1,0 +1,33 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {
+  ADDRESS_AUTOCOMPLETE_SUGGEST_API,
+  getExample,
+  getLinksByTag,
+} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'purchase.address-autocomplete.suggest',
+  description: `
+  An extension target that provides address autocomplete suggestions for address forms at checkout. Suggestions are presented to customers for delivery, billing, and pickup point addresses.
+
+  The extension target must return a list of address [\`suggestions\`](/docs/api/checkout-ui-extensions/unstable/targets/address/purchase-address-autocomplete-suggest#addressautocompletesuggestoutput-propertydetail-suggestions).
+
+  If a formatted address is provided with each suggestion, then it will be used to auto-populate the fields in the address form when the customer selects a suggested address.
+
+  Optionally, you can implement the [\`purchase.address-autocomplete.format-suggestion\`](/docs/api/checkout-ui-extensions/unstable/targets/address/purchase-address-autocomplete-format-suggestion) extension target to format an address based on the address suggestion selected by the customer.
+
+  > Note:
+  > - This target does not support rendering UI components.
+  > - This extension can only be developed as a JavaScript extension using the \`ui-extensions\` library.
+  > - The [app extension configuration](/docs/apps/app-extensions/configuration) \`shopify.extension.toml\` file is shared between this extension target and [\`purchase.address-autocomplete.format-suggestion\`](/docs/api/checkout-ui-extensions/unstable/targets/address/purchase-address-autocomplete-format-suggestion). This includes extension settings specified in the configuration file.
+  `,
+  subCategory: 'Address',
+  defaultExample: getExample('purchase.address-autocomplete.suggest/default', [
+    'js',
+  ]),
+  related: getLinksByTag('targets', 'Tutorials'),
+  ...ADDRESS_AUTOCOMPLETE_SUGGEST_API,
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout.ts
@@ -143,9 +143,22 @@ export type {PickupLocationItemApi} from './checkout/api/pickup/pickup-location-
 export type {ShippingOptionItemApi} from './checkout/api/shipping/shipping-option-item';
 export type {ShippingOptionListApi} from './checkout/api/shipping/shipping-option-list';
 export type {
-  AddressAutocompleteSuggestion,
+  AddressAutocompleteFormatSuggestionApi,
+  AddressAutocompleteFormatSuggestionOutput,
+} from './checkout/api/address-autocomplete/format-suggestion';
+
+export type {
   AddressAutocompleteSuggestApi,
-} from './checkout/api/address-autocomplete/address-autocomplete';
+  AddressAutocompleteSuggestOutput,
+} from './checkout/api/address-autocomplete/suggest';
+
+export type {
+  AddressAutocompleteSuggestion,
+  MatchedSubstring,
+  AutocompleteAddress,
+} from './checkout/api/address-autocomplete/shared';
+
+export type {AddressAutocompleteStandardApi} from './checkout/api/address-autocomplete/standard';
 
 export type {
   PaymentMethodAttributesResult,

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts
@@ -1,0 +1,24 @@
+import type {
+  AddressAutocompleteSuggestion,
+  AutocompleteAddress,
+} from './shared';
+
+export interface AddressAutocompleteFormatSuggestionApi {
+  /**
+   * The autocomplete suggestion that the buyer selected during checkout.
+   *
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   */
+  target: Target;
+}
+
+interface Target {
+  selectedSuggestion: AddressAutocompleteSuggestion;
+}
+
+export interface AddressAutocompleteFormatSuggestionOutput {
+  /**
+   * The formatted address that will be used to populate the native address fields.
+   */
+  formattedAddress: AutocompleteAddress;
+}

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/shared.ts
@@ -1,0 +1,59 @@
+import type {MailingAddress} from '../../../checkout';
+
+/**
+ * A partial mailing address with only fields relevant to address autocomplete.
+ * All fields are optional
+ */
+export interface AutocompleteAddress
+  extends Pick<
+    MailingAddress,
+    'address1' | 'address2' | 'city' | 'provinceCode' | 'zip' | 'countryCode'
+  > {}
+
+export interface AddressAutocompleteSuggestion {
+  /**
+   * The address suggestion text presented to the buyer in the list of autocomplete suggestions.
+   *
+   * This text is shown to the buyer as-is. No attempts will be made to parse it.
+   *
+   * @example "123 Main St, Toronto, ON, CA"
+   */
+  label: string;
+
+  /**
+   * A textual identifier that uniquely identifies an autocomplete suggestion
+   * or address. This identifier may be used to search for a formatted address.
+   *
+   * @example "35ef8d55-dceb-4ed8-847b-2f2fc7472f14"
+   */
+  id?: string;
+
+  /**
+   * A list of substrings that matched the original search query.
+   *
+   * If `matchedSubstrings` are provided, then they will be used to highlight the substrings
+   * of the suggestions that matched the original search query.
+   *
+   * @example [{offset: 0, length: 4}]
+   */
+  matchedSubstrings?: MatchedSubstring[];
+
+  /**
+   * The formatted address that will auto-fill the remaining address fields.
+   *
+   * If this value is returned for every suggestion, then the
+   * `purchase.address-autocomplete.format-suggestion` extension target is not needed.
+   */
+  formattedAddress?: AutocompleteAddress;
+}
+
+export interface MatchedSubstring {
+  /**
+   * The start location of the matched substring in the suggestion label text.
+   */
+  offset: number;
+  /**
+   * The length of the matched substring in the suggestion label text.
+   */
+  length: number;
+}

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
@@ -1,0 +1,289 @@
+import type {
+  Analytics,
+  AppMetafieldEntry,
+  Capability,
+  CheckoutToken,
+  Country,
+  Currency,
+  Editor,
+  ExtensionSettings,
+  I18n,
+  Language,
+  Market,
+  Metafield,
+  SessionToken,
+  Shop,
+  Storage,
+  Version,
+} from '../standard/standard';
+import type {Attribute, MailingAddress} from '../shared';
+import type {
+  ApiVersion,
+  GraphQLError,
+  StorefrontApiVersion,
+  Timezone,
+} from '../../../../shared';
+
+export interface AddressAutocompleteStandardApi<
+  Target extends
+    | 'purchase.address-autocomplete.suggest'
+    | 'purchase.address-autocomplete.format-suggestion',
+> {
+  /**
+   * The metafields requested in the
+   * [`shopify.extension.toml`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration)
+   * file. These metafields are updated when there's a change in the merchandise items
+   * being purchased by the customer.
+   *
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   *
+   * > Tip:
+   * > Cart metafields are only available on carts created via the Storefront API version `2023-04` or later.*
+   */
+  appMetafields: AppMetafieldEntry[];
+
+  /**
+   * The methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
+   */
+  analytics: Analytics;
+
+  /**
+   * The custom attributes left by the customer to the merchant, either in their cart or during checkout.
+   */
+  attributes: Attribute[] | undefined;
+
+  /**
+   * The proposed customer billing address. The address updates when the field is
+   * committed (on change) rather than every keystroke.
+   *
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   */
+  billingAddress?: MailingAddress | undefined;
+
+  /**
+   * A stable ID that represents the current checkout.
+   *
+   * Matches the `token` field in the [WebPixel checkout payload](https://shopify.dev/docs/api/pixels/customer-events#checkout)
+   * and the `checkout_token` field in the [REST Admin API `Order` resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object).
+   */
+  checkoutToken: CheckoutToken | undefined;
+
+  /**
+   * The meta information about the extension.
+   */
+  extension: Extension<Target>;
+
+  /**
+   * Utilities for translating content and formatting values according to the current
+   * [`localization`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization)
+   * Type 'RunnableExtensionInstance<keyof RunnableExtensionTargets>' is not assignable to type 'ExtensionInstance<Target>'.
+   *
+   * Refer to [`localization` examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#examples)
+   * for more information.
+   */
+  i18n: I18n;
+
+  /**
+   * The details about the location, language, and currency of the customer. For utilities to easily
+   * format and translate content based on these details, you can use the
+   * [`i18n`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-i18n)
+   * object instead.
+   */
+  localization: Localization;
+
+  /**
+   * The metafields that apply to the current checkout.
+   *
+   * Metafields are stored locally on the client and are applied to the order object after the checkout completes.
+   * They are shared by all extensions running on checkout, and
+   * persist for as long as the customer is working on this checkout.
+   *
+   * Once the order is created, you can query these metafields using the
+   * [GraphQL Admin API](https://shopify.dev/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)
+   */
+  metafields: Metafield[];
+
+  /**
+   * The method used to query the Storefront GraphQL API with a prefetched token.
+   *
+   * Refer to [Storefront API access examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/storefront-api) for more information.
+   */
+  query: <Data = unknown, Variables = Record<string, unknown>>(
+    query: string,
+    options?: {variables?: Variables; version?: StorefrontApiVersion},
+  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;
+
+  /**
+   * The session token providing a set of claims as a signed JSON Web Token (JWT).
+   *
+   * The token has a TTL of 5 minutes.
+   *
+   * If the previous token expires, this value will reflect a new session token with a new signature and expiry.
+   *
+   * Refer to [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/session-token) for more information.
+   */
+  sessionToken: SessionToken;
+
+  /**
+   * The settings matching the settings definition written in the
+   * [`shopify.extension.toml`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration) file.
+   *
+   *  Refer to [settings examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.
+   *
+   * > Note: The settings are empty when an extension is being installed in the [checkout editor](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-editor).
+
+   */
+  settings: ExtensionSettings;
+
+  /**
+   * The proposed customer shipping address. During the information step,
+   * the address updates when the field is committed (on change) rather than every keystroke.
+   *
+   * > Note: An address value is only present if delivery is required. Otherwise, the subscribable value is undefined.
+   *
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   */
+  shippingAddress?: MailingAddress | undefined;
+
+  /** The shop where the checkout is taking place. */
+  shop: Shop;
+
+  /**
+   * The key-value storage for the extension.
+   *
+   * It uses `localStorage` and should persist across the customer's current checkout session.
+   *
+   * > Caution: Data persistence isn't guaranteed and storage is reset when the customer starts a new checkout.
+   *
+   * Data is shared across all activated extension targets of this extension. In versions 2023-07 and earlier,
+   * each activated extension target had its own storage.
+   */
+  storage: Storage;
+
+  /**
+   * The runner version being used for the extension.
+   *
+   * @example 'unstable'
+   */
+  version: Version;
+}
+
+interface Extension<
+  Target extends
+    | 'purchase.address-autocomplete.suggest'
+    | 'purchase.address-autocomplete.format-suggestion',
+> {
+  /**
+   * The API version that was set in the extension config file.
+   *
+   * @example '2023-07', '2023-10', '2024-01', '2024-04', 'unstable'
+   */
+  apiVersion: ApiVersion;
+
+  /**
+   * The allowed capabilities of the extension, defined
+   * in your [shopify.extension.toml](https://shopify.dev/docs/api/checkout-ui-extensions/configuration) file.
+   *
+   * * [`api_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.
+   *
+   * * [`network_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.
+   *
+   * * [`block_progress`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a customer's progress and the merchant has allowed this blocking behavior.
+   *
+   * * [`collect_buyer_consent.sms_marketing`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.
+   *
+   * * [`collect_buyer_consent.customer_privacy`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that will be honored on Shopify-managed services.
+   */
+  capabilities: Capability[];
+
+  /**
+   * The information about the editor where the extension is being rendered.
+   *
+   * If the value is undefined, then the extension is not running in an editor.
+   */
+  editor?: Editor;
+
+  /**
+   * A Boolean to show whether your extension is currently rendered to the screen.
+   *
+   * Shopify might render your extension before it's visible in the UI,
+   * typically to pre-render extensions that will appear on a later step of the
+   * checkout.
+   *
+   * Your extension might also continue to run after the customer has navigated away
+   * from where it was rendered. The extension continues running so that
+   * your extension is immediately available to render if the customer navigates back.
+   *
+   * If the extension is not capable of rendering UI components, then the value will always be false.
+   */
+  rendered: boolean;
+
+  /**
+   * The URL to the script that started the extension target.
+   */
+  scriptUrl: string;
+  /**
+   * The identifier that specifies where in Shopify’s UI your code is being
+   * injected. This will be one of the targets you have included in your
+   * extension’s configuration file.
+   *
+   * @example 'purchase.checkout.block.render'
+   * @see https://shopify.dev/docs/api/checkout-ui-extensions/unstable/extension-targets-overview
+   * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
+   */
+  target: Target;
+
+  /**
+   * The published version of the running extension target.
+   *
+   * For unpublished extensions, the value is `undefined`.
+   *
+   * @example 3.0.10
+   */
+  version?: string;
+}
+
+interface Localization {
+  /**
+   * The currency that the customer sees for money amounts in the checkout.
+   */
+  currency: Currency;
+
+  /**
+   * The buyer’s time zone.
+   */
+  timezone: Timezone;
+
+  /**
+   * The language the customer sees in the checkout.
+   */
+  language: Language;
+
+  /**
+   * This is the customer's language, as supported by the extension.
+   * If the customer's actual language is not supported by the extension,
+   * then this is the language that is used for translations.
+   *
+   * For example, if the customer's language is 'fr-CA' but your extension
+   * only supports translations for 'fr', then the `isoCode` for this
+   * language is 'fr'. If your extension does not provide french
+   * translations at all, then this value is the default locale for your
+   * extension (that is, the one matching your .default.json file).
+   */
+  extensionLanguage: Language;
+
+  /**
+   * The country context of the checkout. This value carries over from the
+   * context of the cart, where it was used to contextualize the storefront
+   * experience. If the country is unknown, then the value is undefined.
+   */
+  country: Country | undefined;
+
+  /**
+   * The [market](https://shopify.dev/docs/apps/markets) context of the
+   * checkout. This value carries over from the context of the cart, where it
+   * was used to contextualize the storefront experience. If the market is unknown,
+   * then the value is undefined.
+   */
+  market: Market | undefined;
+}

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
@@ -1,0 +1,61 @@
+import type {CountryCode} from '../../../checkout';
+
+import type {AddressAutocompleteSuggestion} from './shared';
+
+export interface AddressAutocompleteSuggestApi {
+  /**
+   * The signal that the extension should listen to for cancellation requests.
+   *
+   * If the signal is aborted, the extension should cancel any ongoing requests.
+   * The signal will be aborted either when the buyer navigates away from the
+   * address field or when the debounced query value changes.
+   *
+   * Pass this signal to any asynchronous operations that need to be cancelled,
+   * like `fetch`.
+   */
+  signal: AbortSignal;
+
+  /**
+   * The current state of the address form that the buyer is interacting with.
+   *
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   */
+  target: Target;
+}
+
+interface Target {
+  /**
+   * The current value of the `field` the buyer is interacting with.
+   *
+   * @example "123 M"
+   */
+  value: string;
+
+  /**
+   * The `MailingAddress` field that the buyer is interacting with.
+   *
+   * This field can either be `address1` or `zip` depending on the country
+   * selected by the buyer during checkout.
+   *
+   * @example "address1"
+   */
+  field: 'address1' | 'zip';
+
+  /**
+   * The `countryCode` selected in the address form that the buyer is interacting with.
+   *
+   * This code is in ISO 3166 Alpha-2 format representing the buyer's country. Refer to https://www.iso.org/iso-3166-country-codes.html.
+   *
+   * @example 'CA' for Canada.
+   */
+  selectedCountryCode?: CountryCode;
+}
+
+export interface AddressAutocompleteSuggestOutput {
+  /**
+   * An array of address autocomplete suggestions to show to the buyer.
+   *
+   * > Note: Only the first five suggestions will be displayed to the buyer.
+   */
+  suggestions: AddressAutocompleteSuggestion[];
+}

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -295,7 +295,7 @@ export interface GiftCardRemoveChange {
   type: 'removeGiftCard';
 
   /**
-   * Gift card code.
+   * The full gift card code, or the last four digits of the code.
    */
   code: string;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -72,7 +72,7 @@ export type Capability =
   | 'collect_buyer_consent.customer_privacy';
 
 /**
- * Meta information about an extension target.
+ * The meta information about an extension target.
  */
 export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
   /**
@@ -90,31 +90,31 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * * [`network_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.
    *
-   * * [`block_progress`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a buyer's progress and the merchant has allowed this blocking behavior.
+   * * [`block_progress`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a customer's progress and the merchant has allowed this blocking behavior.
    *
-   * * [`collect_buyer_consent.sms_marketing`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect buyer consent for SMS marketing.
+   * * [`collect_buyer_consent.sms_marketing`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.
    *
-   * * [`collect_buyer_consent.customer_privacy`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register buyer consent decisions that will be honored on Shopify-managed services.
+   * * [`collect_buyer_consent.customer_privacy`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that will be honored on Shopify-managed services.
    */
   capabilities: StatefulRemoteSubscribable<Capability[]>;
 
   /**
    * Information about the editor where the extension is being rendered.
    *
-   * The value is undefined if the extension is not rendering in an editor.
+   * If the value is undefined, then the extension is not running in an editor.
    */
   editor?: Editor;
 
   /**
-   * Whether your extension is currently rendered to the screen.
+   * A Boolean to show whether your extension is currently rendered to the screen.
    *
    * Shopify might render your extension before it's visible in the UI,
    * typically to pre-render extensions that will appear on a later step of the
    * checkout.
    *
-   * Your extension might also continue to run after the buyer has navigated away
+   * Your extension might also continue to run after the customer has navigated away
    * from where it was rendered. The extension continues running so that
-   * your extension is immediately available to render if the buyer navigates back.
+   * your extension is immediately available to render if the customer navigates back.
    */
   rendered: StatefulRemoteSubscribable<boolean>;
 
@@ -368,7 +368,7 @@ export interface Market {
 
 export interface Localization {
   /**
-   * The currency that the buyer sees for money amounts in the checkout.
+   * The currency that the customer sees for money amounts in the checkout.
    */
   currency: StatefulRemoteSubscribable<Currency>;
 
@@ -378,19 +378,19 @@ export interface Localization {
   timezone: StatefulRemoteSubscribable<Timezone>;
 
   /**
-   * The language the buyer sees in the checkout.
+   * The language the customer sees in the checkout.
    */
   language: StatefulRemoteSubscribable<Language>;
 
   /**
-   * This is the buyer's language, as supported by the extension.
-   * If the buyer's actual language is not supported by the extension,
-   * this is the fallback locale used for translations.
+   * This is the customer's language, as supported by the extension.
+   * If the customer's actual language is not supported by the extension,
+   * then this is the language that is used for translations.
    *
-   * For example, if the buyer's language is 'fr-CA' but your extension
+   * For example, if the customer's language is 'fr-CA' but your extension
    * only supports translations for 'fr', then the `isoCode` for this
    * language is 'fr'. If your extension does not provide french
-   * translations at all, this value is the default locale for your
+   * translations at all, then this value is the default locale for your
    * extension (that is, the one matching your .default.json file).
    */
   extensionLanguage: StatefulRemoteSubscribable<Language>;
@@ -399,7 +399,7 @@ export interface Localization {
    * The country context of the checkout. This value carries over from the
    * context of the cart, where it was used to contextualize the storefront
    * experience. It will update if the buyer changes the country of their
-   * shipping address. The value is undefined if unknown.
+   * shipping address. If the country is unknown, then the value is undefined.
    */
   country: StatefulRemoteSubscribable<Country | undefined>;
 
@@ -407,8 +407,8 @@ export interface Localization {
    * The [market](https://shopify.dev/docs/apps/markets) context of the
    * checkout. This value carries over from the context of the cart, where it
    * was used to contextualize the storefront experience. It will update if the
-   * buyer changes the country of their shipping address. The value is undefined
-   * if unknown.
+   * buyer changes the country of their shipping address.  If the market is unknown,
+   * then the value is undefined.
    */
   market: StatefulRemoteSubscribable<Market | undefined>;
 }
@@ -500,7 +500,7 @@ export interface BuyerJourneyStep {
 
 export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
-   * Methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
+   * The methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
    */
   analytics: Analytics;
 
@@ -523,7 +523,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   appMetafields: StatefulRemoteSubscribable<AppMetafieldEntry[]>;
 
   /**
-   * Custom attributes left by the customer to the merchant, either in their cart or during checkout.
+   * The custom attributes left by the customer to the merchant, either in their cart or during checkout.
    */
   attributes: StatefulRemoteSubscribable<Attribute[] | undefined>;
 
@@ -542,7 +542,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * Provides details on the buyer's progression through the checkout.
    *
-   * See [buyer journey](https://shopify.dev/docs/api/checkout-ui-extensions/apis/buyer-journey#examples)
+   * Refer to [buyer journey](https://shopify.dev/docs/api/checkout-ui-extensions/apis/buyer-journey#examples)
    * examples for more information.
    */
   buyerJourney: BuyerJourney;
@@ -553,10 +553,10 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   checkoutSettings: StatefulRemoteSubscribable<CheckoutSettings>;
 
   /**
-   * A stable id that represents the current checkout.
+   * A stable ID that represents the current checkout.
    *
    * Matches the `token` field in the [WebPixel checkout payload](https://shopify.dev/docs/api/pixels/customer-events#checkout)
-   * and the `checkout_token` field in the [Admin REST API Order resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object).
+   * and the `checkout_token` field in the [REST Admin API `Order` resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object).
    */
   checkoutToken: StatefulRemoteSubscribable<CheckoutToken | undefined>;
 
@@ -581,7 +581,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   discountAllocations: StatefulRemoteSubscribable<CartDiscountAllocation[]>;
 
   /**
-   * Meta information about the extension.
+   * The meta information about the extension.
    */
   extension: Extension<Target>;
 
@@ -603,7 +603,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * [`localization`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization)
    * of the checkout.
    *
-   * See [localization examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#examples)
+   * Refer to [`localization` examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#examples)
    * for more information.
    */
   i18n: I18n;
@@ -614,7 +614,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   lines: StatefulRemoteSubscribable<CartLine[]>;
 
   /**
-   * Details about the location, language, and currency of the buyer. For utilities to easily
+   * The details about the location, language, and currency of the customer. For utilities to easily
    * format and translate content based on these details, you can use the
    * [`i18n`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-i18n)
    * object instead.
@@ -640,9 +640,9 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   note: StatefulRemoteSubscribable<string | undefined>;
 
   /**
-   * Used to query the Storefront GraphQL API with a prefetched token.
+   * The method used to query the Storefront GraphQL API with a prefetched token.
    *
-   * See [storefront api access examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/storefront-api) for more information.
+   * Refer to [Storefront API access examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/storefront-api) for more information.
    */
   query: <Data = unknown, Variables = Record<string, unknown>>(
     query: string,
@@ -655,9 +655,13 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   selectedPaymentOptions: StatefulRemoteSubscribable<SelectedPaymentOption[]>;
 
   /**
-   * Provides access to session tokens, which can be used to verify token claims on your app's server.
+   * The session token providing a set of claims as a signed JSON Web Token (JWT).
    *
-   * See [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/session-token) for more information.
+   * The token has a TTL of 5 minutes.
+   *
+   * If the previous token expires, this value will reflect a new session token with a new signature and expiry.
+   *
+   * Refer to [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/session-token) for more information.
    */
   sessionToken: SessionToken;
 
@@ -665,7 +669,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * The settings matching the settings definition written in the
    * [`shopify.extension.toml`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration) file.
    *
-   *  See [settings examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/settings) for more information.
+   *  Refer to [settings examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.
    *
    * > Note: When an extension is being installed in the editor, the settings will be empty until
    * a merchant sets a value. In that case, this object will be updated in real time as a merchant fills in the settings.
@@ -673,7 +677,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   settings: StatefulRemoteSubscribable<ExtensionSettings>;
 
   /**
-   * The proposed buyer shipping address. During the information step, the address
+   * The proposed customer shipping address. During the information step, the address
    * updates when the field is committed (on change) rather than every keystroke.
    * An address value is only present if delivery is required. Otherwise, the
    * subscribable value is undefined.
@@ -683,22 +687,24 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   shippingAddress?: StatefulRemoteSubscribable<MailingAddress | undefined>;
 
   /**
-   * The proposed buyer billing address. The address updates when the field is
+   * The proposed customer billing address. The address updates when the field is
    * committed (on change) rather than every keystroke.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   billingAddress?: StatefulRemoteSubscribable<MailingAddress | undefined>;
 
-  /** Shop where the checkout is taking place. */
+  /** The shop where the checkout is taking place. */
   shop: Shop;
 
   /**
-   * Key-value storage for the extension.
-   * Uses `localStorage` and should persist across the buyer's current checkout session.
-   * However, data persistence isn't guaranteed and storage is reset when the buyer starts a new checkout.
+   * The key-value storage for the extension.
    *
-   * Data is shared across all activated extension targets of this extension. In versions `<=2023-07`,
+   * It uses `localStorage` and should persist across the customer's current checkout session.
+   *
+   * > Caution: Data persistence isn't guaranteed and storage is reset when the customer starts a new checkout.
+   *
+   * Data is shared across all activated extension targets of this extension. In versions 2023-07 and earlier,
    * each activated extension target had its own storage.
    */
   storage: Storage;
@@ -782,7 +788,7 @@ export interface BuyerIdentity {
 }
 
 /**
- * Information about a company that the business customer is purchasing on behalf of.
+ * The information about a company that the business customer is purchasing on behalf of.
  */
 export interface PurchasingCompany {
   /**
@@ -1153,7 +1159,7 @@ export interface SelectedPaymentOption {
   /**
    * The unique handle referencing `PaymentOption.handle`.
    *
-   * See [availablePaymentOptions](https://shopify.dev/docs/api/checkout-ui-extensions/apis/payments#standardapi-propertydetail-availablepaymentoptions).
+   * Refer to [availablePaymentOptions](https://shopify.dev/docs/api/checkout-ui-extensions/apis/payments#standardapi-propertydetail-availablepaymentoptions).
    */
   handle: string;
 }
@@ -1417,7 +1423,7 @@ export interface PaymentTermsTemplate {
    */
   id: string;
   /**
-   * The name of the payment terms translated to the buyer's current language. See [localization.language](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-localization).
+   * The name of the payment terms translated to the buyer's current language. Refer to [localization.language](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-localization).
    */
   name: string;
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -1,6 +1,9 @@
 import type {
-  AddressAutocompleteSuggestion,
   AddressAutocompleteSuggestApi,
+  AddressAutocompleteSuggestOutput,
+  AddressAutocompleteFormatSuggestionApi,
+  AddressAutocompleteFormatSuggestionOutput,
+  AddressAutocompleteStandardApi,
 } from '../checkout';
 
 import type {CartLineItemApi} from './api/cart-line/cart-line-item';
@@ -722,13 +725,32 @@ export interface RenderExtensionTargets {
 
 export interface RunnableExtensionTargets {
   /**
-   * An extension target used to provide address autocomplete suggestions. It does not support rendering UI components.
-   * @private
-   * @experimental
+   * An extension target that provides address autocomplete suggestions. These suggestions are shown to buyers as they
+   * interact with address forms during checkout.
+   *
+   * It must return a list of address suggestions. If a formatted address is provided with each suggestion, it will be
+   * used to auto-populate the fields in the address form when the buyer selects a suggestion.
+   *
+   * This target does not support rendering UI components.
    */
   'purchase.address-autocomplete.suggest': RunnableExtension<
-    AddressAutocompleteSuggestApi,
-    AddressAutocompleteSuggestion[]
+    AddressAutocompleteStandardApi<'purchase.address-autocomplete.suggest'> &
+      AddressAutocompleteSuggestApi,
+    AddressAutocompleteSuggestOutput
+  >;
+  /**
+   * An extension target that formats the selected address suggestion provided by a
+   * `purchase.address-autocomplete.suggest` target. This address is used to auto-populate the fields in the address
+   * form.
+   *
+   * It must return a formatted address.
+   *
+   * This target does not support rendering UI components.
+   */
+  'purchase.address-autocomplete.format-suggestion': RunnableExtension<
+    AddressAutocompleteStandardApi<'purchase.address-autocomplete.format-suggestion'> &
+      AddressAutocompleteFormatSuggestionApi,
+    AddressAutocompleteFormatSuggestionOutput
   >;
 }
 
@@ -762,7 +784,7 @@ export type ArgumentsForExtension<Target extends keyof ExtensionTargets> =
  * For RenderExtensionTargets, this API type is the second argument to
  * the callback for that extension target.
  *
- * For RunnableExtensionTargets, this API type if the only argument to
+ * For RunnableExtensionTargets, this API type is the only argument to
  * the callback for that extension target.
  */
 export type ApiForExtension<Target extends ExtensionTarget> =
@@ -800,14 +822,14 @@ type ExtractedApiFromRenderExtension<T> = T extends RenderExtension<
   : never;
 
 /**
- * Deprecated. Use `ApiForExtensionTarget` instead.
+ * Deprecated. Use `ApiForExtension` instead.
  *
  * For a given rendering extension target, returns the type of the API that the
  * extension will receive at runtime. This API type is the second argument to
  * the callback for that extension target. The first callback for all of the rendering
  * extension targets each receive a `RemoteRoot` object.
  *
- * @deprecated  Use `ApiForExtensionTarget` instead.
+ * @deprecated  Use `ApiForExtension` instead.
  */
 export type ApiForRenderExtension<Target extends keyof RenderExtensions> =
   ExtractedApiFromRenderExtension<RenderExtensions[Target]>;


### PR DESCRIPTION
### Background
We're adding support for Address Autocomplete Extension Targets.
(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution
- Patching 2024-04 to include Address Autocomplete extension targets and APIs.
- Also including doc changes and new examples
(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
