### PR TITLE
update generate-doc verision for 2024-07

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "prettier": "^2.8.0",
     "react": ">=18.0.0",
     "typescript": "^4.9.0",
-    "@shopify/generate-docs": "0.16.0"
+    "@shopify/generate-docs": "0.16.4"
   }
 }

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -67,7 +67,7 @@
     "@remote-ui/core": "^2.2.4"
   },
   "devDependencies": {
-    "@shopify/generate-docs": "0.16.0",
+    "@shopify/generate-docs": "0.16.4",
     "typescript": "^4.9.0"
   },
   "publishConfig": {


### PR DESCRIPTION
### Background

To solve the issue of Extension and Location not correctly linking to their APIs we need to update the generate-docs version in 2024-07. This is the checkout-web part of https://github.com/Shopify/checkout-web/issues/37106

This is the PR for it being updated in unstable : https://github.com/Shopify/ui-extensions/pull/2313

It is also being updated in 2024-04

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
