### PR TITLE
Fix typo where BasicComponents were being added to the list of APIs

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -35,9 +35,8 @@ export interface ExtensionTargets {
     ActionComponents
   >;
   'pos.purchase.post.action.render': RenderExtension<
-    ActionTargetApi<'pos.purchase.post.action.render'> &
-      OrderApi &
-      BasicComponents
+    ActionTargetApi<'pos.purchase.post.action.render'> & OrderApi,
+    BasicComponents
   >;
   'pos.product-details.action.menu-item.render': RenderExtension<
     StandardApi<'pos.product-details.action.menu-item.render'> &
@@ -55,9 +54,8 @@ export interface ExtensionTargets {
     BasicComponents
   >;
   'pos.order-details.action.render': RenderExtension<
-    ActionTargetApi<'pos.order-details.action.render'> &
-      OrderApi &
-      BasicComponents
+    ActionTargetApi<'pos.order-details.action.render'> & OrderApi,
+    BasicComponents
   >;
   'pos.order-details.action.menu-item.render': RenderExtension<
     StandardApi<'pos.order-details.action.menu-item.render'> &


### PR DESCRIPTION
### Background

There was a typo that combined these instead of keeping them separate. The first param is the list of API's, and the second param is the list of components. The typo accidentally combined the component list into the API list, causing errors.

### Solution

Fix the typo
