### PR TITLE
Fix empty bulkCartUpdate typing in docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -12,10 +12,14 @@ export interface Cart {
   properties: Record<string, string>;
 }
 
-export type CartUpdateInput = Omit<
-  Cart,
-  'subtotal' | 'taxTotal' | 'grandTotal'
->;
+export interface CartUpdateInput {
+  note?: string;
+  cartDiscount?: Discount;
+  cartDiscounts: Discount[];
+  customer?: Customer;
+  lineItems: LineItem[];
+  properties: Record<string, string>;
+}
 
 export interface Customer {
   id: number;


### PR DESCRIPTION
Resolves https://github.com/Shopify/shopify-dev/issues/53252

### Background

The omit operators don't play well when generating dev docs. I will update the type to exclude the variables instead. Since the docs are evaluated based on the interfaces, they are no generated json file diffs. I ran npm run docs:point-of-sale to be sure.

https://shopify-dev.ui-extensions-pp9g.victor-chu.us.spin.dev/docs/api/pos-ui-extensions/unstable/apis/cart-api#cartapi-propertydetail-bulkcartupdate

Before
![Screenshot 2025-02-12 at 12 59 18 PM](https://github.com/user-attachments/assets/268039b7-877e-4f9f-b747-782feb165a57)

After
![Screenshot 2025-02-12 at 1 14 51 PM](https://github.com/user-attachments/assets/53ad2c4b-76d3-446a-9c58-044ccbeb844e)
