### PR TITLE
move settings to standard api

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/settings.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/settings.doc.ts
@@ -1,19 +1,18 @@
 import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
-import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
+import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Settings',
   description: 'The API for interacting with merchant settings.',
   isVisualComponent: false,
   category: 'APIs',
-  subCategory: 'Order Status API',
   type: 'API',
   definitions: [
     {
-      title: ORDER_STATUS_API_DEFINITION.title,
-      description: ORDER_STATUS_API_DEFINITION.description,
-      type: 'Docs_OrderStatus_SettingsApi',
+      title: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.title,
+      description: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.description,
+      type: 'Docs_Standard_SettingsApi',
     },
     {
       title: 'useSettings',
@@ -27,12 +26,12 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Accessing merchant settings',
       tabs: [
         {
-          code: '../../examples/apis/settings-access.example.tsx',
+          code: '../examples/apis/settings-access.example.tsx',
           language: 'jsx',
           title: 'React',
         },
         {
-          code: '../../examples/apis/settings-access.example.ts',
+          code: '../examples/apis/settings-access.example.ts',
           language: 'js',
           title: 'JavaScript',
         },
@@ -49,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Define merchant settings',
           tabs: [
             {
-              code: '../../examples/apis/settings.example.toml',
+              code: '../examples/apis/settings.example.toml',
               language: 'toml',
               title: 'shopify.extension.toml',
             },

--- a/packages/ui-extensions/src/surfaces/customer-account/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api.ts
@@ -3,7 +3,6 @@ export type {
   CartLineCost,
   CheckoutSettings,
   OrderStatusCustomer,
-  ExtensionSettings,
   Merchandise,
   ImageDetails,
   Product,
@@ -85,4 +84,5 @@ export type {
   Localization,
   CompanyLocationApi,
   OrderApi,
+  ExtensionSettings,
 } from './api/standard-api/standard-api';

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -31,12 +31,6 @@ export interface Docs_OrderStatus_GiftCardsApi
 export interface Docs_OrderStatus_NoteApi
   extends Pick<OrderStatusApi<any>, 'note'> {}
 
-export interface Docs_OrderStatus_SettingsApi
-  extends Pick<OrderStatusApi<any>, 'settings'> {}
-
-export interface Docs_OrderStatus_SettingsApi
-  extends Pick<OrderStatusApi<any>, 'settings'> {}
-
 export interface Docs_OrderStatus_AddressApi
   extends Pick<OrderStatusApi<any>, 'shippingAddress' | 'billingAddress'> {}
 
@@ -72,6 +66,9 @@ export interface Docs_Standard_LocalizationApi
 
 export interface Docs_Standard_SessionTokenApi
   extends Pick<StandardApi<any>, 'sessionToken'> {}
+
+export interface Docs_Standard_SettingsApi
+  extends Pick<StandardApi, 'settings'> {}
 
 export interface Docs_Standard_StorageApi
   extends Pick<StandardApi<any>, 'storage'> {}

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -316,17 +316,6 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
   checkoutToken: StatefulRemoteSubscribable<CheckoutToken | undefined>;
 
   /**
-   * The settings matching the settings definition written in the
-   * [`shopify.ui.extension.toml`](https://shopify.dev/docs/api/customer-account-ui-extensions/configuration) file.
-   *
-   *  See [settings examples](https://shopify.dev/docs/api/customer-account-ui-extensions/apis/standardapi#example-settings) for more information.
-   *
-   * > Note: When an extension is being installed in the editor, the settings will be empty until
-   * a merchant sets a value. In that case, this object will be updated in real time as a merchant fills in the settings.
-   */
-  settings: StatefulRemoteSubscribable<ExtensionSettings>;
-
-  /**
    * The buyer shipping address used for the order.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
@@ -960,13 +949,6 @@ export interface StoreCreditAccount {
    * The current balance of the Store Credit Account.
    */
   balance: Money;
-}
-
-/**
- * The merchant-defined setting values for the extension.
- */
-export interface ExtensionSettings {
-  [key: string]: string | number | boolean | undefined;
 }
 
 export interface Analytics {

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -14,6 +14,12 @@ import type {ExtensionTarget} from '../../targets';
 import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 /**
+ * The merchant-defined setting values for the extension.
+ */
+export interface ExtensionSettings {
+  [key: string]: string | number | boolean | undefined;
+}
+/**
  * The following APIs are provided to all extension targets.
  */
 export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
@@ -69,6 +75,17 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * See [session token examples](https://shopify.dev/docs/api/customer-account-ui-extensions/apis/session-token#examples) for more information.
    */
   sessionToken: SessionToken;
+
+  /**
+   * The settings matching the settings definition written in the
+   * [`shopify.ui.extension.toml`](https://shopify.dev/docs/api/customer-account-ui-extensions/configuration) file.
+   *
+   *  See [settings examples](https://shopify.dev/docs/api/customer-account-ui-extensions/apis/standardapi#example-settings) for more information.
+   *
+   * > Note: When an extension is being installed in the editor, the settings will be empty until
+   * a merchant sets a value. In that case, this object will be updated in real time as a merchant fills in the settings.
+   */
+  settings: StatefulRemoteSubscribable<ExtensionSettings>;
 
   /**
    * Methods to interact with the extension's UI.


### PR DESCRIPTION
### Background
Every extension target has access to it, not just order status targets.

### 🎩

- Go to https://shopify-dev.checkout-web-api-docs-4hcy.robin-drexler.us.spin.dev/docs/api/customer-account-ui-extensions/unstable/apis
- `Settings` should not be in the `OrderStatus` section anymore, but in `Uncategorized`
- Click on `Settings`
- The page should still work and you should still be able to see the examples 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
