### PR TITLE
Add `POSReceiptBlock` component

### DIFF
--- a/.changeset/plenty-houses-train.md
+++ b/.changeset/plenty-houses-train.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-react': minor
+'@shopify/ui-extensions': minor
+---
+
+Add "POSReceiptBlock" component.

--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/components.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/components.ts
@@ -17,6 +17,7 @@ export {PinPad} from './components/PinPad/PinPad';
 export {PrintPreview} from './components/PrintPreview/PrintPreview';
 export {POSBlock} from './components/POSBlock/POSBlock';
 export {POSBlockRow} from './components/POSBlock/POSBlockRow';
+export {POSReceiptBlock} from './components/POSReceiptBlock/POSReceiptBlock';
 export {RadioButtonList} from './components/RadioButtonList/RadioButtonList';
 export {Screen} from './components/Screen/Screen';
 export {ScrollView} from './components/ScrollView/ScrollView';

--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/components/POSReceiptBlock/POSReceiptBlock.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/components/POSReceiptBlock/POSReceiptBlock.ts
@@ -1,0 +1,12 @@
+import {
+  POSReceiptBlock as BasePOSReceiptBlock,
+  POSReceiptBlockProps,
+  AllowedChildrenComponents,
+} from '@shopify/ui-extensions/point-of-sale';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const POSReceiptBlock = createRemoteReactComponent<
+  typeof BasePOSReceiptBlock,
+  POSReceiptBlockProps,
+  AllowedChildrenComponents
+>(BasePOSReceiptBlock);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSReceiptBlock.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSReceiptBlock.doc.ts
@@ -1,0 +1,44 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateCodeBlockForPOSReceiptBlock = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'pos-receipt-block', fileName);
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'POSReceiptBlock',
+  description: `A component used to group other components together for display on POS receipts.
+  > Note:
+  > This component only accepts \`Text\` and \`Image\` components as children.`,
+  isVisualComponent: true,
+  type: 'component',
+  // eslint-disable-next-line no-warning-comments
+  // TODO: add images (and update description, examples, types, related) after determining what child components are allowed.
+  // thumbnail: 'pos-receipt-block-thumbnail.png',
+  definitions: [
+    {
+      title: 'POSReceiptBlock',
+      description: '',
+      type: 'POSReceiptBlockProps',
+    },
+  ],
+  category: 'Components',
+  related: [
+    {
+      name: 'Text',
+      url: '/docs/api/pos-ui-extensions/components/text',
+    },
+    {
+      name: 'Image',
+      url: '/docs/api/pos-ui-extensions/components/image',
+    },
+  ],
+  defaultExample: {
+    // image: 'pos-receipt-block-default.png',
+    codeblock: generateCodeBlockForPOSReceiptBlock(
+      'Render a POSReceiptBlock in POS receipts',
+      'default.example',
+    ),
+  },
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/pos-receipt-block/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/pos-receipt-block/default.example.ts
@@ -1,0 +1,28 @@
+import {
+  POSReceiptBlock,
+  Image,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.receipt-footer.block.render',
+  (root) => {
+    const block = root.createComponent(
+      POSReceiptBlock,
+    );
+    const text = root.createComponent(
+      Text,
+      {},
+      'Submission ID: acde070d-8c2c-b0b0-9d8a-162843c10333',
+    );
+    const image = root.createComponent(Image, {
+      src: 'example.png',
+      size: 's',
+    });
+
+    block.append(text);
+    block.append(image);
+    root.append(block);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/pos-receipt-block/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/pos-receipt-block/default.example.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {
+  POSReceiptBlock,
+  Image,
+  Text,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const ReceiptFooterBlock = () => (
+  <POSReceiptBlock>
+    <Text>
+      Submission ID:
+      acde070d-8c2c-b0b0-9d8a-162843c10333
+    </Text>
+    <Image src="example.png" size="s" />
+  </POSReceiptBlock>
+);
+
+export default reactExtension(
+  'pos.receipt-footer.block.render',
+  () => <ReceiptFooterBlock />,
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-receipt-footer-block-render.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-receipt-footer-block-render.ts
@@ -1,0 +1,13 @@
+import {
+  POSReceiptBlock,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.receipt-footer.block.render', (root, api) => {
+  const block = root.createComponent(POSReceiptBlock);
+  const text = root.createComponent(Text, {}, `Order ID: ${api.order.id}`);
+
+  block.append(text);
+  root.append(block);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-receipt-footer-block-render.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-receipt-footer-block-render.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import {
+  Text,
+  useApi,
+  reactExtension,
+  POSReceiptBlock,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Block = () => {
+  const api = useApi<'pos.receipt-footer.block.render'>();
+  return (
+    <POSReceiptBlock>
+      <Text>{`Order ID: ${api.order.id}`}</Text>
+    </POSReceiptBlock>
+  );
+};
+
+export default reactExtension('pos.receipt-footer.block.render', () => (
+  <Block />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-footer.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-footer.block.render.doc.ts
@@ -1,9 +1,17 @@
 import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
 import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReceiptFooterBlockRender,
   description: 'Renders a custom section within the POS receipt footer',
+  defaultExample: {
+    codeblock: generateCodeBlock(
+      'Block',
+      'targets',
+      'pos-receipt-footer-block-render',
+    ),
+  },
   category: 'Targets',
   subCategory: 'Receipts',
   isVisualComponent: false,
@@ -11,6 +19,10 @@ const data: ReferenceEntityTemplateSchema = {
     {
       name: 'Order API',
       url: '/docs/api/pos-ui-extensions/apis/order-api',
+    },
+    {
+      name: 'POSReceiptBlock',
+      url: '/docs/api/pos-ui-extensions/components/posreceiptblock',
     },
   ],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -51,6 +51,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Added support for the ${TargetLink.PosTransactionCompleteObserve} target.
 - Added support for cash tracking session. ${TargetLink.PosCashTrackingSessionStartObserve}, ${TargetLink.PosCashTrackingSessionCancelObserve}, ${TargetLink.PosCashTrackingSessionCompleteObserve} targets.
 - Added support for the ${TargetLink.PosReceiptFooterBlockRender} target.
+- Introduced a [POSReceiptBlock component](/docs/api/pos-ui-extensions/components/posreceiptblock). It's the required parent component for ${TargetLink.PosReceiptFooterBlockRender} targets.
       `,
     },
     {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
@@ -65,6 +65,11 @@ export {POSBlock} from './render/components/POSBlock/POSBlock';
 export type {POSBlockProps} from './render/components/POSBlock/POSBlock';
 export {POSBlockRow} from './render/components/POSBlock/POSBlockRow';
 export type {POSBlockRowProps} from './render/components/POSBlock/POSBlockRow';
+export {
+  POSReceiptBlock,
+  type POSReceiptBlockProps,
+  type AllowedChildrenComponents,
+} from './render/components/POSReceiptBlock/POSReceiptBlock';
 export {PrintPreview} from './render/components/PrintPreview/PrintPreview';
 export type {PrintPreviewProps} from './render/components/PrintPreview/PrintPreview';
 export {RadioButtonList} from './render/components/RadioButtonList/RadioButtonList';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/POSReceiptBlock/POSReceiptBlock.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/POSReceiptBlock/POSReceiptBlock.ts
@@ -1,0 +1,16 @@
+import {createRemoteComponent} from '@remote-ui/core';
+import {Image} from '../Image/Image';
+import {Text} from '../Text/Text';
+
+/**
+ * Renders a `POSReceiptBlock`. A `POSReceiptBlock` only accepts
+ * `Text` and `Image` as children (more to be added in the future).
+ */
+export interface POSReceiptBlockProps {}
+export type AllowedChildrenComponents = typeof Text | typeof Image;
+
+export const POSReceiptBlock = createRemoteComponent<
+  'POSReceiptBlock',
+  POSReceiptBlockProps,
+  AllowedChildrenComponents
+>('POSReceiptBlock');

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -10,6 +10,9 @@ import {DraftOrderApi} from './render/api/draft-order-api/draft-order-api';
 
 type SmartGridComponents = AnyComponentBuilder<Pick<Components, 'Tile'>>;
 type ActionComponents = AnyComponentBuilder<Pick<Components, 'Button'>>;
+type ReceiptComponents = AnyComponentBuilder<
+  Pick<Components, 'POSReceiptBlock' | 'Text' | 'Image'>
+>;
 type BasicComponents = AnyComponentBuilder<Omit<Components, 'Tile'>>;
 type BlockComponents = AnyComponentBuilder<
   Pick<
@@ -129,7 +132,7 @@ export interface ExtensionTargets {
   >;
   'pos.receipt-footer.block.render': RenderExtension<
     StandardApi<'pos.receipt-footer.block.render'> & OrderApi,
-    BlockComponents
+    ReceiptComponents
   >;
 }
 


### PR DESCRIPTION
Resolves https://github.com/Shopify/retail-hq-store-management/issues/755

Part 2 of 2. [Part 1 here.](https://github.com/Shopify/ui-extensions/pull/2643)

- Add `POSReceiptBlock` with children limitations and documentations.

### Background

`POSReceiptBlock` is a block wrapper specific for the POS receipt section and does not do anything UI-wise other than gating the allowed children.

### Solution

- Defined acceptable children is currently set to `Image` and `Text` only. New components will be introduced in later PRs.
- Documentation is WIP since no screenshots + other descriptions.
- Did this under the `2025.04` release.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have updated relevant documentation
