### PR TITLE
Adds row and column gap for POS stack

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/shared/inner-layouts.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/shared/inner-layouts.ts
@@ -8,6 +8,24 @@ export interface GapProps {
    * @default 'none'
    */
   gap?: SpacingKeyword;
+
+  /**
+   * Adjust spacing between elements in the block axis.
+   *
+   * This overrides the row value of `gap`.
+   *
+   * @default '' - meaning no override
+   */
+  rowGap?: SpacingKeyword | '';
+
+  /**
+   * Adjust spacing between elements in the inline axis.
+   *
+   * This overrides the column value of `gap`.
+   *
+   * @default '' - meaning no override
+   */
+  columnGap?: SpacingKeyword | '';
 }
 
 export type ContentPosition = 'center' | 'start' | 'end';


### PR DESCRIPTION
### Background

Adds [row and column gap ](https://github.com/Shopify/ui-api-design/blob/177092940cd7202d5d3a81973ef9781f6eb6c53d/ui-api-design/shared/inner-layout.ts#L24-L33) overrides for the Stack component. 

This is a really useful addition for when a Stack wraps to another line as it allows the dev to customize spacing along both axis.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
