### PR TITLE
POS UI Ext: add badge and banner examples to docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Badge.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Badge.doc.ts
@@ -1,4 +1,8 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateCodeBlockForBadge = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'badge', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Badge',
@@ -15,6 +19,36 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Components',
   related: [],
+  defaultExample: {
+    codeblock: generateCodeBlockForBadge('Badge', 'default.example'),
+  },
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'guidelines',
+      title: 'Guidelines',
+      sectionContent: `
+- Badges should be positioned as close as possible to the item they’re related to.
+`,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'content-guidelines',
+      title: 'Content guidelines',
+      sectionContent: `
+- Be concise. Use a single word to describe the status of an item. 
+- Only use two or three words if you need to describe a complex state, for example "partially fulfilled".
+
+✅ fulfilled
+❌ order fulfilled
+
+Statuses should ideally be written as adjectives:
+
+✅ unpaid
+❌ payment not received
+      `,
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Banner.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Banner.doc.ts
@@ -1,4 +1,8 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateCodeBlockForBanner = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'banner', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Banner',
@@ -15,6 +19,20 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Components',
   related: [],
+  defaultExample: {
+    codeblock: generateCodeBlockForBanner('Banner', 'default.example'),
+  },
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'guidelines',
+      title: 'Guidelines',
+      sectionContent: `
+- Use when needing to communicate to merchants in a way that is persistent but non-interruptive.
+- Only one banner should be visible at a time.
+`,
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/badge/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/badge/default.example.ts
@@ -1,0 +1,27 @@
+import {
+  Badge,
+  Screen,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.home.modal.render',
+  (root) => {
+    const mainScreen = root.createComponent(
+      Screen,
+      {
+        name: 'Home',
+        title: 'Home',
+      },
+    );
+
+    const badge = root.createComponent(Badge, {
+      text: 'Badge',
+      variant: 'success',
+      status: 'complete',
+    });
+
+    mainScreen.append(badge);
+    root.append(mainScreen);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/badge/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/badge/default.example.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {
+  Badge,
+  Screen,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  return (
+    <Screen title="Home" name="Home">
+      <Badge
+        text="Badge"
+        variant="success"
+        status="complete"
+      />
+    </Screen>
+  );
+};
+
+export default reactExtension(
+  'pos.home.modal.render',
+  () => <SmartGridModal />,
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/banner/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/banner/default.example.ts
@@ -1,0 +1,54 @@
+import {
+  Banner,
+  ScrollView,
+  Screen,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.home.modal.render',
+  (root) => {
+    const screen = root.createComponent(Screen, {
+      title: 'Home',
+      name: 'Home',
+    });
+    const scrollView =
+      root.createComponent(ScrollView);
+
+    scrollView.appendChild(
+      root.createComponent(Banner, {
+        title: 'Information Banner',
+        variant: 'information',
+        action: 'Ok',
+        visible: true,
+      }),
+    );
+
+    scrollView.appendChild(
+      root.createComponent(Banner, {
+        title: 'Confirmation Banner',
+        variant: 'confirmation',
+        visible: true,
+      }),
+    );
+
+    scrollView.appendChild(
+      root.createComponent(Banner, {
+        title: 'Alert Banner',
+        variant: 'alert',
+        visible: true,
+      }),
+    );
+
+    scrollView.appendChild(
+      root.createComponent(Banner, {
+        title: 'Error Banner',
+        variant: 'error',
+        visible: true,
+      }),
+    );
+
+    screen.appendChild(scrollView);
+    root.appendChild(screen);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/banner/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/banner/default.example.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+  Banner,
+  ScrollView,
+  Screen,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  return (
+    <Screen title="Home" name="Home">
+      <ScrollView>
+        <Banner
+          title="Information Banner"
+          variant="information"
+          action="Ok"
+          visible
+        />
+        <Banner
+          title="Confirmation Banner"
+          variant="confirmation"
+          visible
+        />
+        <Banner
+          title="Alert Banner"
+          variant="alert"
+          visible
+        />
+        <Banner
+          title="Error Banner"
+          variant="error"
+          visible
+        />
+      </ScrollView>
+    </Screen>
+  );
+};
+
+export default reactExtension(
+  'pos.home.modal.render',
+  () => <SmartGridModal />,
+);

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.ts
@@ -9,6 +9,11 @@ export type BadgeVariant =
 
 export type BadgeStatus = 'empty' | 'partial' | 'complete';
 
+/**
+ * @property text - The text displayed inside the badge.
+ * @property variant - The appearance and function of the badge.
+ * @property status - A circle icon displaying the status of the badge.
+ */
 export interface BadgeProps {
   /**
    * The text displayed inside the badge.
@@ -21,7 +26,7 @@ export interface BadgeProps {
   variant: BadgeVariant;
 
   /**
-   * A circle icon on the badge.
+   * A circle icon displaying the status of the badge.
    */
   status?: BadgeStatus;
 }


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/36292

### Background

Adds Badge and Banner examples, descriptions for props and guidelines.

### 🎩

- [Badge](https://shopify-dev.ui-extensions-psgn.victor-chu.us.spin.dev/docs/api/pos-ui-extensions/unstable/components/badge)
- [Banner](https://shopify-dev.ui-extensions-psgn.victor-chu.us.spin.dev/docs/api/pos-ui-extensions/unstable/components/banner)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
