### PR TITLE
removes acceptsMarketing from customer profile

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1359,16 +1359,6 @@ export interface Customer {
    */
   image: ImageDetails;
   /**
-   * Defines if the customer email accepts marketing activities.
-   *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
-   *
-   * > Caution: This field is deprecated and will be removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.
-   *
-   * @deprecated Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.
-   */
-  acceptsMarketing: boolean;
-  /**
    * Defines if the customer accepts email marketing activities.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).


### PR DESCRIPTION
### Background
Partially solves https://github.com/Shopify/checkout-web/issues/37877
Provides a fast fix for removing `acceptsMarketing` from customer profiles. This was depricate. The removal from `checkout-web` will need to be fast follow up after the release tomorrow. 

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
