### PR TITLE
implement draft-order-details api, docs, and examples

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-draft-order-details-action.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-draft-order-details-action.tsx
@@ -15,7 +15,7 @@ const Modal = () => {
     <Navigator>
       <Screen name="DraftOrderDetailsAction" title="Draft Order Details Action">
         <ScrollView>
-          <Text>{`Order ID: ${api.product.id}`}</Text>
+          <Text>{`Order ID: ${api.order.id}`}</Text>
         </ScrollView>
       </Screen>
     </Navigator>

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-draft-order-details-block-render.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-draft-order-details-block-render.ts
@@ -1,0 +1,28 @@
+import {
+  POSBlock,
+  Text,
+  POSBlockRow,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.product-details.block.render', (root, api) => {
+  const block = root.createComponent(POSBlock, {
+    action: {title: 'Open action', onPress: api.action.presentModal},
+  });
+
+  const mainText = root.createComponent(Text);
+  mainText.append('This is a block extension');
+
+  const subtitleText = root.createComponent(Text);
+  subtitleText.append(`Order ID for this product: ${api.order.id}`);
+
+  const blockMainRow = root.createComponent(POSBlockRow);
+  blockMainRow.append(mainText);
+
+  const blockSubtitleRow = root.createComponent(POSBlockRow);
+  blockSubtitleRow.append(subtitleText);
+  block.append(blockMainRow);
+  block.append(blockSubtitleRow);
+
+  root.append(block);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-draft-order-details-block-render.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-draft-order-details-block-render.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import {
+  Text,
+  useApi,
+  reactExtension,
+  POSBlock,
+  POSBlockRow,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Block = () => {
+  const api = useApi<'pos.draft-order-details.block.render'>();
+  return (
+    <POSBlock action={{title: 'Open action', onPress: api.action.presentModal}}>
+      <POSBlockRow>
+        <Text>{'This is a block extension'}</Text>
+        <Text>{`Draft Order ID for this product: ${api.order.id}`}</Text>
+      </POSBlockRow>
+    </POSBlock>
+  );
+};
+
+export default reactExtension('pos.product-details.block.render', () => (
+  <Block />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.menu-item.render.doc.ts
@@ -21,6 +21,10 @@ const data: ReferenceEntityTemplateSchema = {
       name: ExtensionTargetType.PosDraftOrderDetailsActionRender,
       url: '/docs/api/pos-ui-extensions/targets/pos-draft-order-details-action-render',
     },
+    {
+      name: ExtensionTargetType.PosDraftOrderDetailsBlockRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-draft-order-details-block-render',
+    },
   ],
   type: 'Target',
 };

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.block.render.doc.ts
@@ -3,14 +3,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: ExtensionTargetType.PosDraftOrderDetailsActionRender,
+  name: ExtensionTargetType.PosDraftOrderDetailsBlockRender,
   description:
-    'A full-screen extension target that renders when a `pos.draft-order-details.action.render` target calls for it',
+    'Renders a custom section within the native draft order details screen',
   defaultExample: {
     codeblock: generateCodeBlock(
-      'Draft order details action',
+      'Block',
       'targets',
-      'pos-draft-order-details-action',
+      'pos-draft-order-details-block-render',
     ),
   },
   category: 'Targets',
@@ -22,12 +22,8 @@ const data: ReferenceEntityTemplateSchema = {
       url: '/docs/api/pos-ui-extensions/targets/pos-draft-order-details-action-menu-item-render',
     },
     {
-      name: ExtensionTargetType.PosDraftOrderDetailsBlockRender,
-      url: '/docs/api/pos-ui-extensions/targets/pos-draft-order-details-block-render',
-    },
-    {
-      name: 'Draft order details API',
-      url: '/docs/api/pos-ui-extensions/apis/draft-order-api',
+      name: ExtensionTargetType.PosDraftOrderDetailsActionRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-draft-order-details-action-render',
     },
   ],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
@@ -13,6 +13,7 @@ export enum ExtensionTargetType {
   PosCustomerDetailsActionRender = 'pos.customer-details.action.render',
   PosDraftOrderDetailsActionMenuItemRender = 'pos.draft-order-details.action.menu-item.render',
   PosDraftOrderDetailsActionRender = 'pos.draft-order-details.action.render',
+  PosDraftOrderDetailsBlockRender = 'pos.draft-order-details.block.render',
 }
 
 export enum TargetLink {
@@ -30,4 +31,5 @@ export enum TargetLink {
   PosCustomerDetailsActionRender = '[pos.customer-details.action.render](/docs/api/pos-ui-extensions/targets/customer-details/pos-customer-details-action-render)',
   PosDraftOrderDetailsActionMenuItemRender = '[pos.draft-order-details.action.menu-item.render](/docs/api/pos-ui-extensions/targets/draft-order-details/pos-draft-order-details-action-menu-item-render)',
   PosDraftOrderDetailsActionRender = '[pos.draft-order-details.action.render](/docs/api/pos-ui-extensions/targets/draft-order-details/pos-draft-order-details-action-render)',
+  PosDraftOrderDetailsBlockRender = '[pos.draft-order-details.action.render](/docs/api/pos-ui-extensions/targets/draft-order-details/pos-draft-order-details-block-render)',
 }

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/extension-targets.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/extension-targets.doc.ts
@@ -173,6 +173,14 @@ Displays an action target modally when a menu item is tapped.
 Review [all extension targets](/docs/api/pos-ui-extensions/targets).
 `,
         },
+        {
+          title: 'Block',
+          description: `
+Renders a custom section within the native post purchase screen.
+
+Review [all extension targets](/docs/api/pos-ui-extensions/targets).
+`,
+        },
       ],
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -101,6 +101,13 @@ export interface ExtensionTargets {
       CartApi,
     BasicComponents
   >;
+  'pos.draft-order-details.block.render': RenderExtension<
+    StandardApi<'pos.draft-order-details.block.render'> &
+      ActionApi &
+      CartApi &
+      DraftOrderApi,
+    ActionComponents
+  >;
   'pos.customer-details.action.menu-item.render': RenderExtension<
     StandardApi<'pos.customer-details.action.menu-item.render'> &
       ActionApi &


### PR DESCRIPTION
### Background

resolves https://github.com/orgs/Shopify/projects/5331/views/43?pane=issue&itemId=70955685

### Solution

This adds the Order details block extension target and related documentation updates.

### 🎩

[- ...](https://shopify-dev.ui-extensions-kdfh.marco-yip.us.spin.dev/docs/api/pos-ui-extensions)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
