### PR TITLE
WIP: Replace `BaseInput` with `BaseMetaInput`

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/input/BaseInput.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/input/BaseInput.ts
@@ -1,8 +1,12 @@
 import type {ConnectivityState, Device, Session} from '../../../point-of-sale';
 
-export interface BaseInput {
+// meta-type data that's automatically included by POS.
+export interface BaseMetaInput {
   connectivity: ConnectivityState;
   device: Device;
   locale: string;
   session: Session;
 }
+
+// required input by all event targets.
+export interface BaseInput {}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/input.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/input.ts
@@ -1,4 +1,4 @@
-export type {BaseInput} from './event/input/BaseInput';
+export type {BaseInput, BaseMetaInput} from './event/input/BaseInput';
 export type {TransactionCompleteInput} from './event/input/TransactionCompleteInput';
 
 export type {Device} from './types/device';


### PR DESCRIPTION
### Background

Spawned from, https://github.com/Shopify/pos-next-react-native/pull/51443 which automatically prepends `BaseInput` data to every worker run call on POS.

Goal here is so there is a clear separation for,
1) event target input types from,
1) the "meta data" input types.

Coupling them makes it difficult to separate type concerns on POS.

### Solution

- Move `BaseInput` properties to `BaseMetaInput`.
- Left `BaseInput` as placeholder for all event targets `*Inputs`.
- The `BaseMetaInput` types are not needed as arguments for `ExtensionRunner.run()`, only for `UnifiedExtensionWorker.run()`.
- With this PR, typing on POS is simpler with `ExtensionRunner.run()` referencing the correct `*Inputs` type, and optionally `UnifiedExtensionWorker.run()` can reference the combined typings (currently typed as `any`).

### 🎩

1) Check out this branch locally.
1) On POS RN, run `./scripts/ui-extensions/yalc-local-extensions add`.
1) Validate on IDE lint. This should not have type errors.
    ```ts
    // example:
    ExtensionRunner.run('pos.cash-tracking-session-start.event.observe', {
      cashTrackingSessionStart: {
        id: getId(cashTrackingSession.id),
        openingTime: cashTrackingSession.openingTime,
      },
    });
    ```
| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/c426d466-baf0-453f-b0e3-a553290a9ee3) | ![image](https://github.com/user-attachments/assets/fdb6d27d-ecc7-4dbe-97be-3ca54cfad2a4) |

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
