### PR TITLE
Add CustomerAPI to POS UI ext

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -13,7 +13,7 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Action',
+      title: 'ActionApi',
       description: '',
       type: 'ActionApiContent',
     },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -1,0 +1,48 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateCodeBlockForCustomerApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'customer-api', fileName);
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Customer API',
+  description:
+    'The customer API provides an extension with data about the current customer.',
+  isVisualComponent: false,
+  type: 'APIs',
+  requires:
+    ExtensionTargetType.PosCustomerDetailsActionMenuItemRender ||
+    ExtensionTargetType.PosCustomerDetailsActionRender,
+  definitions: [
+    {
+      title: 'CustomerApi',
+      description: '',
+      type: 'CustomerApiContent',
+    },
+  ],
+  examples: {
+    description: 'Examples of using the Customer API.',
+    examples: [
+      {
+        codeblock: generateCodeBlockForCustomerApi(
+          'Retrieve the ID of the customer.',
+          'id',
+        ),
+      },
+    ],
+  },
+  category: 'APIs',
+  related: [
+    {
+      name: ExtensionTargetType.PosCustomerDetailsActionMenuItemRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-customer-details-action-menu-item-render',
+    },
+    {
+      name: ExtensionTargetType.PosCustomerDetailsActionRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-customer-details-action-render',
+    },
+  ],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -16,7 +16,7 @@ const data: ReferenceEntityTemplateSchema = {
     ExtensionTargetType.PosProductDetailsActionRender,
   definitions: [
     {
-      title: 'Product API',
+      title: 'ProductApi',
       description: '',
       type: 'ProductApiContent',
     },
@@ -26,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         codeblock: generateCodeBlockForProductApi(
-          'Retreive the ID of the product.',
+          'Retrieve the ID of the product.',
           'id',
         ),
       },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/customer-api/id.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/customer-api/id.ts
@@ -1,0 +1,23 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.customer-details.action.render', (root, api) => {
+  const navigator = root.createComponent(Navigator);
+  const screen = root.createComponent(Screen, {
+    name: 'CustomerApi',
+    title: 'Customer Api',
+  });
+  const scrollView = root.createComponent(ScrollView);
+  const text = root.createComponent(Text);
+
+  text.append(`Customer ID: ${api.customer.id}`);
+  scrollView.append(text);
+  screen.append(scrollView);
+  navigator.append(screen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/customer-api/id.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/customer-api/id.tsx
@@ -10,18 +10,18 @@ import {
 } from '@shopify/ui-extensions-react/point-of-sale';
 
 const Modal = () => {
-  const api = useApi<'pos.product-details.action.render'>();
+  const api = useApi<'pos.customer-details.action.render'>();
   return (
     <Navigator>
-      <Screen name="ProductDetails" title="Product Details">
+      <Screen name="CustomerApi" title="Customer Api">
         <ScrollView>
-          <Text>{`Product ID: ${api.product.id}`}</Text>
+          <Text>{`Customer ID: ${api.customer.id}`}</Text>
         </ScrollView>
       </Screen>
     </Navigator>
   );
 };
 
-export default reactExtension('pos.product-details.action.render', () => (
+export default reactExtension('pos.customer-details.action.render', () => (
   <Modal />
 ));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-api/id.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/product-api/id.tsx
@@ -15,7 +15,7 @@ const Modal = () => {
     <Navigator>
       <Screen name="ProductApi" title="Product Api">
         <ScrollView>
-          <Text>{`Product ID: ${api.product.id}`}/Text>
+          <Text>{`Product ID: ${api.product.id}`}</Text>
         </ScrollView>
       </Screen>
     </Navigator>

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/customer-details-action.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/customer-details-action.ts
@@ -1,0 +1,23 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.customer-details.action.render', (root, api) => {
+  const navigator = root.createComponent(Navigator);
+  const screen = root.createComponent(Screen, {
+    name: 'CustomerDetails',
+    title: 'Customer Details',
+  });
+  const scrollView = root.createComponent(ScrollView);
+  const text = root.createComponent(Text);
+
+  text.append(`Customer ID: ${api.customer.id}`);
+  scrollView.append(text);
+  screen.append(scrollView);
+  navigator.append(screen);
+  root.append(navigator);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/customer-details-action.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/customer-details-action.tsx
@@ -10,18 +10,18 @@ import {
 } from '@shopify/ui-extensions-react/point-of-sale';
 
 const Modal = () => {
-  const api = useApi<'pos.product-details.action.render'>();
+  const api = useApi<'pos.customer-details.action.render'>();
   return (
     <Navigator>
-      <Screen name="ProductDetails" title="Product Details">
+      <Screen name="CustomerDetails" title="Customer Details">
         <ScrollView>
-          <Text>{`Product ID: ${api.product.id}`}</Text>
+          <Text>{`Customer ID: ${api.customer.id}`}</Text>
         </ScrollView>
       </Screen>
     </Navigator>
   );
 };
 
-export default reactExtension('pos.product-details.action.render', () => (
+export default reactExtension('pos.customer-details.action.render', () => (
   <Modal />
 ));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/customer-details-menu-item.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/customer-details-menu-item.ts
@@ -1,0 +1,15 @@
+import {ActionItem, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.customer-details.action.menu-item.render',
+  (root, api) => {
+    const actionItem = root.createComponent(ActionItem, {
+      onPress: () => api.action.presentModal(),
+      enabled: true,
+    });
+
+    console.log(`Customer ID: ${api.customer.id}`);
+
+    root.append(actionItem);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/customer-details-menu-item.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/customer-details-menu-item.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {
+  reactExtension,
+  ActionItem,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const ActionItemComponent = () => {
+  const api = useApi<'pos.customer-details.action.menu-item.render'>();
+
+  console.log(`Customer ID: ${api.customer.id}`);
+
+  return <ActionItem enabled onPress={() => api.action.presentModal()} />;
+};
+
+export default reactExtension(
+  'pos.customer-details.action.menu-item.render',
+  () => <ActionItemComponent />,
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.menu-item.render.doc.ts
@@ -1,0 +1,32 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: ExtensionTargetType.PosCustomerDetailsActionMenuItemRender,
+  description:
+    'A static extension target that renders as a menu item on the customer details screen',
+  defaultExample: {
+    codeblock: generateCodeBlock(
+      'Menu item',
+      'targets',
+      'customer-details-menu-item',
+    ),
+  },
+  category: 'Targets',
+  subCategory: 'Customer details',
+  isVisualComponent: false,
+  related: [
+    {
+      name: ExtensionTargetType.PosCustomerDetailsActionRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-customer-details-action-render',
+    },
+    {
+      name: 'Customer API',
+      url: '/docs/api/pos-ui-extensions/apis/customer-api',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.render.doc.ts
@@ -1,0 +1,32 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: ExtensionTargetType.PosCustomerDetailsActionRender,
+  description:
+    'A full-screen extension target that renders when a `pos.customer-details.action.menu-item.render` target calls for it',
+  defaultExample: {
+    codeblock: generateCodeBlock(
+      'Action',
+      'targets',
+      'customer-details-action',
+    ),
+  },
+  category: 'Targets',
+  subCategory: 'Customer details',
+  isVisualComponent: false,
+  related: [
+    {
+      name: ExtensionTargetType.PosCustomerDetailsActionMenuItemRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-customer-details-action-menu-item-render',
+    },
+    {
+      name: 'Customer API',
+      url: '/docs/api/pos-ui-extensions/apis/customer-api',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
@@ -7,4 +7,6 @@ export enum ExtensionTargetType {
   PosProductDetailsActionRender = 'pos.product-details.action.render',
   PosOrderDetailsActionRender = 'pos.order-details.action.render',
   PosOrderDetailsActionMenuItemRender = 'pos.order-details.action.menu-item.render',
+  PosCustomerDetailsActionMenuItemRender = 'pos.customer-details.action.menu-item.render',
+  PosCustomerDetailsActionRender = 'pos.customer-details.action.render',
 }

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/extension-targets.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/extension-targets.doc.ts
@@ -62,6 +62,55 @@ Review [all extension targets](/docs/api/pos-ui-extensions/targets).
         },
       ],
     },
+
+    {
+      type: 'GenericAccordion',
+      title: 'Customer details',
+      anchorLink: 'customer-details',
+      sectionContent: 'The customer details screen',
+      accordionContent: [
+        {
+          title: 'Menu item',
+          description: `
+Displays a menu item on the customer details screen.
+
+Review [all extension targets](/docs/api/pos-ui-extensions/targets).
+`,
+        },
+        {
+          title: 'Action',
+          description: `
+Displays an action target modally when a menu item is tapped.
+
+Review [all extension targets](/docs/api/pos-ui-extensions/targets).
+`,
+        },
+      ],
+    },
+    {
+      type: 'GenericAccordion',
+      title: 'Product details',
+      anchorLink: 'product-details',
+      sectionContent: 'The product details screen',
+      accordionContent: [
+        {
+          title: 'Menu item',
+          description: `
+Displays a menu item on the product details screen.
+
+Review [all extension targets](/docs/api/pos-ui-extensions/targets).
+`,
+        },
+        {
+          title: 'Action',
+          description: `
+Displays an action target modally when a menu item is tapped.
+
+Review [all extension targets](/docs/api/pos-ui-extensions/targets).
+`,
+        },
+      ],
+    },
     {
       type: 'GenericAccordion',
       title: 'Order details',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -18,6 +18,11 @@ export type {
   ConnectivityApi,
 } from './api/connectivity-api/connectivity-api';
 
+export type {
+  CustomerApi,
+  CustomerApiContent,
+} from './api/customer-api/customer-api';
+
 export type {LocaleApi, LocaleApiContent} from './api/locale-api/locale-api';
 
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/customer-api/customer-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/customer-api/customer-api.ts
@@ -1,0 +1,10 @@
+export interface CustomerApi {
+  customer: CustomerApiContent;
+}
+
+export interface CustomerApiContent {
+  /**
+   * The unique identifier for the customer
+   */
+  id: number;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -2,10 +2,9 @@ import {StandardApi} from './api/standard/standard-api';
 import {
   // eslint-disable-next-line import/no-deprecated
   SmartGridApi,
-  NavigationApi,
-  ScannerApi,
   OrderApi,
   CartApi,
+  CustomerApi,
 } from './api';
 import {RenderExtension} from './extension';
 import type {Components} from './shared';
@@ -25,7 +24,7 @@ export interface ExtensionTargets {
     SmartGridComponents
   >;
   'pos.home.modal.render': RenderExtension<
-    StandardApi<'pos.home.modal.render'> & NavigationApi & ScannerApi & CartApi,
+    ActionTargetApi<'pos.home.modal.render'> & CartApi,
     BasicComponents
   >;
   'pos.purchase.post.action.menu-item.render': RenderExtension<
@@ -46,22 +45,32 @@ export interface ExtensionTargets {
     ActionComponents
   >;
   'pos.product-details.action.render': RenderExtension<
-    StandardApi<'pos.product-details.action.render'> &
-      CartApi &
-      NavigationApi &
-      ScannerApi &
-      ProductApi,
-    BasicComponents
-  >;
-  'pos.order-details.action.render': RenderExtension<
-    ActionTargetApi<'pos.order-details.action.render'> & OrderApi,
+    ActionTargetApi<'pos.product-details.action.render'> & CartApi & ProductApi,
     BasicComponents
   >;
   'pos.order-details.action.menu-item.render': RenderExtension<
     StandardApi<'pos.order-details.action.menu-item.render'> &
       ActionApi &
+      CartApi &
       OrderApi,
     ActionComponents
+  >;
+  'pos.order-details.action.render': RenderExtension<
+    ActionTargetApi<'pos.order-details.action.render'> & CartApi & OrderApi,
+    BasicComponents
+  >;
+  'pos.customer-details.action.menu-item.render': RenderExtension<
+    StandardApi<'pos.customer-details.action.menu-item.render'> &
+      ActionApi &
+      CartApi &
+      CustomerApi,
+    ActionComponents
+  >;
+  'pos.customer-details.action.render': RenderExtension<
+    ActionTargetApi<'pos.customer-details.action.render'> &
+      CartApi &
+      CustomerApi,
+    BasicComponents
   >;
 }
 


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/37677

### Background

Adds the customer detail's apis, targets and documentation
![Screenshot 2024-06-12 at 5 43 05 PM](https://github.com/Shopify/ui-extensions/assets/29528613/b7eb0c98-08a0-4deb-820a-fa73126f1ff5)
![Screenshot 2024-06-12 at 5 43 30 PM](https://github.com/Shopify/ui-extensions/assets/29528613/5f6e117d-ef7c-4a20-8e87-6a48ad41ac3d)

### 🎩
https://shopify-dev.ui-extensions-ttt9.victor-chu.us.spin.dev/docs/api/pos-ui-extensions/unstable/targets