### PR TITLE
Fixes typo `ow to` ⇨ `how to`

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/debugging.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/debugging.doc.ts
@@ -78,7 +78,7 @@ This section covers how to view POS UI Extension logs and errors on iOS devices.
 
 ### Demo
 
-The following demo shows ow to debug a POS UI Extension on iOS by using the Safari dev tools. The example extension code has \`console.log\` statements that appear when we open the Safari dev tools.
+The following demo shows how to debug a POS UI Extension on iOS by using the Safari dev tools. The example extension code has \`console.log\` statements that appear when we open the Safari dev tools.
 
 ![Debugging demo](/assets/api/pos/debug-ui-extension-ios.gif)
 `,


### PR DESCRIPTION
### Background

The issue is visible on this page: [Debugging](https://shopify.dev/docs/api/pos-ui-extensions/2025-01/debugging#debugging-on-ios)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
