### PR TITLE
Add doc for `customer-account.order.page.render`

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.page.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.page.render.doc.ts
@@ -1,0 +1,31 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {
+  CUSTOMER_ACCOUNT_FULL_PAGE_API_DEFINITION,
+  CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION,
+  ORDER_STATUS_API_DEFINITION,
+} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'customer-account.order.page.render',
+  description: `This [full-page extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#full-page-extension-full-page-extension-(order-specific)) allows you to create a new page in customer accounts, **tied to a specific order**. It renders in the main content area—below the header, and above the footer.
+  
+If the page you're building is not tied to a specific order, use [customer-account.page.render](/docs/api/customer-account-ui-extensions/targets/full-page/customer-account-page-render) instead.
+
+For example:
+- A Return Request page that requires the context of a specific order should use customer-account.order.page.render
+- A Wishlist page that does **not** require the context of a specific order should use customer-account.page.render
+`,
+  category: 'Targets',
+  isVisualComponent: false,
+  subCategory: 'Full page',
+  related: [],
+  definitions: [
+    CUSTOMER_ACCOUNT_FULL_PAGE_API_DEFINITION,
+    ORDER_STATUS_API_DEFINITION,
+    CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION,
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.page.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.page.render.doc.ts
@@ -7,10 +7,17 @@ import {
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'customer-account.page.render',
-  description: `This [full-page extension](/docs/api/customer-account-ui-extensions/extension-targets-overview#full-page-extension-target) allows you to create a new page in customer accounts. It renders in the main content area, below the header, and above the footer.`,
+  description: `This [full-page extension](/docs/api/customer-account-ui-extensions/unstable/extension-targets-overview#full-page-extension-full-page-extension) allows you to create a new page in customer accounts. It renders in the main content area—below the header, and above the footer.\n
+
+If the page you're building is tied to a specific order, use [customer-account.order.page.render](/docs/api/customer-account-ui-extensions/targets/full-page/customer-account-order-page-render) instead.
+
+For example:
+- A Return Request page that requires the context of a specific order should use customer-account.order.page.render
+- A Wishlist page that does **not** require the context of a specific order should use customer-account.page.render
+`,
   category: 'Targets',
   isVisualComponent: false,
-  subCategory: 'Full-page',
+  subCategory: 'Full page',
   defaultExample: {
     description: '',
     codeblock: {

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/custom-protocols/extension-link.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/custom-protocols/extension-link.example.tsx
@@ -1,1 +1,7 @@
-<Link to={`extension:${extension.handle}/${path}`} />
+<Linkto={`extension:${extension.handle}/${path}`}>
+  To full-page extension
+</Link>;
+
+<Link to={`extension:${extension.handle}/customer-account.order.page.render/${orderId}/${path}`}>
+  To full-page extension (order-specific)
+</Link>;

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/extension-targets-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/extension-targets-overview.doc.ts
@@ -242,14 +242,29 @@ You register for targets in your [configuration file](/docs/api/checkout-ui-exte
       ],
     },
     {
-      type: 'Generic',
+      type: 'GenericAccordion',
       anchorLink: 'full-page-extension-target',
       title: 'Full-page extension',
       sectionContent:
-        'This full-page extension allows you to create a new page in customer accounts. It renders in the main content area, below the header, and above the footer.',
-      image: 'target-overview-full-page-extension.png',
-      altText:
-        'A desktop view of the header and footer of customer accounts. The entire main content area between the header and footer is occupied by a large blue dotted-line box that says Full-page extension, indicating that this area can be populated by a full-page customer account UI extension.',
+        'Build new pages for customer accounts. Full-page extensions render in the main content area—below the header, and above the footer.',
+      accordionContent: [
+        {
+          title: 'Full-page extension',
+          description: `This full-page extension target is for building pages that are **not** tied to a specific order. For example, a Wishlist page.
+          \nSee all [extension targets](/docs/api/customer-account-ui-extensions/targets).`,
+          image: 'target-overview-full-page-extension.png',
+          altText:
+            'A desktop view of the header and footer of customer accounts. The entire main content area between the header and footer is occupied by a large blue dotted-line box that says Full-page extension, indicating that this area can be populated by a full-page customer account UI extension.',
+        },
+        {
+          title: 'Full-page extension (order-specific)',
+          description: `This full-page extension target is for building pages that are tied to a specific order. For example, a Request Return page. 
+          \nSee all [extension targets](/docs/api/customer-account-ui-extensions/targets).`,
+          image: 'target-overview-full-page-extension.png',
+          altText:
+            'A desktop view of the header and footer of customer accounts. The entire main content area between the header and footer is occupied by a large blue dotted-line box that says Full-page extension, indicating that this area can be populated by a full-page customer account UI extension.',
+        },
+      ],
     },
   ],
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
@@ -242,7 +242,10 @@ const data: LandingTemplateSchema = {
         {
           title: 'Extension Protocol',
           description:
-            'Triggers a navigation to an extension using the `extension:` protocol. The handle is the handle of the extension that will be navigated to in the same application. Add a [full-page extension](/apps/customer-accounts/full-page-extensions) to create a separate page and handle the navigation.',
+            'Triggers a navigation to an extension using the `extension:` protocol. \
+The handle is the handle of the extension that will be navigated to in \
+the same application. Build a [full-page extension](/apps/customer-accounts/full-page-extension) to create a new page in \
+customer accounts and handle the navigation.',
           codeblock: {
             title: 'extension:handle',
             tabs: [


### PR DESCRIPTION
### Background

Big shout-out to @deannatron for her great work!

Add docs for `customer-account.order.page.render` target together with updating existing `customer-account.page.render` extension 

### 🎩

Figma here https://www.figma.com/board/RmPHPRlPNZT9vLSncNZW4C/Order-full-page-extension?node-id=0-1&node-type=canvas&t=73kBLjfn2hOxVWU9-0 

And I attached all the figma and spin link for each updated file. 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
