### PR TITLE
Fix missing global shopify type for Admin

### DIFF
--- a/.changeset/spicy-mugs-drop.md
+++ b/.changeset/spicy-mugs-drop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Fix shopify global declaration

--- a/packages/ui-extensions/src/surfaces/admin.ts
+++ b/packages/ui-extensions/src/surfaces/admin.ts
@@ -3,3 +3,4 @@ export * from './admin/components';
 export * from './admin/extension-targets';
 export * from './admin/extension';
 export * from './admin/shared';
+export * from './admin/globals';

--- a/packages/ui-extensions/src/surfaces/admin/globals.ts
+++ b/packages/ui-extensions/src/surfaces/admin/globals.ts
@@ -6,3 +6,10 @@ export interface ShopifyGlobal {
     extend: ExtensionTargets[ExtensionTarget],
   ): void;
 }
+
+declare global {
+  // conflicts with build/ts/globals.d.ts
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const shopify: ShopifyGlobal;
+}

--- a/packages/ui-extensions/src/surfaces/checkout/globals.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/globals.ts
@@ -9,10 +9,8 @@ export interface ShopifyGlobal {
 }
 
 declare global {
-  interface WorkerGlobalScope {
-    // conflicts with packages/checkout-ui-extensions/build/ts/globals.d.ts
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    readonly le_shopify: ShopifyGlobal;
-  }
+  // conflicts with build/ts/globals.d.ts
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const shopify: ShopifyGlobal;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/globals.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/globals.ts
@@ -9,10 +9,8 @@ export interface ShopifyGlobal {
 }
 
 declare global {
-  interface WorkerGlobalScope {
-    // conflicts with packages/checkout-ui-extensions/build/ts/globals.d.ts
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    readonly le_shopify: ShopifyGlobal;
-  }
+  // conflicts with build/ts/globals.d.ts
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const shopify: ShopifyGlobal;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
@@ -9,10 +9,8 @@ export interface ShopifyGlobal {
 }
 
 declare global {
-  interface WorkerGlobalScope {
-    // conflicts with build/ts/globals.d.ts
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    readonly shopify: ShopifyGlobal;
-  }
+  // conflicts with build/ts/globals.d.ts
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const shopify: ShopifyGlobal;
 }


### PR DESCRIPTION
### Background

The `shopify` global declaration was incorrect all along. With these changes doing `shopify.extend` inside an extension now works to pick up the types. 

Try this out by consuming the snapshot build and inside an extension either use the `/// <reference types="@shopify/ui-extensions/admin" />` or import the `extension` function.