### PR TITLE
import hooks from main entry point in tests

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/api.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/api.test.tsx
@@ -1,4 +1,4 @@
-import {useApi} from '../api';
+import {useApi} from '..';
 
 import {mount} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/app-metafields.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/app-metafields.test.ts
@@ -1,7 +1,7 @@
 import {Metafield} from '@shopify/ui-extensions/customer-account';
 import {faker} from '@faker-js/faker';
 
-import {useAppMetafields} from '../app-metafields';
+import {useAppMetafields} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/authenticated-account.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/authenticated-account.test.tsx
@@ -3,7 +3,7 @@ import {faker} from '@faker-js/faker';
 import {
   useAuthenticatedAccountCustomer,
   useAuthenticatedAccountPurchasingCompany,
-} from '../authenticated-account';
+} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/authentication-state.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/authentication-state.test.tsx
@@ -1,4 +1,4 @@
-import {useAuthenticationState} from '../authentication-state';
+import {useAuthenticationState} from '..';
 import type {Extension} from '@shopify/ui-extensions/customer-account';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/buyer-identity-businessCustomer.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/buyer-identity-businessCustomer.test.ts
@@ -1,4 +1,4 @@
-import {usePurchasingCompany} from '../buyer-identity';
+import {usePurchasingCompany} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/buyer-identity.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/buyer-identity.test.tsx
@@ -2,7 +2,7 @@ import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 import {faker} from '@faker-js/faker';
 
 import {ScopeNotGrantedError} from '../../errors';
-import {useCustomer, useEmail, usePhone} from '../buyer-identity';
+import {useCustomer, useEmail, usePhone} from '..';
 
 import {mount} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/capabilities.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/capabilities.test.ts
@@ -1,9 +1,6 @@
 import type {Extension} from '@shopify/ui-extensions/customer-account';
 
-import {
-  useExtensionCapabilities,
-  useExtensionCapability,
-} from '../capabilities';
+import {useExtensionCapabilities, useExtensionCapability} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/checkout-settings.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/checkout-settings.test.ts
@@ -1,6 +1,6 @@
 import {CheckoutSettings} from '@shopify/ui-extensions/customer-account';
 
-import {useCheckoutSettings} from '../checkout-settings';
+import {useCheckoutSettings} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/configuration.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/configuration.test.ts
@@ -1,4 +1,4 @@
-import {useSettings} from '../settings';
+import {useSettings} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/country.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/country.test.tsx
@@ -1,6 +1,6 @@
 import {CountryCode} from '@shopify/ui-extensions/customer-account';
 
-import {useLocalizationCountry} from '../country';
+import {useLocalizationCountry} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/currency.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/currency.test.tsx
@@ -1,6 +1,6 @@
 import {CurrencyCode} from '@shopify/ui-extensions/customer-account';
 
-import {useCurrency} from '../currency';
+import {useCurrency} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/discounts.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/discounts.test.tsx
@@ -3,7 +3,7 @@ import {
   CartDiscountAllocation,
 } from '@shopify/ui-extensions/customer-account';
 
-import {useDiscountAllocations, useDiscountCodes} from '../discounts';
+import {useDiscountAllocations, useDiscountCodes} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 import type {PartialExtensionApi} from './mount';

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/extension-language.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/extension-language.test.tsx
@@ -1,4 +1,4 @@
-import {useExtensionLanguage} from '../extension-language';
+import {useExtensionLanguage} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/gift-cards.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/gift-cards.test.tsx
@@ -1,6 +1,6 @@
 import {AppliedGiftCard} from '@shopify/ui-extensions/customer-account';
 
-import {useAppliedGiftCards} from '../gift-cards';
+import {useAppliedGiftCards} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 import type {PartialExtensionApi} from './mount';

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/i18n.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/i18n.test.tsx
@@ -1,5 +1,5 @@
 import {mount} from './mount';
-import {useI18n} from '../i18n';
+import {useI18n} from '..';
 
 describe('useI18n', () => {
   it('returns the i18n utilities', () => {

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/live-navigation.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/live-navigation.test.tsx
@@ -1,5 +1,5 @@
 import {mount} from './mount';
-import {useNavigationCurrentEntry} from '../live-navigation';
+import {useNavigationCurrentEntry} from '..';
 import {destroyAll} from '@quilted/react-testing';
 
 describe('useNavigationCurrentEntry', () => {

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/market.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/market.test.tsx
@@ -1,4 +1,4 @@
-import {useLocalizationMarket} from '../market';
+import {useLocalizationMarket} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/navigation.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/navigation.test.tsx
@@ -1,5 +1,5 @@
 import {mount} from './mount';
-import {useNavigation} from '../navigation';
+import {useNavigation} from '..';
 
 describe('useNavigation', () => {
   it('returns the navigation', () => {

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/notes.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/notes.test.tsx
@@ -1,4 +1,4 @@
-import {useNote} from '../note';
+import {useNote} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/session-token.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/session-token.test.tsx
@@ -1,4 +1,4 @@
-import {useSessionToken} from '../session-token';
+import {useSessionToken} from '..';
 
 import {mount} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/shipping-address.test.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/shipping-address.test.ts
@@ -1,6 +1,6 @@
 import {MailingAddress} from '@shopify/ui-extensions/customer-account';
 
-import {useShippingAddress} from '../shipping-address';
+import {useShippingAddress} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/shopping-address.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/shopping-address.test.tsx
@@ -1,5 +1,5 @@
 import {ScopeNotGrantedError} from '../../errors';
-import {useShippingAddress} from '../shipping-address';
+import {useShippingAddress} from '..';
 
 import {mount} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/timezone.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/timezone.test.tsx
@@ -1,4 +1,4 @@
-import {useTimezone} from '../timezone';
+import {useTimezone} from '..';
 
 import {mount, createMockStatefulRemoteSubscribable} from './mount';
 

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/translate.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/translate.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {useTranslate} from '../translate';
+import {useTranslate} from '..';
 
 import {mount} from './mount';
 


### PR DESCRIPTION
Import from the main entry point in tests instead from subfolders. This should help us catch cases like https://github.com/Shopify/ui-extensions/pull/2164 more easily.

Some tests already did this too.

### 🎩
- green ci 

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
