### PR TITLE
Add line item properties to Web Pixel checkout data

### DIFF
--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -712,6 +712,15 @@ export const pixelEvents = {
               "The selling plan associated with the line item and the effect that each selling plan has on variants when they're purchased. This property is only available if the shop has [upgraded to Checkout Extensibility](https://help.shopify.com/manual/checkout-settings/checkout-extensibility/checkout-upgrade).",
           },
         },
+        properties: {
+          metadata: {
+            description:
+              'The properties of the line item. Add or allow customers to add custom information to a line item with line item properties. Line item properties consist of a name and value pair.',
+          },
+          elements: {
+            ref: 'Property',
+          },
+        },
       },
     },
     DiscountAllocation: {
@@ -876,6 +885,25 @@ export const pixelEvents = {
           type: 'string',
           metadata: {
             description: 'The product variant’s untranslated title.',
+          },
+        },
+      },
+    },
+    Property: {
+      metadata: {
+        description: 'The line item additional custom properties.',
+      },
+      properties: {
+        key: {
+          type: 'string',
+          metadata: {
+            description: 'The key for the property.',
+          },
+        },
+        value: {
+          type: 'string',
+          metadata: {
+            description: 'The value for the property.',
           },
         },
       },

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -898,6 +898,13 @@ export interface CheckoutLineItem {
   id: string;
 
   /**
+   * The properties of the line item. Add or allow customers to add custom
+   * information to a line item with line item properties. Line item properties
+   * consist of a name and value pair.
+   */
+  properties: Property[];
+
+  /**
    * The quantity of the line item.
    */
   quantity: number;
@@ -1560,6 +1567,21 @@ export interface ProductVariant {
    * The product variant’s untranslated title.
    */
   untranslatedTitle: string;
+}
+
+/**
+ * The line item additional custom properties.
+ */
+export interface Property {
+  /**
+   * The key for the property.
+   */
+  key: string;
+
+  /**
+   * The value for the property.
+   */
+  value: string;
 }
 
 /**


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/ce-customer-behaviour/issues/5069
WPM PR: https://github.com/Shopify/web-pixels-manager/pull/817

### Solution

Add `properties` to `CheckoutLineItem`

### 🎩

https://shop1.shopify.checkout-line-item.james-calverley.us.spin.dev/

View product
Add additional information in the custom properties
Add product to cart
Checkout
Ensure that the properties you have added are captured in the checkout_started and checkout_completed events.

### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
