### PR TITLE
Document missing `auth.idToken.get()` API

### DIFF
--- a/.changeset/old-zebras-exist.md
+++ b/.changeset/old-zebras-exist.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add missing documentation for `auth.idToken.get()` API

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -90,7 +90,7 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       title: 'App Authentication',
       sectionContent:
-        "Admin UI extensions can also make authenticated calls to your app's backend. When you use `fetch()` to make a request to your app's configured auth domain or any of its subdomains, an `Authorization` header is automatically added with a Shopify [OpenID Connect ID Token](https://shopify.dev/docs/api/app-bridge-library/reference/id-token). There's no need to manually manage session tokens.\n\nRelative URLs passed to `fetch()` are resolved against your app's `app_url`. This means if your app's backend is on the same domain as your `app_url`, you can make requests to it using `fetch('/path')`.",
+        "Admin UI extensions can also make authenticated calls to your app's backend. When you use `fetch()` to make a request to your app's configured auth domain or any of its subdomains, an `Authorization` header is automatically added with a Shopify [OpenID Connect ID Token](https://shopify.dev/docs/api/app-bridge-library/reference/id-token). There's no need to manually manage ID tokens.\n\nRelative URLs passed to `fetch()` are resolved against your app's `app_url`. This means if your app's backend is on the same domain as your `app_url`, you can make requests to it using `fetch('/path')`.\n\nIf you need to make requests to a different domain, you can use the [`auth.idToken.get()` method](/docs/api/admin-extensions/api/standard-api#standardapi-propertydetail-auth) to retrieve the ID token and manually add it to your request headers.",
       anchorLink: 'app-authentication',
       codeblock: {
         title: "Make requests to your app's backend",
@@ -99,6 +99,11 @@ const data: LandingTemplateSchema = {
             code: './examples/authenticated-fetch.jsx',
             language: 'tsx',
             title: 'Get Product Data',
+          },
+          {
+            code: './examples/custom-authenticated-fetch.jsx',
+            language: 'tsx',
+            title: 'Get Data from a different domain',
           },
         ],
       },

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/custom-authenticated-fetch.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/custom-authenticated-fetch.jsx
@@ -1,0 +1,30 @@
+import {reactExtension, useApi, Text} from '@shopify/ui-extensions-react/admin';
+import {useEffect, useState} from 'react';
+
+// Get product info from a different app backend
+async function getProductInfo(id, auth) {
+  const token = await auth.idToken.get();
+  const res = await fetch(`https://app.example.com/api/products/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return res.json();
+}
+
+const TARGET = 'admin.product-details.block.render';
+
+export default reactExtension(TARGET, () => <App />);
+
+function App() {
+  // Contextual "input" data passed to this extension:
+  const {data, auth} = useApi(TARGET);
+  const productId = data.selected?.[0]?.id;
+
+  const [productInfo, setProductInfo] = useState();
+  useEffect(() => {
+    getProductInfo(productId, auth).then(setProductInfo);
+  }, [productId, auth]);
+
+  return <Text>Info: {productInfo?.title}</Text>;
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
@@ -20,6 +20,15 @@ export interface GraphQLError {
   };
 }
 
+interface Auth {
+  /**
+   * Retrieves a Shopify OpenID Connect ID token for the current user.
+   */
+  idToken: {
+    get: () => Promise<string | null>;
+  };
+}
+
 /**
  * The following APIs are provided to all extension targets.
  */
@@ -30,6 +39,11 @@ export interface StandardApi<ExtensionTarget extends AnyExtensionTarget> {
   extension: {
     target: ExtensionTarget;
   };
+
+  /**
+   * Provides methods for authenticating calls to an app backend.
+   */
+  auth: Auth;
 
   /**
    * Utilities for translating content according to the current localization of the admin.


### PR DESCRIPTION
### Background

Fixes https://github.com/Shopify/app-ui/issues/1507

RE: https://github.com/Shopify/app-ui/issues/1619

Admin UI extensions have an API for fetching an OpenID Connect ID token for the currently authenticated user, but we forgot to document it. We patch `fetch` to the app developer's origin to automatically include the `Authorization` header. 

However, a developer may wish to call additional third-party domains and will require access to this Authorization token. 

### Solution

This PR outlines how they can leverage the existing undocumented `auth` API to do so.

### 🎩

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
