### PR TITLE
update error message for useNavigationCurrentEntry

### DIFF
--- a/.changeset/tasty-coats-shave.md
+++ b/.changeset/tasty-coats-shave.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-react': patch
+'@shopify/ui-extensions': patch
+---
+
+update error message for useNavigationCurrentEntry api

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/live-navigation.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/live-navigation.ts
@@ -16,7 +16,7 @@ export function useNavigationCurrentEntry<
   useEffect(() => {
     if (!currentEntry || !removeEventListener || !addEventListener) {
       throw new Error(
-        'useNavigationCurrentEntry must be used in an extension with the customer-account.page.render target only',
+        'useNavigationCurrentEntry must be used in an extension with the customer-account.page.render or customer-account.order.page.render target only',
       );
     }
     addEventListener('currententrychange', update);

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/live-navigation.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/live-navigation.test.tsx
@@ -54,7 +54,7 @@ describe('useNavigationCurrentEntry', () => {
     );
   });
 
-  it('throws an error when its not a full page extension', async () => {
+  it('throws an error when its not a full page extension or order full page extension', async () => {
     const mock = {
       navigate: jest.fn(),
     };
@@ -68,7 +68,7 @@ describe('useNavigationCurrentEntry', () => {
     };
 
     await expect(runner).rejects.toThrow(
-      'useNavigationCurrentEntry must be used in an extension with the customer-account.page.render target only',
+      'useNavigationCurrentEntry must be used in an extension with the customer-account.page.render or customer-account.order.page.render target only',
     );
   });
 });


### PR DESCRIPTION
### Background

update error message for `useNavigationCurrentEntry`.
This hook can also be used when the extension target is `customer-account.order.page.render` . 

Content confirmed with @deannatron 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
