### PR TITLE
Updates github actions in for 2024-07

### DIFF
--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -9,6 +9,7 @@ on:
       - 2023-10
       - 2024-01
       - 2024-04
+      - 2024-07
       - unstable
     paths:
       - 'packages/*/src/**'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
       - 2023-10
       - 2024-01
       - 2024-04
+      - 2024-07
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Background
This adds the `2024-07` to the changeset reminder and deploy actions in `unstable` which are added in the `2024-07` branch.
