### PR TITLE
avoid duplicated types from checkout when generating docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.sh
@@ -38,11 +38,17 @@ else
   echo "export {}" > src/surfaces/checkout.ts
   echo "export {}" > src/surfaces/admin.ts
   echo "export {}" > src/surfaces/point-of-sale.ts
+  echo "export {}" > ../ui-extensions-react/src/surfaces/checkout.ts
+  echo "export {}" > ../ui-extensions-react/src/surfaces/admin.ts
+  echo "export {}" > ../ui-extensions-react/src/surfaces/point-of-sale.ts
   eval $COMPILE_DOCS && eval $COMPILE_STATIC_PAGES && eval $COMPILE_CATEGORY_PAGES
   build_exit=$?
   git checkout HEAD -- src/surfaces/checkout.ts
   git checkout HEAD -- src/surfaces/admin.ts
   git checkout HEAD -- src/surfaces/point-of-sale.ts
+  git checkout HEAD -- ../ui-extensions-react/src/surfaces/checkout.ts
+  git checkout HEAD -- ../ui-extensions-react/src/surfaces/admin.ts
+  git checkout HEAD -- ../ui-extensions-react/src/surfaces/point-of-sale.ts
 fi
 
 


### PR DESCRIPTION
### Background

Even if we have said that the type input should only come from `src/surfaces/customer-account` , we can still get types from checkout.  ( for example the hooks )
<img width="952" alt="Screenshot 2024-07-03 at 4 24 21 PM" src="https://github.com/Shopify/ui-extensions/assets/12724940/fc6df6ad-7227-4ec2-b4fd-8faa3789e0b8">


### Solution

Do not include any react version types from other folders. 

### 🎩


1. with this branch there is no warning saying there are more than 1 definitions for `UseShippingAddressGeneratedType` when generating the doc

unstable branch:
<img width="1512" alt="Screenshot 2024-07-03 at 4 26 30 PM" src="https://github.com/Shopify/ui-extensions/assets/12724940/d0eb9632-f8c3-4e40-a143-a6939008e547">

this branch:
<img width="1512" alt="Screenshot 2024-07-03 at 4 24 58 PM" src="https://github.com/Shopify/ui-extensions/assets/12724940/2c83189e-7aac-4b20-b9ef-7b074451ec82">

2. The docs still have correct and clickable types
https://shopify-dev.typetype.brian-shen.us.spin.dev/docs/api/customer-account-ui-extensions/unstable/apis/order-status-api/addresses 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
