### PR TITLE
Checkout: rename `overlay` target to `chat`

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -710,6 +710,14 @@ export interface RenderExtensionTargets {
     AnyComponent
   >;
   /**
+   * A static extension target that is rendered on top of the Checkout page as an overlay.
+   * It is positioned in the bottom right corner of the screen.
+   */
+  'purchase.checkout.chat.render': RenderExtension<
+    CheckoutApi & StandardApi<'purchase.checkout.chat.render'>,
+    AllowedComponents<'Chat'>
+  >;
+  /**
    * A static extension target that is rendered below the header on the **Thank you** page.
    */
   'purchase.thank-you.header.render-after': RenderExtension<
@@ -726,10 +734,11 @@ export interface RenderExtensionTargets {
     AnyComponent
   >;
   /**
-   * A static extension target that is rendered on top of the Checkout page as an overlay.
+   * A static extension target that is rendered on top of the **Thank you** page as an overlay.
+   * It is positioned in the bottom right corner of the screen.
    */
-  'purchase.checkout.overlay.render': RenderExtension<
-    CheckoutApi & StandardApi<'purchase.checkout.overlay.render'>,
+  'purchase.thank-you.chat.render': RenderExtension<
+    CheckoutApi & StandardApi<'purchase.checkout.chat.render'>,
     AllowedComponents<'Chat'>
   >;
 }


### PR DESCRIPTION
It was decided to rename the previously generic `purchase.checkout.overlay.render` and `purchase.thank-you.overlay.render` to a feature specific name. In our case, its for the Chat feature.

New:
- `purchase.checkout.chat.render`
- `purchase.thank-you.chat.render`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
