### PR TITLE
Documented Text and Stack changes

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Stack.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Stack.doc.ts
@@ -16,7 +16,7 @@ const generateCodeBlockForStack = (title: string, fileName: string) => {
 const data: ReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
-    'A container for other components that allows them to be stacked horizontally or vertically. When building complex UIs, this will be your primary building block.',
+    'A container for other components that allows them to be stacked horizontally or vertically. When building complex UIs, this will be your primary building block. Stacks always wrap the content to the next column or row.',
   isVisualComponent: true,
   type: 'component',
   definitions: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Text.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Text.doc.ts
@@ -4,7 +4,7 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Text',
   description:
-    'Text can be rendered in different sizes and colors in order to structure content.',
+    'Text can be rendered in different sizes and colors in order to structure content. By default, `Text` will always stretch to fill the width of the container, but it can be wrapped in a `Box` to limit its width to what it needs. When the width of `Text` reaches its limit, the `string` will automatically wrap to 2 lines before being truncated.',
   isVisualComponent: true,
   type: 'component',
   definitions: [


### PR DESCRIPTION
### Background
We changed the behaviour of Text and Stack to solve a bug where Text was not truncating properly on POS. The new behaviour is as such:

- Stacks always wrap content to the next column or row (in alignment with other extension surfaces).
- Text will always take up the most that it can horizontally, however, wrapping it in a Box will make it take only the amount that it needs. You can also use a Box to set a maximum width. In both of those cases, the Text will wrap to the second line (max 2 lines) and truncate if it's even longer than that.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
