### PR TITLE
[Modal]: Primary and Secondary actions

### DIFF
--- a/.changeset/eight-peas-buy.md
+++ b/.changeset/eight-peas-buy.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-react': minor
+'@shopify/ui-extensions': minor
+---
+
+Add primary and secondary actions to Modal component

--- a/packages/ui-extensions-react/src/surfaces/checkout/components/Modal/Modal.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/components/Modal/Modal.ts
@@ -4,4 +4,6 @@ import type {ReactPropsFromRemoteComponentType} from '@remote-ui/react';
 
 export type ModalProps = ReactPropsFromRemoteComponentType<typeof BaseModal>;
 
-export const Modal = createRemoteReactComponent(BaseModal);
+export const Modal = createRemoteReactComponent(BaseModal, {
+  fragmentProps: ['primaryAction', 'secondaryActions'],
+});

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.ts
@@ -1,3 +1,4 @@
+import type {RemoteFragment} from '@remote-ui/core';
 import {createRemoteComponent} from '@remote-ui/core';
 
 export interface ModalProps {
@@ -37,6 +38,16 @@ export interface ModalProps {
    * @default 'auto'
    */
   size?: 'small' | 'auto' | 'large' | 'max';
+  /**
+   * The primary action to perform, provided as a `Button` component.
+   * The property allows only one button to be rendered.
+   */
+  primaryAction?: RemoteFragment;
+  /**
+   * The secondary action to perform, provided as a `Button` component.
+   * The property allows only one button to be rendered.
+   */
+  secondaryActions?: RemoteFragment;
 }
 
 /**


### PR DESCRIPTION
### Background

- Export new primary and secondary actions for modal component

### Solution

- Exporting the properties

### 🎩

- [Docs](https://shopify-dev.primary-secondary-modal-actions.igor-deoliveiramartins.us.spin.dev/docs/api/checkout-ui-extensions/unstable/components/overlays/modal)

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
