### PR TITLE
exclude data-extensions changes from 2025-01 release

### DIFF
--- a/.changeset/bright-lemons-knock.md
+++ b/.changeset/bright-lemons-knock.md
@@ -1,5 +1,0 @@
----
-'@shopify/data-extensions': patch
----
-
-Add data-extensions package

--- a/.changeset/lemon-dots-rhyme.md
+++ b/.changeset/lemon-dots-rhyme.md
@@ -1,6 +1,5 @@
 ---
 '@shopify/ui-extensions-react': minor
-'@shopify/data-extensions': minor
 '@shopify/ui-extensions': minor
 ---
 


### PR DESCRIPTION
### Background

This PR removes the `data-extensions` change logs to exclude the `data-extensions` updates from the `2025-01` stable release.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
