### PR TITLE
Minor fix: PrepareReceiptInput extends BaseInput

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/input/PrepareReceiptInput.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/input/PrepareReceiptInput.ts
@@ -1,5 +1,6 @@
 import {Checkout} from '../../types/checkout';
+import {BaseInput} from './BaseInput';
 
-export interface PrepareReceiptInput {
+export interface PrepareReceiptInput extends BaseInput {
   checkout: Checkout;
 }


### PR DESCRIPTION
### Background

Minor fix.

Add `extends BaseInput` to `PrepareReceiptInput`

No need to update docs, this is a new interface

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
