### PR TITLE
Add wallet icon for Template Icons

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate.ts
@@ -21,6 +21,7 @@ export type CustomerSegmentTemplateIcon =
   | 'buyButtonMajor'
   | 'followUpEmailMajor'
   | 'confettiMajor'
+  | 'walletMajor'
   | 'viewMajor';
 
 export type CustomerSegmentTemplateCategory =


### PR DESCRIPTION
### Background

We are adding a few templates that require this `walletMajor` icon

<img width="429" alt="Screenshot 2024-11-09 at 03 19 00" src="https://github.com/user-attachments/assets/b849eda8-e490-4e45-803e-f19bbaad3f07">


### Solution


### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
