### PR TITLE
Added documentation for Screen and Navigator

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Navigator.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Navigator.doc.ts
@@ -1,4 +1,8 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateCodeBlockForComponent = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'navigator-screen', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Navigator',
@@ -14,6 +18,29 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Components',
   related: [],
+  examples: {
+    description: 'Using a Navigator to navigate between Screens',
+    examples: [
+      {
+        codeblock: generateCodeBlockForComponent(
+          'Navigate to another screen',
+          'navigate',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForComponent(
+          'Navigate to another screen with parameters',
+          'navigate-params',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForComponent(
+          'Navigate to another screen with sheet presentation',
+          'navigate-sheet',
+        ),
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Screen.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Screen.doc.ts
@@ -1,4 +1,8 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateCodeBlockForComponent = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'navigator-screen', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Screen',
@@ -12,9 +16,43 @@ const data: ReferenceEntityTemplateSchema = {
       description: '',
       type: 'ScreenProps',
     },
+    {
+      title: 'ScreenPresentationProps',
+      description: '',
+      type: 'ScreenPresentationProps',
+    },
+    {
+      title: 'SecondaryActionProps',
+      description: '',
+      type: 'SecondaryActionProps',
+    },
   ],
   category: 'Components',
   related: [],
+  examples: {
+    description:
+      'Navigating using NavigationAPI with Screens within Navigators',
+    examples: [
+      {
+        codeblock: generateCodeBlockForComponent(
+          'Navigate to another screen',
+          'navigate',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForComponent(
+          'Navigate to another screen with parameters',
+          'navigate-params',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForComponent(
+          'Navigate to another screen with sheet presentation',
+          'navigate-sheet',
+        ),
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate-params.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate-params.ts
@@ -1,0 +1,41 @@
+import {
+  extension,
+  Screen,
+  Navigator,
+  Text,
+  Button,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const homeScreen = root.createComponent(Screen, {
+    name: 'Home',
+    title: 'Home',
+  });
+
+  const homeText = root.createComponent(Text);
+  homeText.append('Home screen');
+  homeScreen.append(homeText);
+
+  const navigateButton = root.createComponent(Button, {
+    title: 'Navigate to details',
+    onPress: () => api.navigation.navigate('Details', {orderId: '123'}),
+  });
+  homeScreen.append(navigateButton);
+
+  const detailsText = root.createComponent(Text);
+
+  const detailsScreen = root.createComponent(Screen, {
+    name: 'Details',
+    title: 'Details',
+    onReceiveParams: (params) => {
+      detailsText.replaceChildren(`Order ID: ${params.orderId}`);
+    },
+  });
+
+  detailsScreen.append(detailsText);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(homeScreen);
+  navigator.append(detailsScreen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate-params.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate-params.tsx
@@ -1,0 +1,49 @@
+import React, {useState} from 'react';
+
+import {
+  Screen,
+  Text,
+  Navigator,
+  reactExtension,
+  Button,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  return (
+    <Navigator>
+      <HomeScreen />
+      <DetailsScreen />
+    </Navigator>
+  );
+};
+
+const HomeScreen = () => {
+  const api = useApi<'pos.home.modal.render'>();
+  return (
+    <Screen name="Home" title="Home">
+      <Text>Home screen</Text>
+      <Button
+        title="Navigate to details"
+        onPress={() => api.navigation.navigate('Details', {orderId: '123'})}
+      />
+    </Screen>
+  );
+};
+
+const DetailsScreen = () => {
+  const [params, setParams] = useState<pos.home.modal.render>();
+
+  return (
+    <Screen
+      name="Details"
+      title="Details"
+      presentation={{sheet: true}}
+      onReceiveParams={setParams}
+    >
+      <Text>{`Order ID: ${params.orderId}`}</Text>
+    </Screen>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate-sheet.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate-sheet.ts
@@ -1,0 +1,39 @@
+import {
+  extension,
+  Screen,
+  Navigator,
+  Text,
+  Button,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const homeScreen = root.createComponent(Screen, {
+    name: 'Home',
+    title: 'Home',
+  });
+
+  const homeText = root.createComponent(Text);
+  homeText.append('Home screen');
+  homeScreen.append(homeText);
+
+  const navigateButton = root.createComponent(Button, {
+    title: 'Navigate to details',
+    onPress: () => api.navigation.navigate('Details'),
+  });
+  homeScreen.append(navigateButton);
+
+  const detailsScreen = root.createComponent(Screen, {
+    name: 'Details',
+    title: 'Details',
+    presentation: {sheet: true},
+  });
+
+  const detailsText = root.createComponent(Text);
+  detailsText.append('Details screen');
+  detailsScreen.append(detailsText);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(homeScreen);
+  navigator.append(detailsScreen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate-sheet.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate-sheet.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { Screen, Text, Navigator, reactExtension, Button, useApi } from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+
+  return (
+    <Navigator>
+      <Screen name="Home" title="Home">
+        <Text>Home screen</Text>
+        <Button title="Navigate to details" onPress={() => api.navigation.navigate('Details')} />
+      </Screen>
+      <Screen name="Details" title="Details" presentation={{sheet: true}}>
+        <Text>Details screen</Text>
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate.ts
@@ -1,0 +1,38 @@
+import {
+  extension,
+  Screen,
+  Navigator,
+  Text,
+  Button,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const homeScreen = root.createComponent(Screen, {
+    name: 'Home',
+    title: 'Home',
+  });
+
+  const homeText = root.createComponent(Text);
+  homeText.append('Home screen');
+  homeScreen.append(homeText);
+
+  const navigateButton = root.createComponent(Button, {
+    title: 'Navigate to details',
+    onPress: () => api.navigation.navigate('Details'),
+  });
+  homeScreen.append(navigateButton);
+
+  const detailsScreen = root.createComponent(Screen, {
+    name: 'Details',
+    title: 'Details',
+  });
+
+  const detailsText = root.createComponent(Text);
+  detailsText.append('Details screen');
+  detailsScreen.append(detailsText);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(homeScreen);
+  navigator.append(detailsScreen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigator-screen/navigate.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { Screen, Text, Navigator, reactExtension, Button, useApi } from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.home.modal.render'>();
+
+  return (
+    <Navigator>
+      <Screen name="Home" title="Home">
+        <Text>Home screen</Text>
+        <Button title="Navigate to details" onPress={() => api.navigation.navigate('Details')} />
+      </Screen>
+      <Screen name="Details" title="Details">
+        <Text>Details screen</Text>
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Navigator/Navigator.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Navigator/Navigator.ts
@@ -1,9 +1,12 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 /**
- * @property `initialScreenName` sets the initial Screen by its `name` property.
+ * @property `initialScreenName` sets the initial `Screen` whose `name` matches.
  */
 export interface NavigatorProps {
+  /**
+   * Sets the initial `Screen` whose `name` matches.
+   */
   initialScreenName?: string;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Screen/Screen.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Screen/Screen.ts
@@ -4,17 +4,29 @@ import {createRemoteComponent} from '@remote-ui/core';
  * @property `sheet` displays the screen from the bottom on `navigate` when `true`.
  */
 export interface ScreenPresentationProps {
+  /**
+   * Displays the screen from the bottom on `navigate` when `true`.
+   */
   sheet?: boolean;
 }
 
 /** Represents the secondary action button of a screen in the navigation stack.
  * @property `text` displays the name of the secondary action in the action bar.
  * @property `onPress` triggered when the secondary action button is pressed.
- * @property `isEnabled` displays the secondary action button when set `true`.
+ * @property `isEnabled` sets whether the action can be tapped.
  */
 export interface SecondaryActionProps {
+  /**
+   * Displays the name of the secondary action in the action bar.
+   */
   text: string;
+  /**
+   * Triggered when the secondary action button is pressed.
+   */
   onPress: () => void;
+  /**
+   * Sets whether the action can be tapped.
+   */
   isEnabled?: boolean;
 }
 
@@ -22,21 +34,50 @@ export interface SecondaryActionProps {
  * @property `name` used to identify this screen as a destination in the navigation stack.
  * @property `title` the title of the screen which will be displayed on the UI.
  * @property `isLoading` displays a loading indicator when `true`. Set this to `true` when performing an asynchronous task, and then to false when the data becomes available to the UI.
+ * @property `presentation` dictates how the `Screen` will be presented when navigated to.
  * @property `secondaryAction` displays a secondary action button on the screen.
  * @property `onNavigate` triggered when the screen is navigated to.
  * @property `onNavigateBack` triggered when the user navigates back from this screen. Runs after screen is unmounted.
- * @property `overrideNavigateBack` is a callback that allows you to override the secondary navigation action. Runs when screen is mounted.
+ * @property `overrideNavigateBack` a callback that allows you to override the secondary navigation action. Runs when screen is mounted.
  * @property `onReceiveParams` a callback that gets triggered when the navigation event completes and the screen receives the parameters.
  */
 export interface ScreenProps {
+  /**
+   * Used to identify this screen as a destination in the navigation stack.
+   */
   name: string;
+  /**
+   * The title of the screen which will be displayed on the UI.
+   */
   title: string;
+  /**
+   * Displays a loading indicator when `true`.
+   * Set this to `true` when performing an asynchronous task, and then to false when the data becomes available to the UI.
+   */
   isLoading?: boolean;
+  /**
+   * Dictates how the `Screen` will be presented when navigated to.
+   */
   presentation?: ScreenPresentationProps;
+  /**
+   * Displays a secondary action button on the screen.
+   */
   secondaryAction?: SecondaryActionProps;
+  /**
+   * Triggered when the screen is navigated to.
+   */
   onNavigate?: () => void;
+  /**
+   * Triggered when the user navigates back from this screen. Runs after screen is unmounted.
+   */
   onNavigateBack?: () => void;
+  /**
+   * A callback that allows you to override the secondary navigation action. Runs when screen is mounted.
+   */
   overrideNavigateBack?: () => void;
+  /**
+   * A callback that gets triggered when the navigation event completes and the screen receives the parameters.
+   */
   onReceiveParams?: (params: any) => void;
 }
 


### PR DESCRIPTION
### Resolves https://github.com/Shopify/pos-next-react-native/issues/36294

### Background

This adds docs and examples for Navigator and Screen.

### Solution

It adds fresh examples for the Screen and Navigator components.

### 🎩

Navigator: https://shopify-dev.ui-extensions-ruz5.jeansebastien-goupil.us.spin.dev/docs/api/pos-ui-extensions/unstable/components/navigator

Screen: https://shopify-dev.ui-extensions-ruz5.jeansebastien-goupil.us.spin.dev/docs/api/pos-ui-extensions/unstable/components/screen

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
