### PR TITLE
updated image and icon docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Icon.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Icon.doc.ts
@@ -1,4 +1,5 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
@@ -13,7 +14,27 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Components',
-  related: [],
+  related: [
+    {
+      name: 'Figma UI Kit Icons',
+      subtitle:
+        'See the Figma UI Kit to get a full list of icons to design your extension',
+      url: 'https://www.figma.com/design/0UcHY7C4hqrhvA5tjynunA/Shopify-POS-UI-Kit-(Community)?node-id=15-15&t=Ygce7CbfazMNpKsA-0',
+      type: 'star',
+    },
+  ],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'guidelines',
+      title: 'Guidelines',
+      sectionContent: `
+- Icons in POS are used in areas where they specifically add clarity and structure to the UI, aiding in creating a deeper understanding of the product and common interaction points nested throughout the experience.`,
+    },
+  ],
+  defaultExample: {
+    codeblock: generateCodeBlock('Example icons', 'icon', 'default-example'),
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Image.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Image.doc.ts
@@ -1,4 +1,5 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
@@ -15,6 +16,9 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Components',
   related: [],
+  defaultExample: {
+    codeblock: generateCodeBlock('Example image', 'image', 'default-example'),
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/icon/default-example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/icon/default-example.ts
@@ -1,0 +1,39 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Icon,
+  IconName,
+  IconSize,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.modal.render', (root, api) => {
+  const iconsData: {name: IconName; size: IconSize}[] = [
+    {name: 'call', size: 'minor'},
+    {name: 'card-reader', size: 'major'},
+    {name: 'circle-cancel', size: 'spot'},
+    {name: 'orders', size: 'caption'},
+    {name: 'star', size: 'badge'},
+  ];
+  const scrollView = root.createComponent(ScrollView);
+
+  iconsData.forEach((iconData) => {
+    const icon = root.createComponent(Icon, {
+      name: iconData.name,
+      size: iconData.size,
+    });
+    scrollView.append(icon);
+  });
+
+  const screen = root.createComponent(Screen, {
+    name: 'Icon',
+    title: 'Icon Example',
+  });
+  screen.append(scrollView);
+
+  const navigator = root.createComponent(Navigator);
+  navigator.append(screen);
+
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/icon/default-example.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/icon/default-example.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import {
+  Icon,
+  Screen,
+  ScrollView,
+  Navigator,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  return (
+    <Navigator>
+      <Screen name="Image" title="Image Example">
+        <ScrollView>
+          <Icon name="call" size="minor" />
+          <Icon name="card-reader" size="major" />
+          <Icon name="circle-cancel" size="spot" />
+          <Icon name="orders" size="caption" />
+          <Icon name="star" size="badge" />
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension('pos.home.modal.render', () => (
+  <SmartGridModal />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/image/default-example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/image/default-example.ts
@@ -1,0 +1,32 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Image,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.home.modal.render',
+  (root, api) => {
+    const image = root.createComponent(Image, {
+      src: 'example.png',
+    });
+
+    const scrollView =
+      root.createComponent(ScrollView);
+    scrollView.append(image);
+
+    const screen = root.createComponent(Screen, {
+      name: 'Image',
+      title: 'Image Example',
+    });
+    screen.append(scrollView);
+
+    const navigator =
+      root.createComponent(Navigator);
+    navigator.append(screen);
+
+    root.append(navigator);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/image/default-example.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/image/default-example.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import {
+  Image,
+  Screen,
+  ScrollView,
+  Navigator,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridModal = () => {
+  return (
+    <Navigator>
+      <Screen name="Image" title="Image Example">
+        <ScrollView>
+          <Image src="example.png" />
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension(
+  'pos.home.modal.render',
+  () => <SmartGridModal />,
+);

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.ts
@@ -86,7 +86,14 @@ export type IconName =
 export type IconSize = 'minor' | 'major' | 'spot' | 'caption' | 'badge';
 
 export interface IconProps {
+  /**
+   * A name used to render the icon.
+   */
   name: IconName;
+  /**
+   * Size of the icon.
+   * @defaultValue 'major'
+   */
   size?: IconSize;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.ts
@@ -1,6 +1,9 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 export interface ImageProps {
+  /**
+   * The source of the image to be displayed.
+   */
   src?: string;
 }
 


### PR DESCRIPTION
Closes https://github.com/Shopify/pos-next-react-native/issues/36296
### Background

- Updates iconProps and imageProps to docs.
- Adds React and Vanilla typescript examples for icon and image docs.
- Adds image of all icons into icon docs.

https://github.com/Shopify/ui-extensions/assets/81783308/f6dc8567-6455-42e8-88bd-661b58455c87


### 🎩

- Visit [THIS SPINSTANCE](https://shopify-dev.ui-extensions-3tyr.marco-yip.us.spin.dev/docs/api/pos-ui-extensions)
- Compare it with the old docs [Image](https://shopify.dev/docs/api/pos-extensions/ui-extensions-reference/components/image) [Icon](https://shopify.dev/docs/api/pos-extensions/ui-extensions-reference/components/icon)
- Click through both sections
- Take note of formatting, word choices, and layout

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
