### PR TITLE
Add note for print preview

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/PrintPreview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/PrintPreview.doc.ts
@@ -6,14 +6,18 @@ const generateCodeBlockForPrintPreview = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'PrintPreview',
-  description: `A component that displays a preview of a printable document. Use this component to let users review documents before printing.`,
+  description: `
+  A component that displays a preview of a printable document. 
+  > Note:
+  > This component must be a direct child of the Screen component and cannot be nested inside any other component.`,
   isVisualComponent: true,
   type: 'component',
   thumbnail: 'print-preview-thumbnail.png',
   definitions: [
     {
       title: 'PrintPreview',
-      description: 'Renders a preview of a printable document',
+      description:
+        'Renders a preview of a printable document. This component must a direct child of the Screen component.',
       type: 'PrintPreviewProps',
     },
   ],


### PR DESCRIPTION
### Background

There are rendering limitations with the PrintPreview component. This PR adds a note which epxlicity tells developers to use it directly as a child of the Screen component

![Screenshot 2025-01-17 at 12 43 31 PM](https://github.com/user-attachments/assets/350bf401-4624-4469-8496-90dea4272dac)


### 🎩

https://shopify-dev.ui-extensions-pp9g.victor-chu.us.spin.dev/docs/api/pos-ui-extensions/unstable/components/printpreview