### PR TITLE
Fix docs building in Spin

### DIFF
--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -2,11 +2,11 @@
   "name": "@shopify/ui-extensions",
   "version": "0.0.0-unstable",
   "scripts": {
-    "docs:admin": "sh ./docs/surfaces/admin/build-docs.sh",
-    "gen-docs:admin": "sh ./docs/surfaces/admin/create-doc-files.sh \"admin\"",
-    "docs:checkout": "sh ./docs/surfaces/checkout/build-docs.sh",
-    "docs:point-of-sale": "sh ./docs/surfaces/point-of-sale/build-docs.sh",
-    "docs:customer-account": "sh ./docs/surfaces/customer-account/build-docs.sh"
+    "docs:admin": "bash ./docs/surfaces/admin/build-docs.sh",
+    "gen-docs:admin": "bash ./docs/surfaces/admin/create-doc-files.sh \"admin\"",
+    "docs:checkout": "bash ./docs/surfaces/checkout/build-docs.sh",
+    "docs:point-of-sale": "bash ./docs/surfaces/point-of-sale/build-docs.sh",
+    "docs:customer-account": "bash ./docs/surfaces/customer-account/build-docs.sh"
   },
   "main": "index.js",
   "module": "index.mjs",


### PR DESCRIPTION
...by using `bash` rather than `sh` because it properly supports double square brackets.

### Background

Docs building is broken in Spin right now because we're running scripts with `sh` rather than `bash` or `zsh`. I don't know why it doesn't fail in MacOS. Maybe `sh` is a different version?

Previous attempts: e.g. #2319 #2296 
