### PR TITLE
expose switch to customer account unstable surface

### DIFF
--- a/.changeset/fast-crabs-act.md
+++ b/.changeset/fast-crabs-act.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-react': patch
+'@shopify/ui-extensions': patch
+---
+
+expose Switch component to customer account unstable surface

--- a/packages/ui-extensions-react/src/surfaces/customer-account/components/shared-checkout-components.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/components/shared-checkout-components.ts
@@ -101,6 +101,8 @@ export {
   type SpinnerProps,
   Stepper,
   type StepperProps,
+  Switch,
+  type SwitchProps,
   Tag,
   type TagProps,
   Text,

--- a/packages/ui-extensions/src/surfaces/customer-account/components/shared-checkout-components.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/shared-checkout-components.ts
@@ -101,6 +101,8 @@ export {
   type SpinnerProps,
   Stepper,
   type StepperProps,
+  Switch,
+  type SwitchProps,
   Tag,
   type TagProps,
   Text,


### PR DESCRIPTION
### Background

expose switch to customer account unstable surface 

Part of this issue https://github.com/Shopify/ui-extensions/issues/2283 

### Solution

Expose them to customer account unstable surface, and will include them to 2024-10 stable version. 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
