### PR TITLE
Add UI Extensions StorageAPI

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -100,3 +100,12 @@ export type {
 export type {CountryCode} from './api/types/country-code';
 
 export type {Session} from './api/types/session';
+
+export type {
+  StorageApi,
+  StorageApiContent,
+} from './api/storage-api/storage-api';
+export {
+  StorageApiError,
+  StorageApiErrorCode,
+} from './api/storage-api/storage-api';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/standard/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/standard/standard-api.ts
@@ -4,6 +4,7 @@ import type {LocaleApi} from '../locale-api/locale-api';
 import type {SessionApi} from '../session-api/session-api';
 import type {ToastApi} from '../toast-api/toast-api';
 import type {ProductSearchApi} from '../product-search-api/product-search-api';
+import {StorageApi} from '../storage-api/storage-api';
 
 export type StandardApi<T> = {[key: string]: any} & {
   extensionPoint: T;
@@ -12,4 +13,5 @@ export type StandardApi<T> = {[key: string]: any} & {
   SessionApi &
   ProductSearchApi &
   DeviceApi &
+  StorageApi &
   ConnectivityApi;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/storage-api/storage-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/storage-api/storage-api.ts
@@ -1,0 +1,32 @@
+export interface StorageApi {
+  storage: StorageApiContent;
+}
+
+export enum StorageApiErrorCode {
+  DataSizeLimitExceeded = 'DATA_SIZE_LIMIT_EXCEEDED',
+}
+export class StorageApiError extends Error {
+  constructor(message: string, public code: StorageApiErrorCode) {
+    super(message);
+    this.name = 'StorageApiError';
+    this.code = code;
+  }
+}
+
+export interface StorageApiContent {
+  /**
+   * Get the value of a key from the storage
+   * @param key
+   * @returns the value of the key or undefined if the key does not exist
+   */
+  get(key: string): Promise<string | undefined>;
+
+  /**
+   * Set the value of a key in the storage
+   * Value must be encoded as a string
+   * @throws StorageApiError with code=StorageApiErrorCode.DataSizeLimitExceeded if the data size limit is exceeded
+   * @param key
+   * @param value
+   */
+  set(key: string, value: string): Promise<void>;
+}


### PR DESCRIPTION
### Background

[Hackdays project](https://hackdays.shopify.io/projects/18478)
[Partners Issue](https://github.com/Shopify/ui-extensions/issues/975)

Adding interfaces for new Storage API for POS UI Extensions

It will let UI extensions to store up to 100_000 symbols of data in POSSecureStorage and fetch it from there instead of fetching it from external API

### Solution

Add interfaces so that we could add that API to the[ pos-next-react-native](https://github.com/Shopify/pos-next-react-native/pull/38424)

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
