### PR TITLE
Link to the Metafields tutorial from Customer Account UI extension page

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
@@ -320,6 +320,18 @@ Customer account UI extensions don't have access to the DOM and can't return DOM
           url: '/docs/apps/customer-accounts/full-page-extensions/build-full-page-extensions',
           type: 'blocks',
         },
+        {
+          name: 'Building metafield writes into extensions',
+          subtitle: 'Tutorial',
+          url: '/docs/apps/build/customer-accounts/metafields',
+          type: 'blocks',
+        },
+        {
+          name: 'Build Pre-auth Order Status page extensions',
+          subtitle: 'Tutorial',
+          url: '/docs/apps/build/customer-accounts/pre-auth-order-status-page-extensions/build-pre-auth-order-status-page-extensions',
+          type: 'blocks',
+        },
       ],
     },
     {


### PR DESCRIPTION
### Background

https://shopify.dev/docs/api/customer-account-ui-extensions#tutorials is missing a link to the metafields tutorial.

### Solution

Add a link

### 🎩

https://shopify-dev.doc-update.jr-rafols.us.spin.dev/docs/api/customer-account-ui-extensions#tutorials
[resume](https://spin-control.shopify.io/instances/doc-update.jr-rafols.us.spin.dev/resume)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
