### PR TITLE
Updates unstable changelogs with 2025-01 changes

### DIFF
--- a/.changeset/chatty-mugs-appear.md
+++ b/.changeset/chatty-mugs-appear.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions-react': minor
-'@shopify/ui-extensions': minor
----
-
-New UI component `ClipboardItem`. `activateTarget` and `activateAction` properties added to action components.

--- a/.changeset/clever-actors-cry.md
+++ b/.changeset/clever-actors-cry.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': minor
----
-
-Passing a new icon type to the segment templates

--- a/.changeset/curly-bugs-suffer.md
+++ b/.changeset/curly-bugs-suffer.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-Image and Box component updates

--- a/.changeset/famous-parents-punch.md
+++ b/.changeset/famous-parents-punch.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': minor
----
-
-Defaulting to string type for enabled features passed to the templates

--- a/.changeset/fluffy-rules-burn.md
+++ b/.changeset/fluffy-rules-burn.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions-react': minor
-'@shopify/ui-extensions': minor
----
-
-Adds the Localized Fields API and `useLocalizedFields` hook.

--- a/.changeset/fuzzy-trainers-work.md
+++ b/.changeset/fuzzy-trainers-work.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions-react': minor
-'@shopify/ui-extensions': minor
----
-
-Release a new Chat component, chat.render targets and preloads.chat configuration

--- a/.changeset/gorgeous-zebras-trade.md
+++ b/.changeset/gorgeous-zebras-trade.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions-react': minor
-'@shopify/ui-extensions': minor
----
-
-expose ClipboardItem to customer accounts extensions

--- a/.changeset/healthy-cups-wash.md
+++ b/.changeset/healthy-cups-wash.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': minor
----
-
-Add shouldRender method to admin ui-extensions

--- a/.changeset/hot-insects-float.md
+++ b/.changeset/hot-insects-float.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions-react': minor
-'@shopify/ui-extensions': minor
----
-
-Removed deprecated props, components, and APIs

--- a/.changeset/hot-shirts-clean.md
+++ b/.changeset/hot-shirts-clean.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Make POS UI Ext PrintAPI async

--- a/.changeset/hot-years-relate.md
+++ b/.changeset/hot-years-relate.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-POS UI Ext PrintAPI src non-optional

--- a/.changeset/itchy-readers-think.md
+++ b/.changeset/itchy-readers-think.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Remove shouldRender method

--- a/.changeset/kind-flowers-dress.md
+++ b/.changeset/kind-flowers-dress.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-(POS) Add PrintApi and PrintPreview

--- a/.changeset/lemon-dots-rhyme.md
+++ b/.changeset/lemon-dots-rhyme.md
@@ -1,7 +1,0 @@
----
-'@shopify/ui-extensions-react': minor
-'@shopify/data-extensions': minor
-'@shopify/ui-extensions': minor
----
-
-Add Picker

--- a/.changeset/many-ways-leave.md
+++ b/.changeset/many-ways-leave.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-Added support for Image sizes. Added Box.

--- a/.changeset/moody-rings-call.md
+++ b/.changeset/moody-rings-call.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions': minor
-'@shopify/ui-extensions-react': minor
----
-
-Updated the POS Stack component to spec

--- a/.changeset/neat-paws-smile.md
+++ b/.changeset/neat-paws-smile.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions-react': patch
----
-
-surfaces/admin: the reactExtension will only allow .render targets to run

--- a/.changeset/orange-baboons-grab.md
+++ b/.changeset/orange-baboons-grab.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': minor
----
-
-Add metafields to ShippingOption

--- a/.changeset/rotten-donuts-clap.md
+++ b/.changeset/rotten-donuts-clap.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-AdminBlock remove summary prop and add collapsedSummary

