### PR TITLE
Add back cart-update event target to versions

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-update.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-update.event.observe.doc.ts
@@ -3,7 +3,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCartUpdateObserve,
-  description: 'An event extension target that observes cart updates',
+  description: `An event extension target that observes cart updates
+  > Note:
+  > This is part of a POS UI Extensions developer preview. More information to come.`,
   category: 'Targets',
   subCategory: 'Cart details',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -54,6 +54,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 **Developer Preview**:
   - Added support for the ${TargetLink.PosTransactionCompleteObserve} target.
   - Added support for cash tracking session. ${TargetLink.PosCashTrackingSessionStartObserve}, ${TargetLink.PosCashTrackingSessionCompleteObserve} targets.
+  - Added support for the ${TargetLink.PosCartUpdateObserve} target.
   - Added support for the ${TargetLink.PosReceiptFooterBlockRender} target.
   - Introduced a [POSReceiptBlock component](/docs/api/pos-ui-extensions/components/posreceiptblock). It's the required parent component for ${TargetLink.PosReceiptFooterBlockRender} targets.
   - Introduced a [QRCode component](/docs/api/pos-ui-extensions/components/qrcode). It can be used to render a QR code in POS receipts but must be within a [POSReceiptBlock component](/docs/api/pos-ui-extensions/components/posreceiptblock).


### PR DESCRIPTION
### Background

Adding back `pos.cart-update.event.observe` to versions log since it was accidentally removed.

### Solution

Referring to [this PR](https://github.com/Shopify/ui-extensions/pull/2608) that added it initially.
- Added developer preview blurb to target doc.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have updated relevant documentation
