### PR TITLE
fix CA useCustomer hook react type

### DIFF
--- a/.changeset/light-pugs-grin.md
+++ b/.changeset/light-pugs-grin.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-react': patch
+'@shopify/ui-extensions': patch
+---
+
+fix customer account useCustomer hook type

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/buyer-identity.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/buyer-identity.ts
@@ -1,7 +1,7 @@
 import type {
-  Customer,
+  OrderStatusCustomer,
   OrderStatusBuyerIdentity,
-  PurchasingCompany,
+  OrderStatusPurchasingCompany,
   RenderOrderStatusExtensionTarget,
 } from '@shopify/ui-extensions/customer-account';
 
@@ -17,7 +17,7 @@ import {useSubscription} from './subscription';
  */
 export function useCustomer<
   Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
->(): Customer | undefined {
+>(): OrderStatusCustomer | undefined {
   const buyerIdentity = useInternalBuyerIdentity<Target>();
 
   return useSubscription(buyerIdentity.customer);
@@ -56,7 +56,7 @@ export function usePhone<
  */
 export function usePurchasingCompany<
   Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
->(): PurchasingCompany | undefined {
+>(): OrderStatusPurchasingCompany | undefined {
   const buyerIdentity = useInternalBuyerIdentity<Target>();
 
   return useSubscription(buyerIdentity.purchasingCompany);


### PR DESCRIPTION
### Background

Fix type erros here 
https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis/order-status-api/buyer-identity#useCustomer-returns 

<img width="1245" alt="Screenshot 2025-02-27 at 4 24 22 PM" src="https://github.com/user-attachments/assets/6cb55feb-8f36-47d4-8a03-134a064c0258" />

We have 
- Customer, which only has `id` and is used for https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis/authenticated-account#useAuthenticatedAccountCustomer
- OrderStatusCustomer, which has more fields, and is used for https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis/order-status-api/buyer-identity#useCustomer-returns  

same as `OrderStatusPurchasingCompany`

### Solution

Use the right type 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
