### PR TITLE
Remove Dev Preview note from Customer Account Extensibility docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
@@ -3,12 +3,7 @@ import type {LandingTemplateSchema} from '@shopify/generate-docs';
 const data: LandingTemplateSchema = {
   title: 'Customer account UI extensions',
   description: `
-  <aside class="note">
-    <h4>Developer preview</h4>
-    <p>Customer account UI extensions are included in the <a target="_blank" href="/docs/api/release-notes/developer-previews">Checkout and Customer Accounts Extensibility developer preview</a>.</p>
-  </aside>
-
-  \nCustomer account UI extensions let app developers build custom functionality that merchants can install at defined points on the **Order index**, **Order status**, and **Profile** pages in customer accounts.
+  Customer account UI extensions let app developers build custom functionality that merchants can install at defined points on the **Order index**, **Order status**, and **Profile** pages in customer accounts.
 
   \n\n > Shopify Plus: \n>Some static extensions on the Profile page only render for B2B customers. B2B on Shopify is only available on the [Shopify Plus](https://www.shopify.com/plus) plan. [See B2B Profile targets](/api/customer-account-ui-extensions/unstable/extension-targets-overview#profile-b2b)
   `,


### PR DESCRIPTION
### Background

The Dev Preview note needs to be removed from [here](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable)

### Solution

Update content and run `yarn docs:customer-account` and `yarn docs:customer-account 2024-10` to re-generate the static page content.

### 🎩

See https://github.com/Shopify/shopify-dev/pull/51666

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
