### PR TITLE
Add data extensions package with conditional action targets

### DIFF
--- a/.changeset/bright-lemons-knock.md
+++ b/.changeset/bright-lemons-knock.md
@@ -1,0 +1,5 @@
+---
+'@shopify/data-extensions': patch
+---
+
+Add data-extensions package

--- a/packages/data-extensions/README.md
+++ b/packages/data-extensions/README.md
@@ -1,0 +1,27 @@
+# `@shopify/data-extensions`
+
+This package contains the public type definitions and utilities needed to create a Shopify data extension.
+
+## What is a data extension?
+
+A data extension is a JavaScript-based module that can hook in to client-side behaviors on Shopify’s first party UI surface areas. It differs from a UI extension in that it does not establish a long-lived channel or render any UI on the surface. It runs once and returns data.
+
+Currently, this package contains the API for one surface.
+
+- [`admin`](./src/surfaces/admin)
+
+All extensions, regardless of where they appear in Shopify, make use of the same [underlying technology](../../documentation/how-extensions-work.md) and most of the same capabilities (e.g., direct API access, session tokens).
+
+A data extension using “vanilla” JavaScript would be written as follows:
+
+```ts
+import {dataExtension} from '@shopify/data-extensions/admin';
+
+export default dataExtension(
+  'admin.product-details.action.should-render',
+  (root, {data}) => {
+    ...
+    return {display: true}
+  },
+);
+```

--- a/packages/data-extensions/README.md
+++ b/packages/data-extensions/README.md
@@ -4,7 +4,7 @@ This package contains the public type definitions and utilities needed to create
 
 ## What is a data extension?
 
-A data extension is a JavaScript-based module that can hook in to client-side behaviors on Shopify’s first party UI surface areas. It differs from a UI extension in that it does not establish a long-lived channel or render any UI on the surface. It runs once and returns data.
+A data extension is a JavaScript-based module that can hook in to client-side behaviors on Shopify’s first party UI surface areas. It differs from a UI extension in that it does not establish a long-lived channel or render any UI on the surface. It is a stateless function that executes and returns data.
 
 Currently, this package contains the API for one surface.
 

--- a/packages/data-extensions/loom.config.ts
+++ b/packages/data-extensions/loom.config.ts
@@ -1,0 +1,9 @@
+import {createPackage} from '@shopify/loom';
+
+import {defaultProjectPlugin} from '../../config/loom';
+
+export default createPackage((pkg) => {
+  pkg.entry({root: './src/index.ts'});
+  pkg.entry({name: 'admin', root: './src/surfaces/admin.ts'});
+  pkg.use(defaultProjectPlugin());
+});

--- a/packages/data-extensions/package.json
+++ b/packages/data-extensions/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@shopify/data-extensions",
+  "version": "0.0.0-unstable",
+  "main": "index.js",
+  "module": "index.mjs",
+  "esnext": "index.esnext",
+  "types": "./build/ts/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "admin": [
+        "./build/ts/surfaces/admin.d.ts"
+      ]
+    }
+  },
+  "exports": {
+    ".": {
+      "types": "./build/ts/index.d.ts",
+      "esnext": "./index.esnext",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./admin": {
+      "types": "./build/ts/surfaces/admin.d.ts",
+      "esnext": "./build/esnext/surfaces/admin.esnext",
+      "import": "./build/esm/surfaces/admin.mjs",
+      "require": "./build/cjs/surfaces/admin.js"
+    }
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "devDependencies": {
+    "typescript": "^4.9.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org/"
+  },
+  "files": [
+    "build",
+    "src",
+    "index.*",
+    "README.md"
+  ]
+}

