### PR TITLE
[Docs]: Removing react types from docs generation

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -32,11 +32,17 @@ else
   echo "export {}" > src/surfaces/customer-account.ts
   echo "export {}" > src/surfaces/admin.ts
   echo "export {}" > src/surfaces/point-of-sale.ts
+  echo "export {}" > ../ui-extensions-react/src/surfaces/customer-account.ts
+  echo "export {}" > ../ui-extensions-react/src/surfaces/admin.ts
+  echo "export {}" > ../ui-extensions-react/src/surfaces/point-of-sale.ts
   eval $COMPILE_DOCS && eval $COMPILE_STATIC_PAGES
   build_exit=$?
   git checkout HEAD -- src/surfaces/customer-account.ts
   git checkout HEAD -- src/surfaces/admin.ts
   git checkout HEAD -- src/surfaces/point-of-sale.ts
+  git checkout HEAD -- ../ui-extensions-react/src/surfaces/customer-account.ts
+  git checkout HEAD -- ../ui-extensions-react/src/surfaces/admin.ts
+  git checkout HEAD -- ../ui-extensions-react/src/surfaces/point-of-sale.ts
 fi
 
 # TODO: get generate-docs to stop requiring JS files:


### PR DESCRIPTION
### Background

- We've been facing issues where the generate docs script gets duplicate documentation. and adds mentions of build files on docs, like seen on [this PR](https://github.com/Shopify/shopify-dev/pull/46425)

### Solution

- Removing the ui-react packages from the generation fixes the issue.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
