### PR TITLE
update number and email field docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/EmailField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/EmailField.doc.ts
@@ -1,4 +1,5 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'EmailField',
@@ -13,6 +14,9 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'EmailFieldProps',
     },
   ],
+  defaultExample: {
+    codeblock: generateCodeBlock('Email Input', 'email-field', 'email-input'),
+  },
   category: 'Components',
   related: [],
 };

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/EmailField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/EmailField.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   defaultExample: {
-    codeblock: generateCodeBlock('Email Input', 'email-field', 'email-input'),
+    codeblock: generateCodeBlock('Email input', 'email-field', 'email-input'),
   },
   category: 'Components',
   related: [],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/NumberField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/NumberField.doc.ts
@@ -1,4 +1,5 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'NumberField',
@@ -15,6 +16,13 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Components',
   related: [],
+  defaultExample: {
+    codeblock: generateCodeBlock(
+      'Number Field',
+      'number-field',
+      'number-input',
+    ),
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/NumberField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/NumberField.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   related: [],
   defaultExample: {
     codeblock: generateCodeBlock(
-      'Number Input',
+      'Number input',
       'number-field',
       'number-input',
     ),

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/NumberField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/NumberField.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   related: [],
   defaultExample: {
     codeblock: generateCodeBlock(
-      'Number Field',
+      'Number Input',
       'number-field',
       'number-input',
     ),

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/email-field/email-input.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/email-field/email-input.ts
@@ -1,0 +1,46 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Text,
+  EmailField,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const clearHandler = () => {
+    emailField.updateProps({value: ''});
+    textBox.replaceChildren('');
+  };
+  const emailField = root.createComponent(EmailField, {
+    label: 'Email',
+    value: '',
+    action: {label: 'Clear', onPress: clearHandler},
+  });
+
+  const textBox = root.createComponent(Text);
+
+  const onChangeHandler = (newValue: string) => {
+    emailField.updateProps({value: newValue});
+
+    const textContent = `Selected Date: ${newValue}`;
+    textBox.replaceChildren(textContent);
+  };
+
+  emailField.updateProps({onChange: onChangeHandler});
+
+  const scrollView = root.createComponent(ScrollView);
+  scrollView.append(emailField);
+  scrollView.append(textBox);
+
+  const screen = root.createComponent(Screen, {
+    name: 'DateField',
+    title: 'Date Field Example',
+  });
+  screen.append(scrollView);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
+
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/email-field/email-input.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/email-field/email-input.tsx
@@ -1,0 +1,38 @@
+import React, {useState} from 'react';
+import {
+  EmailField,
+  Screen,
+  ScrollView,
+  Navigator,
+  Text,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  const [email, setEmail] = useState('');
+  return (
+    <Navigator>
+      <Screen name="DateField" title="DateField Example">
+        <ScrollView>
+          <EmailField
+            label="Email"
+            placeholder="example@email.com"
+            helpText="Please enter a valid email"
+            value={email}
+            onChange={setEmail}
+            required={true}
+            action={{
+              label: 'Clear',
+              onPress: () => setEmail(''),
+            }}
+          />
+          <Text>Entered Email: {email}</Text>
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => (
+  <SmartGridModal />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/number-field/number-input.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/number-field/number-input.ts
@@ -1,0 +1,48 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Text,
+  NumberField,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const clearHandler = () => {
+    numberField.updateProps({value: ''});
+    textBox.replaceChildren('');
+  };
+  const numberField = root.createComponent(NumberField, {
+    label: 'Number',
+    placeholder: '1234',
+    helpText: 'Enter a numeric value.',
+    value: '',
+    action: {label: 'Clear', onPress: clearHandler},
+  });
+
+  const textBox = root.createComponent(Text);
+
+  const onChangeHandler = (newValue: string) => {
+    numberField.updateProps({value: newValue});
+
+    const textContent = `Selected Date: ${newValue}`;
+    textBox.replaceChildren(textContent);
+  };
+
+  numberField.updateProps({onChange: onChangeHandler});
+
+  const scrollView = root.createComponent(ScrollView);
+  scrollView.append(numberField);
+  scrollView.append(textBox);
+
+  const screen = root.createComponent(Screen, {
+    name: 'NumberField',
+    title: 'Number Field Example',
+  });
+  screen.append(scrollView);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
+
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/number-field/number-input.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/number-field/number-input.tsx
@@ -1,0 +1,38 @@
+import React, {useState} from 'react';
+import {
+  NumberField,
+  Screen,
+  ScrollView,
+  Navigator,
+  Text,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  const [number, setNumber] = useState('');
+  return (
+    <Navigator>
+      <Screen name="NumberField" title="NumberField Example">
+        <ScrollView>
+          <NumberField
+            label="Number"
+            placeholder="1234"
+            helpText="Enter a numeric value."
+            value={number}
+            onChange={setNumber}
+            required={true}
+            action={{
+              label: 'Clear',
+              onPress: () => setNumber(''),
+            }}
+          />
+          <Text>Entered Value: {number}</Text>
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => (
+  <SmartGridModal />
+));

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.ts
@@ -5,8 +5,6 @@ import type {InputProps} from '../shared/InputField';
  * Represents the properties for the NumberField component.
  * @typedef {Object} NumberFieldProps
  * @property {'decimal' | 'numeric'} [inputMode] - The mode of input, can be either 'decimal' or 'numeric'.
- * @property {number} [max] - The highest decimal or integer to be accepted for the field.
- * @property {number} [min] - The lowest decimal or integer to be accepted for the field.
  */
 export interface NumberFieldProps extends InputProps {
   inputMode?: 'decimal' | 'numeric';


### PR DESCRIPTION
closes https://github.com/Shopify/pos-next-react-native/issues/36298

### Background

- Updated docs for NumberField and added examples in react and vanilla typescript.
- Omitted inputMode, max, and min props due to the fact that they were not working in Storybook and in Ui extensions. I will revisit this in a future PR.
- Updated docs for EmailField and added examples in react and vanilla typescript. 

https://github.com/Shopify/ui-extensions/assets/81783308/1f8988d1-3cc1-4989-8fd2-15b8ab7f79b1


### 🎩
- Visit [THIS SPINSTANCE](https://shopify-dev.ui-extensions-snq3.marco-yip.us.spin.dev/docs/api/pos-ui-extensions/unstable/components/numberfield)
- Compare it with the old docs [NumberField](https://shopify.dev/docs/api/pos-extensions/ui-extensions-reference/components/number-field) [EmailField](https://shopify.dev/docs/api/pos-extensions/ui-extensions-reference/components/email-field)
- Click through both sections.
- Take note of formatting, word choices, and layout.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
