### PR TITLE
Officially add null as Badge status option

### DIFF
--- a/.changeset/strange-terms-rule.md
+++ b/.changeset/strange-terms-rule.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Signal support for null in Badge status prop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
       - id: typescript-cache
         name: Restore TypeScript cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: |
             packages/*/build/ts
@@ -31,7 +31,7 @@ jobs:
 
       - id: jest-cache
         name: Restore jest cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .loom/cache/jest/
           key: ${{ runner.os }}-jest-v1-${{ github.sha }}
@@ -50,7 +50,7 @@ jobs:
 
       - id: eslint-cache
         name: Restore ESLint cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .loom/cache/eslint
           key: ${{ runner.os }}-eslint-v1-${{ github.sha }}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/Badge/Badge.ts
@@ -7,7 +7,7 @@ export type BadgeVariant =
   | 'success'
   | 'highlight';
 
-export type BadgeStatus = 'empty' | 'partial' | 'complete';
+export type BadgeStatus = 'empty' | 'partial' | 'complete' | null;
 
 /**
  * @property text - The text displayed inside the badge.
@@ -26,7 +26,7 @@ export interface BadgeProps {
   variant: BadgeVariant;
 
   /**
-   * A circle icon displaying the status of the badge.
+   * A circle icon displaying the status of the badge. Use `null` to hide the status icon.
    */
   status?: BadgeStatus;
 }


### PR DESCRIPTION
Part of https://github.com/Shopify/pos-next-react-native/issues/32885

### Background

Badge has a prop called status that is optional. Typically, removing this prop should hide the icon, but something about the extensibility bridge retains the last-known value instead. This workaround allows partners to hide the icon, and is already in use per Shopify guidance.

### Solution

This adds null as an officially supported badge status type so that folks know it's OK to use.

### 🎩

Set a Badge's status prop to something other than undefined or null.
Verify the status icon appears.
Set the Badge's status prop to null.
Verify the status icon disappears.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
