### PR TITLE
Deprecate custom validator from formatted text field

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
@@ -21,8 +21,11 @@ export interface FormattedTextFieldProps extends BaseTextFieldProps {
    */
   autoCapitalize?: AutoCapitalizationType;
   /**
-   * Applies a custom validator that can dictate whether or not an entered value is valid.
-   * @deprecated: This callback will be removed in version 2025-01.
+   * **Warning:** This callback is currently broken and will not work as intended.
+   *
+   * Custom validator function to determine the validity of an entered value.
+   *
+   * @deprecated This callback will be removed in version 2025-01.
    * Please update your code to avoid using this feature.
    */
   customValidator?: (text: string) => boolean;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
@@ -22,6 +22,8 @@ export interface FormattedTextFieldProps extends BaseTextFieldProps {
   autoCapitalize?: AutoCapitalizationType;
   /**
    * Applies a custom validator that can dictate whether or not an entered value is valid.
+   * @deprecated: This callback will be removed in version 2025-01.
+   * Please update your code to avoid using this feature.
    */
   customValidator?: (text: string) => boolean;
 }


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/27757

### Background

It seems that callbacks for extensions cannot be defined with a return value other than void. I'm not exactly sure why extensions can't return values from callbacks but to resolve this issue lets deprecate and remove this for 2025-01 since it was never working in the first place.

You can find my investigations in the ticket issue description. Open to solutions.

If the team is fine with this, I will close the original issue and open a new one to track removal of this callback after 2024-10 gets released.

