### PR TITLE
Introduce CartLineItem APIs and targets

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/get-line-item.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/get-line-item.ts
@@ -1,0 +1,14 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    subtitle: 'Call cart function',
+    enabled: true,
+    onPress: () => {
+      api.cart.getLineItem('aa-1234567');
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/get-line-item.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/get-line-item.tsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+  Tile
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const api = useApi<'pos.home.tile.render'>();
+
+  return (
+    <Tile 
+      title='My App' 
+      subtitle='Call cart function' 
+      enabled 
+      onPress={() => api.cart.getLineItem('aa-1234567')}
+    />
+  );
+};
+
+export default reactExtension(
+  'pos.home.tile.render',
+  () => <SmartGridTile />
+);

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cart-api/cart-api.ts
@@ -5,6 +5,7 @@ import type {
   CartUpdateInput,
   Customer,
   CustomSale,
+  LineItem,
   SetLineItemDiscountInput,
   SetLineItemPropertiesInput,
 } from '../../../types/cart';
@@ -86,6 +87,11 @@ export interface CartApiContent {
    * @param uuid the uuid of the line item that should be removed
    */
   removeLineItem(uuid: string): Promise<void>;
+
+  /** Get the line item at this uuid from the cart
+   * @param uuid the uuid of the line item that should be retrieved
+   */
+  getLineItem(uuid: string): Promise<LineItem | undefined>;
 
   /** Adds custom properties to the cart
    * @param properties the custom key to value object to attribute to the cart

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cart-line-item-api/cart-line-item-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cart-line-item-api/cart-line-item-api.ts
@@ -1,0 +1,10 @@
+export interface CartLineItemApi {
+  cartLineItem: CartLineItemApiContent;
+}
+
+export interface CartLineItemApiContent {
+  /**
+   * The unique identifier for the cart line item.
+   */
+  uuid: string;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -7,6 +7,7 @@ import {ActionApi} from './render/api/action-api/action-api';
 import {ProductApi} from './render/api/product-api/product-api';
 import {ActionTargetApi} from './render/api/action-target-api/action-target-api';
 import {DraftOrderApi} from './render/api/draft-order-api/draft-order-api';
+import {CartLineItemApi} from './render/api/cart-line-item-api/cart-line-item-api';
 
 type SmartGridComponents = AnyComponentBuilder<Pick<Components, 'Tile'>>;
 type ActionComponents = AnyComponentBuilder<Pick<Components, 'Button'>>;
@@ -133,6 +134,30 @@ export interface ExtensionTargets {
   'pos.receipt-footer.block.render': RenderExtension<
     StandardApi<'pos.receipt-footer.block.render'> & OrderApi,
     ReceiptComponents
+  >;
+  // New targets for manage line items
+  'pos.manage-line.action.render': RenderExtension<
+    ActionTargetApi<'pos.manage-line.action.render'> &
+      CartApi &
+      ActionApi &
+      ProductApi &
+      CartLineItemApi,
+    BasicComponents
+  >;
+  'pos.manage-line.block.render': RenderExtension<
+    StandardApi<'pos.manage-line.block.render'> &
+      CartApi &
+      ProductApi &
+      CartLineItemApi,
+    BlockComponents
+  >;
+  'pos.manage-line.action.menu-item.render': RenderExtension<
+    StandardApi<'pos.manage-line.action.menu-item.render'> &
+      ActionApi &
+      CartApi &
+      ProductApi &
+      CartLineItemApi,
+    ActionComponents
   >;
 }
 


### PR DESCRIPTION
In this PR we are introducing new targets and APIs for cart lineitems. 

### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

- Add CartLineItemAPI
- Add getLineItem to Cart API
- Include new targets for Cart Line Item

### Links

- [Point of Sale Draft PR](https://github.com/Shopify/pos-next-react-native/pull/54949)
- [Manage lineitem extension example](https://github.com/shopify/manage-line-item-extension)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
