### PR TITLE
Return the new line item uuid upon add line item

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -78,11 +78,11 @@ export interface CartApiContent {
    */
   addCustomSale(customSale: CustomSale): Promise<void>;
 
-  /** Add a line item by variant ID to the cart
+  /** Add a line item by variant ID to the cart. Returns the UUID of the newly added line item.
    * @param variantId the product variant's numeric ID to add to the cart
    * @param quantity the number of this variant to add to the cart
    */
-  addLineItem(variantId: number, quantity: number): Promise<void>;
+  addLineItem(variantId: number, quantity: number): Promise<string>;
 
   /** Remove the line item at this uuid from the cart
    * @param uuid the uuid of the line item that should be removed

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -73,10 +73,10 @@ export interface CartApiContent {
   /** Remove the current customer from the cart */
   removeCustomer(): Promise<void>;
 
-  /** Add a custom sale to the cart
+  /** Add a custom sale to the cart. Returns the UUID of the newly added line item.
    * @param customSale the custom sale object to add to the cart
    */
-  addCustomSale(customSale: CustomSale): Promise<void>;
+  addCustomSale(customSale: CustomSale): Promise<string>;
 
   /** Add a line item by variant ID to the cart. Returns the UUID of the newly added line item.
    * @param variantId the product variant's numeric ID to add to the cart


### PR DESCRIPTION
### Background

This is a popular request, and a low hanging fruit and it seems like it would help out the devs a lot. https://github.com/Shopify/ui-extensions/issues/1495

### Solution
On the POS side, we will be returning the UUID of the new line item.

### 🎩


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
