### PR TITLE
[CI] Update actions/cache and actions/checkout to latest

### DIFF
--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 2
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: mskelton/changelog-reminder-action@v2
         with:
           changelogRegex: "\\.changeset"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/actions/prepare
 
       - id: typescript-cache
@@ -26,7 +26,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/actions/prepare
 
       - id: jest-cache
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/actions/prepare
 
       - id: eslint-cache
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/actions/prepare
 
       - id: test-build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/internal-snapshot.yml
+++ b/.github/workflows/internal-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
     name: Internal Snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -10,7 +10,7 @@ jobs:
     name: Snapit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/unstable-snapshot.yml
+++ b/.github/workflows/unstable-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
     name: Unstable Snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 


### PR DESCRIPTION
CI Failing due to actions/cache being out of date (previously on v1, latest is v4).
Bumping of actions/checkout is purely boyscouting. 