--- a/packages/data-extensions/src/api.ts
+++ b/packages/data-extensions/src/api.ts
@@ -1,0 +1,95 @@
+/**
+ * Union of supported API versions
+ */
+export type ApiVersion = 'unstable';
+
+export interface Auth {
+  /**
+   * Retrieves a Shopify OpenID Connect ID token for the current user.
+   */
+  idToken: () => Promise<string | null>;
+}
+
+/**
+ * GraphQL error returned by the Shopify Admin API.
+ */
+export interface GraphQLError {
+  message: string;
+  locations: {
+    line: number;
+    column: string;
+  };
+}
+
+/**
+ * This defines the i18n.translate() signature.
+ */
+export interface I18nTranslate {
+  /**
+   * This returns a translated string matching a key in a locale file.
+   *
+   * @example translate("banner.title")
+   */
+  <ReplacementType = string>(
+    key: string,
+    options?: Record<string, ReplacementType | string | number>,
+  ): ReplacementType extends string | number
+    ? string
+    : (string | ReplacementType)[];
+}
+
+export interface I18n {
+  /**
+   * Returns a localized number.
+   *
+   * This function behaves like the standard `Intl.NumberFormat()`
+   * with a style of `decimal` applied. It uses the buyer's locale by default.
+   *
+   * @param options.inExtensionLocale - if true, use the extension's locale
+   */
+  formatNumber: (
+    number: number | bigint,
+    options?: {inExtensionLocale?: boolean} & Intl.NumberFormatOptions,
+  ) => string;
+
+  /**
+   * Returns a localized currency value.
+   *
+   * This function behaves like the standard `Intl.NumberFormat()`
+   * with a style of `currency` applied. It uses the buyer's locale by default.
+   *
+   * @param options.inExtensionLocale - if true, use the extension's locale
+   */
+  formatCurrency: (
+    number: number | bigint,
+    options?: {inExtensionLocale?: boolean} & Intl.NumberFormatOptions,
+  ) => string;
+
+  /**
+   * Returns a localized date value.
+   *
+   * This function behaves like the standard `Intl.DateTimeFormatOptions()` and uses
+   * the buyer's locale by default. Formatting options can be passed in as
+   * options.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat0
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#using_options
+   *
+   * @param options.inExtensionLocale - if true, use the extension's locale
+   */
+  formatDate: (
+    date: Date,
+    options?: {inExtensionLocale?: boolean} & Intl.DateTimeFormatOptions,
+  ) => string;
+
+  /**
+   * Returns translated content in the buyer's locale,
+   * as supported by the extension.
+   *
+   * - `options.count` is a special numeric value used in pluralization.
+   * - The other option keys and values are treated as replacements for interpolation.
+   * - If the replacements are all primitives, then `translate()` returns a single string.
+   * - If replacements contain UI components, then `translate()` returns an array of elements.
+   */
+  translate: I18nTranslate;
+}

--- a/packages/data-extensions/src/extension.ts
+++ b/packages/data-extensions/src/extension.ts
@@ -1,0 +1,3 @@
+export interface Extension<Api, Result> {
+  (api: Api): Result;
+}

--- a/packages/data-extensions/src/index.ts
+++ b/packages/data-extensions/src/index.ts
@@ -1,0 +1,2 @@
+export * from './api';
+export * from './extension';

--- a/packages/data-extensions/src/surfaces/admin.ts
+++ b/packages/data-extensions/src/surfaces/admin.ts
@@ -1,0 +1,3 @@
+export * from './admin/api';
+export * from './admin/extension-targets';
+export * from './admin/extension';

--- a/packages/data-extensions/src/surfaces/admin/api.ts
+++ b/packages/data-extensions/src/surfaces/admin/api.ts
@@ -1,0 +1,1 @@
+export type {StandardApi} from './api/standard/standard';

--- a/packages/data-extensions/src/surfaces/admin/api/standard/README.md
+++ b/packages/data-extensions/src/surfaces/admin/api/standard/README.md
@@ -1,0 +1,1 @@
+# Standard API

