### PR TITLE
Unified type for shipping line

### DIFF
--- a/.changeset/ten-goats-wink.md
+++ b/.changeset/ten-goats-wink.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Made shippingLines a simpler type

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/shipping-line.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/shipping-line.ts
@@ -1,14 +1,14 @@
-export type ShippingLine = CalculatedShippingLine | CustomShippingLine;
-
-export interface CalculatedShippingLine {
+export interface ShippingLine {
+  handle: string;
   price: string;
   title: string;
-  methodType: 'SHIPPING' | 'RETAIL';
-  type: 'Calculated';
 }
 
-export interface CustomShippingLine {
-  price: string;
-  title: string;
+export interface CalculatedShippingLine extends ShippingLine {
+  type: 'Calculated';
+  methodType: 'SHIPPING' | 'RETAIL';
+}
+
+export interface CustomShippingLine extends ShippingLine {
   type: 'Custom';
 }


### PR DESCRIPTION
### Background
TS on the POS side is having a hard time reconciling the idea that methodType only exists on one of the types. Let's just unified the type, and make methodType optional, in the case of custom. Much simpler interface and we can document it easily.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
