### PR TITLE
add collapsedSummary prop to AdminBlock 

### DIFF
--- a/.changeset/rotten-donuts-clap.md
+++ b/.changeset/rotten-donuts-clap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+AdminBlock remove summary prop and add collapsedSummary

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ts
@@ -7,11 +7,9 @@ export interface AdminBlockProps {
   title?: string;
 
   /**
-   * The summary to display when the app block is collapsed.
-   *
-   * @deprecated App blocks no longer have a collapsed state, so this prop is no longer supported.
+   * The summary to display when the app block is collapsed. Summary longer than 30 characters will be truncated.
    */
-  summary?: string;
+  collapsedSummary?: string;
 }
 
 export const AdminBlock = createRemoteComponent<'AdminBlock', AdminBlockProps>(


### PR DESCRIPTION
### Background
Adding a new prop for dev to add summary text when the Block Extension has no content.

#### Example
<img width="646" alt="Screenshot 2024-11-25 at 18 07 29" src="https://github.com/user-attachments/assets/2db2cd27-5999-4a84-9b5b-a8466af7c388">


### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
