### PR TITLE
Use correct props for DateField

### DIFF
--- a/.changeset/breezy-flowers-trade.md
+++ b/.changeset/breezy-flowers-trade.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-react': patch
+---
+
+Use correct props for DateField

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
@@ -10,9 +10,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: '',
   definitions: [
     {
-      title: 'DatePickerProps',
+      title: 'DateFieldProps',
       description: '',
-      type: 'DatePickerProps',
+      type: 'DateFieldProps',
     },
   ],
   category: 'Components',


### PR DESCRIPTION
### Background

DateField was using the DatePicker props, which is incorrect.

[We heard about this on slack here.](https://shopify.slack.com/archives/C04K7BZDH3N/p1741687157987469)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
