### PR TITLE
Deprecated FormattedTextField

### DIFF
--- a/.changeset/tiny-moles-serve.md
+++ b/.changeset/tiny-moles-serve.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-react': minor
+'@shopify/ui-extensions': minor
+---
+
+Marked FormattedTextField as deprecated for pos ui

--- a/packages/ui-extensions-react/src/surfaces/point-of-sale.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale.ts
@@ -69,7 +69,7 @@ export type {
   SuccessProps,
   PasswordProps,
   EmbeddedElementProps,
-  NewTextFieldProps,
+  TextFieldProps,
   TileProps,
   TimeFieldProps,
   TimePickerProps,

--- a/packages/ui-extensions-react/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
+++ b/packages/ui-extensions-react/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
@@ -1,6 +1,9 @@
 import {FormattedTextField as BaseFormattedTextField} from '@shopify/ui-extensions/point-of-sale';
 import {createRemoteReactComponent} from '@remote-ui/react';
 
+/**
+ * @deprecated Use the `TextField` component instead.
+ */
 export const FormattedTextField = createRemoteReactComponent(
   BaseFormattedTextField,
 );

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/FormattedTextField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/FormattedTextField.doc.ts
@@ -7,7 +7,7 @@ const generateCodeBlockForComponent = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'FormattedTextField',
   description:
-    'Use a formatted text field when you require additional functionality such as the text field input type or a custom validator.',
+    'This component is deprecated. Please use the [`TextField`](/docs/api/pos-ui-extensions/components/textfield) component instead. Use a formatted text field when you require additional functionality such as the text field input type or a custom validator.',
   isVisualComponent: true,
   type: 'component',
   definitions: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/TextField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/TextField.doc.ts
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'TextField',
       description:
         'Use a text field to allow merchants to input or modify multiline text.',
-      type: 'NewTextFieldProps',
+      type: 'TextFieldProps',
     },
   ],
   category: 'Components',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -46,6 +46,9 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Removed in POS version: N/A
 - Release day: N/A
 
+### Breaking Changes
+- Renamed \`NewTextFieldProps\` to \`TextFieldProps\`.
+
 ### Features
 
 - Added support for the ${TargetLink.PosTransactionCompleteObserve} target.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
@@ -119,7 +119,7 @@ export {TextArea} from './render/components/TextArea/TextArea';
 export type {TextAreaProps} from './render/components/TextArea/TextArea';
 export {TextField} from './render/components/TextField/TextField';
 export type {
-  NewTextFieldProps,
+  TextFieldProps,
   ActionProps,
   InfoProps,
   SuccessProps,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/FormattedTextField/FormattedTextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/FormattedTextField/FormattedTextField.ts
@@ -22,6 +22,9 @@ export interface FormattedTextFieldProps extends BaseTextFieldProps {
   autoCapitalize?: AutoCapitalizationType;
 }
 
+/**
+ * @deprecated Use the `TextField` component instead.
+ */
 export const FormattedTextField = createRemoteComponent<
   'FormattedTextField',
   FormattedTextFieldProps

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/TextField/TextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/TextField/TextField.ts
@@ -29,8 +29,8 @@ export type EmbeddedElementProps =
   | SuccessProps
   | PasswordProps;
 
-export interface NewTextFieldProps extends InputProps {}
+export interface TextFieldProps extends InputProps {}
 
-export const TextField = createRemoteComponent<'TextField', NewTextFieldProps>(
+export const TextField = createRemoteComponent<'TextField', TextFieldProps>(
   'TextField',
 );


### PR DESCRIPTION
Part of https://github.com/Shopify/temp-project-mover-Archetypically-20250612104008/issues/53

### Background
This TextField is now deprecated, in favour for the TextField component.

### Solution
I took the liberty of renaming `NewTextFieldProps` to `TextField` props since that name is now available without conflict. 

### 🎩
- You can build the package and drop it into the node modules of an existing project's ui-extensions build folder. `yarn build` at the root of the ui-extensions package.
- Make sure the field is marked as deprecated 

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
