### PR TITLE
Automatically set calver version in changelog and package.json

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           title: Version Packages (${{ github.ref_name }})
           publish: yarn run deploy --tag ${{ github.ref_name }}
+          version: yarn calver
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}

--- a/documentation/versions-and-deploys.md
+++ b/documentation/versions-and-deploys.md
@@ -46,8 +46,7 @@ Like the `unstable` branch, the `internal` branch also publishes snapshot releas
 To create a new stable version, you will need to follow these steps:
 
 1. Run the "create stable version" action.
-1. Pull down the branch that that was created by the GitHub action (it should have the name `changeset-release/{{BRANCH_NAME}}`). Instead of the patch version changes that were made by the action, update the version of all packages manually to be the first patch release of a new version range. For example, if you are creating a `2025-01` API version, you will set the package versions of all packages to `2025.1.0`. Apply this change to `packages/ui-extensions/package.json`, `packages/ui-extensions/CHANGELOG.md`, `packages/ui-extensions-react/package.json`, and `packages/ui-extensions-react/CHANGELOG.md`.
-   > Note: do not update the root-level `package.json`.
+1. Verify that the versions in the package.json and changelog.md files in packages/ were updated correctly. Make sure you get the PR reviewed by one other member of the [UI Extension Stewards GitHub team](https://github.com/orgs/Shopify/teams/ui-extension-stewards).
 1. Push your new changes, and make sure you get the PR reviewed by one other member of the [UI Extension Stewards GitHub team](https://github.com/orgs/Shopify/teams/ui-extension-stewards).
 1. Merge the PR, and let robots release the new versions to NPM and tag it appropriately.
 1. For any changes from `unstable` that have been incorporated into the new version, delete their changeset files on the `unstable` branch and replace the existing `CHANGELOG.md` files in `unstable` with what was just shipped.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "run:ts:watch": "nodemon --ext .ts,.tsx,.mjs,.json,.graphql node_modules/.bin/babel-node --extensions .ts,.tsx,.mjs,.js,.json",
     "scaffold-docs:admin": "./packages/ui-extensions/docs/surfaces/admin/create-doc-files.sh \"admin\"",
     "test": "loom test",
-    "type-check": "loom type-check"
+    "type-check": "loom type-check",
+    "calver": "changeset version && ./scripts/calver.sh"
   },
   "devDependencies": {
     "@babel/node": "^7.8.7",

--- a/scripts/calver.sh
+++ b/scripts/calver.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Get the current version from a package.json file
+get_version() {
+  grep -m1 '"version":' "$1" | awk -F'"' '{print $4}'
+}
+
+ui_version=$(get_version "packages/ui-extensions/package.json")
+react_version=$(get_version "packages/ui-extensions-react/package.json")
+
+create_new_version() {
+  branch_name=$(git rev-parse --abbrev-ref HEAD)
+  # Split the branch name into year and month
+  IFS='-' read -r year month <<<"$branch_name"
+
+  # Remove leading zero from month
+  month=${month#0}
+
+  echo "$year.$month.0"
+}
+
+increment_patch() {
+  echo "$1" | awk -F. '{$NF = $NF + 1;}1' OFS=.
+}
+
+# Determine the new versions
+if [ "$ui_version" = "0.0.0" ]; then
+  new_version=$(create_new_version)
+else
+  new_version=$(increment_patch "$ui_version")
+fi
+if [ "$react_version" = "0.0.0" ]; then
+  new_version_react=$(create_new_version)
+else
+  new_version_react=$(increment_patch "$react_version")
+fi
+
+update_version() {
+  local package_file="$1"
+  local changelog_file="$2"
+  local version="$3"
+
+  # Update package.json
+  awk -v version="$version" '
+    /"version":/ { gsub(/"version": "[^"]*"/, "\"version\": \"" version "\"") }
+    /"peerDependencies"/, /}/ {
+      if (/"@shopify\/ui-extensions":/) {
+        gsub(/"@shopify\/ui-extensions": "[^"]*"/, "\"@shopify/ui-extensions\": \"" version "\"")
+      }
+    }
+    /"devDependencies"/, /}/ {
+      if (/"@shopify\/ui-extensions":/) {
+        gsub(/"@shopify\/ui-extensions": "[^"]*"/, "\"@shopify/ui-extensions\": \"" version "\"")
+      }
+    }
+    { print }
+  ' "$package_file" >"${package_file}.tmp" && mv "${package_file}.tmp" "$package_file"
+
+  # Update CHANGELOG.md
+  awk -v version="$version" '
+    /^## 0\.0\.0/ { sub(/^## 0\.0\.0/, "## " version); }
+    { print }
+  ' "$changelog_file" >"${changelog_file}.tmp" && mv "${changelog_file}.tmp" "$changelog_file"
+}
+
+# Update versions in all relevant files
+update_version "packages/ui-extensions/package.json" "packages/ui-extensions/CHANGELOG.md" "$new_version"
+update_version "packages/ui-extensions-react/package.json" "packages/ui-extensions-react/CHANGELOG.md" "$new_version_react"
+
+echo "Version updated to $new_version"


### PR DESCRIPTION
### Background

Just an idea I had: https://shopify.slack.com/archives/C0683EBQ55M/p1727287021016169?thread_ts=1727285984.795059&cid=C0683EBQ55M

### Solution

We add a script to be run after `changeset version` which should simplify step 5 of [Creating new stable versions](https://github.com/Shopify/ui-extensions/blob/unstable/documentation/versions-and-deploys.md#creating-new-stable-versions)

### 🎩

1. [Create a github personal access token](https://github.com/settings/tokens/new) with `read:user` and `repo:status` permissions. Copy its value.
2. In the [list of PATs](https://github.com/settings/tokens), select Configure SSO -> Authorize next to Shopify.
3. Checkout this branch, and then checkout a new branch from here with a valid name (YYYY-MM, so 2027-03, or whatever value you like).
4. In your terminal run `GITHUB_TOKEN=<your token here> yarn calver` - this simulates a new stable release created from unstable.
5. Check the package.json and CHANGELOG.md files in each of the packages/ subdirectories (the top-level package.json doesn't change). They should all have a version corresponding to your branch name. For example, if you chose 2027-03 as your branch you should see 2027.3.0.
6. Run `GITHUB_TOKEN=<your token here> yarn calver` - This simulates a patch release on a pre-existing stable release.
7. Check the package.json and CHANGELOG.md files again. You should see the patch number incremented by 1. For example, if you chose 2027-03 as your branch, and you saw 2027.3.0 in the previous step, it should now read 2027.3.1.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
