### PR TITLE
Wpm 1.10 update

### DIFF
--- a/packages/web-pixels-extension/src/types/ExtensionApi.ts
+++ b/packages/web-pixels-extension/src/types/ExtensionApi.ts
@@ -1,12 +1,17 @@
 import type {Browser} from './PixelEvents';
-import type {WebPixelsManager} from './WebPixelsManager';
+import type {Events} from './WebPixelsManager';
 import type {RegisterInit} from './RegisterInit';
 import type {CustomerPrivacyEventBus} from './PrivacyApi';
+import type {SubscriberCallback, SubscriberOptions} from './EventBus';
 
 export interface ExtensionApi {
   readonly settings: Record<string, any>;
   readonly analytics: {
-    readonly subscribe: WebPixelsManager['subscribe'];
+    subscribe<K extends string>(
+      name: K,
+      callback: SubscriberCallback<Events[K]>,
+      options?: SubscriberOptions,
+    ): () => boolean;
   };
   readonly browser: Browser;
   readonly init: RegisterInit;

--- a/packages/web-pixels-extension/src/types/WebPixelsManager.ts
+++ b/packages/web-pixels-extension/src/types/WebPixelsManager.ts
@@ -56,7 +56,7 @@ export interface WebPixelsManager {
   ): boolean;
   subscribe<K extends string>(
     name: K,
-    callback: SubscriberCallback<Events[K], Promise<void>>,
+    callback: SubscriberCallback<Events[K]>,
     options?: SubscriberOptions,
   ): () => boolean;
 }


### PR DESCRIPTION
### Background

EPIC: https://github.com/Shopify/ce-customer-behaviour/issues/4868

ISSUE: https://github.com/Shopify/ce-customer-behaviour/issues/5357

The final step to release our new types is update the wpm ui-extensions packages so our new types can be seen.


### Solution

Ran `yarn schema:publish`
### 🎩

We can see code completion showing our new types in the web pixels test app and not complaining about the callback type signature


![image](https://github.com/Shopify/ui-extensions/assets/66790620/b274e13d-0e52-474a-8eb3-855fdda1340f)


- ...

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
