### PR TITLE
Bump WPM public package after making Checkout schema changes

### DIFF
--- a/packages/web-pixels-extension/package.json
+++ b/packages/web-pixels-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/web-pixels-extension",
   "description": "Provides tools to author Web Pixels extension",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
### Background

Bump WPM public package after shipping [this PR](https://github.com/Shopify/ui-extensions/pull/2242) to update Checkout schema.

Check that a tag with a matching commit hash was created [here](https://github.com/Shopify/ui-extensions/tags).

### Solution

Following from step 4 of [this guide](https://github.com/Shopify/web-pixels-manager/blob/main/help-docs/updating-events.md#updating-the-public-package) to update the WPM public package


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
