### PR TITLE
[release] add 2024-10 branch to github action branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       - 2024-01
       - 2024-04
       - 2024-07
+      - 2024-10
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)
Adding new version branch `2024-10` in preparation of new API release Oct 1, 2024. 

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
