### PR TITLE
[Docs] Add End of Support plan to POS UI Extensions

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/FormattedTextField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/FormattedTextField.doc.ts
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'formatted-text-field-default.png',
     codeblock: generateCodeBlockForComponent(
-      'Render a FormattedTextField that validates email addresses',
+      'Render a FormattedTextField for an email addresses',
       'default.example',
     ),
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/formatted-text-field/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/formatted-text-field/default.example.ts
@@ -13,8 +13,8 @@ export default extension(
     const homeScreen = root.createComponent(
       Screen,
       {
-        name: 'Home',
-        title: 'Home',
+        name: 'FormattedTextField',
+        title: 'FormattedTextField Example',
       },
     );
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/formatted-text-field/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/formatted-text-field/default.example.tsx
@@ -15,8 +15,8 @@ const SmartGridModal = () => {
   return (
     <Navigator>
       <Screen
-        name="TextArea"
-        title="Text Area Example"
+        name="FormattedTextField"
+        title="FormattedTextField Example"
       >
         <ScrollView>
           <FormattedTextField

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -39,6 +39,20 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
     },
     {
       type: 'Generic',
+      anchorLink: '202501',
+      title: '2025.01',
+      sectionContent: `
+- Added in POS version: N/A
+- Removed in POS version: N/A
+- Release day: 1/1/2025
+
+### Features
+
+- Removed \`customValidator\` prop from the [FormattedTextField](/docs/api/pos-ui-extensions/apis/formatted-text-field) component.
+      `,
+    },
+    {
+      type: 'Generic',
       anchorLink: '202410',
       title: '2024.10',
       sectionContent: `

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
@@ -20,15 +20,6 @@ export interface FormattedTextFieldProps extends BaseTextFieldProps {
    * Dictates when the text should be auto-capitalized.
    */
   autoCapitalize?: AutoCapitalizationType;
-  /**
-   * **Warning:** This callback is currently broken and will not work as intended.
-   *
-   * Custom validator function to determine the validity of an entered value.
-   *
-   * @deprecated This callback will be removed in version 2025-01.
-   * Please update your code to avoid using this feature.
-   */
-  customValidator?: (text: string) => boolean;
 }
 
 export const FormattedTextField = createRemoteComponent<


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/pos-next-react-native/issues/43667
Resolves https://github.com/Shopify/ui-extensions/issues/2295

### Solution

Adds a section to the Versions page describing the End of Support Plan for POS UI Extensions.
Tack-on: Removes customValidator from FormattedTextField

### 🎩

https://shopify-dev.ui-extensions-k324.nathan-oliveira.us.spin.dev/docs/api/pos-ui-extensions/unstable/versions

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
