### PR TITLE
Make build-docs work with local `dev`

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
@@ -10,6 +10,15 @@ fail_and_exit() {
   exit $1
 }
 
+run_sed() {
+  if [ -z $SPIN ]
+  then
+    sed -i '' "$1" $2
+  else
+    sed -i "$1" $2
+  fi
+}
+
 if [ -z $API_VERSION ]
 then
   API_VERSION="unstable"
@@ -39,33 +48,36 @@ fi
 
 # Make sure https://shopify.dev URLs are relative so they work in Spin.
 # See https://github.com/Shopify/generate-docs/issues/181
-sed -i 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data.json
+run_sed 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data.json
 sed_exit=$?
 if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
-if [ -n "$SPIN" ]; then
+if [ -d ~/src/github.com/Shopify/shopify-dev ]; then
+  mkdir -p ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION
+  cp ./$DOCS_PATH/generated/* ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION
+  # Replace 'unstable' with the exact API version in relative doc links
+  run_sed \
+    "s/\/docs\/api\/admin-extensions\/unstable/\/docs\/api\/admin-extensions\/$API_VERSION/gi" \
+    ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION/generated_docs_data.json
+  sed_exit=$?
+  if [ $sed_exit -ne 0 ]; then
+    fail_and_exit $sed_exit
+  fi
+  rsync -a --delete ./$DOCS_PATH/screenshots/ ~/src/github.com/Shopify/shopify-dev/app/assets/images/templated-apis-screenshots/admin-extensions/$API_VERSION
+
+  cd ~/src/github.com/Shopify/shopify-dev
+
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
-
-    mkdir -p ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION
-    cp ./$DOCS_PATH/generated/* ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION
-    # Replace 'unstable' with the exact API version in relative doc links
-    sed -i \
-      "s/\/docs\/api\/admin-extensions\/unstable/\/docs\/api\/admin-extensions\/$API_VERSION/gi" \
-      ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION/generated_docs_data.json
-    sed_exit=$?
-    if [ $sed_exit -ne 0 ]; then
-      fail_and_exit $sed_exit
-    fi
-    rsync -a --delete ./$DOCS_PATH/screenshots/ ~/src/github.com/Shopify/shopify-dev/app/assets/images/templated-apis-screenshots/admin-extensions/$API_VERSION
-
-    cd ~/src/github.com/Shopify/shopify-dev
-
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/admin-extensions"
   else
-    echo "If you include shopify-dev in your Spin constellation, this will automatically copy ./$DOCS_PATH/generated to shopify-dev"
+    echo "Docs: https://shopify-dev.myshopify.io/docs/api/admin-extensions"
   fi
 else
-  echo "Not copying docs to shopify-dev because we're not in Spin"
+  if [ -n $SPIN ]; then
+    echo "If you include shopify-dev in your Spin constellation, this will automatically copy ./$DOCS_PATH/generated to shopify-dev"
+  else
+    echo "If you have shopify-dev cloned to ~/src/github.com/Shopify/shopify-dev, this will automatically copy ./$DOCS_PATH/generated to shopify-dev"
+  fi
 fi


### PR DESCRIPTION
### Background

You can't build the docs currently on an Apple Macintosh computer. We should change that 😄 

### Solution

- Fixed some stuff with `sed` (did you know that `-i ''` is required for Mac? idk why)
- Updated some conditional checks to make things work in both local and Spin dev
- Printed out the correct docs link based on current environment

### 🎩

- Clone it down
- Run `yarn docs:admin` for example

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
