### PR TITLE
Only allow .render targets to run reactExtension

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/admin/render.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/render.tsx
@@ -34,6 +34,12 @@ export function reactExtension<ExtensionTarget extends RenderExtensionTarget>(
   // Playground extension, since all render extensions have the same general
   // shape (`RenderExtension`).
   return extension<'Playground'>(target as any, async (root, api) => {
+    if (!target.match(/\.render$/)) {
+      throw new Error(
+        `reactExtension can only be used for .render extension targets, got: ${target}`,
+      );
+    }
+
     const element = await render(api as ApiForRenderExtension<ExtensionTarget>);
 
     return remoteRootRender(


### PR DESCRIPTION
### Background
Using `reactExtension` for non-react extensions causes an infinite loop

### Solution
Only allow `.render` targets to run reactExtension

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
