### PR TITLE
Removes changesets included in 2024-07 release

### DIFF
--- a/.changeset/calm-crabs-run.md
+++ b/.changeset/calm-crabs-run.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': patch
-'@shopify/ui-extensions-react': patch
----
-
-Homogenizes terminology to use the term "placement" in place of "supported location", "placement reference", and others.

--- a/.changeset/famous-pillows-work.md
+++ b/.changeset/famous-pillows-work.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-Add new block extension targets: collection, draft-order, abandoned-checkout, and product-variant

--- a/.changeset/fresh-shoes-buy.md
+++ b/.changeset/fresh-shoes-buy.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-Updates Order Status API with `processedAt` attribute

--- a/.changeset/happy-kings-shop.md
+++ b/.changeset/happy-kings-shop.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-- Adds `useCustomerPrivacy` hook.

--- a/.changeset/heavy-adults-joke.md
+++ b/.changeset/heavy-adults-joke.md
@@ -1,8 +1,0 @@
----
-'@shopify/ui-extensions-react': minor
-'@shopify/ui-extensions': minor
----
-
-Added `CartInstructions` (accessed using `api.instructions`) to checkout. These represent the cart instructions used to create the checkout and possibly limit extension capabilities. These instructions should be checked prior to performing any actions that may be affected by them.
-
-For example, if you intend to add a discount code via the `applyDiscountCodeChange` method, check `api.instructions.discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.

--- a/.changeset/hot-flowers-glow.md
+++ b/.changeset/hot-flowers-glow.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Moves `Capability` type to shared types file

--- a/.changeset/hungry-beans-complain.md
+++ b/.changeset/hungry-beans-complain.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': minor
----
-
-Adds `selectedCountryCode` to `AddressAutocompleteSuggestionApi`.

--- a/.changeset/long-news-prove.md
+++ b/.changeset/long-news-prove.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-Support split shipping in Shipping option list and item targets.

--- a/.changeset/lovely-pots-scream.md
+++ b/.changeset/lovely-pots-scream.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Add metafields to PickupLocationOption

--- a/.changeset/nasty-hotels-press.md
+++ b/.changeset/nasty-hotels-press.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Added `appMetafields` field to `AddressAutocompleteStandardApi`

--- a/.changeset/new-pugs-shop.md
+++ b/.changeset/new-pugs-shop.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': patch
-'@shopify/ui-extensions-react': patch
----
-
-add authenticationState api to customer account ui extension

--- a/.changeset/orange-ants-sniff.md
+++ b/.changeset/orange-ants-sniff.md
@@ -1,7 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-- Adds the ability to read and write tracking consent metafield data to the Customer Privacy API.
-- Updates the `Sheet` component and examples.

--- a/.changeset/rich-chicken-repeat.md
+++ b/.changeset/rich-chicken-repeat.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': patch
-'@shopify/ui-extensions-react': patch
----
-
-Publish display property

--- a/.changeset/serious-experts-admire.md
+++ b/.changeset/serious-experts-admire.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-Add Extension Target for Reorder Flow

--- a/.changeset/silver-jobs-sneeze.md
+++ b/.changeset/silver-jobs-sneeze.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': patch
-'@shopify/ui-extensions-react': patch
----
-
-Add Switch component

--- a/.changeset/swift-cherries-prove.md
+++ b/.changeset/swift-cherries-prove.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': minor
----
-
-Add resource picker to admin block extension

--- a/.changeset/tall-cows-explain.md
+++ b/.changeset/tall-cows-explain.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-Add AdminPrintAction component

--- a/.changeset/tall-fireants-sleep.md
+++ b/.changeset/tall-fireants-sleep.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-Add admin print action targets

--- a/.changeset/twelve-otters-think.md
+++ b/.changeset/twelve-otters-think.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': patch
-'@shopify/ui-extensions-react': patch
----
-
-Improve error messaging when a React hook is used from a different API surface than the extension calling it.

--- a/.changeset/violet-flowers-deny.md
+++ b/.changeset/violet-flowers-deny.md
@@ -1,8 +1,0 @@
----
-'@shopify/ui-extensions-react': minor
-'@shopify/ui-extensions': minor
----
-
-- Adds `oneTimeUse` to `ShippingAddress` to denote whether the address can be saved in checkout.
-- Adds `sku` to `ProductVariant` in checkout.
-- Adds `bullet` icon in checkout.

--- a/.changeset/weak-snakes-ring.md
+++ b/.changeset/weak-snakes-ring.md
@@ -1,7 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-- Add code examples for custom address autocomplete extensions
-- Update documentation for custom address autocomplete extensions
-- Misc. type updates and documentation updates

--- a/.changeset/yellow-lions-behave.md
+++ b/.changeset/yellow-lions-behave.md
@@ -1,7 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-- Adds `purchase.address-autocomplete.suggest` extension target
-- Adds the `primaryAction` and `secondaryAction` to the `Sheet` component


### PR DESCRIPTION
### Background
`2024-07` was released yesterday https://github.com/Shopify/ui-extensions/pull/2122

This PR removes the changesets included in that release from the `unstable` branch.
