### PR TITLE
added list examples

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/List.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/List.doc.ts
@@ -1,4 +1,5 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'List',
@@ -14,7 +15,23 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Components',
-  related: [],
+  related: [
+    {
+      name: 'ProductSearch API',
+      subtitle:
+        'See how to use the ProductSearch API with a SearchBar to search for products.',
+      url: '/api/pos-ui-extensions/apis/productsearch-api#example-search-for-products-with-a-search-bar',
+    },
+  ],
+  examples: {
+    description: 'Examples of using the TextField component',
+    examples: [
+      {
+        codeblock: generateCodeBlock('Product List', 'list', 'products'),
+      },
+    ],
+  },
+
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/list/products.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/list/products.ts
@@ -1,0 +1,82 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  List,
+  Text,
+  Section,
+  ListRowSubtitle,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  let showDetails = false;
+  const scrollView = root.createComponent(ScrollView);
+  const section = root.createComponent(Section, {
+    title: 'Our T-shirts',
+  });
+
+  const triggerShowDetails = () => {
+    showDetails = !showDetails;
+    if (showDetails) {
+      scrollView.append(section);
+    } else {
+      scrollView.removeChild(section);
+    }
+  };
+
+  const listData = [
+    {
+      id: 'graphicTees',
+      leftSide: {
+        label: 'Graphic Tees',
+        subtitle: [{content: 'Summer Collection'}, {content: 'Unisex'}] as [
+          ListRowSubtitle,
+          ListRowSubtitle?,
+        ],
+      },
+      rightSide: {
+        label: 'Product details',
+        showChevron: true,
+      },
+      onPress: () => triggerShowDetails(),
+    },
+    {
+      id: 'denimShorts',
+      leftSide: {
+        label: 'Denim Shorts',
+        subtitle: [{content: 'Summer Collection'}, {content: 'Denim'}] as [
+          ListRowSubtitle,
+          ListRowSubtitle?,
+        ],
+      },
+    },
+  ];
+  const list = root.createComponent(List, {
+    title: 'Products',
+    data: listData,
+  });
+
+  const textBlock = root.createComponent(
+    Text,
+    null,
+    'Our shirts are made with 100% organic cotton!',
+  );
+
+  section.append(textBlock);
+
+  scrollView.append(list);
+  if (showDetails) {
+    scrollView.append(section);
+  }
+  const screen = root.createComponent(Screen, {
+    name: 'TextArea',
+    title: 'Text Area Example',
+  });
+  screen.append(scrollView);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
+
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/list/products.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/list/products.tsx
@@ -1,0 +1,60 @@
+import React, {useState} from 'react';
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  List,
+  Text,
+  Section,
+  ListRowSubtitle,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  const [seeDetails, setSeeDetails] = useState(false);
+  const listData = [
+    {
+      id: 'graphicTees',
+      leftSide: {
+        label: 'Graphic Tees',
+        subtitle: [{content: 'Summer Collection'}, {content: 'Unisex'}] as [
+          ListRowSubtitle,
+          ListRowSubtitle?,
+        ],
+      },
+      rightSide: {
+        label: 'Product details',
+        showChevron: true,
+      },
+      onPress: () => setSeeDetails(!seeDetails),
+    },
+    {
+      id: 'denimShorts',
+      leftSide: {
+        label: 'Denim Shorts',
+        subtitle: [{content: 'Summer Collection'}, {content: 'Denim'}] as [
+          ListRowSubtitle,
+          ListRowSubtitle?,
+        ],
+      },
+    },
+  ];
+  return (
+    <Navigator>
+      <Screen name="TextArea" title="Text Area Example">
+        <ScrollView>
+          <List title="Products" data={listData} />
+          {seeDetails && (
+            <Section title="Our T-shirts">
+              <Text>Our shirts are made with 100% organic cotton!</Text>
+            </Section>
+          )}
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => (
+  <SmartGridModal />
+));


### PR DESCRIPTION
### Background
closes https://github.com/Shopify/pos-next-react-native/issues/36295

- Adds code examples for the list component in vanilla typescript and react.
- Props were added in a previous PR.

https://github.com/Shopify/ui-extensions/assets/81783308/12bfef29-90c2-46ed-bcdc-7e5648d1a82b


### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- Visit [THIS SPINSTANCE](https://shopify-dev.ui-extensions-3tyr.marco-yip.us.spin.dev/docs/api/pos-ui-extensions)
- Review the displayed code in Vanilla Typescript and for React.
- Take note of formatting, word choices, and overall layout

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
