### PR TITLE
Revert primaryAction and secondaryAction addition to AdminActionJSXProps type declaration

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -5604,8 +5604,6 @@ declare module 'preact' {
 
 export interface AdminActionJSXProps extends Partial<AdminActionProps> {
   id?: string;
-  primaryAction: ComponentChild;
-  secondaryAction: ComponentChild;
 }
 
 declare const tagName$1 = 's-admin-block';


### PR DESCRIPTION
<!-- Start of Slack thread -->

## Summary

- Charles noted that a recent pull request merged, which updated types for `AdminActionJSXProps` to include `secondaryAction` and `primaryAction`, is causing type errors across multiple pull requests that updated to the latest release candidate snapshot.
- Charles questioned whether this issue is a bug or if there was a missing update step on the admin-web side, pointing out that the `AdminAction` component already includes these properties.
- Charles and another user plan to revert the type changes for `primaryAction` and `secondaryAction` in the release candidate branch to allow the affected pull requests to be shipped.
- They indicated that they would address the issue and implement a fix in the following day.

_This summary was generated using [OpenAI's gpt-4o-mini with a temperature of 0.5](https://openai.com/blog/openai-api/)._
<details>
<summary>:thread: Slack Thread <img align="right" src="https://github.com/gwyneplaine.png" width="32" /></summary>


<table>
  <thead>
    <tr>
      <th colspan="2" width="181px">User</th>
      <th width="619px">Message</th>
    </tr>
  </thead>
  <tbody>
    <tr>
  <th><img src="https://github.com/gwyneplaine.png" width="32" /></th>
  <td>
    <sup>
      <a href="https://github.com/gwyneplaine">Charles Lee</a><br/>
      <time>2025&#8209;02&#8209;25&#160;04:41</time>
    </sup>
  </td>
  <td>
    @vividviolet Looks like this <a href="https://github.com/Shopify/admin-ui-foundations/pull/2128/files">PR</a> merged today
Updated types for AdminActionJSXProps to include <code>secondaryAction</code> and <code>primaryAction</code>
This is causing the following type error (see attached image).

This is occurring on all PRs where we've updated to the latest RC snapshot <a href="https://github.com/Shopify/web/pull/159690">Select</a>, <a href="https://github.com/Shopify/web/pull/159689">NumberField</a>, <a href="https://github.com/Shopify/web/pull/156401">Banner</a>

Is this a bug? Or are we missing a crucial update step on the admin-web side. Curiously, <a href="https://github.com/Shopify/web/blob/ba5f418cb71ea23903863b93f5ff4c65ae5a21b5/areas/clients/admin-web/app/shared/domains/extensibility/ui-extensions/components/AdminAction/definition.ts">AdminAction</a> already has a slot property with <code>secondaryAction</code> and <code>primaryAction</code> as values.

<pre>export const AdminAction: PropsToComponentConstructorAdminActionJSXProps = {
  properties: {
    id: {type: &#39;string&#39;},
    loading: {type: &#39;boolean&#39;},
    title: {type: &#39;string&#39;},
  },
  slots: [&#39;primaryAction&#39;, &#39;secondaryAction&#39;],
};</pre>
cc @alex-page

<hr />

<img src="https://storage.googleapis.com/shopify-ihub-github-archiver/07f3de262994335f298f2e550ad066d516fdf1aef2e96c60f7398b18c6bd2f35.png" width="100" alt="Screenshot 2025-02-25 at 3.37.12 pm.png" />
  </td>
</tr>
<tr>
  <th><img src="https://github.com/gwyneplaine.png" width="32" /></th>
  <td>
    <sup>
      <a href="https://github.com/gwyneplaine">Charles Lee</a><br/>
      <time>2025&#8209;02&#8209;25&#160;04:44</time>
    </sup>
  </td>
  <td>
    @alex-page and I will revert the type change adding <code>primaryAction</code> and <code>secondaryAction</code> to the <code>component.d.ts</code> in the RC branch, so as to get these PR's shipped, we can fix forward tomorrow.
  </td>
</tr>
  </tbody>
</table>
</details>

<hr />

<a href="https://github.com/gwyneplaine">Charles Lee</a> archived this <a href="https://shopify.slack.com/archives/C06UT7UK3R7/p1740458462800139?thread_ts=1740458462.800139&amp;cid=C06UT7UK3R7">conversation from <code>admin-ui-foundations</code></a> at <time>2025&#8209;02&#8209;25&#160;04:47</time>.
All times are in UTC.


<!-- End of Slack thread -->
