### PR TITLE
add full page navigation api to order full page

### DIFF
--- a/.changeset/new-badgers-mix.md
+++ b/.changeset/new-badgers-mix.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+add full page navigation api to order full page extension target

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -92,14 +92,16 @@ export interface OrderStatusExtensionTargets {
   >;
   'customer-account.order.page.render': RenderExtension<
     OrderStatusApi<'customer-account.order.page.render'> &
-      StandardApi<'customer-account.order.page.render'>,
+      Omit<StandardApi<'customer-account.order.page.render'>, 'navigation'> &
+      FullPageApi,
     AllComponents
   >;
 }
 export type OrderStatusExtensionTarget = keyof OrderStatusExtensionTargets;
 
 export type RenderCustomerAccountFullPageExtensionTarget =
-  'customer-account.page.render';
+  | 'customer-account.page.render'
+  | 'customer-account.order.page.render';
 
 export interface CustomerAccountExtensionTargets {
   'customer-account.page.render': RenderExtension<


### PR DESCRIPTION
### Background

Part of this ticket https://github.com/Shopify/core-issues/issues/76913 
resolves https://github.com/Shopify/core-issues/issues/76861 

Add full page extension API to order full page extension target. 

### 🎩

The PR itself is just adding the interface, if you want to test the real function, follow tophat here: 
https://github.com/Shopify/customer-account-web/pull/5449

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
