### PR TITLE
Njo/add migration note

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Icon.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Icon.doc.ts
@@ -16,7 +16,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Components',
   related: [
     {
-      name: 'Figma UI Kit Icons',
+      name: 'Figma UI Kit',
       subtitle:
         'See the Figma UI Kit to get a full list of icons to design your extension',
       url: 'https://www.figma.com/community/file/1255225508400961281/shopify-pos-ui-kit',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Icon.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Icon.doc.ts
@@ -19,7 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
       name: 'Figma UI Kit Icons',
       subtitle:
         'See the Figma UI Kit to get a full list of icons to design your extension',
-      url: 'https://www.figma.com/design/0UcHY7C4hqrhvA5tjynunA/Shopify-POS-UI-Kit-(Community)?node-id=15-15&t=Ygce7CbfazMNpKsA-0',
+      url: 'https://www.figma.com/community/file/1255225508400961281/shopify-pos-ui-kit',
       type: 'star',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/migrating.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/migrating.doc.ts
@@ -19,6 +19,13 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       anchorLink: 'overview',
       title: 'Overview',
+      sectionNotice: [
+        {
+          type: 'warning',
+          title: 'Minimum CLI Version',
+          sectionContent: 'Migration requires a minimum CLI version of 3.64.0.',
+        },
+      ],
       sectionContent: `
 POS UI Extensions are moving to the newer \`@shopify/ui-extensions\` package, shared with [Checkout UI Extensions](https://shopify.dev/docs/api/checkout-ui-extensions) and [Admin UI Extensions](https://shopify.dev/docs/api/admin-extensions). This will allow your extensions to use the same package regardless of the surface they extend, and for a single extension to implement multiple targets across different surfaces of Shopify more easily.
 
@@ -100,7 +107,7 @@ Validate your migration by running \`yarn dev\` or \`npm run dev\`
       anchorLink: 'finalize',
       title: 'Finalize the migration',
       sectionContent: `
-1. Deploy your app by running \`npm run deploy\`. 
+1. Deploy your app by running \`npm run deploy\`.
 2. When prompted to migrate your extension from \`pos_ui_extension\` to \`ui_extension\`, select "Yes, confirm migration from pos_ui_extension".
 3. Your extension should now deploy as the new ui_extension type.
 `,


### PR DESCRIPTION
### Background

This adds a warning for migrating to make sure partners have at least CLI 3.64. It also fixes a broken figma link to the design kit.

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation

Matching docs PR: https://github.com/Shopify/shopify-dev/pull/48303
