### PR TITLE
Added navigation and scanner APIs to PP action

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -20,7 +20,9 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
-  requires: ExtensionTargetType.PosHomeModalRender,
+  requires:
+    ExtensionTargetType.PosHomeModalRender ||
+    ExtensionTargetType.PosPurchasePostActionRender,
   examples: {
     description: 'Examples of using the Navigation API',
     examples: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -20,7 +20,9 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
-  requires: ExtensionTargetType.PosHomeModalRender,
+  requires:
+    ExtensionTargetType.PosHomeModalRender ||
+    ExtensionTargetType.PosPurchasePostActionRender,
   examples: {
     description: 'Examples of receiving updates from the Scanner API',
     examples: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -27,7 +27,10 @@ export interface ExtensionTargets {
     BasicComponents
   >;
   'pos.purchase.post.action.render': RenderExtension<
-    StandardApi<'pos.purchase.post.action.render'> & OrderApi,
+    StandardApi<'pos.purchase.post.action.render'> &
+      OrderApi &
+      NavigationApi &
+      ScannerApi,
     BasicComponents
   >;
   'pos.purchase.post.action.menu-item.render': RenderExtension<


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/37280

### Background

The ScannerAPI and the NavigationAPI do work for the post purchase action target, however we were not adding it to the type in the package. This fixes the problem, and will allow developers to see that these APIs do exist on these targets. I also updated our docs. 

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
