### PR TITLE
Refactor payment methods

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -101,7 +101,7 @@ export type {
 
 export type {TaxLine} from './types/tax-line';
 
-export type {PaymentMethod, CardSource} from './types/payment';
+export type {PaymentMethod, Payment} from './types/payment';
 
 export type {MultipleResourceResult} from './types/multiple-resource-result';
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/intent/PrepareReceiptIntent.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/intent/PrepareReceiptIntent.ts
@@ -25,9 +25,11 @@ export type PrepareReceiptAdditionalLineType =
  *  - value: "Custom description"
  */
 export interface PrepareReceiptAdditionalLine {
-  type: PrepareReceiptAdditionalLineType;
-  title: string;
-  value: string;
+  data: {
+    type: PrepareReceiptAdditionalLineType;
+    title: string;
+    value: string;
+  };
 }
 
 export interface PrepareReceiptIntent extends BaseIntent {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/checkout.ts
@@ -1,14 +1,15 @@
 import {Discount, LineItem} from './cart';
-import {PaymentMethod} from './payment';
+import {Payment} from './payment';
 import {ShippingLine} from './shipping-line';
 import {TaxLine} from './tax-line';
 
 export interface Checkout {
+  uuid: string;
   discounts: Discount[];
   draftCheckoutUuid: string;
   lineItems: LineItem[];
   orderId?: number;
-  paymentMethods: PaymentMethod[];
+  paymentMethods: Payment[];
   shippingLine?: ShippingLine;
   taxLines?: TaxLine[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/payment.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/payment.ts
@@ -1,48 +1,15 @@
 export type PaymentMethod =
-  | CashPayment
-  | CreditPayment
-  | GiftCardPayment
-  | ShopPayPayment
-  | CustomPayment
-  | UnknownPayment;
-
-export type CardSource = 'manual' | 'swiped' | 'emv';
-
-interface BasePayment {
-  amount: string;
-}
-
-interface CreditPayment extends BasePayment {
-  type: 'CreditCard';
-  brand: string;
-  tipAmount: string;
-  cardSource?: CardSource;
-  hasPendingOfflineTransactions: boolean;
-}
-
-interface CashPayment extends BasePayment {
-  type: 'Cash';
-  changeAmount: string;
-  roundedAmount?: string;
-}
-
-interface GiftCardPayment extends BasePayment {
-  type: 'GiftCard';
-  lastCharacters: string;
-  balance?: string;
-}
-
-interface ShopPayPayment extends BasePayment {
-  type: 'ShopPay';
-  isInstallmentsPayment: boolean;
-  orderTransactionId?: string;
-}
-
-interface CustomPayment extends BasePayment {
-  type: 'Custom';
-  name: string;
-}
-
-interface UnknownPayment extends BasePayment {
-  type: 'Unknown';
+  | 'Cash'
+  | 'Custom'
+  | 'CreditCard'
+  | 'CardPresentRefund'
+  | 'StripeCardPresentRefund'
+  | 'GiftCard'
+  | 'StripeCreditCard'
+  | 'ShopPay'
+  | 'Unknown';
+export interface Payment {
+  amount: number;
+  currency: string;
+  type: PaymentMethod;
 }


### PR DESCRIPTION
### Background

Closes https://github.com/Shopify/pos-next-react-native/issues/51827

### Solution

Sync Payments interfaces with RN https://github.com/Shopify/pos-next-react-native/blob/d75c0cadd2ef1a4345da8c71df642bc9125729a7/src/native_libraries/CheckoutSDK/models/Transaction.ts#L8 

We don't need all the details and all those interfaces, we only need an amount, currency (if it is different from store currency), and  payment type

This is a minor update for the feature that is already in a version doc. No need to update changeset
### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
