### PR TITLE
update page examples

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/Page/examples/basic-Page-react.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/Page/examples/basic-Page-react.example.tsx
@@ -12,7 +12,7 @@ function App() {
     <Page
       title="Order #1411"
       subtitle="Confirmed Oct 5"
-      secondaryAction={<Button onPress={() => {}}>Button</Button>}
+      secondaryAction={<Button accessibilityLabel="Button" onPress={() => {}}/>}
       primaryActionLabel="Manage"
       primaryAction={
         <>

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-js.example.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-js.example.ts
@@ -18,7 +18,7 @@ async function renderApp(root, api) {
   await primaryAction.append(root.createComponent(Button, {onPress: () => {console.log("primary action 3")}}, 'Buy again primary 3'));
 
   const secondaryAction = root.createFragment();
-  await secondaryAction.append(root.createComponent(Button, {onPress: () => {}}, 'Button'))
+  await secondaryAction.append(root.createComponent(Button, {accessibilityLabel: 'Button', onPress: () => {}}))
 
   const page = root.createComponent(
     Page,


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/core-issues/issues/72042

The Page examples are using the wrong prop.

### Solution

I updated the example to use `accessibilityLabel` instead of `children`.

### 🎩

https://shopify-dev.customer-account-web-shopify-dev-u5w6.sylvain-hamann.us.spin.dev/docs/api/customer-account-ui-extensions/unstable/components/page

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
