### PR TITLE
Update receipt block API

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -7,6 +7,8 @@ import {ActionApi} from './render/api/action-api/action-api';
 import {ProductApi} from './render/api/product-api/product-api';
 import {ActionTargetApi} from './render/api/action-target-api/action-target-api';
 import {DraftOrderApi} from './render/api/draft-order-api/draft-order-api';
+import {TransactionCompleteData} from './event/data/TransactionCompleteData';
+import {ReprintReceiptData} from './event/data/ReprintReceiptData';
 
 type SmartGridComponents = AnyComponentBuilder<Pick<Components, 'Tile'>>;
 type ActionComponents = AnyComponentBuilder<Pick<Components, 'Button'>>;
@@ -124,10 +126,9 @@ export interface ExtensionTargets {
     BasicComponents
   >;
   'pos.customer-details.block.render': RenderExtension<
-    StandardApi<'pos.customer-details.block.render'> &
-      CartApi &
-      CustomerApi &
-      ActionApi,
+    {
+      [key: string]: any;
+    } & (TransactionCompleteData | {transaction: ReprintReceiptData}),
     BlockComponents
   >;
   'pos.receipt-footer.block.render': RenderExtension<


### PR DESCRIPTION
### Background

Update receipt block API according to the [tech doc](https://docs.google.com/document/d/14BTDCMIN6QPb2AXels7iWFioYVhXn9AUSC0gQH6C7ts/edit?tab=t.4uw1bxi66q3o#heading=h.6fdsablvy6pz)

This is a new target added after 2025-01 release, so no change notes

### Solution



### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
N/A ~- [ ] I have updated relevant documentation~