### PR TITLE
Update POS render function to use createRoot

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/admin/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/render.tsx
@@ -1,5 +1,4 @@
 import type {ReactElement} from 'react';
-import {render as remoteRender} from '@remote-ui/react';
 
 import {extension} from '@shopify/ui-extensions/admin';
 import type {
@@ -9,6 +8,7 @@ import type {
 } from '@shopify/ui-extensions/admin';
 
 import {ExtensionApiContext} from './context';
+import {remoteRootRender} from '../../utilities/remoteRootRender';
 
 /**
  * Registers your React-based UI Extension to run for the selected extension point.
@@ -36,24 +36,12 @@ export function reactExtension<ExtensionTarget extends RenderExtensionTarget>(
   return extension<'Playground'>(target as any, async (root, api) => {
     const element = await render(api as ApiForRenderExtension<ExtensionTarget>);
 
-    await new Promise<void>((resolve, reject) => {
-      try {
-        remoteRender(
-          <ExtensionApiContext.Provider value={api}>
-            {element}
-          </ExtensionApiContext.Provider>,
-          root,
-          () => {
-            resolve();
-          },
-        );
-      } catch (error) {
-        // Workaround for https://github.com/Shopify/ui-extensions/issues/325
-        // eslint-disable-next-line no-console
-        console.error(error);
-        reject(error);
-      }
-    });
+    return remoteRootRender(
+      <ExtensionApiContext.Provider value={api}>
+        {element}
+      </ExtensionApiContext.Provider>,
+      root,
+    );
   }) as any;
 }
 

--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/render.tsx
@@ -1,6 +1,5 @@
 import type {ReactElement, PropsWithChildren} from 'react';
 import {Component} from 'react';
-import {createRoot} from '@remote-ui/react';
 import {extension} from '@shopify/ui-extensions/point-of-sale';
 import type {
   ExtensionTargets,
@@ -9,6 +8,7 @@ import type {
 } from '@shopify/ui-extensions/point-of-sale';
 
 import {ExtensionApiContext} from './context';
+import {remoteRootRender} from '../../utilities/remoteRootRender';
 
 /**
  * Registers your React-based UI Extension to run for the selected extension target.
@@ -38,24 +38,12 @@ export function reactExtension<Target extends RenderExtensionTarget>(
   // shape (`RenderExtension`).
   return extension<'pos.home.tile.render'>(target as any, async (root, api) => {
     const element = await render(api as ApiForRenderExtension<Target>);
-
-    return new Promise<() => void>((resolve, reject) => {
-      try {
-        const remoteRoot = createRoot(root);
-        remoteRoot.render(
-          <ExtensionApiContext.Provider value={api}>
-            <ErrorBoundary>{element}</ErrorBoundary>
-          </ExtensionApiContext.Provider>,
-        );
-
-        resolve(remoteRoot.unmount);
-      } catch (error) {
-        // Workaround for https://github.com/Shopify/ui-extensions/issues/325
-        // eslint-disable-next-line no-console
-        console.error(error);
-        reject(error);
-      }
-    });
+    return remoteRootRender(
+      <ExtensionApiContext.Provider value={api}>
+        <ErrorBoundary>{element}</ErrorBoundary>
+      </ExtensionApiContext.Provider>,
+      root,
+    );
   }) as any;
 }
 

--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/render.tsx
@@ -1,6 +1,6 @@
 import type {ReactElement, PropsWithChildren} from 'react';
 import {Component} from 'react';
-import {render as remoteRender} from '@remote-ui/react';
+import {createRoot} from '@remote-ui/react';
 import {extension} from '@shopify/ui-extensions/point-of-sale';
 import type {
   ExtensionTargets,
@@ -39,17 +39,16 @@ export function reactExtension<Target extends RenderExtensionTarget>(
   return extension<'pos.home.tile.render'>(target as any, async (root, api) => {
     const element = await render(api as ApiForRenderExtension<Target>);
 
-    await new Promise<void>((resolve, reject) => {
+    return new Promise<() => void>((resolve, reject) => {
       try {
-        remoteRender(
+        const remoteRoot = createRoot(root);
+        remoteRoot.render(
           <ExtensionApiContext.Provider value={api}>
             <ErrorBoundary>{element}</ErrorBoundary>
           </ExtensionApiContext.Provider>,
-          root,
-          () => {
-            resolve();
-          },
         );
+
+        resolve(remoteRoot.unmount);
       } catch (error) {
         // Workaround for https://github.com/Shopify/ui-extensions/issues/325
         // eslint-disable-next-line no-console

--- a/packages/ui-extensions-react/src/utilities/remoteRootRender.ts
+++ b/packages/ui-extensions-react/src/utilities/remoteRootRender.ts
@@ -1,0 +1,18 @@
+import {ReactNode} from 'react';
+import {RemoteRoot, createRoot} from '@remote-ui/react';
+
+export const remoteRootRender = (node: ReactNode, root: RemoteRoot) => {
+  return new Promise<() => void>((resolve, reject) => {
+    try {
+      const remoteRoot = createRoot(root);
+      remoteRoot.render(node);
+
+      resolve(remoteRoot.unmount);
+    } catch (error) {
+      // Workaround for https://github.com/Shopify/ui-extensions/issues/325
+      // eslint-disable-next-line no-console
+      console.error(error);
+      reject(error);
+    }
+  });
+};

--- a/packages/ui-extensions-react/src/utilities/remoteRootRender.ts
+++ b/packages/ui-extensions-react/src/utilities/remoteRootRender.ts
@@ -7,7 +7,7 @@ export const remoteRootRender = (node: ReactNode, root: RemoteRoot) => {
       const remoteRoot = createRoot(root);
       remoteRoot.render(node);
 
-      resolve(remoteRoot.unmount);
+      resolve(() => remoteRoot.unmount());
     } catch (error) {
       // Workaround for https://github.com/Shopify/ui-extensions/issues/325
       // eslint-disable-next-line no-console

--- a/packages/ui-extensions/src/extension.ts
+++ b/packages/ui-extensions/src/extension.ts
@@ -37,10 +37,10 @@ export interface RenderExtensionWithRemoteRoot<
     any
   > = RemoteComponentType<any, any, any>,
 > {
-  (
-    root: RemoteRoot<AllowedComponents, AllowedComponents>,
-    api: Api,
-  ): void | Promise<void>;
+  (root: RemoteRoot<AllowedComponents, AllowedComponents>, api: Api):
+    | void
+    | Promise<() => void>
+    | Promise<void>;
 }
 
 export interface RunnableExtension<Api, Output> {

--- a/packages/ui-extensions/src/extension.ts
+++ b/packages/ui-extensions/src/extension.ts
@@ -39,8 +39,8 @@ export interface RenderExtensionWithRemoteRoot<
 > {
   (root: RemoteRoot<AllowedComponents, AllowedComponents>, api: Api):
     | void
-    | Promise<() => void>
-    | Promise<void>;
+    | Promise<void>
+    | Promise<() => void>;
 }
 
 export interface RunnableExtension<Api, Output> {


### PR DESCRIPTION
### Background

Currently all of our teardown functionality does not work. For example, the return method from a useEffect does not work in UI Extensions for POS (and I think on the other surfaces it's also broken?).

### Solution

This replaces the deprecated render call with the `createRoot` function, which returns a root which has a `render` function, and an `unmount` function. We are passing the unmount method into the `Promise.resolve`, which means that it can be used on the host side to properly `unmount` everything when POS unmounts the `UIExtensionContainer`.

### 🎩

You can tophat this on POS with the following POS Branch:  https://github.com/Shopify/pos-next-react-native/pull/42289

1. Pull this branch to your machine.
2. Run yarn build, and go to the build directory for ui-extensions-react, and find the `esm/surfaces/point-of-sale/render.mjs` file that gets generated. Copy the contents.
3. In a POS UI Extension running locally, paste the contents of that into the `node_modules/@shopify/ui-extensions-react/build/esm/surfaces/point-of-sale/render.mjs`.
4. Run your UI Extension and implement a useEffect with a tear down function.
5. Inject your UI Extension into POS on the branch I specified at the top of this tophat section.
6. Using a webview debugging console, make sure your tear down is getting called!

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
