### PR TITLE
Publish

### DIFF
--- a/packages/web-pixels-extension/package.json
+++ b/packages/web-pixels-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/web-pixels-extension",
   "description": "Provides tools to author Web Pixels extension",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
 - @shopify/web-pixels-extension@2.5.0

### Background

Related to https://github.com/Shopify/ce-customer-behaviour/issues/4994
Publishing changes for removal of `ordersCount` from:  https://github.com/Shopify/ui-extensions/pull/2078


### Solution

followed these [steps](https://github.com/Shopify/web-pixels-manager/blob/main/help-docs/updating-events.md#updating-the-public-package) for updating the public package
### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
