### PR TITLE
Add suffix to textfield and numberfield apis

### DIFF
--- a/.changeset/light-dancers-pump.md
+++ b/.changeset/light-dancers-pump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add suffix to NumberField and TextField

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.ts
@@ -6,12 +6,14 @@ import {
   AutocompleteFieldSecurityCodeAlias,
   InputProps,
   NumberConstraintsProps,
+  FieldDecorationProps,
 } from '../shared';
 
 export interface NumberFieldProps
   extends InputProps<number>,
     NumberConstraintsProps,
-    AutocompleteProps<NumberAutocompleteField> {
+    AutocompleteProps<NumberAutocompleteField>,
+    FieldDecorationProps {
   /**
    * Sets the virtual keyboard.
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.ts
@@ -4,12 +4,14 @@ import {
   TextAutocompleteField,
   InputProps,
   MinMaxLengthProps,
+  FieldDecorationProps,
 } from '../shared';
 
 export interface TextFieldProps
   extends InputProps<string>,
     MinMaxLengthProps,
-    AutocompleteProps<TextAutocompleteField> {}
+    AutocompleteProps<TextAutocompleteField>,
+    FieldDecorationProps {}
 
 export const TextField = createRemoteComponent<'TextField', TextFieldProps>(
   'TextField',

--- a/packages/ui-extensions/src/surfaces/admin/components/shared/index.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/shared/index.ts
@@ -115,6 +115,22 @@ export interface InputProps<T> {
   value?: T;
 }
 
+export interface FieldDecorationProps {
+  /**
+   * A value to be displayed immediately after the editable portion of the field.
+   *
+   * This is useful for displaying an implied part of the value, such as "@shopify.com", or "%".
+   *
+   * This cannot be edited by the user, and it isn't included in the value of the field.
+   *
+   * It may not be displayed until the user has interacted with the input.
+   * For example, an inline label may take the place of the suffix until the user focuses the input.
+   *
+   * @default ''
+   */
+  suffix?: string;
+}
+
 export interface MinMaxLengthProps {
   /**
    * Specifies the maximum number of characters allowed.


### PR DESCRIPTION
### Background

Add the ability to add a suffix to TextFields and NumberFields

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
