### PR TITLE
rename RendererVersion to Version and type as string

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api.ts
@@ -10,7 +10,6 @@ export type {
   SelectedOption,
   Money,
   Shop,
-  Version,
   Metafield,
   AppMetafield,
   AppMetafieldEntryTarget,
@@ -72,7 +71,7 @@ export type {
 export type {CartLineItemApi} from './api/cart-line/cart-line-item';
 
 export type {
-  RendererVersion,
+  Version,
   StandardApi,
   FullExtensionNavigation,
   StandardExtensionNavigation,

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -51,7 +51,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * @example 'unstable'
    */
-  version: RendererVersion;
+  version: Version;
 
   /**
    * Details about the language of the buyer.
@@ -227,4 +227,4 @@ export interface NavigateFunction {
   (url: string, options?: NavigationOptions): void;
 }
 
-export type RendererVersion = 'unstable';
+export type Version = string;


### PR DESCRIPTION
### Background
To make it consistent [with checkout](https://github.com/Shopify/ui-extensions/blob/unstable/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts#L240)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
