### PR TITLE
[QRCode] [Docs] Fix broken bulleted list formatting

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.doc.ts
@@ -41,11 +41,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Generic',
       anchorLink: 'best-practices',
       title: 'Best Practices',
-      sectionContent: `
-        - Always test that the QR code is scannable from a smartphone.
-        - Include a square logo if that’s what your customers are familiar with.
-        - Increase usability by adding a text description of what the QR code does and provide alternate methods to get to the same destination, like a text input containing the value.
-      `,
+      sectionContent: `- Always test that the QR code is scannable from a smartphone.\n\n- Include a square logo if that’s what your customers are familiar with.\n\n- Increase usability by adding a text description of what the QR code does and provide alternate methods to get to the same destination, like a text input containing the value.`,
     },
   ],
   examples: {


### PR DESCRIPTION
### Background
While Markdown formatting works in these, list rendering on shopify.dev doesn't seem to work as expected.
This PR reverts a last-minute change introduced in #2220 where we got rid of `\n\n`.

![image](https://github.com/user-attachments/assets/65efbac3-f4f4-40af-9717-4637a19c25e6)
https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components/other/qrcode#best-practices

### Solution
Reintroduce line separation with `\n\n`.

### 🎩
https://shopify-dev.qr-code-component.lucas-lacerda.us.spin.dev/docs/api/checkout-ui-extensions/unstable/components/other/qrcode#best-practices

### Checklist
- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
