### PR TITLE
Doc changes for `purchase.checkout.shipping-option-item.render-after`

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.shipping-option-item.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.checkout.shipping-option-item.render-after.doc.ts
@@ -8,8 +8,12 @@ import {
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'purchase.checkout.shipping-option-item.render-after',
-  description:
-    'A static extension target that is rendered after the shipping method details within the shipping method option list, for each option.',
+  description: `
+A static extension target that is rendered after the shipping method details within the shipping method option list, for each option.
+
+> Note:
+> In split shipping scenarios, this target will render within a Modal when \`renderMode.overlay\` is true. In this case, it is recommended to avoid using components that render an overlay such as Modals.
+`,
   defaultExample: getExample(
     'purchase.checkout.shipping-option-item.render-after/default',
     ['jsx', 'js'],


### PR DESCRIPTION
### Background

Same change as in https://github.com/Shopify/ui-extensions/pull/2227, but targetting 2024-07 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
