### PR TITLE
Add note about attachment param

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.ts
@@ -93,6 +93,8 @@ interface ButtonAnchorProps extends CommonProps {
   /**
    * Tells browsers to download the linked resource instead of navigating to it.
    * Optionally accepts filename value to rename file.
+   * Use `attachment` query param in URL to force download behavior.
+   * eg. `to="filename.jpg?attachment"`
    */
   download?: boolean | string;
 


### PR DESCRIPTION
### Background

In response to a [question about the `download` param not working in button](https://community.shopify.dev/t/download-a-file-using-admin-block-extension/6543), this PR adds a note about the `attachment` query param. 

This will update these [docs](https://shopify.dev/docs/api/admin-extensions/unstable/components/actions/button).

### Solution

Adding the following to the download prop description. 

```
* Use `attachment` query param in URL to force download behavior.
* eg. `to="filename.jpg?attachment"`
```

### 🎩

Just a comment; Will generate docs after this PR. 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
