### PR TITLE
Updating the WPM public package to expose new Checkout schema changes

### DIFF
--- a/packages/web-pixels-extension/src/schemas/pixel-events.ts
+++ b/packages/web-pixels-extension/src/schemas/pixel-events.ts
@@ -615,6 +615,7 @@ export const pixelEvents = {
         },
         currencyCode: {
           type: 'string',
+          nullable: true,
           metadata: {
             description:
               'The three-letter code that represents the currency, for example, USD. Supported codes include standard ISO 4217 codes, legacy codes, and non-standard codes.',
@@ -708,6 +709,7 @@ export const pixelEvents = {
         },
         subtotalPrice: {
           ref: 'MoneyV2',
+          nullable: true,
           metadata: {
             description:
               'The price at checkout before duties, shipping, and taxes.',
@@ -715,12 +717,14 @@ export const pixelEvents = {
         },
         token: {
           type: 'string',
+          nullable: true,
           metadata: {
             description: 'A unique identifier for a particular checkout.',
           },
         },
         totalPrice: {
           ref: 'MoneyV2',
+          nullable: true,
           metadata: {
             description:
               'The sum of all the prices of all the items in the checkout, including duties, taxes, and discounts.',
@@ -761,6 +765,7 @@ export const pixelEvents = {
         },
         id: {
           type: 'string',
+          nullable: true,
           metadata: {
             description: 'A globally unique identifier.',
           },
@@ -1007,6 +1012,7 @@ export const pixelEvents = {
       properties: {
         src: {
           type: 'string',
+          nullable: true,
           metadata: {
             description: 'The location of the image as a URL.',
           },
@@ -1066,6 +1072,7 @@ export const pixelEvents = {
       properties: {
         isoCode: {
           type: 'string',
+          nullable: true,
           metadata: {
             description:
               'The ISO-3166-1 code for this country, for example, "US".',
@@ -1095,12 +1102,14 @@ export const pixelEvents = {
       properties: {
         id: {
           type: 'string',
+          nullable: true,
           metadata: {
             description: 'A globally unique identifier.',
           },
         },
         handle: {
           type: 'string',
+          nullable: true,
           metadata: {
             description: 'A human-readable, shop-scoped identifier.',
           },
@@ -1171,8 +1180,10 @@ export const pixelEvents = {
         },
         id: {
           type: 'string',
+          nullable: true,
           metadata: {
-            description: 'The ID of the order.',
+            description:
+              'The ID of the order. ID will be null for all events except checkout_completed.',
           },
         },
       },
@@ -1541,7 +1552,7 @@ export const pixelEvents = {
               type: 'string',
               metadata: {
                 description:
-                  "The type of payment method used for the transaction.\n\n- `creditCard`: A vaulted or manually entered credit card.\n- `redeemable`: A redeemable payment method, such as a gift card or store credit.\n- `deferred`: A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecing payment later.\n- `local`: A [local payment method](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market.\n- `manualPayment`: A manual payment method, such as an in-person retail transaction.\n- `paymentOnDelivery`: A payment that will be collected on delivery.\n- `wallet`: An integrated wallet, such as PayPal, Google Pay, Apple Pay, etc.\n- `offsite`: A payment processed outside of Shopify's checkout, excluding integrated wallets.\n- `customOnSite`: A custom payment method that is processed through a checkout extension with a payments app.\n- `other`: Another type of payment not defined here.\n",
+                  "The type of payment method used for the transaction.\n\n- `creditCard`: A vaulted or manually entered credit card.\n- `redeemable`: A redeemable payment method, such as a gift card or store credit.\n- `deferred`: A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecting payment later.\n- `local`: A [local payment method](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market.\n- `manualPayment`: A manual payment method, such as an in-person retail transaction.\n- `paymentOnDelivery`: A payment that will be collected on delivery.\n- `wallet`: An integrated wallet, such as PayPal, Google Pay, Apple Pay, etc.\n- `offsite`: A payment processed outside of Shopify's checkout, excluding integrated wallets.\n- `customOnSite`: A custom payment method that is processed through a checkout extension with a payments app.\n- `other`: Another type of payment not defined here.\n",
                 enum: [
                   'creditCard',
                   'redeemable',

--- a/packages/web-pixels-extension/src/types/PixelEvents/index.ts
+++ b/packages/web-pixels-extension/src/types/PixelEvents/index.ts
@@ -807,7 +807,7 @@ export interface Checkout {
    * Supported codes include standard ISO 4217 codes, legacy codes, and non-
    * standard codes.
    */
-  currencyCode: string;
+  currencyCode: string | null;
 
   /**
    * Represents the selected delivery options for a checkout. This
@@ -882,18 +882,18 @@ export interface Checkout {
   /**
    * The price at checkout before duties, shipping, and taxes.
    */
-  subtotalPrice: MoneyV2;
+  subtotalPrice: MoneyV2 | null;
 
   /**
    * A unique identifier for a particular checkout.
    */
-  token: string;
+  token: string | null;
 
   /**
    * The sum of all the prices of all the items in the checkout, including
    * duties, taxes, and discounts.
    */
-  totalPrice: MoneyV2;
+  totalPrice: MoneyV2 | null;
 
   /**
    * The sum of all the taxes applied to the line items and shipping lines in
@@ -931,7 +931,7 @@ export interface CheckoutLineItem {
   /**
    * A globally unique identifier.
    */
-  id: string;
+  id: string | null;
 
   /**
    * The properties of the line item. A shop may add, or enable customers to add
@@ -1020,7 +1020,7 @@ export interface Country {
   /**
    * The ISO-3166-1 code for this country, for example, "US".
    */
-  isoCode: string;
+  isoCode: string | null;
 }
 
 /**
@@ -1285,7 +1285,7 @@ export interface Image {
   /**
    * The location of the image as a URL.
    */
-  src: string;
+  src: string | null;
 }
 
 export interface InitData {
@@ -1494,12 +1494,12 @@ export interface Market {
   /**
    * A human-readable, shop-scoped identifier.
    */
-  handle: string;
+  handle: string | null;
 
   /**
    * A globally unique identifier.
    */
-  id: string;
+  id: string | null;
 }
 
 /**
@@ -1551,9 +1551,10 @@ export interface Order {
   customer: OrderCustomer | null;
 
   /**
-   * The ID of the order.
+   * The ID of the order. ID will be null for all events except
+   * checkout_completed.
    */
-  id: string;
+  id: string | null;
 }
 
 /**
@@ -1808,7 +1809,7 @@ export interface TransactionPaymentMethod {
    * credit.
    * - `deferred`: A [deferred
    * payment](https://help.shopify.com/en/manual/orders/deferred-payments), such
-   * as invoicing the buyer and collecing payment later.
+   * as invoicing the buyer and collecting payment later.
    * - `local`: A [local payment
    * method](https://help.shopify.com/en/manual/payments/shopify-payments/local-
    * payment-methods) specific to the current region or market.


### PR DESCRIPTION
### Background
Closes Shopify/ce-customer-behaviour#5656

Updating the web-pixels extension to reflect schema changes that happened as part of [this issue](https://github.com/Shopify/ce-customer-behaviour/issues/5210) to clean up the Checkout object in C1.

This PR:
- Updates `Localization.country.isoCode`  to make it nullable
- Updates `Localization.market.id`  to make it nullable
- Updates `Localization.market.handle`  to make it nullable
- Updates `token`  to make it nullable
- Updates `subtotalPrice` to make it nullable
- Updates `totalPrice`  to make it nullable
- Updates `currencyCode` to make it nullable
- Updates `Order.id` to make it nullable

### Solution

Following [this guide](https://github.com/Shopify/web-pixels-manager/blob/main/help-docs/updating-events.md#updating-the-public-package) and running `yarn schema:publish` in wpm.
### 🎩

Tested that this works by running `yarn build-consumer web-pixels-test-app web-pixels-extension`

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
