### PR TITLE
Make print api print action async

### DIFF
--- a/.changeset/hot-shirts-clean.md
+++ b/.changeset/hot-shirts-clean.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Make POS UI Ext PrintAPI async

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/print-api/print-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/print-api/print-api.ts
@@ -5,7 +5,7 @@ export interface PrintApiContent {
   /** Trigger a print dialog
    * @param src the source URL of the content to print. This URL must be a path of the app backend. Valid document types are text, HTML, image, and PDF.
    */
-  print(src: string): void;
+  print(src: string): Promise<void>;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/print-api/print-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/print-api/print-api.ts
@@ -2,8 +2,10 @@
  * Access the print API for printing functionality
  */
 export interface PrintApiContent {
-  /** Trigger a print dialog
+  /**
+   * Trigger a print dialog.
    * @param src the source URL of the content to print. This URL must be a path of the app backend. Valid document types are text, HTML, image, and PDF.
+   * @returns Promise<void> that resolves when content is ready and native print dialog appears.
    */
   print(src: string): Promise<void>;
 }


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/45380
Part of https://github.com/Shopify/pos-next-react-native/issues/41454

### Background

This switches the interface return type from `void` to `Promise<void>`. We have validated the implementation using Yalc.


https://github.com/user-attachments/assets/94fe13d3-caac-40d5-ac6c-2309944a36b4