--- a/packages/data-extensions/src/surfaces/admin/api/standard/standard.ts
+++ b/packages/data-extensions/src/surfaces/admin/api/standard/standard.ts
@@ -1,0 +1,33 @@
+import {ApiVersion, Auth, GraphQLError, I18n} from '../../../../api';
+import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+
+/**
+ * The following APIs are provided to all extension targets.
+ */
+export interface StandardApi<ExtensionTarget extends AnyExtensionTarget> {
+  /**
+   * The identifier of the running extension target.
+   */
+  extension: {
+    target: ExtensionTarget;
+  };
+
+  /**
+   * Provides methods for authenticating calls to an app backend.
+   */
+  auth: Auth;
+
+  /**
+   * Utilities for translating content according to the current localization of the admin.
+   * More info - https://shopify.dev/docs/apps/checkout/best-practices/localizing-ui-extensions
+   */
+  i18n: I18n;
+
+  /**
+   * Used to query the Admin GraphQL API
+   */
+  query: <Data = unknown, Variables = {[key: string]: unknown}>(
+    query: string,
+    options?: {variables?: Variables; version?: Omit<ApiVersion, '2023-04'>},
+  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;
+}

--- a/packages/data-extensions/src/surfaces/admin/api/standard/standard.ts
+++ b/packages/data-extensions/src/surfaces/admin/api/standard/standard.ts
@@ -6,16 +6,21 @@ import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-target
  */
 export interface StandardApi<ExtensionTarget extends AnyExtensionTarget> {
   /**
+   * Provides methods for authenticating calls to an app backend.
+   */
+  auth: Auth;
+
+  /**
+   * Information about the currently viewed or selected items.
+   */
+  data: {selected: [{id: string}]};
+
+  /**
    * The identifier of the running extension target.
    */
   extension: {
     target: ExtensionTarget;
   };
-
-  /**
-   * Provides methods for authenticating calls to an app backend.
-   */
-  auth: Auth;
 
   /**
    * Utilities for translating content according to the current localization of the admin.

--- a/packages/data-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/data-extensions/src/surfaces/admin/extension-targets.ts
@@ -1,0 +1,209 @@
+import type {Extension} from '../../extension';
+
+import type {StandardApi} from './api';
+
+interface ShouldRender {
+  display: boolean;
+}
+
+export interface ExtensionTargets {
+  /** Abandoned checkouts targets */
+  /**
+   * Determines whether an admin action trigger displays in the abandoned checkout details page.
+   */
+  'admin.abandoned-checkout-details.action.should-render': Extension<
+    StandardApi<'admin.abandoned-checkout-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /** Catalog targets */
+  /**
+   * Determines whether an admin action trigger displays in the catalog details page.
+   */
+  'admin.catalog-details.action.should-render': Extension<
+    StandardApi<'admin.catalog-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /** Collection targets */
+  /**
+   * Determines whether an admin action trigger displays in the collection index page.
+   */
+  'admin.collection-index.action.should-render': Extension<
+    StandardApi<'admin.collection-index.action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the collection details page.
+   */
+  'admin.collection-details.action.should-render': Extension<
+    StandardApi<'admin.collection-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /** Company targets */
+  /**
+   * Determines whether an admin action trigger displays in the company details page.
+   */
+  'admin.company-details.action.should-render': Extension<
+    StandardApi<'admin.company-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /** Customer targets */
+  /**
+   * Determines whether an admin action trigger displays in the customer index page.
+   */
+  'admin.customer-index.action.should-render': Extension<
+    StandardApi<'admin.customer-index.action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the customer bulk selection action.
+   */
+  'admin.customer-index.selection-action.should-render': Extension<
+    StandardApi<'admin.customer-index.selection-action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the customer details page.
+   */
+  'admin.customer-details.action.should-render': Extension<
+    StandardApi<'admin.customer-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether a customer segment admin action trigger displays in the customer details page.
+   */
+  'admin.customer-segment-details.action.should-render': Extension<
+    StandardApi<'admin.customer-segment-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /** Discount targets */
+  /**
+   * Determines whether an admin action trigger displays in the discount index page.
+   */
+  'admin.discount-index.action.should-render': Extension<
+    StandardApi<'admin.discount-index.action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the discount details page.
+   */
+  'admin.discount-details.action.should-render': Extension<
+    StandardApi<'admin.discount-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /** Draft order targets */
+  /**
+   * Determines whether an admin action trigger displays in the draft order index page.
+   */
+  'admin.draft-order-index.action.should-render': Extension<
+    StandardApi<'admin.draft-order-index.action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the draft order bulk selection action.
+   */
+  'admin.draft-order-index.selection-action.should-render': Extension<
+    StandardApi<'admin.draft-order-index.selection-action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the draft order details page.
+   */
+  'admin.draft-order-details.action.should-render': Extension<
+    StandardApi<'admin.draft-order-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /** Gift card targets */
+  /**
+   * Determines whether an admin action trigger displays in the gift card details page.
+   */
+  'admin.gift-card-details.action.should-render': Extension<
+    StandardApi<'admin.gift-card-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /** Order targets */
+  /**
+   * Determines whether an admin action trigger displays in the order index page.
+   */
+  'admin.order-index.action.should-render': Extension<
+    StandardApi<'admin.order-index.action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the order bulk selection action.
+   */
+  'admin.order-index.selection-action.should-render': Extension<
+    StandardApi<'admin.order-index.selection-action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the order details page.
+   */
+  'admin.order-details.action.should-render': Extension<
+    StandardApi<'admin.order-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the order fulfilled card.
+   */
+  'admin.order-fulfilled-card.action.should-render': Extension<
+    StandardApi<'admin.order-fulfilled-card.action.should-render'>,
+    ShouldRender
+  >;
+
+  /** Product targets */
+  /**
+   * Determines whether an admin action trigger displays in the product index page.
+   */
+  'admin.product-index.action.should-render': Extension<
+    StandardApi<'admin.product-index.action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the product bulk selection action.
+   */
+  'admin.product-index.selection-action.should-render': Extension<
+    StandardApi<'admin.product-index.selection-action.should-render'>,
+    ShouldRender
+  >;
+
+  /**
+   * Determines whether an admin action trigger displays in the product details page.
+   */
+  'admin.product-details.action.should-render': Extension<
+    StandardApi<'admin.product-details.action.should-render'>,
+    ShouldRender
+  >;
+
+  /** Product variant targets */
+  /**
+   * Determines whether an admin action trigger displays in the product variant details page.
+   */
+  'admin.product-variant-details.action.should-render': Extension<
+    StandardApi<'admin.product-variant-details.action.should-render'>,
+    ShouldRender
+  >;
+}
+
+export type ExtensionTarget = keyof ExtensionTargets;
+
+export type ExtensionForExtensionTarget<T extends ExtensionTarget> =
+  ExtensionTargets[T];

--- a/packages/data-extensions/src/surfaces/admin/extension.ts
+++ b/packages/data-extensions/src/surfaces/admin/extension.ts
@@ -1,0 +1,8 @@
+import {createExtensionRegistrationFunction} from '../../utilities/registration';
+
+import type {ExtensionTargets} from './extension-targets';
+
+export * from '../../extension';
+
+export const dataExtension =
+  createExtensionRegistrationFunction<ExtensionTargets>();

--- a/packages/data-extensions/src/surfaces/admin/globals.ts
+++ b/packages/data-extensions/src/surfaces/admin/globals.ts
@@ -6,3 +6,12 @@ export interface ShopifyGlobal {
     callback: ExtensionTargets[ExtensionTarget],
   ): void;
 }