--- a/.changeset/rude-suns-type.md
+++ b/.changeset/rude-suns-type.md
@@ -1,6 +1,0 @@
----
-'@shopify/ui-extensions-react': minor
-'@shopify/ui-extensions': minor
----
-
-Removed customer account targets as valid targets for checkout UI extensions. Use [customer account UI extensions](https://shopify.dev/docs/api/customer-account-ui-extensions) instead.

--- a/.changeset/slimy-knives-decide.md
+++ b/.changeset/slimy-knives-decide.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': minor
----
-
-Add discount function settings api

--- a/.changeset/spicy-mugs-drop.md
+++ b/.changeset/spicy-mugs-drop.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Fix shopify global declaration

--- a/.changeset/stale-planes-wonder.md
+++ b/.changeset/stale-planes-wonder.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': minor
----
-
-Add bulkUpdateCart function to POS useCartApi

--- a/.changeset/sweet-toes-taste.md
+++ b/.changeset/sweet-toes-taste.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Sync picker and resourcePicker docs with app-bridge

--- a/.changeset/unlucky-cows-vanish.md
+++ b/.changeset/unlucky-cows-vanish.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Remove shouldRender method as it will not be used.

--- a/packages/ui-extensions-react/CHANGELOG.md
+++ b/packages/ui-extensions-react/CHANGELOG.md
@@ -1,5 +1,38 @@
 # @shopify/ui-extensions-react
 
+## 2025.1.0
+
+### Minor Changes
+
+- [#2515](https://github.com/Shopify/ui-extensions/pull/2515) [`76f0c1c4f23432ae34750eabc33d051a380c1d60`](https://github.com/Shopify/ui-extensions/commit/76f0c1c4f23432ae34750eabc33d051a380c1d60) Thanks [@shopify-github-actions-access](https://github.com/apps/shopify-github-actions-access)! - New UI component `ClipboardItem`. `activateTarget` and `activateAction` properties added to action components.
+
+- [#2537](https://github.com/Shopify/ui-extensions/pull/2537) [`7297c37f77e55f4e1c0fb7761940dcde64c5822e`](https://github.com/Shopify/ui-extensions/commit/7297c37f77e55f4e1c0fb7761940dcde64c5822e) Thanks [@merkoyep](https://github.com/merkoyep)! - Image and Box component updates
+
+- [`436df118e4e24eb694f250585dfe439b19d6f190`](https://github.com/Shopify/ui-extensions/commit/436df118e4e24eb694f250585dfe439b19d6f190) Thanks [@rcaplanshopify](https://github.com/rcaplanshopify)! - Adds the Localized Fields API and `useLocalizedFields` hook.
+
+- [#2457](https://github.com/Shopify/ui-extensions/pull/2457) [`4a8c5140266a17a796a8abccb63fa89f54eb9b7e`](https://github.com/Shopify/ui-extensions/commit/4a8c5140266a17a796a8abccb63fa89f54eb9b7e) Thanks [@shopify-github-actions-access](https://github.com/apps/shopify-github-actions-access)! - Release a new Chat component, chat.render targets and preloads.chat configuration
+
+- [#2527](https://github.com/Shopify/ui-extensions/pull/2527) [`a0ee371b5000d865d0c9ecaac285a063c3a8256e`](https://github.com/Shopify/ui-extensions/commit/a0ee371b5000d865d0c9ecaac285a063c3a8256e) Thanks [@robin-drexler](https://github.com/robin-drexler)! - expose ClipboardItem to customer accounts extensions
+
+- [#2528](https://github.com/Shopify/ui-extensions/pull/2528) [`85a6c8cb425fe85301b78a73b11ba2d3bbb8095e`](https://github.com/Shopify/ui-extensions/commit/85a6c8cb425fe85301b78a73b11ba2d3bbb8095e) Thanks [@NathanJolly](https://github.com/NathanJolly)! - Removed deprecated props, components, and APIs
+
+- [#2416](https://github.com/Shopify/ui-extensions/pull/2416) [`9ab3a8b4dda750ffb76dabd63eab70be7bcf27a9`](https://github.com/Shopify/ui-extensions/commit/9ab3a8b4dda750ffb76dabd63eab70be7bcf27a9) Thanks [@NathanJolly](https://github.com/NathanJolly)! - (POS) Add PrintApi and PrintPreview
+
+- [#2379](https://github.com/Shopify/ui-extensions/pull/2379) [`d37623a29ffd145ecccd81d8d6f9344b37d8ff41`](https://github.com/Shopify/ui-extensions/commit/d37623a29ffd145ecccd81d8d6f9344b37d8ff41) Thanks [@MitchLillie](https://github.com/MitchLillie)! - Add Picker
+
+- [#2545](https://github.com/Shopify/ui-extensions/pull/2545) [`9bbc772ec246e1bae1ea75bc851fdb3bb8489e4d`](https://github.com/Shopify/ui-extensions/commit/9bbc772ec246e1bae1ea75bc851fdb3bb8489e4d) Thanks [@NathanJolly](https://github.com/NathanJolly)! - Added support for Image sizes. Added Box.
+
+- [#2535](https://github.com/Shopify/ui-extensions/pull/2535) [`0b39f30b8f5b89e4d32bf1ffa98a8daac7a94184`](https://github.com/Shopify/ui-extensions/commit/0b39f30b8f5b89e4d32bf1ffa98a8daac7a94184) Thanks [@js-goupil](https://github.com/js-goupil)! - Updated the POS Stack component to spec
+
+- [#2551](https://github.com/Shopify/ui-extensions/pull/2551) [`cae2ae9b9a818bc3821c498be796e8d68051328e`](https://github.com/Shopify/ui-extensions/commit/cae2ae9b9a818bc3821c498be796e8d68051328e) Thanks [@jamesvidler](https://github.com/jamesvidler)! - Removed customer account targets as valid targets for checkout UI extensions. Use [customer account UI extensions](https://shopify.dev/docs/api/customer-account-ui-extensions) instead.
+
+### Patch Changes
+
+- [#2498](https://github.com/Shopify/ui-extensions/pull/2498) [`88b01fc80c8db9c9fa9d0a7101d297bf4ae23df0`](https://github.com/Shopify/ui-extensions/commit/88b01fc80c8db9c9fa9d0a7101d297bf4ae23df0) Thanks [@belalsj](https://github.com/belalsj)! - surfaces/admin: the reactExtension will only allow .render targets to run
+
+- Updated dependencies [[`76f0c1c4f23432ae34750eabc33d051a380c1d60`](https://github.com/Shopify/ui-extensions/commit/76f0c1c4f23432ae34750eabc33d051a380c1d60), [`8cec076417bf2d5195eb095efb761e7b0d4ec6e8`](https://github.com/Shopify/ui-extensions/commit/8cec076417bf2d5195eb095efb761e7b0d4ec6e8), [`7297c37f77e55f4e1c0fb7761940dcde64c5822e`](https://github.com/Shopify/ui-extensions/commit/7297c37f77e55f4e1c0fb7761940dcde64c5822e), [`48eb7c31c115d2ff0e3d82cd9cdbe888059d1e7e`](https://github.com/Shopify/ui-extensions/commit/48eb7c31c115d2ff0e3d82cd9cdbe888059d1e7e), [`436df118e4e24eb694f250585dfe439b19d6f190`](https://github.com/Shopify/ui-extensions/commit/436df118e4e24eb694f250585dfe439b19d6f190), [`4a8c5140266a17a796a8abccb63fa89f54eb9b7e`](https://github.com/Shopify/ui-extensions/commit/4a8c5140266a17a796a8abccb63fa89f54eb9b7e), [`a0ee371b5000d865d0c9ecaac285a063c3a8256e`](https://github.com/Shopify/ui-extensions/commit/a0ee371b5000d865d0c9ecaac285a063c3a8256e), [`e1e195c66f5153def3aa9ef3121b4ed6f1d4d251`](https://github.com/Shopify/ui-extensions/commit/e1e195c66f5153def3aa9ef3121b4ed6f1d4d251), [`85a6c8cb425fe85301b78a73b11ba2d3bbb8095e`](https://github.com/Shopify/ui-extensions/commit/85a6c8cb425fe85301b78a73b11ba2d3bbb8095e), [`9ac908787a77f7914386ed9918777ef3dbacf9fa`](https://github.com/Shopify/ui-extensions/commit/9ac908787a77f7914386ed9918777ef3dbacf9fa), [`ad25544dcb9813a321dd105bc7c07304357a0dd7`](https://github.com/Shopify/ui-extensions/commit/ad25544dcb9813a321dd105bc7c07304357a0dd7), [`b7d0232144f0145f3220f1490bddd8e5fa3d9d54`](https://github.com/Shopify/ui-extensions/commit/b7d0232144f0145f3220f1490bddd8e5fa3d9d54), [`9ab3a8b4dda750ffb76dabd63eab70be7bcf27a9`](https://github.com/Shopify/ui-extensions/commit/9ab3a8b4dda750ffb76dabd63eab70be7bcf27a9), [`d37623a29ffd145ecccd81d8d6f9344b37d8ff41`](https://github.com/Shopify/ui-extensions/commit/d37623a29ffd145ecccd81d8d6f9344b37d8ff41), [`9bbc772ec246e1bae1ea75bc851fdb3bb8489e4d`](https://github.com/Shopify/ui-extensions/commit/9bbc772ec246e1bae1ea75bc851fdb3bb8489e4d), [`0b39f30b8f5b89e4d32bf1ffa98a8daac7a94184`](https://github.com/Shopify/ui-extensions/commit/0b39f30b8f5b89e4d32bf1ffa98a8daac7a94184), [`317f49a5271b8241c995ed53714164a01a2bcca6`](https://github.com/Shopify/ui-extensions/commit/317f49a5271b8241c995ed53714164a01a2bcca6), [`1e1f82e4f05af62246421851638db5dff4c79046`](https://github.com/Shopify/ui-extensions/commit/1e1f82e4f05af62246421851638db5dff4c79046), [`cae2ae9b9a818bc3821c498be796e8d68051328e`](https://github.com/Shopify/ui-extensions/commit/cae2ae9b9a818bc3821c498be796e8d68051328e), [`12486707b5fb9d5c9c3b471434297aeb55936b39`](https://github.com/Shopify/ui-extensions/commit/12486707b5fb9d5c9c3b471434297aeb55936b39), [`4f8ebb54dea1a1b93d4c8e515b1e0f8f32651caa`](https://github.com/Shopify/ui-extensions/commit/4f8ebb54dea1a1b93d4c8e515b1e0f8f32651caa), [`74b06c4a3010a3e270c64332f3afd1b17c16d3a5`](https://github.com/Shopify/ui-extensions/commit/74b06c4a3010a3e270c64332f3afd1b17c16d3a5), [`c40904b88fccd4ce1023c0d986ceb7e0b3b21f26`](https://github.com/Shopify/ui-extensions/commit/c40904b88fccd4ce1023c0d986ceb7e0b3b21f26), [`97a7f5255e7928bde649ce26735d7a6a74e9a8ef`](https://github.com/Shopify/ui-extensions/commit/97a7f5255e7928bde649ce26735d7a6a74e9a8ef)]:
+  - @shopify/ui-extensions@2025.1.0
+
 ## 2024.10.0
 
 ### Minor Changes

--- a/packages/ui-extensions/CHANGELOG.md
+++ b/packages/ui-extensions/CHANGELOG.md
@@ -1,5 +1,59 @@
 # @shopify/ui-extensions
 
+## 2025.1.0
+
+### Minor Changes
+
+- [#2515](https://github.com/Shopify/ui-extensions/pull/2515) [`76f0c1c4f23432ae34750eabc33d051a380c1d60`](https://github.com/Shopify/ui-extensions/commit/76f0c1c4f23432ae34750eabc33d051a380c1d60) Thanks [@shopify-github-actions-access](https://github.com/apps/shopify-github-actions-access)! - New UI component `ClipboardItem`. `activateTarget` and `activateAction` properties added to action components.
+
+- [#2470](https://github.com/Shopify/ui-extensions/pull/2470) [`8cec076417bf2d5195eb095efb761e7b0d4ec6e8`](https://github.com/Shopify/ui-extensions/commit/8cec076417bf2d5195eb095efb761e7b0d4ec6e8) Thanks [@aeperea](https://github.com/aeperea)! - Passing a new icon type to the segment templates
+
+- [#2537](https://github.com/Shopify/ui-extensions/pull/2537) [`7297c37f77e55f4e1c0fb7761940dcde64c5822e`](https://github.com/Shopify/ui-extensions/commit/7297c37f77e55f4e1c0fb7761940dcde64c5822e) Thanks [@merkoyep](https://github.com/merkoyep)! - Image and Box component updates
+
+- [#2487](https://github.com/Shopify/ui-extensions/pull/2487) [`48eb7c31c115d2ff0e3d82cd9cdbe888059d1e7e`](https://github.com/Shopify/ui-extensions/commit/48eb7c31c115d2ff0e3d82cd9cdbe888059d1e7e) Thanks [@aeperea](https://github.com/aeperea)! - Defaulting to string type for enabled features passed to the templates
+
+- [`436df118e4e24eb694f250585dfe439b19d6f190`](https://github.com/Shopify/ui-extensions/commit/436df118e4e24eb694f250585dfe439b19d6f190) Thanks [@rcaplanshopify](https://github.com/rcaplanshopify)! - Adds the Localized Fields API.
+
+- [#2457](https://github.com/Shopify/ui-extensions/pull/2457) [`4a8c5140266a17a796a8abccb63fa89f54eb9b7e`](https://github.com/Shopify/ui-extensions/commit/4a8c5140266a17a796a8abccb63fa89f54eb9b7e) Thanks [@shopify-github-actions-access](https://github.com/apps/shopify-github-actions-access)! - Release a new Chat component, chat.render targets and preloads.chat configuration
+
+- [#2527](https://github.com/Shopify/ui-extensions/pull/2527) [`a0ee371b5000d865d0c9ecaac285a063c3a8256e`](https://github.com/Shopify/ui-extensions/commit/a0ee371b5000d865d0c9ecaac285a063c3a8256e) Thanks [@robin-drexler](https://github.com/robin-drexler)! - expose ClipboardItem to customer accounts extensions
+
+- [#2458](https://github.com/Shopify/ui-extensions/pull/2458) [`e1e195c66f5153def3aa9ef3121b4ed6f1d4d251`](https://github.com/Shopify/ui-extensions/commit/e1e195c66f5153def3aa9ef3121b4ed6f1d4d251) Thanks [@elanalynn](https://github.com/elanalynn)! - Add shouldRender method to admin ui-extensions
+
+- [#2528](https://github.com/Shopify/ui-extensions/pull/2528) [`85a6c8cb425fe85301b78a73b11ba2d3bbb8095e`](https://github.com/Shopify/ui-extensions/commit/85a6c8cb425fe85301b78a73b11ba2d3bbb8095e) Thanks [@NathanJolly](https://github.com/NathanJolly)! - Removed deprecated props, components, and APIs
+
+- [#2416](https://github.com/Shopify/ui-extensions/pull/2416) [`9ab3a8b4dda750ffb76dabd63eab70be7bcf27a9`](https://github.com/Shopify/ui-extensions/commit/9ab3a8b4dda750ffb76dabd63eab70be7bcf27a9) Thanks [@NathanJolly](https://github.com/NathanJolly)! - (POS) Add PrintApi and PrintPreview
+
+- [#2379](https://github.com/Shopify/ui-extensions/pull/2379) [`d37623a29ffd145ecccd81d8d6f9344b37d8ff41`](https://github.com/Shopify/ui-extensions/commit/d37623a29ffd145ecccd81d8d6f9344b37d8ff41) Thanks [@MitchLillie](https://github.com/MitchLillie)! - Add Picker
+
+- [#2545](https://github.com/Shopify/ui-extensions/pull/2545) [`9bbc772ec246e1bae1ea75bc851fdb3bb8489e4d`](https://github.com/Shopify/ui-extensions/commit/9bbc772ec246e1bae1ea75bc851fdb3bb8489e4d) Thanks [@NathanJolly](https://github.com/NathanJolly)! - Added support for Image sizes. Added Box.
+
+- [#2535](https://github.com/Shopify/ui-extensions/pull/2535) [`0b39f30b8f5b89e4d32bf1ffa98a8daac7a94184`](https://github.com/Shopify/ui-extensions/commit/0b39f30b8f5b89e4d32bf1ffa98a8daac7a94184) Thanks [@js-goupil](https://github.com/js-goupil)! - Updated the POS Stack component to spec
+
+- [#2426](https://github.com/Shopify/ui-extensions/pull/2426) [`317f49a5271b8241c995ed53714164a01a2bcca6`](https://github.com/Shopify/ui-extensions/commit/317f49a5271b8241c995ed53714164a01a2bcca6) Thanks [@stevenpslade](https://github.com/stevenpslade)! - Add metafields to ShippingOption
+
+- [#2551](https://github.com/Shopify/ui-extensions/pull/2551) [`cae2ae9b9a818bc3821c498be796e8d68051328e`](https://github.com/Shopify/ui-extensions/commit/cae2ae9b9a818bc3821c498be796e8d68051328e) Thanks [@jamesvidler](https://github.com/jamesvidler)! - Removed customer account targets as valid targets for checkout UI extensions. Use [customer account UI extensions](https://shopify.dev/docs/api/customer-account-ui-extensions) instead.
+
+- [#2534](https://github.com/Shopify/ui-extensions/pull/2534) [`12486707b5fb9d5c9c3b471434297aeb55936b39`](https://github.com/Shopify/ui-extensions/commit/12486707b5fb9d5c9c3b471434297aeb55936b39) Thanks [@devisscher](https://github.com/devisscher)! - Add discount function settings api
+
+- [#2531](https://github.com/Shopify/ui-extensions/pull/2531) [`74b06c4a3010a3e270c64332f3afd1b17c16d3a5`](https://github.com/Shopify/ui-extensions/commit/74b06c4a3010a3e270c64332f3afd1b17c16d3a5) Thanks [@vctrchu](https://github.com/vctrchu)! - Add bulkUpdateCart function to POS useCartApi
+
+### Patch Changes
+
+- [#2441](https://github.com/Shopify/ui-extensions/pull/2441) [`9ac908787a77f7914386ed9918777ef3dbacf9fa`](https://github.com/Shopify/ui-extensions/commit/9ac908787a77f7914386ed9918777ef3dbacf9fa) Thanks [@vctrchu](https://github.com/vctrchu)! - Make POS UI Ext PrintAPI async
+
+- [#2428](https://github.com/Shopify/ui-extensions/pull/2428) [`ad25544dcb9813a321dd105bc7c07304357a0dd7`](https://github.com/Shopify/ui-extensions/commit/ad25544dcb9813a321dd105bc7c07304357a0dd7) Thanks [@vctrchu](https://github.com/vctrchu)! - POS UI Ext PrintAPI src non-optional
+
+- [#2485](https://github.com/Shopify/ui-extensions/pull/2485) [`b7d0232144f0145f3220f1490bddd8e5fa3d9d54`](https://github.com/Shopify/ui-extensions/commit/b7d0232144f0145f3220f1490bddd8e5fa3d9d54) Thanks [@elanalynn](https://github.com/elanalynn)! - Remove shouldRender method
+
+- [#2491](https://github.com/Shopify/ui-extensions/pull/2491) [`1e1f82e4f05af62246421851638db5dff4c79046`](https://github.com/Shopify/ui-extensions/commit/1e1f82e4f05af62246421851638db5dff4c79046) Thanks [@belalsj](https://github.com/belalsj)! - AdminBlock remove summary prop and add collapsedSummary
+
+- [#2493](https://github.com/Shopify/ui-extensions/pull/2493) [`4f8ebb54dea1a1b93d4c8e515b1e0f8f32651caa`](https://github.com/Shopify/ui-extensions/commit/4f8ebb54dea1a1b93d4c8e515b1e0f8f32651caa) Thanks [@vividviolet](https://github.com/vividviolet)! - Fix shopify global declaration
+
+- [#2496](https://github.com/Shopify/ui-extensions/pull/2496) [`c40904b88fccd4ce1023c0d986ceb7e0b3b21f26`](https://github.com/Shopify/ui-extensions/commit/c40904b88fccd4ce1023c0d986ceb7e0b3b21f26) Thanks [@MitchLillie](https://github.com/MitchLillie)! - Sync picker and resourcePicker docs with app-bridge
+
+- [#2501](https://github.com/Shopify/ui-extensions/pull/2501) [`97a7f5255e7928bde649ce26735d7a6a74e9a8ef`](https://github.com/Shopify/ui-extensions/commit/97a7f5255e7928bde649ce26735d7a6a74e9a8ef) Thanks [@belalsj](https://github.com/belalsj)! - Remove shouldRender method as it will not be used.
+
 ## 2024.10.0
 
 ### Major Changes


### PR DESCRIPTION
### Background

- **removes changelog files for released 2025-01 changes**
- **updates ui-extensions and ui-extensions-react changelog files with 2025.1.0 entries**

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
