### PR TITLE
Add cash tracking session event targets for POS Compliance

### DIFF
--- a/.changeset/funny-walls-flash.md
+++ b/.changeset/funny-walls-flash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add "pos.cash-tracking-session-start.event.observe", "pos.cash-tracking-session-cancel.event.observe", and "pos.cash-tracking-session-complete.event.observe" and renamed "pos.transaction-completed.event.observe".

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-cancel.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-cancel.event.observe.doc.ts
@@ -1,0 +1,24 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: ExtensionTargetType.PosCashTrackingSessionCancelObserve,
+  description:
+    'An event extension target that observes when cash tracking session is canceled',
+  category: 'Targets',
+  subCategory: 'Cash tracking',
+  isVisualComponent: false,
+  related: [
+    {
+      name: ExtensionTargetType.PosCashTrackingSessionStartObserve,
+      url: '/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-start-observe',
+    },
+    {
+      name: ExtensionTargetType.PosCashTrackingSessionCompleteObserve,
+      url: '/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-complete-observe',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-complete.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-complete.event.observe.doc.ts
@@ -1,0 +1,24 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: ExtensionTargetType.PosCashTrackingSessionCompleteObserve,
+  description:
+    'An event extension target that observes when cash tracking session completes',
+  category: 'Targets',
+  subCategory: 'Cash tracking',
+  isVisualComponent: false,
+  related: [
+    {
+      name: ExtensionTargetType.PosCashTrackingSessionCancelObserve,
+      url: '/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-cancel-observe',
+    },
+    {
+      name: ExtensionTargetType.PosCashTrackingSessionStartObserve,
+      url: '/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-start-observe',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-start.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-start.event.observe.doc.ts
@@ -1,0 +1,24 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: ExtensionTargetType.PosCashTrackingSessionStartObserve,
+  description:
+    'An event extension target that observes when cash tracking session starts',
+  category: 'Targets',
+  subCategory: 'Cash tracking',
+  isVisualComponent: false,
+  related: [
+    {
+      name: ExtensionTargetType.PosCashTrackingSessionCancelObserve,
+      url: '/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-cancel-observe',
+    },
+    {
+      name: ExtensionTargetType.PosCashTrackingSessionCompleteObserve,
+      url: '/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-complete-observe',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.transaction-complete.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.transaction-complete.event.observe.doc.ts
@@ -2,7 +2,7 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: ExtensionTargetType.PosTransactionCompletedObserve,
+  name: ExtensionTargetType.PosTransactionCompleteObserve,
   description: 'An event extension target that observes completed transactions',
   category: 'Targets',
   subCategory: 'Post-purchase',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
@@ -16,7 +16,10 @@ export enum ExtensionTargetType {
   PosDraftOrderDetailsActionMenuItemRender = 'pos.draft-order-details.action.menu-item.render',
   PosDraftOrderDetailsActionRender = 'pos.draft-order-details.action.render',
   PosDraftOrderDetailsBlockRender = 'pos.draft-order-details.block.render',
-  PosTransactionCompletedObserve = 'pos.transaction-completed.observe',
+  PosTransactionCompleteObserve = 'pos.transaction-complete.event.observe',
+  PosCashTrackingSessionStartObserve = 'pos.cash-tracking-session-start.event.observe',
+  PosCashTrackingSessionCancelObserve = 'pos.cash-tracking-session-cancel.event.observe',
+  PosCashTrackingSessionCompleteObserve = 'pos.cash-tracking-session-complete.event.observe',
 }
 
 export enum TargetLink {
@@ -37,5 +40,8 @@ export enum TargetLink {
   PosDraftOrderDetailsActionMenuItemRender = '[pos.draft-order-details.action.menu-item.render](/docs/api/pos-ui-extensions/targets/draft-order-details/pos-draft-order-details-action-menu-item-render)',
   PosDraftOrderDetailsActionRender = '[pos.draft-order-details.action.render](/docs/api/pos-ui-extensions/targets/draft-order-details/pos-draft-order-details-action-render)',
   PosDraftOrderDetailsBlockRender = '[pos.draft-order-details.block.render](/docs/api/pos-ui-extensions/targets/draft-order-details/pos-draft-order-details-block-render)',
-  PosTransactionCompletedObserve = '[pos.transaction-completed.observe](/docs/api/pos-ui-extensions/targets/post-purchase/pos-transaction-completed-observe)',
+  PosTransactionCompleteObserve = '[pos.transaction-complete.event.observe](/docs/api/pos-ui-extensions/targets/post-purchase/pos-transaction-complete-observe)',
+  PosCashTrackingSessionStartObserve = '[pos.cash-tracking-session-start.event.observe](/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-start-observe)',
+  PosCashTrackingSessionCancelObserve = '[pos.cash-tracking-session-cancel.event.observe](/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-cancel-observe)',
+  PosCashTrackingSessionCompleteObserve = '[pos.cash-tracking-session-complete.event.observe](/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-complete-observe)',
 }

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -48,7 +48,8 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 
 ### Features
 
-- Added support for the ${TargetLink.PosTransactionCompletedObserve} target.
+- Added support for the ${TargetLink.PosTransactionCompleteObserve} target.
+- Added support for cash tracking session. ${TargetLink.PosCashTrackingSessionStartObserve}, ${TargetLink.PosCashTrackingSessionCancelObserve}, ${TargetLink.PosCashTrackingSessionCompleteObserve} targets.
       `,
     },
     {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/input/CashTrackingSessionInput.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/input/CashTrackingSessionInput.ts
@@ -1,0 +1,24 @@
+import {BaseInput} from './BaseInput';
+
+export interface CashTrackingSessionStartInput extends BaseInput {
+  cashTrackingSessionStart: {
+    id: number;
+    openingTime: string;
+  };
+}
+
+export interface CashTrackingSessionCompleteInput extends BaseInput {
+  cashTrackingSessionComplete: {
+    id: number;
+    openingTime: string;
+    closingTime: string;
+  };
+}
+
+export interface CashTrackingSessionCancelInput extends BaseInput {
+  cashTrackingSessionCancel: {
+    id: number;
+    openingTime?: string;
+    closingTime?: string;
+  };
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/targets.ts
@@ -1,9 +1,23 @@
 import {BaseIntent} from '../intent';
+import {
+  CashTrackingSessionStartInput,
+  CashTrackingSessionCompleteInput,
+  CashTrackingSessionCancelInput,
+} from './input/CashTrackingSessionInput';
 import {PurchaseCompleteInput} from './input/PurchaseCompleteInput';
 
 export interface EventExtensionTargets {
-  'pos.transaction-completed.observe': (
+  'pos.transaction-complete.event.observe': (
     input: PurchaseCompleteInput,
+  ) => BaseIntent;
+  'pos.cash-tracking-session-start.event.observe': (
+    input: CashTrackingSessionStartInput,
+  ) => BaseIntent;
+  'pos.cash-tracking-session-cancel.event.observe': (
+    input: CashTrackingSessionCancelInput,
+  ) => BaseIntent;
+  'pos.cash-tracking-session-complete.event.observe': (
+    input: CashTrackingSessionCompleteInput,
   ) => BaseIntent;
 }
 


### PR DESCRIPTION
### Background

Part of, https://github.com/Shopify/pos-next-react-native/issues/51030

### Solution

- Rename event-initiated extension targets per https://github.com/Shopify/pos-next-react-native/issues/51181
- Add 3 cash tracking session targets for POS Compliance.
  - `pos.cash-tracking-session-start.event.observe`
  - `pos.cash-tracking-session-cancel.event.observe`
  - `pos.cash-tracking-session-complete.event.observe`
- Added preliminary inputs for Cash session object.
- Add to docs.

### 🎩

- TODO: how?

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have updated relevant documentation