+
+declare global {
+  interface WorkerGlobalScope {
+    // conflicts with build/ts/globals.d.ts
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    readonly shopify: ShopifyGlobal;
+  }
+}

--- a/packages/data-extensions/src/surfaces/admin/globals.ts
+++ b/packages/data-extensions/src/surfaces/admin/globals.ts
@@ -1,0 +1,8 @@
+import type {ExtensionTargets} from './extension-targets';
+
+export interface ShopifyGlobal {
+  dataExtension<ExtensionTarget extends keyof ExtensionTargets>(
+    target: ExtensionTarget,
+    callback: ExtensionTargets[ExtensionTarget],
+  ): void;
+}

--- a/packages/data-extensions/src/utilities/registration.ts
+++ b/packages/data-extensions/src/utilities/registration.ts
@@ -12,7 +12,7 @@ export function createExtensionRegistrationFunction<
     target,
     callback,
   ) => {
-    (globalThis as any).shopify?.run(target, callback);
+    (globalThis as any).shopify?.dataExtension(target, callback);
     return callback;
   };
 

--- a/packages/data-extensions/src/utilities/registration.ts
+++ b/packages/data-extensions/src/utilities/registration.ts
@@ -1,0 +1,20 @@
+export interface ExtensionRegistrationFunction<ExtensionPoints> {
+  <Target extends keyof ExtensionPoints>(
+    target: Target,
+    callback: ExtensionPoints[Target],
+  ): ExtensionPoints[Target];
+}
+
+export function createExtensionRegistrationFunction<
+  ExtensionPoints,
+>(): ExtensionRegistrationFunction<ExtensionPoints> {
+  const extensionWrapper: ExtensionRegistrationFunction<ExtensionPoints> = (
+    target,
+    callback,
+  ) => {
+    (globalThis as any).shopify?.run(target, callback);
+    return callback;
+  };
+
+  return extensionWrapper;
+}

