### PR TITLE
Added an onPress handler for block row

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlockRow.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlockRow.ts
@@ -9,6 +9,12 @@ export interface POSBlockRowProps {
    * @defaultValue false
    */
   removeInsets?: boolean;
+
+  /**
+   * A callback for when the row is tapped.
+   * @defaultValue undefined
+   */
+  onPress?: () => void;
 }
 
 export const POSBlockRow = createRemoteComponent<

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlockRow.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlockRow.ts
@@ -5,14 +5,7 @@ import {createRemoteComponent} from '@remote-ui/core';
  */
 export interface POSBlockRowProps {
   /**
-   * Whether to remove the default padding from the `POSBlockRow`.
-   * @defaultValue false
-   */
-  removeInsets?: boolean;
-
-  /**
    * A callback for when the row is tapped.
-   * @defaultValue undefined
    */
   onPress?: () => void;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -28,7 +28,6 @@ type BlockComponents = AnyComponentBuilder<
     | 'Image'
     | 'POSBlock'
     | 'POSBlockRow'
-    | 'Selectable'
     | 'Stack'
     | 'Text'
     | 'TimePicker'


### PR DESCRIPTION
### Background

As we discovered, implementing custom selectable rows by removign insets and using a Selectable plus Stack with the correct insets is tedious and will likely result in 3P devs using the wrong padding.

This will guarantee the correct padding.

Should we also remove Selectable from the allowable components list? I'm leaning on yes.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
