### PR TITLE
[UI Components]: Publish display property

### DIFF
--- a/.changeset/rich-chicken-repeat.md
+++ b/.changeset/rich-chicken-repeat.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Publish display property

--- a/packages/ui-extensions-react/src/surfaces/checkout.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout.ts
@@ -40,6 +40,7 @@ export type {
   DisclosureActivatorProps,
   DisclosureOpen,
   DisabledDate,
+  Display,
   ExtensionTarget,
   ExtensionTargets,
   Fit,

--- a/packages/ui-extensions/src/surfaces/checkout/components.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components.ts
@@ -217,6 +217,7 @@ export type {
   CornerProps,
   DisclosureActivatorProps,
   DisclosureOpen,
+  Display,
   Fit,
   GridItemSize,
   InlineAlignment,

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.doc.ts
@@ -44,7 +44,14 @@ const data: ReferenceEntityTemplateSchema = {
         '| Value | Description |\n| --- | --- |\n| <code>"main"</code> | Used to indicate the primary content. |\n| <code>"header"</code> | Used to indicate the component is a header. |\n| <code>"footer"</code> | Used to display information such as copyright information, navigation links, and privacy statements. |\n| <code>"section"</code> | Used to indicate a generic section. |\n| <code>"complementary"</code> | Used to designate a supporting section that relates to the main content. |\n| <code>"navigation"</code> | Used to identify major groups of links used for navigating. |\n| <code>"orderedList"</code> | Used to identify a list of ordered items. |\n| <code>"listItem"</code> | Used to identify an item inside a list of items. |\n| <code>"unorderedList"</code> | Used to identify a list of unordered items. |\n| <code>"separator"</code> | Used to indicates the component acts as a divider that separates and distinguishes sections of content. |\n| <code>"status"</code> | Used to define a live region containing advisory information for the user that is not important enough to be an alert. |\n| <code>"alert"</code> | Used for important, and usually time-sensitive, information. |',
     },
   ],
-  related: [],
+  related: [
+    {
+      subtitle: 'Utility',
+      name: 'StyleHelper',
+      url: '/docs/api/checkout-ui-extensions/unstable/components/utilities/stylehelper',
+      type: 'utility',
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.doc.ts
@@ -54,7 +54,14 @@ const data: ReferenceEntityTemplateSchema = {
         '| Value | Description |\n| --- | --- |\n| <code>"main"</code> | Used to indicate the primary content. |\n| <code>"header"</code> | Used to indicate the component is a header. |\n| <code>"footer"</code> | Used to display information such as copyright information, navigation links, and privacy statements. |\n| <code>"section"</code> | Used to indicate a generic section. |\n| <code>"complementary"</code> | Used to designate a supporting section that relates to the main content. |\n| <code>"navigation"</code> | Used to identify major groups of links used for navigating. |\n| <code>"orderedList"</code> | Used to identify a list of ordered items. |\n| <code>"listItem"</code> | Used to identify an item inside a list of items. |\n| <code>"unorderedList"</code> | Used to identify a list of unordered items. |\n| <code>"separator"</code> | Used to indicates the component acts as a divider that separates and distinguishes sections of content. |\n| <code>"status"</code> | Used to define a live region containing advisory information for the user that is not important enough to be an alert. |\n| <code>"alert"</code> | Used for important, and usually time-sensitive, information. |',
     },
   ],
-  related: [],
+  related: [
+    {
+      subtitle: 'Utility',
+      name: 'StyleHelper',
+      url: '/docs/api/checkout-ui-extensions/unstable/components/utilities/stylehelper',
+      type: 'utility',
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.ts
@@ -4,6 +4,7 @@ import type {
   BackgroundProps,
   BorderProps,
   CornerProps,
+  IdProps,
   InlineAlignment,
   SizingProps,
   Spacing,
@@ -16,6 +17,7 @@ export interface BlockStackProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,
     CornerProps,
+    IdProps,
     SizingProps,
     SpacingProps {
   /**
@@ -48,10 +50,6 @@ export interface BlockStackProps
    */
   accessibilityLabel?: string;
   /**
-   * A unique identifier for the component.
-   */
-  id?: string;
-  /**
    * Sets the overflow behavior of the element.
    *
    * `hidden`: clips the content when it is larger than the element’s container.
@@ -63,6 +61,18 @@ export interface BlockStackProps
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
+  /**
+   * Changes the display of the component.
+   *
+   * `auto` the component's initial value. The actual value depends on the component and context.
+   *
+   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   *
+   * @defaultValue 'auto'
+   */
+  display?: MaybeResponsiveConditionalStyle<'auto' | 'none'>;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.doc.ts
@@ -51,6 +51,12 @@ const data: ReferenceEntityTemplateSchema = {
       url: 'grid',
       type: 'Component',
     },
+    {
+      subtitle: 'Utility',
+      name: 'StyleHelper',
+      url: '/docs/api/checkout-ui-extensions/unstable/components/utilities/stylehelper',
+      type: 'utility',
+    },
   ],
 };
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.ts
@@ -7,6 +7,7 @@ import type {
   BorderProps,
   Columns,
   CornerProps,
+  IdProps,
   InlineAlignment,
   Rows,
   SizingProps,
@@ -17,6 +18,7 @@ import type {
 
 export interface GridProps
   extends Pick<BackgroundProps, 'background'>,
+    IdProps,
     BorderProps,
     CornerProps,
     SizingProps,
@@ -104,10 +106,6 @@ export interface GridProps
    */
   accessibilityLabel?: string;
   /**
-   * A unique identifier for the component.
-   */
-  id?: string;
-  /**
    * Sets the overflow behavior of the element.
    *
    * `hidden`: clips the content when it is larger than the element’s container.
@@ -119,6 +117,19 @@ export interface GridProps
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
+  /**
+   * Changes the display of the component.
+   *
+   *
+   * `auto` the component's initial value. The actual value depends on the component and context.
+   *
+   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   *
+   * @defaultValue 'auto'
+   */
+  display?: MaybeResponsiveConditionalStyle<'auto' | 'none'>;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.doc.ts
@@ -51,6 +51,12 @@ const data: ReferenceEntityTemplateSchema = {
       url: 'grid',
       type: 'Component',
     },
+    {
+      subtitle: 'Utility',
+      name: 'StyleHelper',
+      url: '/docs/api/checkout-ui-extensions/unstable/components/utilities/stylehelper',
+      type: 'utility',
+    },
   ],
 };
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.ts
@@ -5,6 +5,7 @@ import type {
   BackgroundProps,
   BorderProps,
   CornerProps,
+  IdProps,
   SizingProps,
   SpacingProps,
   ViewLikeAccessibilityRole,
@@ -14,6 +15,7 @@ export interface GridItemProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,
     CornerProps,
+    IdProps,
     SizingProps,
     SpacingProps {
   /**
@@ -38,10 +40,6 @@ export interface GridItemProps
    */
   accessibilityRole?: ViewLikeAccessibilityRole;
   /**
-   * A unique identifier for the component.
-   */
-  id?: string;
-  /**
    * Sets the overflow behavior of the element.
    *
    * `hidden`: clips the content when it is larger than the element’s container.
@@ -53,6 +51,19 @@ export interface GridItemProps
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
+  /**
+   * Changes the display of the component.
+   *
+   *
+   * `auto` the component's initial value. The actual value depends on the component and context.
+   *
+   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   *
+   * @defaultValue 'auto'
+   */
+  display?: MaybeResponsiveConditionalStyle<'auto' | 'none'>;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineLayout/InlineLayout.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineLayout/InlineLayout.doc.ts
@@ -55,7 +55,14 @@ const data: ReferenceEntityTemplateSchema = {
         '| Value | Description |\n| --- | --- |\n| <code>"main"</code> | Used to indicate the primary content. |\n| <code>"header"</code> | Used to indicate the component is a header. |\n| <code>"footer"</code> | Used to display information such as copyright information, navigation links, and privacy statements. |\n| <code>"section"</code> | Used to indicate a generic section. |\n| <code>"complementary"</code> | Used to designate a supporting section that relates to the main content. |\n| <code>"navigation"</code> | Used to identify major groups of links used for navigating. |\n| <code>"orderedList"</code> | Used to identify a list of ordered items. |\n| <code>"listItem"</code> | Used to identify an item inside a list of items. |\n| <code>"unorderedList"</code> | Used to identify a list of unordered items. |\n| <code>"separator"</code> | Used to indicates the component acts as a divider that separates and distinguishes sections of content. |\n| <code>"status"</code> | Used to define a live region containing advisory information for the user that is not important enough to be an alert. |\n| <code>"alert"</code> | Used for important, and usually time-sensitive, information. |',
     },
   ],
-  related: [],
+  related: [
+    {
+      subtitle: 'Utility',
+      name: 'StyleHelper',
+      url: '/docs/api/checkout-ui-extensions/unstable/components/utilities/stylehelper',
+      type: 'utility',
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.doc.ts
@@ -44,7 +44,14 @@ const data: ReferenceEntityTemplateSchema = {
         '| Value | Description |\n| --- | --- |\n| <code>"main"</code> | Used to indicate the primary content. |\n| <code>"header"</code> | Used to indicate the component is a header. |\n| <code>"footer"</code> | Used to display information such as copyright information, navigation links, and privacy statements. |\n| <code>"section"</code> | Used to indicate a generic section. |\n| <code>"complementary"</code> | Used to designate a supporting section that relates to the main content. |\n| <code>"navigation"</code> | Used to identify major groups of links used for navigating. |\n| <code>"orderedList"</code> | Used to identify a list of ordered items. |\n| <code>"listItem"</code> | Used to identify an item inside a list of items. |\n| <code>"unorderedList"</code> | Used to identify a list of unordered items. |\n| <code>"separator"</code> | Used to indicates the component acts as a divider that separates and distinguishes sections of content. |\n| <code>"status"</code> | Used to define a live region containing advisory information for the user that is not important enough to be an alert. |\n| <code>"alert"</code> | Used for important, and usually time-sensitive, information. |',
     },
   ],
-  related: [],
+  related: [
+    {
+      subtitle: 'Utility',
+      name: 'StyleHelper',
+      url: '/docs/api/checkout-ui-extensions/unstable/components/utilities/stylehelper',
+      type: 'utility',
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.ts
@@ -6,6 +6,7 @@ import type {
   BlockAlignment,
   BorderProps,
   CornerProps,
+  IdProps,
   InlineAlignment,
   SizingProps,
   Spacing,
@@ -17,6 +18,7 @@ export interface InlineStackProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,
     CornerProps,
+    IdProps,
     SizingProps,
     SpacingProps {
   /**
@@ -61,10 +63,6 @@ export interface InlineStackProps
    **/
   spacing?: MaybeResponsiveConditionalStyle<Spacing | [Spacing, Spacing]>;
   /**
-   * A unique identifier for the component.
-   */
-  id?: string;
-  /**
    * Sets the overflow behavior of the element.
    *
    * `hidden`: clips the content when it is larger than the element’s container.
@@ -76,6 +74,19 @@ export interface InlineStackProps
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
+  /**
+   * Changes the display of the component.
+   *
+   *
+   * `auto` the component's initial value. The actual value depends on the component and context.
+   *
+   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   *
+   * @defaultValue 'auto'
+   */
+  display?: MaybeResponsiveConditionalStyle<'auto' | 'none'>;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.doc.ts
@@ -35,7 +35,14 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
-  related: [],
+  related: [
+    {
+      subtitle: 'Utility',
+      name: 'StyleHelper',
+      url: '/docs/api/checkout-ui-extensions/unstable/components/utilities/stylehelper',
+      type: 'utility',
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.ts
@@ -14,29 +14,35 @@ import type {
   CornerProps,
   Opacity,
   BackgroundProps,
+  IdProps,
 } from '../shared';
 
 export interface PressableProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,
     CornerProps,
+    IdProps,
     SizingProps,
     SpacingProps,
     OverlayActivatorProps,
     DisclosureActivatorProps {
   /**
-   * Changes the display of the Pressable.
+   * Changes the display of the component.
    *
    *
-   * `inline` follows the direction of words in a sentence based on the document’s writing mode.
+   * `inline` the component starts on the same line as preceding inline content and allows subsequent content to continue on the same line.
    *
-   * `block` follows the direction of paragraphs based on the document’s writing mode.
+   * `block` the component starts on its own new line and fills its parent.
    *
+   * `auto` resets the component to its initial value. The actual value depends on the component and context.
    *
-   * @defaultValue 'block'
+   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   *
+   * @defaultValue 'auto'
    */
-  display?: Display;
-
+  display?: MaybeResponsiveConditionalStyle<Display>;
   /**
    * A label that describes the purpose or contents of the element. When set,
    * it will be announced to buyers using assistive technologies and will
@@ -59,11 +65,6 @@ export interface PressableProps
    * Disables the button, disallowing any interaction
    */
   disabled?: boolean;
-
-  /**
-   * A unique identifier for the Pressable.
-   */
-  id?: string;
 
   /**
    * Disables the button while loading. Unlike `Button`, no indicator is rendered while loading.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.doc.ts
@@ -35,7 +35,14 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
-  related: [],
+  related: [
+    {
+      subtitle: 'Utility',
+      name: 'StyleHelper',
+      url: '/docs/api/checkout-ui-extensions/unstable/components/utilities/stylehelper',
+      type: 'utility',
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.ts
@@ -4,9 +4,11 @@ import type {
   BackgroundProps,
   BorderProps,
   CornerProps,
+  IdProps,
   SizingProps,
   SpacingProps,
 } from '../shared';
+import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 
 export interface ScrollViewEvent {
   /**
@@ -33,6 +35,7 @@ export interface ScrollViewProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,
     CornerProps,
+    IdProps,
     SizingProps,
     SpacingProps {
   /**
@@ -74,9 +77,18 @@ export interface ScrollViewProps
    */
   onScrolledToEdge?: (args: ScrollViewEvent) => void;
   /**
-   * A unique identifier for the component.
+   * Changes the display of the component.
+   *
+   *
+   * `auto` the component's initial value. The actual value depends on the component and context.
+   *
+   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   *
+   * @defaultValue 'auto'
    */
-  id?: string;
+  display?: MaybeResponsiveConditionalStyle<'auto' | 'none'>;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/View/View.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/View/View.doc.ts
@@ -44,7 +44,14 @@ const data: ReferenceEntityTemplateSchema = {
         '| Value | Description |\n| --- | --- |\n| <code>"main"</code> | Used to indicate the primary content. |\n| <code>"header"</code> | Used to indicate the component is a header. |\n| <code>"footer"</code> | Used to display information such as copyright information, navigation links, and privacy statements. |\n| <code>"section"</code> | Used to indicate a generic section. |\n| <code>"complementary"</code> | Used to designate a supporting section that relates to the main content. |\n| <code>"navigation"</code> | Used to identify major groups of links used for navigating. |\n| <code>"orderedList"</code> | Used to identify a list of ordered items. |\n| <code>"listItem"</code> | Used to identify an item inside a list of items. |\n| <code>"unorderedList"</code> | Used to identify a list of unordered items. |\n| <code>"separator"</code> | Used to indicates the component acts as a divider that separates and distinguishes sections of content. |\n| <code>"status"</code> | Used to define a live region containing advisory information for the user that is not important enough to be an alert. |\n| <code>"alert"</code> | Used for important, and usually time-sensitive, information. |',
     },
   ],
-  related: [],
+  related: [
+    {
+      subtitle: 'Utility',
+      name: 'StyleHelper',
+      url: '/docs/api/checkout-ui-extensions/unstable/components/utilities/stylehelper',
+      type: 'utility',
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/View/View.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/View/View.ts
@@ -14,6 +14,7 @@ import type {
   ViewLikeAccessibilityRole,
   CornerProps,
   Opacity,
+  IdProps,
 } from '../shared';
 
 export type PositionType = 'absolute' | 'relative' | 'sticky';
@@ -105,27 +106,27 @@ export interface ViewProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,
     CornerProps,
+    IdProps,
     SizingProps,
     SpacingProps,
     VisibilityProps {
   /**
-   * Changes the display of the View.
+   * Changes the display of the component.
    *
    *
-   * `inline` follows the direction of words in a sentence based on the document’s writing mode.
+   * `inline` the component starts on the same line as preceding inline content and allows subsequent content to continue on the same line.
    *
-   * `block` follows the direction of paragraphs based on the document’s writing mode.
+   * `block` the component starts on its own new line and fills its parent.
    *
+   * `auto` resets the component to its initial value. The actual value depends on the component and context.
    *
-   * @defaultValue 'block'
+   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   *
+   * @defaultValue 'auto'
    */
-  display?: Display;
-
-  /**
-   * A unique identifier for the View.
-   */
-  id?: string;
-
+  display?: MaybeResponsiveConditionalStyle<Display>;
   /**
    * Sets the opacity of the View. The opacity will be applied to the background as well as all
    * the children of the View. Use carefully as this could decrease the contrast ratio between

--- a/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
@@ -133,7 +133,7 @@ export type AutocompleteField =
 
 export type Breakpoint = 'base' | 'extraSmall' | 'small' | 'medium' | 'large';
 
-export type Display = 'block' | 'inline';
+export type Display = 'none' | 'auto' | 'inline' | 'block';
 
 export type ShorthandProperty<T> = [T, T] | [T, T, T, T];
 

--- a/packages/ui-extensions/src/surfaces/checkout/style/examples/hiding.example.tsx
+++ b/packages/ui-extensions/src/surfaces/checkout/style/examples/hiding.example.tsx
@@ -1,0 +1,8 @@
+<View
+  display={Style.default('auto').when(
+    {viewportInlineSize: {min: 'small'}},
+    'none',
+  )}
+>
+  Content
+</View>;

--- a/packages/ui-extensions/src/surfaces/checkout/style/style.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/style/style.doc.ts
@@ -64,6 +64,20 @@ const data: ReferenceEntityTemplateSchema = {
           ],
         },
       },
+      {
+        description:
+          'Using the `display` property with conditional styles enables you to hide content for certain viewport sizes. In this example, the View will be hidden on small and above screen sizes.',
+        codeblock: {
+          title: 'Conditionally hiding content',
+          tabs: [
+            {
+              title: 'React',
+              code: './examples/hiding.example.tsx',
+              language: 'tsx',
+            },
+          ],
+        },
+      },
     ],
   },
   subSections: [

--- a/packages/ui-extensions/src/surfaces/checkout/style/types.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/style/types.ts
@@ -109,7 +109,8 @@ export interface ConditionalStyle<
 
 /**
  * A type that represents a value that can be a conditional style.
- * We highly recommend using the Style helper which simplifies the creation of conditional styles.
+ * We highly recommend using the `Style` helper which simplifies the creation of conditional styles.
+ *
  * To learn more check out the [conditional styles](/api/checkout-ui-extensions/components/utilities/stylehelper) documentation.
  */
 export type MaybeConditionalStyle<
@@ -117,6 +118,12 @@ export type MaybeConditionalStyle<
   AcceptedConditions extends BaseConditions = Conditions,
 > = T | ConditionalStyle<T, AcceptedConditions>;
 
+/**
+ * A type that represents a value that can be a conditional style. The conditions are based on the viewport size.
+ * We highly recommend using the `Style` helper which simplifies the creation of conditional styles.
+ *
+ * To learn more check out the [conditional styles](/api/checkout-ui-extensions/components/utilities/stylehelper) documentation.
+ */
 export type MaybeResponsiveConditionalStyle<T> =
   | T
   | ConditionalStyle<T, ViewportSizeCondition>;


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/checkout-web/issues/34173

### Solution

Publish the display property on supported components

### 🎩

Docs:

- `Grid`: https://shopify-dev.checkout-web-api-docs-3xx8.nicolas-cardelino.us.spin.dev/docs/api/checkout-ui-extensions/unstable/components/structure/grid#gridprops-propertydetail-display
- `View`: https://shopify-dev.checkout-web-api-docs-3xx8.nicolas-cardelino.us.spin.dev/docs/api/checkout-ui-extensions/unstable/components/structure/view#viewprops-propertydetail-display

`checkout-web` PR: https://github.com/Shopify/checkout-web/pull/34507


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
