### PR TITLE
Change required sections to markdown in POS API docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -1,14 +1,23 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
-import {ExtensionTargetType} from '../types/ExtensionTargetType';
+import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
 
 const generateCodeBlockForActionApi = (title: string, fileName: string) =>
   generateCodeBlock(title, 'action-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Action API',
-  description:
-    'The Action API allows an action extension to modally present its corresponding modal target.',
+  description: `
+The Action API allows an action extension to modally present its corresponding modal target.
+
+### Supporting targets
+- ${TargetLink.PosHomeTileRender}
+- ${TargetLink.PosPurchasePostActionMenuItemRender}
+- ${TargetLink.PosOrderDetailsActionMenuItemRender}
+- ${TargetLink.PosProductDetailsActionMenuItemRender}
+- ${TargetLink.PosCustomerDetailsActionMenuItemRender}
+- ${TargetLink.PosDraftOrderDetailsActionMenuItemRender}
+`,
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
@@ -20,10 +29,6 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
-  requires:
-    ExtensionTargetType.PosHomeTileRender ||
-    ExtensionTargetType.PosPurchasePostActionMenuItemRender ||
-    ExtensionTargetType.PosOrderDetailsActionMenuItemRender,
   examples: {
     description: 'Examples of using the Action API.',
     examples: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -1,14 +1,27 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
-import {ExtensionTargetType} from '../types/ExtensionTargetType';
+import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
 
 const generateCodeBlockForCartApi = (title: string, fileName: string) =>
   generateCodeBlock(title, 'cart-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Cart API',
-  description:
-    'The Cart API enables UI Extensions to manage and interact with POS cart contents, such as discounts, line items, and customer details. It provides a comprehensive set of functions for adding and removing items, alongside a subscribable object that keeps the UI Extension updated with real-time changes to the cart.',
+  description: `
+The Cart API enables UI Extensions to manage and interact with POS cart contents, such as discounts, line items, and customer details. It provides a comprehensive set of functions for adding and removing items, alongside a subscribable object that keeps the UI Extension updated with real-time changes to the cart.
+
+### Supporting targets
+- ${TargetLink.PosHomeTileRender}
+- ${TargetLink.PosHomeModalRender}
+- ${TargetLink.PosProductDetailsActionMenuItemRender}
+- ${TargetLink.PosProductDetailsActionRender}
+- ${TargetLink.PosCustomerDetailsActionMenuItemRender}
+- ${TargetLink.PosCustomerDetailsActionRender}
+- ${TargetLink.PosOrderDetailsActionMenuItemRender}
+- ${TargetLink.PosOrderDetailsActionRender}
+- ${TargetLink.PosDraftOrderDetailsActionMenuItemRender}
+- ${TargetLink.PosDraftOrderDetailsActionRender}
+`,
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
@@ -20,9 +33,6 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
-  requires:
-    ExtensionTargetType.PosHomeTileRender ||
-    ExtensionTargetType.PosHomeModalRender,
   examples: {
     description: 'Examples of using the Cart API',
     examples: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -1,5 +1,5 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
-import {ExtensionTargetType} from '../types/ExtensionTargetType';
+import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
 const generateCodeBlockForCustomerApi = (title: string, fileName: string) =>
@@ -7,13 +7,15 @@ const generateCodeBlockForCustomerApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Customer API',
-  description:
-    'The customer API provides an extension with data about the current customer.',
+  description: `
+The customer API provides an extension with data about the current customer.
+
+### Supporting targets
+- ${TargetLink.PosCustomerDetailsActionMenuItemRender}
+- ${TargetLink.PosCustomerDetailsActionRender}
+`,
   isVisualComponent: false,
   type: 'APIs',
-  requires:
-    ExtensionTargetType.PosCustomerDetailsActionMenuItemRender ||
-    ExtensionTargetType.PosCustomerDetailsActionRender,
   definitions: [
     {
       title: 'CustomerApi',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
@@ -1,16 +1,19 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
-import {ExtensionTargetType} from '../types/ExtensionTargetType';
+import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Draft Order API',
-  description:
-    'The Draft Order API provides an extension with data about the current draft order.',
+  description: `
+The Draft Order API provides an extension with data about the current draft order.
+
+
+### Supporting targets
+- ${TargetLink.PosDraftOrderDetailsActionMenuItemRender}
+- ${TargetLink.PosDraftOrderDetailsActionRender}
+`,
   isVisualComponent: false,
   type: 'APIs',
-  requires:
-    ExtensionTargetType.PosDraftOrderDetailsActionMenuItemRender ||
-    ExtensionTargetType.PosDraftOrderDetailsActionRender,
   definitions: [
     {
       title: 'DraftOrderApi',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -1,14 +1,23 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
-import {ExtensionTargetType} from '../types/ExtensionTargetType';
+import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
 
 const generateCodeBlockForNavigationApi = (title: string, fileName: string) =>
   generateCodeBlock(title, 'navigation-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Navigation API',
-  description:
-    'The Navigation API enables POS UI extension to navigate between screens.',
+  description: `
+The Navigation API enables POS UI extension to navigate between screens.
+
+### Supporting targets
+- ${TargetLink.PosHomeModalRender}
+- ${TargetLink.PosPurchasePostActionRender}
+- ${TargetLink.PosProductDetailsActionRender}
+- ${TargetLink.PosOrderDetailsActionRender}
+- ${TargetLink.PosDraftOrderDetailsActionRender}
+- ${TargetLink.PosCustomerDetailsActionMenuItemRender}
+`,
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
@@ -20,9 +29,6 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
-  requires:
-    ExtensionTargetType.PosHomeModalRender ||
-    ExtensionTargetType.PosPurchasePostActionRender,
   examples: {
     description: 'Examples of using the Navigation API',
     examples: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -1,17 +1,19 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
-import {ExtensionTargetType} from '../types/ExtensionTargetType';
+import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Order API',
-  description:
-    'The Order API provides an extension with data about the current order.',
+  description: `
+The Order API provides an extension with data about the current order.
+
+### Supporting targets
+- ${TargetLink.PosPurchasePostActionMenuItemRender}
+- ${TargetLink.PosPurchasePostActionRender}
+- ${TargetLink.PosOrderDetailsActionMenuItemRender}
+- ${TargetLink.PosOrderDetailsActionRender}
+`,
   isVisualComponent: false,
   type: 'APIs',
-  requires:
-    ExtensionTargetType.PosPurchasePostActionMenuItemRender ||
-    ExtensionTargetType.PosPurchasePostActionRender ||
-    ExtensionTargetType.PosOrderDetailsActionMenuItemRender ||
-    ExtensionTargetType.PosOrderDetailsActionRender,
   definitions: [
     {
       title: 'OrderApi',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -1,5 +1,5 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
-import {ExtensionTargetType} from '../types/ExtensionTargetType';
+import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
 
 const generateCodeBlockForProductApi = (title: string, fileName: string) =>
@@ -7,13 +7,15 @@ const generateCodeBlockForProductApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Product API',
-  description:
-    'The Product API provides an extension with data about the current Product.',
+  description: `
+The Product API provides an extension with data about the current Product.
+
+### Supporting targets
+- ${TargetLink.PosProductDetailsActionMenuItemRender}
+- ${TargetLink.PosProductDetailsActionRender}
+`,
   isVisualComponent: false,
   type: 'APIs',
-  requires:
-    ExtensionTargetType.PosProductDetailsActionMenuItemRender ||
-    ExtensionTargetType.PosProductDetailsActionRender,
   definitions: [
     {
       title: 'ProductApi',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -1,14 +1,23 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
-import {ExtensionTargetType} from '../types/ExtensionTargetType';
+import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
 
 const generateCodeBlockForScannerApi = (title: string, fileName: string) =>
   generateCodeBlock(title, 'scanner-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Scanner API',
-  description:
-    'The Scanner API enables an extension to access scanner data and available scanning sources supported by the device.',
+  description: `
+The Scanner API enables an extension to access scanner data and available scanning sources supported by the device.
+
+### Supporting targets
+- ${TargetLink.PosHomeModalRender}
+- ${TargetLink.PosPurchasePostActionRender}
+- ${TargetLink.PosProductDetailsActionRender}
+- ${TargetLink.PosOrderDetailsActionRender}
+- ${TargetLink.PosDraftOrderDetailsActionRender}
+- ${TargetLink.PosCustomerDetailsActionMenuItemRender}
+`,
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
@@ -20,9 +29,6 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
-  requires:
-    ExtensionTargetType.PosHomeModalRender ||
-    ExtensionTargetType.PosPurchasePostActionRender,
   examples: {
     description: 'Examples of receiving updates from the Scanner API',
     examples: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
@@ -12,3 +12,18 @@ export enum ExtensionTargetType {
   PosDraftOrderDetailsActionMenuItemRender = 'pos.draft-order-details.action.menu-item.render',
   PosDraftOrderDetailsActionRender = 'pos.draft-order-details.action.render',
 }
+
+export enum TargetLink {
+  PosHomeModalRender = '[pos.home.modal.render](/docs/api/pos-ui-extensions/targets/smart-grid/pos-home-modal-render)',
+  PosHomeTileRender = '[pos.home.tile.render](/docs/api/pos-ui-extensions/targets/smart-grid/pos-home-tile-render)',
+  PosPurchasePostActionMenuItemRender = '[pos.purchase.post.action.menu-item.render](/docs/api/pos-ui-extensions/targets/post-purchase/pos-purchase-post-action-menu-item-render)',
+  PosPurchasePostActionRender = '[pos.purchase.post.action.render](/docs/api/pos-ui-extensions/targets/post-purchase/pos-purchase-post-action-render)',
+  PosProductDetailsActionMenuItemRender = '[pos.product-details.action.menu-item.render](/docs/api/pos-ui-extensions/targets/product-details/pos-product-details-action-menu-item-render)',
+  PosProductDetailsActionRender = '[pos.product-details.action.render](/docs/api/pos-ui-extensions/targets/product-details/pos-product-details-action-render)',
+  PosOrderDetailsActionRender = '[pos.order-details.action.render](/docs/api/pos-ui-extensions/targets/order-details/pos-order-details-action-render)',
+  PosOrderDetailsActionMenuItemRender = '[pos.order-details.action.menu-item.render](/docs/api/pos-ui-extensions/targets/order-details/pos-order-details-action-menu-item-render)',
+  PosCustomerDetailsActionMenuItemRender = '[pos.customer-details.action.menu-item.render](/docs/api/pos-ui-extensions/targets/customer-details/pos-customer-details-action-menu-item-render)',
+  PosCustomerDetailsActionRender = '[pos.customer-details.action.render](/docs/api/pos-ui-extensions/targets/customer-details/pos-customer-details-action-render)',
+  PosDraftOrderDetailsActionMenuItemRender = '[pos.draft-order-details.action.menu-item.render](/docs/api/pos-ui-extensions/targets/draft-order-details/pos-draft-order-details-action-menu-item-render)',
+  PosDraftOrderDetailsActionRender = '[pos.draft-order-details.action.render](/docs/api/pos-ui-extensions/targets/draft-order-details/pos-draft-order-details-action-render)',
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -1,4 +1,5 @@
 import type {LandingTemplateSchema} from '@shopify/generate-docs';
+import {TargetLink} from '../../reference/types/ExtensionTargetType';
 
 const data: LandingTemplateSchema = {
   title: 'Versions',
@@ -14,8 +15,8 @@ const data: LandingTemplateSchema = {
   sections: [
     {
       type: 'Generic',
-      anchorLink: '202408',
-      title: '2024.08',
+      anchorLink: '202407',
+      title: '2024.07',
       sectionContent: `
 - Added in POS version: N/A
 - Removed in POS version: N/A
@@ -26,6 +27,10 @@ const data: LandingTemplateSchema = {
 - Removed \`subtitle\` property to the [FormattedTextField](/docs/api/pos-ui-extensions/apis/formatted-text-field) component.
 - Removed \`subtitle\` property to the [TextField](/docs/api/pos-ui-extensions/apis/text-field) component.
 - Renamed the \`OrderAPIContent\` interface to \`OrderApiContent\`.
+- Added support for the ${TargetLink.PosProductDetailsActionMenuItemRender} and ${TargetLink.PosProductDetailsActionRender} targets.
+- Added support for the ${TargetLink.PosOrderDetailsActionMenuItemRender} and ${TargetLink.PosOrderDetailsActionRender} targets.
+- Added support for the ${TargetLink.PosDraftOrderDetailsActionMenuItemRender} and ${TargetLink.PosDraftOrderDetailsActionRender} targets.
+- Added support for the ${TargetLink.PosCustomerDetailsActionMenuItemRender} and ${TargetLink.PosCustomerDetailsActionRender} targets.
       `,
     },
     {
@@ -46,7 +51,7 @@ const data: LandingTemplateSchema = {
 
 ### Features
 
-- Added support for the [pos.purchase.post.action.menu-item.render](/docs/api/pos-ui-extensions/targets/post-purchase/pos-purchase-post-action-menu-item-render) and [pos.purchase.post.action.render](/docs/api/pos-ui-extensions/targets/post-purchase/pos-purchase-post-action-render) targets.
+- Added support for the ${TargetLink.PosPurchasePostActionMenuItemRender} and ${TargetLink.PosPurchasePostActionRender} targets.
       `,
     },
     {


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/pos-next-react-native/issues/38101

The `required` sections weren't doing what we expected. They were only printing the first string, which makes sense when you think of it logically as code. The first string is truthy, so the rest are ignored.

### Solution

Instead, create a subheader in the description that enumerates the supported targets, with links.

![image](https://github.com/Shopify/ui-extensions/assets/29490857/6f5c2155-36ba-4ced-a6f1-6fc71128a600)

### 🎩

https://shopify-dev.ui-extensions-uga5.nathan-oliveira.us.spin.dev/docs/api/pos-ui-extensions/unstable/apis/cart-api

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
