### PR TITLE
Add clarification to print api on receipt printing

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
@@ -9,17 +9,7 @@ const generateCodeBlockForPrintApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Print API',
-  description: `The Print API enables document printing functionality in your point of sale extension. Use this API to trigger the native print dialog for your documents.
-
-The \`print()\` method accepts either:
-- A relative path that will be appended to your app's [application_url](/docs/apps/build/cli-for-apps/app-configuration#application_url)
-- A full URL to your app's backend that will be used to return the document to print
-
-Supported document types:
-- HTML documents (recommended for best printing experience)
-- Text files
-- Image files (PNG, JPEG, etc.)
-- PDF files (Note: On Android devices, PDFs will be downloaded and must be printed using an external application)`,
+  description: `The Print API enables document printing through the device's native print dialog (such as AirPrint on iOS or the system print dialog on Android). This API is designed for printing documents to standard printers, and does not support direct printing to receipt printers.`,
   isVisualComponent: false,
   type: 'APIs',
   definitions: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/PrintPreview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/PrintPreview.doc.ts
@@ -6,17 +6,7 @@ const generateCodeBlockForPrintPreview = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'PrintPreview',
-  description: `A component that displays a preview of a printable document. Use this component to let users review documents before printing.
-
-The \`src\` prop accepts either:
-- A relative path that will be appended to your app's [application_url](/docs/apps/build/cli-for-apps/app-configuration#application_url)
-- A full URL to your document endpoint
-
-Supported document types:
-- HTML documents (recommended for best preview experience)
-- Text files
-- Image files (PNG, JPEG, etc.)
-- PDF files (Note: On Android devices, PDFs will be downloaded and must be printed using an external application)`,
+  description: `A component that displays a preview of a printable document. Use this component to let users review documents before printing.`,
   isVisualComponent: true,
   type: 'component',
   thumbnail: 'print-preview-thumbnail.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/print-api/print-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/print-api/print-api.ts
@@ -4,7 +4,18 @@
 export interface PrintApiContent {
   /**
    * Trigger a print dialog.
-   * @param src the source URL of the content to print. This URL must be a path of the app backend. Valid document types are text, HTML, image, and PDF.
+   *
+   * The src must be either:
+   * - A relative path that will be appended to your app's [application_url](/docs/apps/build/cli-for-apps/app-configuration#application_url)
+   * - A full URL to your app's backend that will be used to return the document to print
+   *
+   * Supported document types:
+   * - HTML documents (recommended for best printing experience)
+   * - Text files
+   * - Image files (PNG, JPEG, etc.)
+   * - PDF files (Note: On Android devices, PDFs will be downloaded and must be printed using an external application)
+   *
+   * @param src the source URL of the content to print.
    * @returns Promise<void> that resolves when content is ready and native print dialog appears.
    */
   print(src: string): Promise<void>;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/PrintPreview/PrintPreview.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/PrintPreview/PrintPreview.ts
@@ -3,6 +3,16 @@ import {createRemoteComponent} from '@remote-ui/core';
 export interface PrintPreviewProps {
   /**
    * The source to print.
+   *
+   * The src must be either:
+   * - A relative path that will be appended to your app's [application_url](/docs/apps/build/cli-for-apps/app-configuration#application_url)
+   * - A full URL to your app's backend that will be used to return the document
+   *
+   * Supported document types:
+   * - HTML documents (recommended for best printing experience)
+   * - Text files
+   * - Image files (PNG, JPEG, etc.)
+   * - PDF files
    */
   src: string;
 }


### PR DESCRIPTION
Part of https://github.com/Shopify/pos-next-react-native/issues/50918

### Background

Explicitly state the native printing capability and non-support for receipt printing.

![Screenshot 2025-01-14 at 2 26 10 PM](https://github.com/user-attachments/assets/38b0ea8a-f6a8-45a1-bc81-395bd6b6ee62)

### 🎩

https://shopify-dev.ui-extensions-pp9g.victor-chu.us.spin.dev/docs/api/pos-ui-extensions/unstable/apis/print-api

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
