### PR TITLE
Made flex and flexChildren available again

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/Stack/Stack.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/Stack/Stack.ts
@@ -57,7 +57,7 @@ export interface StackProps extends PaddingProps, SizingProps, GapProps {
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
    * @default 'stretch'
    */
-  alignItems?: 'stretch' | ContentPosition;
+  alignItems?: 'stretch' | 'baseline' | ContentPosition;
 
   /**
    * The vertical padding around the stack.


### PR DESCRIPTION
### Background
Our Stack implementation on POS still has some limitations when it comes to avoiding flex and `flexChildren`. For example, we don't have any way to implement JustifyItems right now which would let the buttons and other components stretch across the main axis, so we still need `flexChildren` to accomplish this. As for `flex`, we need to expose this property so that partners can tell the `Stack` to take the whole screen if they want. Ideally in the future we refactor our Screen implementation to be flex independent, but this will take time and work that we don't have the capacity for right now. 

### Solution
Removes the deprecation warnings for flex and flexChildren. It also fixes up some documentation.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
