### PR TITLE
Add Changeset for Image and Box Component Updates

### DIFF
--- a/.changeset/curly-bugs-suffer.md
+++ b/.changeset/curly-bugs-suffer.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+Image and Box component updates


### PR DESCRIPTION
### Background

As a follow up PR for P[OS Image sizing and Box component implementation](https://github.com/Shopify/ui-extensions/pull/2524), This PR adds the required changesets for the Image and Box component to be published with the POS UI Extensions Packages.

### Solution

Publish Unstable

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
