### PR TITLE
Bump `ui-extension` to 2025.1.2

### DIFF
--- a/.changeset/lovely-keys-compare.md
+++ b/.changeset/lovely-keys-compare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Bump `@shopify/ui-extensions` to `2025.1.2`


### PR DESCRIPTION
### Background

According to this PR: https://github.com/Shopify/ui-extensions/pull/2602/files#diff-e80441d67ba95ef3601f023a0ef3600aa055368fb53c8b147bc1daaf30f32fc5

Ui-extension version is `2025.1.1`
Ui-extensions-react version is `2025.1.2`

This PR is to make them the same.

Anything I miss?

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
