### PR TITLE
Improve ResponsePickerApi type

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.ts
@@ -202,11 +202,11 @@ interface Filters {
   query?: string;
 }
 
-export interface ResourcePickerOptions {
+export interface ResourcePickerOptions<Type extends keyof ResourceTypes> {
   /**
    * The type of resource you want to pick.
    */
-  type: 'product' | 'variant' | 'collection';
+  type: Type;
   /**
    *  The action verb appears in the title and as the primary action of the Resource Picker.
    * @defaultValue 'add'
@@ -235,6 +235,6 @@ export interface ResourcePickerOptions {
   selectionIds?: BaseResource[];
 }
 
-export type ResourcePickerApi = (
-  options: ResourcePickerOptions,
-) => Promise<SelectPayload<ResourcePickerOptions['type']> | undefined>;
+export type ResourcePickerApi = <Type extends keyof ResourceTypes>(
+  options: ResourcePickerOptions<Type>,
+) => Promise<SelectPayload<Type> | undefined>;


### PR DESCRIPTION
### Background

Currently ResourcePickerApi is incorrectly returning `SelectPayload<'product' | 'variant' | 'collection'>` type even when `type: 'product'` is passed to the resourcePIcker. See screenshot below showing before and after

### Solution

Add generic constraints to ResourcePickerApi function type so that the return type is based on the `type` option passed as parameter.

#### Before
![IMG_4227](https://github.com/user-attachments/assets/a3419c5a-93b5-4985-bdf8-39d29fbbaf7d)

#### After
![IMG_4226](https://github.com/user-attachments/assets/083de03f-9102-4143-b437-c21f56546eae)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
