### PR TITLE
Add metafields to ShippingOption

### DIFF
--- a/.changeset/orange-baboons-grab.md
+++ b/.changeset/orange-baboons-grab.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add metafields to ShippingOption

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1586,6 +1586,11 @@ export interface DeliveryOptionBase {
    * The code of the delivery option.
    */
   code: string;
+
+  /**
+   * The metafields associated with this delivery option.
+   */
+  metafields: Metafield[];
 }
 
 /**
@@ -1657,11 +1662,6 @@ export interface PickupPointOption extends DeliveryOptionBase {
    * The location details of the pickup point.
    */
   location: PickupPointLocation;
-
-  /**
-   * The metafields associated with this delivery option.
-   */
-  metafields: Metafield[];
 }
 
 export interface PickupLocationOption extends DeliveryOptionBase {
@@ -1674,11 +1674,6 @@ export interface PickupLocationOption extends DeliveryOptionBase {
    * The location details of the pickup location.
    */
   location: PickupLocation;
-
-  /**
-   * The metafields associated with this delivery option.
-   */
-  metafields: Metafield[];
 }
 
 interface PickupLocation {


### PR DESCRIPTION
### Background

Metafields are added to `ShippingOption`.

### Solution

Adds types for metafields in `DeliveryOptionBase` (extended by `ShippingOption`, `PickupPointOption`, and `PickupLocationOption`).

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
