### PR TITLE
[Checkout UI extensions] Optimizes localized field example comments

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/localized-fields/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/localized-fields/default.example.ts
@@ -30,8 +30,7 @@ export default extension(
                 {
                   message: `${taxIdField.title} is required and
                   cannot exceed 10 characters in length`,
-                  // Show an error under the localized field or
-                  // exclude target to show at the top of the page
+                  // Show an error under the field
                   target: `$.cart.localizedField.${taxIdField.key}`,
                 },
               ],

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/localized-fields/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/localized-fields/default.example.tsx
@@ -32,8 +32,7 @@ function Extension() {
               {
                 message: `${taxIdField.title} is required and
                 cannot exceed 10 characters in length`,
-                // Show an error under the localized field or
-                // exclude target to show at the top of the page
+                // Show an error under the field
                 target: `$.cart.localizedField.${taxIdField.key}`,
               },
             ],


### PR DESCRIPTION
### Background

This PR optimizes comments in the localized field API examples.

There's no change log entry for this because the update pertains to docs only and not anything exported from the package.

### 🎩

[Localized Fields API docs](https://shopify-dev.unstable-release.rick-caplan.us.spin.dev/docs/api/checkout-ui-extensions/unstable/apis/localized-fields)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
