### PR TITLE
Update POS migration docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.npm.bash
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.npm.bash
@@ -9,5 +9,5 @@ npm update react@^18.2.0
 npm update @types/react@^18.2.0
 
 # 4. Install the new packages
-npm install @shopify/ui-extensions@2024.4
-npm install @shopify/ui-extensions-react@2024.4
+npm install @shopify/ui-extensions@2025.4
+npm install @shopify/ui-extensions-react@2025.4

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.yarn.bash
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.yarn.bash
@@ -9,5 +9,5 @@ yarn upgrade react@^18.2.0
 yarn upgrade @types/react@^18.2.0
 
 # 4. Install the new packages
-yarn add @shopify/ui-extensions@2024.4
-yarn add @shopify/ui-extensions-react@2024.4
+yarn add @shopify/ui-extensions@2025.4
+yarn add @shopify/ui-extensions-react@2025.4

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/shopify.extension.toml
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-04"
+api_version = "2025-04"
 
 [[extensions]]
 type = "ui_extension"

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/migrating.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/migrating.doc.ts
@@ -30,8 +30,6 @@ const data: LandingTemplateSchema = {
 POS UI Extensions are moving to the newer \`@shopify/ui-extensions\` package, shared with [Checkout UI Extensions](https://shopify.dev/docs/api/checkout-ui-extensions) and [Admin UI Extensions](https://shopify.dev/docs/api/admin-extensions). This will allow your extensions to use the same package regardless of the surface they extend, and for a single extension to implement multiple targets across different surfaces of Shopify more easily.
 
 \`@shopify/retail-ui-extensions\` and \`@shopify/retail-ui-extensions-react\` are deprecated. They are now maintained as part of \`@shopify/ui-extensions\` and \`@shopify/ui-extensions-react\`. This guide explains how to migrate from the old packages to the new ones.
-
-Aside from these migration steps, \`@shopify/ui-extensions@2024.4\` is backwards compatible with \`@shopify/retail-ui-extensions@1.7.0\`.
       `,
     },
     {
@@ -89,7 +87,7 @@ Migrate your \`shopify.extension.toml\` file to reflect the [new syntax](https:/
 - Specify which \`api_version\` you are using at the top of the file (above \`[[extensions]]\`). This will let POS know which version of the \`ui-extensions\` package you're using.
 
 > Note:
-> \`api_version\` needs to be declared in a \`yyyy-mm\` format. If you are using \`@shopify/ui-extensions\` version \`2024.4\` for example, you must declare your \`api_version\` as 2024-04. The patch is irrelevant to \`api_version\`.
+> \`api_version\` needs to be declared in a \`yyyy-mm\` format. If you are using \`@shopify/ui-extensions\` version \`2025.4\` for example, you must declare your \`api_version\` as 2025-04. The patch is irrelevant to \`api_version\`.
 
 - Declare each extension target and file path in \`shopify.extension.toml\`
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -42,7 +42,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
       anchorLink: '202504',
       title: '2025.04',
       sectionContent: `
-- Added in POS version: N/A
+- Added in POS version: 9.31
 - Removed in POS version: N/A
 - Release day: N/A
 


### PR DESCRIPTION
Initial part of https://github.com/Shopify/pos-next-react-native/issues/54670

### Background

This PR updates the migration and version docs to removes legacy ui extension versions. Additionally it fixes a bulkCartUpdate type that was occurring.

Please check the [shopify-dev PR](https://github.com/Shopify/shopify-dev/pull/54520) to visualize changes 


