### PR TITLE
Bumps @remote-ui dependency versions

### DIFF
--- a/.changeset/silent-plants-cheat.md
+++ b/.changeset/silent-plants-cheat.md
@@ -1,0 +1,9 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Bumps @remote-ui dependencies
+
+- @remote-ui/core version to 2.2.5
+- @remote-ui/react version to 5.0.6
+- @remote-ui/async-subscription version to 2.1.16

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -61,8 +61,8 @@
     }
   },
   "dependencies": {
-    "@remote-ui/async-subscription": "^2.1.12",
-    "@remote-ui/react": "^5.0.2",
+    "@remote-ui/async-subscription": "^2.1.16",
+    "@remote-ui/react": "^5.0.6",
     "@types/react": ">=18.2.67"
   },
   "peerDependencies": {

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -63,8 +63,8 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@remote-ui/async-subscription": "^2.1.12",
-    "@remote-ui/core": "^2.2.4"
+    "@remote-ui/async-subscription": "^2.1.16",
+    "@remote-ui/core": "^2.2.5"
   },
   "devDependencies": {
     "@shopify/generate-docs": "0.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,28 +1775,28 @@
   dependencies:
     jest-matcher-utils "^27.0.0"
 
-"@remote-ui/async-subscription@^2.1.12", "@remote-ui/async-subscription@^2.1.15":
-  version "2.1.15"
-  resolved "https://registry.npmjs.org/@remote-ui/async-subscription/-/async-subscription-2.1.15.tgz"
-  integrity sha512-SdPfO4ExDOVyOPAoCqT9+Tk0UeU97EMplkxlr5qiv3W7c1yRsxgtbETicoBh9l/P49bLzVjiJG6CQIu1au3Vhw==
+"@remote-ui/async-subscription@^2.1.16":
+  version "2.1.16"
+  resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.16.tgz#06c66800980ccad2d7c21f965e0c389831dabbde"
+  integrity sha512-1DPxo+febMhJvHT44Oe1EMFubOAA+EpfToJvQG/6x7brVx1UKF7k47n3tQR5NDM+gNlDgxT1dEnALOeqYA80mQ==
   dependencies:
     "@remote-ui/rpc" "^1.4.5"
 
-"@remote-ui/core@^2.2.4":
-  version "2.2.4"
-  resolved "https://registry.npmjs.org/@remote-ui/core/-/core-2.2.4.tgz"
-  integrity sha512-7ahrsI5GqYvAGcWTcysbKFKbzbhB/mDgIJr9VurF34gor2IqRCrmrPYemLQuOCQhWqPb3AOEUxWFYNLiB5i6kA==
+"@remote-ui/core@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.2.5.tgz#591a4af8137dbb5274bb7f7cd31dc78b99d4cd88"
+  integrity sha512-np+j+Bn5fWjqaOng0UQv4S48JqO/aLkKzCLR07c+PRXbxHxvMuGZeq/MuWOyTheUWhDaV2McrGDk+g/yYKQ8mA==
   dependencies:
     "@remote-ui/rpc" "^1.4.5"
     "@remote-ui/types" "^1.1.3"
 
-"@remote-ui/react@^5.0.2":
-  version "5.0.4"
-  resolved "https://registry.npmjs.org/@remote-ui/react/-/react-5.0.4.tgz"
-  integrity sha512-zrewan3KqKHW8HOCgnpHduG4Ldqyh9ysouGIv8VeE0PlC03eCqi2MFzA+nKIJ1p58LIAbPQ1asp+RwT6ImVImg==
+"@remote-ui/react@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-5.0.6.tgz#989fc162df85450f250938e7c05580e2cdb2e1c5"
+  integrity sha512-oSeZm57ZsT17nB1wndhco+MeqfuytSnEhj2t0Hc9H5T87RUk04T2qzrFDoVg6vTEBpgjVMzYv1B/hRM4z3scaw==
   dependencies:
-    "@remote-ui/async-subscription" "^2.1.15"
-    "@remote-ui/core" "^2.2.4"
+    "@remote-ui/async-subscription" "^2.1.16"
+    "@remote-ui/core" "^2.2.5"
     "@remote-ui/rpc" "^1.4.5"
     "@types/react" ">=17.0.0 <19.0.0"
     "@types/react-reconciler" ">=0.26.0 <0.30.0"


### PR DESCRIPTION
### Background
The latest version of `remote-ui/core` - `2.2.5` - has a small bug fix with `removeChild`.

probably also bump `remote-ui/react` - `5.0.6` and `remote-ui/async-subscription` - `2.1.16`

### Solution
Just updates the package version

### 🎩


### Checklist
- [ ] I have :tophat:'d these changes
- [x] I have updated relevant documentation
