### PR TITLE
Add POS doc for 2024-04

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -30,6 +30,27 @@ const data: LandingTemplateSchema = {
     },
     {
       type: 'Generic',
+      anchorLink: '202404',
+      title: '2024.04',
+      sectionNotice: [
+        {
+          sectionContent: `This is the first version using the \`ui-extensions(-react)\` package. Please see the [migration guide](/docs/api/pos-ui-extensions/migrating) for more information.`,
+          title: 'Note',
+          type: 'Info',
+        },
+      ],
+      sectionContent: `
+- Added in POS version: 9.11
+- Removed in POS version: N/A
+- Release day: 06/10/2024.
+
+### Features
+
+- Added support for the [pos.purchase.post.action.menu-item.render](/docs/api/pos-ui-extensions/targets/post-purchase/pos-purchase-post-action-menu-item-render) and [pos.purchase.post.action.render](/docs/api/pos-ui-extensions/targets/post-purchase/pos-purchase-post-action-render) targets.
+      `,
+    },
+    {
+      type: 'Generic',
       anchorLink: '170',
       title: '1.7.0',
       sectionNotice: [


### PR DESCRIPTION
### Background

We missed a document for version 2024-04, which has caused some confusion in the community.

Resolves https://github.com/Shopify/pos-next-react-native/issues/38034

### Solution

Add a note for 2024-04

### 🎩

https://shopify-dev.ui-extensions-uga5.nathan-oliveira.us.spin.dev/docs/api/pos-ui-extensions/2024-04/versions#202404


### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
