### PR TITLE
LocaleApi Typo fix

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -7,7 +7,7 @@ const generateCodeBlockForLocaleApi = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Locale API',
   description:
-    'The Locale API allows the extension to retreive the merchants locale.',
+    "The Locale API allows the extension to retrieve the merchant's locale.",
   isVisualComponent: false,
   type: 'APIs',
   definitions: [


### PR DESCRIPTION
https://github.com/Shopify/pos-next-react-native/issues/45566
### Background

On October 31, 2024,[ it was identified ](https://shopify.slack.com/archives/C058Z5J64Q6/p1730383048413069)that there was a typo in the POS UI Extensions documentation.

|Before|After|
|--|--|
| <img width="477" alt="image" src="https://github.com/user-attachments/assets/eb1c9e49-d947-4a38-8ca9-a8ee0234fde4">|<img width="485" alt="image" src="https://github.com/user-attachments/assets/fc267416-11c5-44aa-a86d-3ac21e1b189e">|
### Solution

This PR fixes that typo by implementing the change in documentation, then by generating docs that are to be merged into shopify-dev. [PR for shopify-dev](https://github.com/Shopify/shopify-dev/pull/50169)

Additionally, due to an issue with my spin instance, it was required for me to implement an ejson key in order to properly run my environment. [Issue here](https://shopify.slack.com/archives/CUE2DKJ9Z/p1730390109995329). You will notice this 

### 🎩

- Visit this [spinstance](https://shopify-dev.ui-extensions-p6rv.marco-yip.us.spin.dev/docs/api/pos-ui-extensions/unstable/apis/locale-api) and ensure that the typo is resolved.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
