### PR TITLE
Added CLI step to pos migration docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.npm.bash
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.npm.bash
@@ -1,10 +1,13 @@
-# 1. Remove the old packages
+# 1. Update Shopify CLI
+npm i -g @shopify/cli@latest
+
+# 2. Remove the old packages
 npm uninstall @shopify/retail-ui-extensions*
 
-# 2. Upgrade React
+# 3. Upgrade React
 npm update react@^18.2.0
 npm update @types/react@^18.2.0
 
-# 3. Install the new packages
+# 4. Install the new packages
 npm install @shopify/ui-extensions@2024.4
 npm install @shopify/ui-extensions-react@2024.4

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.yarn.bash
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.yarn.bash
@@ -1,10 +1,13 @@
-# 1. Remove the old packages
+# 1. Update Shopify CLI
+yarn global add @shopify/cli@latest
+
+# 2. Remove the old packages
 yarn remove @shopify/retail-ui-extensions*
 
-# 2. Upgrade React
+# 3. Upgrade React
 yarn upgrade react@^18.2.0
 yarn upgrade @types/react@^18.2.0
 
-# 3. Install the new packages
+# 4. Install the new packages
 yarn add @shopify/ui-extensions@2024.4
 yarn add @shopify/ui-extensions-react@2024.4

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/migrating.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/migrating.doc.ts
@@ -47,6 +47,7 @@ Aside from these migration steps, \`@shopify/ui-extensions@2024.4\` is backwards
         ],
       },
       sectionContent: `
+1. Before starting, make sure you have the most up to date version of the [Shopify CLI](https://shopify.dev/docs/api/shopify-cli).
 1. Navigate to your \`package.json\` in the directory of your UI Extension. You'll need to remove \`@shopify/retail-ui-extensions\` or \`@shopify/retail-ui-extensions-react\` (whichever you're using).
 2. If you use React, replace your version of \`react\` and \`@types/react\` (if you use typescript) with version 18 and up. \`@shopify/ui-extensions-react\` does not support any version prior to React 18.
 3. Next you'll need to add the new dependencies, \`@shopify/ui-extensions\` or \`@shopify/ui-extensions-react\`. Currently we support \`2024.4\`. If you are using the \`@shopify/ui-extensions-react\` package, you will also need to install \`@shopify/ui-extensions\`.
@@ -92,6 +93,16 @@ Migrate your \`shopify.extension.toml\` file to reflect the [new syntax](https:/
       title: 'Validation',
       sectionContent: `
 Validate your migration by running \`yarn dev\` or \`npm run dev\`
+`,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'finalize',
+      title: 'Finalize the migration',
+      sectionContent: `
+1. Deploy your app by running \`npm run deploy\`. 
+2. When prompted to migrate your extension from \`pos_ui_extension\` to \`ui_extension\`, select "Yes, confirm migration from pos_ui_extension".
+3. Your extension should now deploy as the new ui_extension type.
 `,
     },
   ],


### PR DESCRIPTION
### Background

We added a new step in the deploy process for the CLI. I updated the migration docs to reflect this.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

You should be able to view the changes here https://shopify-dev.ui-extensions-y1g3.jeansebastien-goupil.us.spin.dev/docs/api/pos-ui-extensions/2024-04/migrating

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
