### PR TITLE
Update package.json to upgrade generate-docs to fix utility type parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prettier": "^2.8.0",
     "react": ">=18.0.0",
     "typescript": "^4.9.0",
-    "@shopify/generate-docs": "0.16.0"
+    "@shopify/generate-docs": "0.16.4"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Public part of: [Extensibility] upgrade generate-docs to fix utility type parser #37155

 Upgraded generate-docs to get this fix for the utility type parser Shopify/generate-docs#320

### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
