### PR TITLE
add authenticationState api to customer account ui extension

### DIFF
--- a/.changeset/new-pugs-shop.md
+++ b/.changeset/new-pugs-shop.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+add authenticationState api to customer account ui extension

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/authentication-state.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/authentication-state.ts
@@ -1,0 +1,16 @@
+import type {
+  AuthenticationState,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useSubscription} from './subscription';
+import {useApi} from './api';
+
+/**
+ * Returns authentication state of Order status page.
+ */
+export function useAuthenticationState<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): AuthenticationState {
+  return useSubscription(useApi<Target>().authenticationState);
+}

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/index.ts
@@ -39,3 +39,5 @@ export {
   useAuthenticatedAccountCustomer,
   useAuthenticatedAccountPurchasingCompany,
 } from './authenticated-account';
+
+export {useAuthenticationState} from './authentication-state';

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/authentication-state.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/authentication-state.test.tsx
@@ -1,0 +1,24 @@
+import {useAuthenticationState} from '../authentication-state';
+import type {Extension} from '@shopify/ui-extensions/customer-account';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useAuthenticationState Hooks', () => {
+  it('returns authenticationState', () => {
+    const authenticationStateSubscribable =
+      createMockStatefulRemoteSubscribable(
+        'fully_authenticated',
+      ) as Extension['authenticationState'];
+
+    const {value} = mount.hook(useAuthenticationState, {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        authenticationState: authenticationStateSubscribable,
+      },
+    });
+    expect(value).toBeDefined();
+    expect(value).toBe('fully_authenticated');
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api.ts
@@ -44,6 +44,7 @@ export type {
   OrderStatusPurchasingCompany,
   OrderStatusBuyerIdentity,
   CheckoutToken,
+  AuthenticationState,
 } from './api/order-status/order-status';
 export type {
   Attribute,

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -46,6 +46,9 @@ export interface Docs_OrderStatus_ShopApi
 export interface Docs_OrderStatus_RequireLoginApi
   extends Pick<OrderStatusApi<any>, 'requireLogin'> {}
 
+export interface Docs_OrderStatus_AuthenticationStateApi
+  extends Pick<OrderStatusApi<any>, 'authenticationState'> {}
+
 export interface Docs_OrderStatus_CartLinesApi
   extends Pick<OrderStatusApi<any>, 'lines'> {}
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -189,6 +189,8 @@ export interface OrderStatusLocalization {
   market: StatefulRemoteSubscribable<Market | undefined>;
 }
 
+export type AuthenticationState = 'fully_authenticated' | 'pre_authenticated';
+
 export interface OrderStatusApi<Target extends ExtensionTarget> {
   /**
    * Methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
@@ -352,6 +354,11 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
    * The requireLogin() method triggers login if the customer is viewing pre-authenticated Order status page.
    */
   requireLogin: () => Promise<void>;
+
+  /**
+   * The authentication state of Order status page.
+   */
+  authenticationState: StatefulRemoteSubscribable<AuthenticationState>;
 }
 
 export interface OrderStatusBuyerIdentity {


### PR DESCRIPTION
### Background

Part of  https://github.com/Shopify/core-issues/issues/71278
Add a new API to order status api to indicate which authentication state it is.

Please also review the customer account web side PR https://github.com/Shopify/customer-account-web/pull/4626 , same tophat .

### 🎩

- go visit https://shopify.renaming.brian-shen.us.spin.dev/3/account/orders/6 => unauthenticated, no extension
- open dev console, execute `document.cookie = "order=eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaVZrTkRneU5XSXdNVFV3WXpKbFpXUXdPVGszTXprellqazJNbVF4TXpNME1BWTZCa1ZVIiwiZXhwIjoiMjAyNC0wNi0xOVQyMDo1Mzo1Ny44NzdaIiwicHVyIjoiY29va2llLm9yZGVyIn19--7b65fadc7e53ff713ac912d8056ae30018000ce6; Path=/3/account/orders/6"` , refresh => extension show, as pre-authenticated
- login with `dev@shopify.com` and [this identity mailer ](https://identity.renaming.brian-shen.us.spin.dev/services/mail) , extension loads, and show as fully_authenticated

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
