### PR TITLE
POS: Add missing BadgeStatus export

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/point-of-sale.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale.ts
@@ -5,6 +5,7 @@ export * from './point-of-sale/hooks';
 export {render, reactExtension} from './point-of-sale/render';
 
 export type {
+  BadgeStatus,
   BadgeVariant,
   BadgeProps,
   BannerProps,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
@@ -1,7 +1,11 @@
 export {ActionItem} from './components/ActionItem/ActionItem';
 export type {ActionItemProps} from './components/ActionItem/ActionItem';
 export {Badge} from './components/Badge/Badge';
-export type {BadgeProps, BadgeVariant} from './components/Badge/Badge';
+export type {
+  BadgeProps,
+  BadgeStatus,
+  BadgeVariant,
+} from './components/Badge/Badge';
 export {Banner} from './components/Banner/Banner';
 export type {BannerProps, BannerVariant} from './components/Banner/Banner';
 export {Button} from './components/Button/Button';


### PR DESCRIPTION
### Background

This export is missing from the chain so it can't be imported in extensions.

### Solution

Add the export

