### PR TITLE
Export SectionHeader component from ui-extensions-react POS package

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/point-of-sale.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale.ts
@@ -43,6 +43,7 @@ export type {
   SearchBarProps,
   SectionHeaderAction,
   SectionProps,
+  SectionHeaderProps,
   Segment,
   SegmentedControlProps,
   SelectableProps,

--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/components.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/components.ts
@@ -19,6 +19,7 @@ export {Screen} from './components/Screen/Screen';
 export {ScrollView} from './components/ScrollView/ScrollView';
 export {SearchBar} from './components/SearchBar/SearchBar';
 export {Section} from './components/Section/Section';
+export {SectionHeader} from './components/SectionHeader/SectionHeader';
 export {SegmentedControl} from './components/SegmentedControl/SegmentedControl';
 export {Selectable} from './components/Selectable/Selectable';
 export {Stack} from './components/Stack/Stack';

--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
@@ -1,0 +1,4 @@
+import {SectionHeader as BaseSectionHeader} from '@shopify/ui-extensions/point-of-sale';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const SectionHeader = createRemoteReactComponent(BaseSectionHeader);


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-for-retail/issues/438

### Background

The `SectionHeader` component was added to the `ui-extensions` POS package but missing from the `ui-extensions-react` one. Adding it here.

### Solution

Export `SectionHeader` from `ui-extensions-react` package.

### 🎩

- ...

### Checklist

~- [ ] I have :tophat:'d these changes~
~- [ ] I have updated relevant documentation~
