### PR TITLE
feat(products): updating Product Configuration extension points to use block extension api & components

### DIFF
--- a/.changeset/tender-boxes-own.md
+++ b/.changeset/tender-boxes-own.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Update Product Configuration extension points to use block extension api and data

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.ts
@@ -1,6 +1,8 @@
-import type {StandardApi} from '../standard/standard';
+import type {BlockExtensionApi} from '../block/block';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+import type {Data} from '../shared';
 
+/* @deprecated */
 interface Product {
   id: string;
   title: string;
@@ -21,6 +23,7 @@ interface Product {
   productComponents: ProductComponent[];
 }
 
+/* @deprecated */
 export interface ProductComponent {
   id: string;
   title: string;
@@ -37,9 +40,12 @@ export interface ProductComponent {
 
 export interface ProductDetailsConfigurationApi<
   ExtensionTarget extends AnyExtensionTarget,
-> extends StandardApi<ExtensionTarget> {
-  data: {
-    /* The product currently being viewed in the admin. */
+> extends BlockExtensionApi<ExtensionTarget> {
+  data: Data & {
+    /*
+      @deprecated 
+      The product currently being viewed in the admin.
+    */
     product: Product;
     app: {
       launchUrl: string;

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.ts
@@ -1,6 +1,8 @@
-import type {StandardApi} from '../standard/standard';
+import type {BlockExtensionApi} from '../block/block';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+import type {Data} from '../shared';
 
+/* @deprecated */
 interface ProductVariant {
   id: string;
   sku: string;
@@ -19,6 +21,7 @@ interface ProductVariant {
   productVariantComponents: ProductVariantComponent[];
 }
 
+/* @deprecated */
 export interface ProductVariantComponent {
   id: string;
   displayName: string;
@@ -38,9 +41,12 @@ export interface ProductVariantComponent {
 
 export interface ProductVariantDetailsConfigurationApi<
   ExtensionTarget extends AnyExtensionTarget,
-> extends StandardApi<ExtensionTarget> {
-  data: {
-    /* The product variant currently being viewed in the admin. */
+> extends BlockExtensionApi<ExtensionTarget> {
+  data: Data & {
+    /*
+      @deprecated
+      The product variant currently being viewed in the admin.
+    */
     variant: ProductVariant;
     app: {
       launchUrl: string;

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -28,22 +28,6 @@ type CustomerSegmentTemplateComponent = AnyComponentBuilder<
   >
 >;
 
-type ProductConfigurationComponents = AnyComponentBuilder<
-  Pick<
-    Components,
-    | 'Box'
-    | 'InlineStack'
-    | 'BlockStack'
-    | 'Divider'
-    | 'HeadingGroup'
-    | 'Heading'
-    | 'Text'
-    | 'Link'
-    | 'Image'
-    | 'Icon'
-  >
->;
-
 type OrderRoutingComponents = AnyComponentBuilder<
   Pick<Components, 'InternalLocationList'>
 >;
@@ -510,7 +494,7 @@ export interface ExtensionTargets {
    */
   'admin.product-details.configuration.render': RenderExtension<
     ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,
-    ProductConfigurationComponents
+    AllComponents
   >;
 
   /**
@@ -520,7 +504,7 @@ export interface ExtensionTargets {
    */
   'admin.product-variant-details.configuration.render': RenderExtension<
     ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,
-    ProductConfigurationComponents
+    AllComponents
   >;
 
   /**


### PR DESCRIPTION
Part of https://github.com/Shopify/temp-project-mover-Archetypically-20250320131408/issues/241

### Background

When the product configuration extension points were first created, all data necessary for rendering had to passed in. This is no longer the case, as ui extensions now have access to a graphql api. [The prior PR in this chain](https://github.com/Shopify/web/pull/158391) added the product or variant id as `selected[0].id` (the same pattern used by block extensions), and this PR updates the types to reflect this new field, and marks the existing product/productVariant objects as deprecated (we'll remove them in a few months, once all third party apps are no longer using it)

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
