### PR TITLE
Add clarification around useAppMetafields limitations to docs (unstable)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -513,7 +513,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
    * > Tip:
-   * > Cart metafields are only available on carts created via the Storefront API version `2023-04` or later.*
+   * > Metafields on an [app reserved namespace](/docs/apps/build/custom-data/reserved-prefixes) cannot be accessed by Checkout UI extensions.
    */
   appMetafields: StatefulRemoteSubscribable<AppMetafieldEntry[]>;
 
@@ -626,6 +626,9 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * Once the order is created, you can query these metafields using the
    * [GraphQL Admin API](https://shopify.dev/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)
+   *
+   * > Tip:
+   * > Cart metafields are only available on carts created via the Storefront API version `2023-04` or later.
    */
   metafields: StatefulRemoteSubscribable<Metafield[]>;
 


### PR DESCRIPTION
### Background

The [StandardAPI docs](https://shopify.dev/docs/api/checkout-ui-extensions/2024-07/apis/metafields#standardapi) do not currently mention that `useAppMetafields` has the limitation that app reserved namespaces cannot be accessed. This PR adds that clarification in a "Tip" box, as well as moving the existing tip box to be adjacent to the `metafields` section that it relates to.
