### PR TITLE
Added end of support versions for older POS UI

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -15,15 +15,15 @@ const data: LandingTemplateSchema = {
   sections: [
     {
       type: 'Generic',
-      anchorLink: 'support-policy',
-      title: 'Support Policy',
+      anchorLink: 'compatibility-policy',
+      title: 'Compatibility Policy',
       sectionContent: '',
       sectionNotice: [
         {
-          title: 'End of Support Plan',
+          title: 'End of Compatibility Plan',
           type: 'Warning',
           sectionContent: `
-          To ensure the best possible ongoing POS UI Extension development experience, starting in April 2025, we will end support for versions on a one-year rolling basis. This table details the end of support schedule.
+          To ensure the best possible ongoing POS UI Extension development experience, starting in April 2025, we will end compatibility for versions on a one-year rolling basis. This means that POS will no longer run extensions using removed versions. This table details the end of compatibility schedule.
 
 |released version|removed versions|
 |---:|---|
@@ -174,7 +174,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
       ],
       sectionContent: `
 - Added in POS version: 9.11
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 06/10/2024.
 
 ### Features
@@ -195,7 +195,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
       ],
       sectionContent: `
 - Added in POS version: 9.4.0
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 03/13/2024.
 
 ### Features
@@ -212,7 +212,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
       title: '1.6.0',
       sectionContent: `
 - Added in POS version: 9.2.0
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 02/15/2024.
 
 ### Features
@@ -227,7 +227,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
       title: '1.5.1',
       sectionContent: `
 - Added in POS version: 8.22.0
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 11/13/2023.
 
 ### Features
@@ -242,7 +242,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
       title: '1.5.0',
       sectionContent: `
 - Added in POS version: 8.21.0
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 10/30/2023.
 
 ### Features
@@ -257,7 +257,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
       title: '1.4.0',
       sectionContent: `
 - Added in POS version: 8.18.0
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 9/27/2023.
 
 ### Features
@@ -273,7 +273,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
       title: '1.3.0',
       sectionContent: `
 - Added in POS version: 8.15.0
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 8/16/2023.
 
 ### Features
@@ -297,7 +297,7 @@ Introduced the following components:
       title: '1.2.0',
       sectionContent: `
 - Added in POS version: 8.12.0
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 6/26/2023.
 
 ### Features
@@ -316,7 +316,7 @@ Introduced the following components:
       title: '1.1.2',
       sectionContent: `
 - Added in POS version: 8.9.0
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 5/15/2023.
 
 ### Features
@@ -331,7 +331,7 @@ Introduced the following components:
       title: '1.0.1',
       sectionContent: `
 - Added in POS version: 8.8.1
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 5/3/2023.
 
 ### Fixes
@@ -345,7 +345,7 @@ Introduced the following components:
       title: '1.0.0',
       sectionContent: `
 - Added in POS version: 8.8.0
-- Removed in POS version: N/A
+- Removed in POS version: 9.31.0
 - Release day: 5/1/2023.
 
 ### Features


### PR DESCRIPTION
### Background
This adds end of support versions for older pos ui extension versions.

### Solution
Our docs now state that as of version 9.31.0, POS UI Extensions of those versions can now longer run

### Screenshots 
<img width="675" alt="Screenshot 2025-03-06 at 10 18 36 AM" src="https://github.com/user-attachments/assets/2dcb8aab-cb00-4aea-a1d6-162db62f5d6b" />

<img width="391" alt="Screenshot 2025-03-06 at 10 18 27 AM" src="https://github.com/user-attachments/assets/1829ce74-a2d8-42f1-aad5-5d8a3fdf7f0a" />

All other affected versions look like this:
<img width="397" alt="Screenshot 2025-03-06 at 10 18 55 AM" src="https://github.com/user-attachments/assets/7e989e56-8ea6-4d2a-a1e1-6c23a8bfa1ac" />

### 🎩


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
