### PR TITLE
Nest shouldrender under target APIs

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -13,6 +13,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'API',
+  subCategory: 'Target APIs',
   related: [],
 };
 


### PR DESCRIPTION
### Background

We moved the target-specific APIs around, now under "API -> Target APIs". ShouldRender missed the cutoff.

See: https://shopify-dev.docs.mitch-lillie.us.spin.dev/docs/api/admin-extensions/unstable/api/target-apis/shouldrender-api

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
