### PR TITLE
[Admin Extension Docs] Add `resourcePicker` to Action Extension Api docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.ts
@@ -2,6 +2,7 @@ import type {StandardApi} from '../standard/standard';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 import type {Data} from '../shared';
 import type {ResourcePickerApi} from '../resource-picker/resource-picker';
+import type {PickerApi} from '../picker/picker';
 
 export interface ActionExtensionApi<ExtensionTarget extends AnyExtensionTarget>
   extends StandardApi<ExtensionTarget> {
@@ -16,7 +17,12 @@ export interface ActionExtensionApi<ExtensionTarget extends AnyExtensionTarget>
   data: Data;
 
   /**
-   * Renders the [Resource Picker](/docs/api/app-bridge-library/apis/resource-picker), allowing users to select a resource for the extension to use as part of its flow.
+   * Renders the [Resource Picker](resource-picker), allowing users to select a resource for the extension to use as part of its flow.
    */
   resourcePicker: ResourcePickerApi;
+
+  /**
+   * Renders a custom [Picker](picker) dialog allowing users to select values from a list.
+   */
+  picker: PickerApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.ts
@@ -1,6 +1,7 @@
 import type {StandardApi} from '../standard/standard';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 import type {Data} from '../shared';
+import type {ResourcePickerApi} from '../resource-picker/resource-picker';
 
 export interface ActionExtensionApi<ExtensionTarget extends AnyExtensionTarget>
   extends StandardApi<ExtensionTarget> {
@@ -13,4 +14,9 @@ export interface ActionExtensionApi<ExtensionTarget extends AnyExtensionTarget>
    * Information about the currently viewed or selected items.
    */
   data: Data;
+
+  /**
+   * Renders the [Resource Picker](/docs/api/app-bridge-library/apis/resource-picker), allowing users to select a resource for the extension to use as part of its flow.
+   */
+  resourcePicker: ResourcePickerApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'API',
   thumbnail: 'picker.png',
   requires:
-    'an [Admin block extension](/docs/api/admin-extensions/unstable/extension-targets#block-locations)',
+    'an Admin [block](/docs/api/admin-extensions/unstable/extension-targets#block-locations), [action](/docs/api/admin-extensions/unstable/extension-targets#action-locations), or [print](/docs/api/admin-extensions/unstable/extension-targets#print-locations) extension.',
   defaultExample: {
     image: 'picker.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.ts
@@ -1,6 +1,7 @@
 import type {StandardApi} from '../standard/standard';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 import type {Data} from '../shared';
+import type {ResourcePickerApi} from '../resource-picker/resource-picker';
 
 export interface PrintActionExtensionApi<
   ExtensionTarget extends AnyExtensionTarget,
@@ -9,4 +10,9 @@ export interface PrintActionExtensionApi<
    * Information about the currently viewed or selected items.
    */
   data: Data;
+
+  /**
+   * Renders the [Resource Picker](/docs/api/app-bridge-library/apis/resource-picker), allowing users to select a resource for the extension to use as part of its flow.
+   */
+  resourcePicker: ResourcePickerApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.ts
@@ -2,6 +2,7 @@ import type {StandardApi} from '../standard/standard';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 import type {Data} from '../shared';
 import type {ResourcePickerApi} from '../resource-picker/resource-picker';
+import type {PickerApi} from '../picker/picker';
 
 export interface PrintActionExtensionApi<
   ExtensionTarget extends AnyExtensionTarget,
@@ -12,7 +13,12 @@ export interface PrintActionExtensionApi<
   data: Data;
 
   /**
-   * Renders the [Resource Picker](/docs/api/app-bridge-library/apis/resource-picker), allowing users to select a resource for the extension to use as part of its flow.
+   * Renders the [Resource Picker](resource-picker), allowing users to select a resource for the extension to use as part of its flow.
    */
   resourcePicker: ResourcePickerApi;
+
+  /**
+   * Renders a custom [Picker](picker) dialog allowing users to select values from a list.
+   */
+  picker: PickerApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'API',
   thumbnail: 'resource-picker.png',
   requires:
-    'an [Admin block extension](/docs/api/admin-extensions/unstable/extension-targets#block-locations)',
+    'an Admin [block](/docs/api/admin-extensions/unstable/extension-targets#block-locations), [action](/docs/api/admin-extensions/unstable/extension-targets#action-locations), or [print](/docs/api/admin-extensions/unstable/extension-targets#print-locations) extension.',
   defaultExample: {
     image: 'resource-picker.png',
     codeblock: {


### PR DESCRIPTION
**Do Not Merge:** Will need to rebase after https://github.com/Shopify/ui-extensions/pull/2379 ships so we can update this PR to include the `GenericPicker` being available in `ActionExtensionsApi`

### Background
Related to https://github.com/Shopify/app-ui/issues/1756
Should ship after https://github.com/Shopify/web/pull/146520 and https://github.com/Shopify/ui-extensions/pull/2379
Follow up `shopify-dev` PR https://github.com/Shopify/shopify-dev/pull/50766

Add `resourcePicker` and `genericPicker` Api to Action Extension Api to support the new Resource Picker availability in action extensions.

### Solution
Update the `ActionExtensionApi` interface to include the `ResourcePickerApi` and `GenericPickerApi`

**NOTE**: Will need to check on https://github.com/Shopify/shopify-dev/pull/49753 to see if there's verbage we'll need to update in https://github.com/Shopify/ui-extensions/blob/unstable/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts so it doesn't say `blocks only`.


### 🎩
Before:
<img width="1213" alt="image" src="https://github.com/user-attachments/assets/c5ce68db-0574-4144-a4b5-e3d7552d1d99">

After:
<img width="1213" alt="image" src="https://github.com/user-attachments/assets/e2363e70-d49c-4f80-9e25-fc430a57c4c5">

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
