### PR TITLE
update generate-doc version to fix parsing issue

### DIFF
--- a/.changeset/silver-tigers-run.md
+++ b/.changeset/silver-tigers-run.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+update version for generate-docs

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -67,7 +67,7 @@
     "@remote-ui/core": "^2.2.4"
   },
   "devDependencies": {
-    "@shopify/generate-docs": "0.16.0",
+    "@shopify/generate-docs": "0.16.4",
     "typescript": "^4.9.0"
   },
   "publishConfig": {


### PR DESCRIPTION
### Background

Updates the `@shopify/generate-docs` to the new version to fix this issue: 
This is the checkout-web part of https://github.com/Shopify/checkout-web/issues/37106

### Solution

Upgraded generate-docs to get this fix for the utility type parser https://github.com/Shopify/generate-docs/pull/320

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
