### PR TITLE
expose more Menu props

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/components/Menu/Menu.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Menu/Menu.ts
@@ -6,6 +6,14 @@ export interface MenuProps extends IdProps {
    * A label to describe the purpose of the menu that is announced by screen readers.
    */
   accessibilityLabel?: string;
+  /**
+   * Callback to run when the Menu is opened
+   */
+  onOpen?: () => void;
+  /**
+   * Callback to run when the Menu is closed
+   */
+  onClose?: () => void;
 }
 
 export const Menu = createRemoteComponent<'Menu', MenuProps>('Menu');


### PR DESCRIPTION
### Background

- checkout PR adding the props to Menu: https://github.com/Shopify/checkout-web/pull/36308
- customer account web PR allowing the props: https://github.com/Shopify/customer-account-web/pull/5056

### Solution

I am just documenting and adding types for `onClose` and `onOpen` on Menu.

### 🎩

The two new props should be visible on https://shopify-dev.customer-account-web-shopify-dev-2fja.sylvain-hamann.us.spin.dev/docs/api/customer-account-ui-extensions/unstable/components/menu

Resume: 
https://spin-control.shopify.io/instances/customer-account-web-shopify-dev-2fja.sylvain-hamann.us.spin.dev/resume


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
