### PR TITLE
Defaulting to string type for enabled features passed to the templates

### DIFF
--- a/.changeset/famous-parents-punch.md
+++ b/.changeset/famous-parents-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Defaulting to string type for enabled features passed to the templates

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.ts
@@ -2,16 +2,11 @@ import type {StandardApi} from '../standard/standard';
 import type {I18n} from '../../../../api';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
-/* List of enabled query language features during a progressive rollout */
-type CustomerSegmentationFeature =
-  /* Enables templates using filters only available when B2B is enabled. For example: companies IS NOT NULL */
-  'b2bEnabled';
-
 export interface CustomerSegmentTemplateApi<
   ExtensionTarget extends AnyExtensionTarget,
 > extends StandardApi<ExtensionTarget> {
   /* Utilities for translating content according to the current `localization` of the admin. */
   i18n: I18n;
   /** @private */
-  __enabledFeatures: CustomerSegmentationFeature[];
+  __enabledFeatures: string[];
 }


### PR DESCRIPTION
### Background

We are now passing obfuscated flags as part of the `__enabledFeatures` property in the `CustomerSegmentTemplateApi` interface. Having hardcoded types defeat the purpose of obfuscation, so we are defaulting to a string type for these flags.

### Solution

Switching types to string[]

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