--- a/packages/data-extensions/tsconfig.json
+++ b/packages/data-extensions/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../config/typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/ts",
+    "stripInternal": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.example.*", "src/**/tests/**"]
+}

--- a/packages/ui-extensions-react/README.md
+++ b/packages/ui-extensions-react/README.md
@@ -6,7 +6,7 @@ This package contains the public type definitions and utilities needed to create
 
 Currently, this package only contains the extension APIs for the [`checkout` surface](./src/surfaces/checkout), but other Shopify surfaces will be added here soon.
 
-All extensions, regardless of where they appear in Shopify, make use the same [underlying technology](../../documentation/how-extensions-work.md), and most of the same “core” components (e.g., `BlockStack`, `Button`, `TextField`, etc) and capabilities (e.g., direct API access, session tokens). Separating APIs by surface makes it easier for a developer to see what is available to them in each context, and gives us a flexible system for introducing components and APIs available in only some areas of Shopify.
+All extensions, regardless of where they appear in Shopify, make use of the same [underlying technology](../../documentation/how-extensions-work.md), and most of the same “core” components (e.g., `BlockStack`, `Button`, `TextField`, etc) and capabilities (e.g., direct API access, session tokens). Separating APIs by surface makes it easier for a developer to see what is available to them in each context, and gives us a flexible system for introducing components and APIs available in only some areas of Shopify.
 
 A checkout extension using React would be written as follows:
 

--- a/packages/ui-extensions/README.md
+++ b/packages/ui-extensions/README.md
@@ -6,7 +6,7 @@ This package contains the public type definitions and utilities needed to create
 
 Currently, this package only contains the extension APIs for the [`checkout`](./src/surfaces/checkout) and [`admin`](./src/surfaces/admin) surfaces, but other Shopify surfaces will be added here soon.
 
-All extensions, regardless of where they appear in Shopify, make use the same [underlying technology](../../documentation/how-extensions-work.md), and most of the same “core” components (e.g., `BlockStack`, `Button`, `TextField`, etc) and capabilities (e.g., direct API access, session tokens). Separating APIs by surface makes it easier for a developer to see what is available to them in each context, and gives us a flexible system for introducing components and APIs available in only some areas of Shopify.
+All extensions, regardless of where they appear in Shopify, make use of the same [underlying technology](../../documentation/how-extensions-work.md), and most of the same “core” components (e.g., `BlockStack`, `Button`, `TextField`, etc) and capabilities (e.g., direct API access, session tokens). Separating APIs by surface makes it easier for a developer to see what is available to them in each context, and gives us a flexible system for introducing components and APIs available in only some areas of Shopify.
 
 A checkout extension using “vanilla” JavaScript would be written as follows:
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "references": [
     {"path": "./tsconfig.repo.json"},
     {"path": "./packages/ui-extensions"},
-    {"path": "./packages/ui-extensions-react"}
+    {"path": "./packages/ui-extensions-react"},
+    {"path": "./packages/data-extensions"}
   ]
 }


### PR DESCRIPTION
### Background

Related to new type of extension: [data extension](https://docs.google.com/document/d/14Y9EoL0b9M8x1K2yEdugBqjrwFeB1vXUXbjOVcMrj74/edit?tab=t.0#heading=h.vqkbcd97wgda)

Closes https://github.com/Shopify/app-ui/issues/1699

### Solution

- Add targets for conditional rendering action extensions in admin
- Expose `dataExtension` registration function
- Copy existing patterns from ui-extensions

### 🎩

Latest snapshot: `"@shopify/data-extensions": "0.0.0-snapshot-20241018231554",`

- Add a data extension that looks like this:

```ts
import {dataExtension} from '@shopify/data-extensions/admin';

export default dataExtension("admin.product-details.action.should-render", () => {
  return {display: false};
});
```

- Use the snapshot build in your data extension

![Screenshot 2024-10-21 at 2 37 13 PM](https://github.com/user-attachments/assets/192b8765-7eff-4ca8-94e1-ea865d5ed6d9)

- Make sure to update the target in the toml file too.
- Confirm that `dataExtension` and various `should-render` targets are available with no type errors 

![Screenshot 2024-10-21 at 3 47 31 PM](https://github.com/user-attachments/assets/7d96cb87-2730-4713-811a-a7a91d58ed9a)

- Confirm that using an invalid target gives you a type error

![Screenshot 2024-10-21 at 3 47 44 PM](https://github.com/user-attachments/assets/c2db795e-b959-4b44-a269-18dc62708244)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
