### PR TITLE
Add discount functions settings api docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -9,3 +9,4 @@ export type {ProductDetailsConfigurationApi} from './api/product-configuration/p
 export type {ProductVariantDetailsConfigurationApi} from './api/product-configuration/product-variant-details-configuration';
 export type {OrderRoutingRuleApi} from './api/order-routing-rule/order-routing-rule';
 export type {ValidationSettingsApi} from './api/checkout-rules/validation-settings';
+export type {DiscountFunctionSettingsApi} from './api/discount-function-settings/discount-function-settings';

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -1,0 +1,26 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Discount Function Settings API',
+  description:
+    'This API is available to Discount Function Settings extensions. Refer to the [tutorial](/docs/apps/build/discounts/build-ui-extension) for more information. Note that the [`FunctionSettings`](/docs/api/admin-extensions/components/forms/functionsettings) component is required to build Discount Function Settings extensions.',
+  isVisualComponent: false,
+  type: 'API',
+  definitions: [
+    {
+      title: 'applyMetafieldChange',
+      description: 'Applies a change to the discount function settings.',
+      type: 'ApplyMetafieldChange',
+    },
+    {
+      title: 'data',
+      description:
+        'The object exposed to the extension that contains the discount function settings.',
+      type: 'DiscountFunctionSettingsData',
+    },
+  ],
+  category: 'API',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.ts
@@ -1,0 +1,15 @@
+import type {StandardApi} from '../standard/standard';
+import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+
+import {ApplyMetafieldChange} from './metafields';
+import {DiscountFunctionSettingsData} from './launch-options';
+
+export interface DiscountFunctionSettingsApi<
+  ExtensionTarget extends AnyExtensionTarget,
+> extends StandardApi<ExtensionTarget> {
+  /**
+   * Applies a change to the discount function settings.
+   */
+  applyMetafieldChange: ApplyMetafieldChange;
+  data: DiscountFunctionSettingsData;
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
@@ -1,0 +1,22 @@
+interface Metafield {
+  description?: string;
+  id: string;
+  namespace: string;
+  key: string;
+  value: string;
+  type: string;
+}
+export enum DiscountClass {
+  Product = 'PRODUCT',
+  Order = 'ORDER',
+  Shipping = 'SHIPPING',
+}
+
+/**
+ * The object that exposes the validation with its settings.
+ */
+export interface DiscountFunctionSettingsData {
+  id: string;
+  metafields: Metafield[];
+  discountClasses: DiscountClass[];
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/metafields.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/metafields.ts
@@ -1,0 +1,76 @@
+const supportedDefinitionTypes = [
+  'boolean',
+  'collection_reference',
+  'color',
+  'date',
+  'date_time',
+  'dimension',
+  'file_reference',
+  'json',
+  'metaobject_reference',
+  'mixed_reference',
+  'money',
+  'multi_line_text_field',
+  'number_decimal',
+  'number_integer',
+  'page_reference',
+  'product_reference',
+  'rating',
+  'rich_text_field',
+  'single_line_text_field',
+  'product_taxonomy_value_reference',
+  'url',
+  'variant_reference',
+  'volume',
+  'weight',
+  'list.collection_reference',
+  'list.color',
+  'list.date',
+  'list.date_time',
+  'list.dimension',
+  'list.file_reference',
+  'list.metaobject_reference',
+  'list.mixed_reference',
+  'list.number_decimal',
+  'list.number_integer',
+  'list.page_reference',
+  'list.product_reference',
+  'list.rating',
+  'list.single_line_text_field',
+  'list.url',
+  'list.variant_reference',
+  'list.volume',
+  'list.weight',
+] as const;
+
+export type SupportedDefinitionType = (typeof supportedDefinitionTypes)[number];
+
+interface MetafieldUpdateChange {
+  type: 'updateMetafield';
+  key: string;
+  namespace?: string;
+  value: string | number;
+  valueType?: SupportedDefinitionType;
+}
+
+interface MetafieldRemoveChange {
+  type: 'removeMetafield';
+  key: string;
+  namespace: string;
+}
+
+type MetafieldChange = MetafieldUpdateChange | MetafieldRemoveChange;
+interface MetafieldChangeResultError {
+  type: 'error';
+  message: string;
+}
+interface MetafieldChangeSuccess {
+  type: 'success';
+}
+type MetafieldChangeResult =
+  | MetafieldChangeSuccess
+  | MetafieldChangeResultError;
+
+export type ApplyMetafieldChange = (
+  change: MetafieldChange,
+) => Promise<MetafieldChangeResult>;

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -11,6 +11,7 @@ import type {
   ProductVariantDetailsConfigurationApi,
   OrderRoutingRuleApi,
   ValidationSettingsApi,
+  DiscountFunctionSettingsApi,
 } from './api';
 import {AnyComponentBuilder} from '../../shared';
 
@@ -94,7 +95,7 @@ export interface ExtensionTargets {
    * See the [list of available components](/docs/api/admin-extensions/components).
    */
   'admin.discount-details.function-settings.render': RenderExtension<
-    BlockExtensionApi<'admin.discount-details.function-settings.render'>,
+    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,
     AllComponents
   >;
 


### PR DESCRIPTION
### Background

This PR adds a section for Discount Function Settings API, similar to the Validation Settings API.

### Solution

Adding the interface and data provided to the extension point.

### 🎩

[Spin Link]()

1. Go to Discount Function Settings API and review content.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
