### PR TITLE
use proper link for components

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/categories/components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/categories/components.doc.ts
@@ -14,7 +14,7 @@ const data: CategoryTemplateSchema = {
           type: 'blocks',
           name: 'Checkout components',
           subtitle: 'More components',
-          url: 'https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components',
+          url: '/docs/api/checkout-ui-extensions/components',
         },
       ],
     },


### PR DESCRIPTION
### Background

Link currently always points to prod and unstable.

It should work in all envs and go to the currently used version not be hardcoded to prod.


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
