### PR TITLE
[2024-10] Fix Payment Options Documentation 

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/payment-options.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/payment-options.doc.ts
@@ -30,10 +30,10 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   related: getLinksByTag('apis'),
-  defaultExample: getHookExample('payments/use-selected-payment-options'),
+  defaultExample: getHookExample('payments/use-available-payment-options'),
   examples: {
     description: '',
-    examples: [getHookExample('payments/use-available-payment-options')],
+    examples: [getHookExample('payments/use-selected-payment-options')],
   },
 };
 


### PR DESCRIPTION
### Background

Related to this issue https://github.com/Shopify/ui-extensions/issues/2305

Improves the order of examples for the payment options api page.

### Solution


### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
