### PR TITLE
Update navigation examples to use `reactExtension`

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/default-react.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/default-react.example.tsx
@@ -1,14 +1,17 @@
 import {
-  render,
+  reactExtension,
+  useApi,
   Button,
-} from '@shopify/customer-account-ui-extensions-react';
+} from '@shopify/ui-extensions-react/customer-account';
 
-render(
+export default reactExtension(
   'customer-account.page.render',
-  (api) => <App api={api} />,
+  () => <App />,
 );
 
-function App({api: {navigation}}) {
+function App() {
+  const {navigation} = useApi();
+
   return (
     <Button
       onPress={() => {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/event-listeners.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/event-listeners.example.tsx
@@ -4,7 +4,8 @@ import React, {
   useCallback,
 } from 'react';
 import {
-  render,
+  reactExtension,
+  useApi,
   BlockStack,
   Heading,
   Image,
@@ -13,11 +14,14 @@ import {
 } from '@shopify/ui-extensions-react/customer-account';
 import type {NavigationCurrentEntryChangeEvent} from '@shopify/ui-extensions/customer-account';
 
-render('customer-account.page.render', (api) => (
-  <App api={api} />
-));
+export default reactExtension(
+  'customer-account.page.render',
+  () => <App />,
+);
 
-function App({api: {navigation}}) {
+function App() {
+  const {navigation} = useApi();
+
   const [currentEntryState, setCurrentEntry] =
     useState<NavigationCurrentEntryChangeEvent>();
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/navigating-to-customer-account-page.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/navigating-to-customer-account-page.example.tsx
@@ -1,14 +1,18 @@
 import {
-  render,
+  reactExtension,
+  useApi,
   Page,
   Button,
 } from '@shopify/customer-account-ui-extensions-react';
 
-render('customer-account.page.render', (api) => (
-  <App api={api} />
-));
+export default reactExtension(
+  'customer-account.page.render',
+  () => <App />,
+);
 
-function App({api: {navigation}}) {
+function App() {
+  const { navigation } = useApi();
+
   return (
     <Page
       title="Wishlist"

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/use-current-entry.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/use-current-entry.example.tsx
@@ -3,7 +3,7 @@ import React, {
   useState,
 } from 'react';
 import {
-  render,
+  reactExtension,
   BlockStack,
   Heading,
   Image,
@@ -13,11 +13,12 @@ import {
 } from '@shopify/ui-extensions-react/customer-account';
 import type {NavigationCurrentEntryChangeEvent} from '@shopify/ui-extensions/customer-account';
 
-render('customer-account.page.render', (api) => (
-  <App api={api} />
-));
+export default reactExtension(
+  'customer-account.page.render',
+  () => <App />,
+);
 
-function App({api: {navigation}}) {
+function App() {
   const currentEntry = useNavigationCurrentEntry();
 
   function getWishlistId(_url: string): string {


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/shopify-dev-feedback/issues/5507
Resolves https://github.com/Shopify/core-issues/issues/67196

Examples were using `render` instead of `reactExtension`

I'll hold off on generating the docs for `shopify-dev` until the `2024-10` release goes out to avoid interfering with some larger doc release work

### Solution

Update the code. Also use `useApi` instead of passing the `api` prop

### 🎩

Trying out local dev with this so no instance. Since these are just code examples, I think code review should be sufficient, but I'll include some screenshots of what the rendered content looks like:

![image](https://github.com/user-attachments/assets/be93d901-bd4a-4db7-8ca3-6cc420ecb220)
(Not sure why this isn't doing any code highlighting, but it was like this before my change as well)

![image](https://github.com/user-attachments/assets/fc877ff6-4a8e-475e-bd62-044bd898eaa2)

![image](https://github.com/user-attachments/assets/e9c184c1-7fa0-48cc-bdc8-d11d359043dc)

![image](https://github.com/user-attachments/assets/e570e6ab-b9ee-43a0-8f53-2c751c2e5993)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
