### PR TITLE
Fix missing customer Id in checkout model and even extension function

### DIFF
--- a/.changeset/tender-toys-thank.md
+++ b/.changeset/tender-toys-thank.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Fixed some POS UI Extension types

--- a/packages/ui-extensions/src/surfaces/point-of-sale/extension.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/extension.ts
@@ -1,11 +1,13 @@
 import {createExtensionRegistrationFunction} from '../../utilities/registration';
+import {EventExtensionTargets} from './event/targets';
 
 import type {ExtensionTargets} from './targets';
 
 export * from '../../extension';
 
-export const extension =
-  createExtensionRegistrationFunction<ExtensionTargets>();
+export const extension = createExtensionRegistrationFunction<
+  ExtensionTargets & EventExtensionTargets
+>();
 
 /**
  * Registers your UI Extension to run for the selected extension target.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/checkout.ts
@@ -5,6 +5,7 @@ import {TaxLine} from './tax-line';
 
 export interface Checkout {
   uuid: string;
+  customerId?: number;
   discounts: Discount[];
   draftCheckoutUuid: string;
   lineItems: LineItem[];


### PR DESCRIPTION
### Background
Fixes two things: The missing customerId from the Checkout model, and the missing `EventExtensionTargets` type for the extension function. This should now autocomplete properly when we try to call the extend function.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩
You can pull this branch, run yarn build and export the build folder into your own project and test the autocomplete of the APIs.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
