### PR TITLE
updates sheet consent banner with form example

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/sheet-consent-banner-with-form.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/sheet-consent-banner-with-form.example.tsx
@@ -84,7 +84,7 @@ function Extension() {
   };
 
   const consentFormMarkup = (
-    <Form onSubmit={handleConsentChange}>
+    <Form onSubmit={() => handleConsentChange()}>
       <BlockStack>
         <Grid spacing="base">
           <Checkbox


### PR DESCRIPTION
### Background

`handleConsentChange` is called from the accept and reject buttons in addition to the form submission. The form's onSubmit logic was updated in the [JS example](https://github.com/Shopify/checkout-web/blob/main/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/sheet-consent-banner-with-form.example.ts#L158), but the react example was passing the method as the prop, which means it would receive the submit event, but it expects an optional visitor consent object.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

[Customer Privacy API example](https://shopify-dev.checkout-web-api-docs-dmx2.rick-caplan.us.spin.dev/docs/api/checkout-ui-extensions/unstable/apis/customer-privacy#examples)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
