### PR TITLE
Updated doc for extension limits for full page 1 add per extension

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.page.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.page.render.doc.ts
@@ -15,6 +15,8 @@ If the page you're building is not tied to a specific order, use [customer-accou
 For example:
 - A Return Request page that requires the context of a specific order should use \`customer-account.order.page.render\`
 - A Wishlist page that does **not** require the context of a specific order should use \`customer-account.page.render\`
+
+A full-page extension target cannot coexist with any other targets in the same extension.
 `,
   category: 'Targets',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.page.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.page.render.doc.ts
@@ -14,6 +14,8 @@ If the page you're building is tied to a specific order, use [customer-account.o
 For example:
 - A Return Request page that requires the context of a specific order should use \`customer-account.order.page.render\`
 - A Wishlist page that does **not** require the context of a specific order should use \`customer-account.page.render\`
+
+A full-page extension target cannot coexist with any other targets in the same extension.
 `,
   category: 'Targets',
   isVisualComponent: false,


### PR DESCRIPTION
### Background

Fixes: https://github.com/Shopify/core-issues/issues/71854
Docs needed to be updated regarding customer account and full page extensions

Following the work done by UX

Link: https://github.com/Shopify/shopify-dev/pull/53184

### Solution



### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have updated relevant documentation
