### PR TITLE
Add optional alt prop to POS image

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export interface ImageProps {
   src?: string;
+  alt?: string;
 }
 
 export const Image = createRemoteComponent<'Image', ImageProps>('Image');


### PR DESCRIPTION
### Background
Adds alt text as an optional prop
Follows what is expected: https://github.com/Shopify/ui-api-design/tree/main/components/Image

### Questions
have I missed anything?

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
