### PR TITLE
Add ordersCount to Web Pixels checkout.order.customer 

### DIFF
--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -538,14 +538,14 @@ export const pixelEvents = {
           type: 'boolean',
           metadata: {
             description:
-              "Indicates whether the customer has consented to be sent marketing material via email. This property is only available if you've [upgraded to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-upgrade).",
+              'Indicates whether the customer has consented to be sent marketing material via email. This property is only available if the shop has [upgraded to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-upgrade).',
           },
         },
         buyerAcceptsSmsMarketing: {
           type: 'boolean',
           metadata: {
             description:
-              "Indicates whether the customer has consented to be sent marketing material via SMS. This property is only available if you've [upgraded to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-upgrade).",
+              'Indicates whether the customer has consented to be sent marketing material via SMS. This property is only available if the shop has [upgraded to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-upgrade).',
           },
         },
         currencyCode: {
@@ -701,7 +701,7 @@ export const pixelEvents = {
           ref: 'MoneyV2',
           metadata: {
             description:
-              "The combined price of all of the items in the line item after line-level discounts have been applied. This property is only available if you've [upgraded to Checkout Extensibility](https://help.shopify.com/manual/checkout-settings/checkout-extensibility/checkout-upgrade).",
+              'The combined price of all of the items in the line item after line-level discounts have been applied. This property is only available if the shop has [upgraded to Checkout Extensibility](https://help.shopify.com/manual/checkout-settings/checkout-extensibility/checkout-upgrade).',
           },
         },
         sellingPlanAllocation: {
@@ -709,7 +709,7 @@ export const pixelEvents = {
           nullable: true,
           metadata: {
             description:
-              "The selling plan associated with the line item and the effect that each selling plan has on variants when they're purchased. This property is only available if you've [upgraded to Checkout Extensibility](https://help.shopify.com/manual/checkout-settings/checkout-extensibility/checkout-upgrade).",
+              "The selling plan associated with the line item and the effect that each selling plan has on variants when they're purchased. This property is only available if the shop has [upgraded to Checkout Extensibility](https://help.shopify.com/manual/checkout-settings/checkout-extensibility/checkout-upgrade).",
           },
         },
       },
@@ -1258,6 +1258,14 @@ export const pixelEvents = {
           nullable: true,
           metadata: {
             description: 'The ID of the customer.',
+          },
+        },
+        ordersCount: {
+          type: 'uint32',
+          nullable: true,
+          metadata: {
+            description:
+              'The total number of orders that the customer has placed. During periods of high order volume, the value of this property may not include the current order. This property is only available for the checkout_completed event if the shop has [upgraded to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-upgrade).',
           },
         },
       },

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -775,17 +775,17 @@ export interface Checkout {
   billingAddress: MailingAddress | null;
 
   /**
-   * Indicates whether the customer has consented to be sent marketing
-   * material via email. This property is only available if you've [upgraded
+   * Indicates whether the customer has consented to be sent marketing material
+   * via email. This property is only available if the shop has [upgraded
    * to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-
    * settings/checkout-extensibility/checkout-upgrade).
    */
   buyerAcceptsEmailMarketing: boolean;
 
   /**
-   * Indicates whether the customer has consented to be sent marketing
-   * material via SMS. This property is only available if you've [upgraded
-   * to Checkout Extensibility](https://help.shopify.com/en/manual/checkout-
+   * Indicates whether the customer has consented to be sent marketing material
+   * via SMS. This property is only available if the shop has [upgraded to
+   * Checkout Extensibility](https://help.shopify.com/en/manual/checkout-
    * settings/checkout-extensibility/checkout-upgrade).
    */
   buyerAcceptsSmsMarketing: boolean;
@@ -882,9 +882,9 @@ export interface CheckoutLineItem {
   discountAllocations: DiscountAllocation[];
 
   /**
-   * The combined price of all of the items in the line
-   * item after line-level discounts have been applied. This
-   * property is only available if you've [upgraded to Checkout
+   * The combined price of all of the items in the line item
+   * after line-level discounts have been applied. This property
+   * is only available if the shop has [upgraded to Checkout
    * Extensibility](https://help.shopify.com/manual/checkout-settings/checkout-
    * extensibility/checkout-upgrade).
    */
@@ -901,9 +901,9 @@ export interface CheckoutLineItem {
   quantity: number;
 
   /**
-   * The selling plan associated with the line item and the effect
-   * that each selling plan has on variants when they're purchased.
-   * This property is only available if you've [upgraded to Checkout
+   * The selling plan associated with the line item and the effect that
+   * each selling plan has on variants when they're purchased. This
+   * property is only available if the shop has [upgraded to Checkout
    * Extensibility](https://help.shopify.com/manual/checkout-settings/checkout-
    * extensibility/checkout-upgrade).
    */
@@ -1467,6 +1467,16 @@ export interface OrderCustomer {
    * The ID of the customer.
    */
   id: string | null;
+
+  /**
+   * The total number of orders that the customer has placed. During
+   * periods of high order volume, the value of this property may not
+   * include the current order. This property is only available for
+   * the checkout_completed event if the shop has [upgraded to Checkout
+   * Extensibility](https://help.shopify.com/en/manual/checkout-
+   * settings/checkout-extensibility/checkout-upgrade).
+   */
+  ordersCount: number | null;
 }
 
 /**


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/ce-customer-behaviour/issues/4994
WPM PR: https://github.com/Shopify/web-pixels-manager/pull/769

### Solution

Adds `orderCount` to `OrderCustomer` type

<img width="500" alt="Screenshot 2024-05-30 at 2 51 20 PM" src="https://github.com/Shopify/ui-extensions/assets/90476041/9556d764-f5b4-412b-94d8-9c855c79986b">



### 🎩

https://shop1.shopify.orders-count-v5.james-calverley.us.spin.dev/

For detailed instructions on manually adding orders please look at this [WPM PR](https://github.com/Shopify/web-pixels-manager/pull/769)


### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
