### PR TITLE
Fix admin doc gen

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,13 @@
     "deploy:unstable": "changeset version --snapshot unstable && changeset publish --tag unstable --no-git-tag",
     "predeploy:internal": "yarn build",
     "deploy:internal": "changeset version --snapshot internal && changeset publish --tag internal --no-git-tag",
-    "gen-docs:admin": "yarn workspace @shopify/ui-extensions gen-docs:admin",
+    "gen-docs:admin": "./packages/ui-extensions/docs/surfaces/admin/create-doc-files.sh",
     "lint": "loom lint",
     "nuke": "rm -rf node_modules && yarn cache clean && rm -rf .loom && git clean -xdf ./packages; rm -rf ./build",
     "restore-consumer": "./scripts/restore-consumer.sh",
     "restore-consumer-spin": "./scripts/restore-consumer-spin.sh",
     "run:ts": "babel-node --extensions .ts,.tsx,.mjs,.js,.json",
     "run:ts:watch": "nodemon --ext .ts,.tsx,.mjs,.json,.graphql node_modules/.bin/babel-node --extensions .ts,.tsx,.mjs,.js,.json",
-    "scaffold-docs:admin": "./packages/ui-extensions/docs/surfaces/admin/create-doc-files.sh \"admin\"",
     "type-check": "loom type-check"
   },
   "devDependencies": {

--- a/packages/ui-extensions/docs/surfaces/admin/ReadMe.md
+++ b/packages/ui-extensions/docs/surfaces/admin/ReadMe.md
@@ -1,0 +1,62 @@
+# create-doc-files.sh
+
+A utility script to scaffold documentation files for UI components in the ui-extensions package.
+
+## Usage
+
+```bash
+./create-doc-files.sh [-t type] component_name1 [component_name2 ...]
+```
+
+### Options
+
+- `-t`: Specifies the type of documentation to create (optional)
+  - Valid values: `components` or `api`
+  - Default: `components`
+
+### Arguments
+
+- `component_name1`: Name of the component to document (required)
+- `component_name2 ...`: Additional component names (optional)
+
+### Examples
+
+# Create documentation for a single component
+
+```bash
+./create-doc-files.sh Button
+```
+
+# Create documentation for multiple components
+
+```bash
+./create-doc-files.sh Button Card
+```
+
+# Create API documentation
+
+```bash
+./create-doc-files.sh -t api Toast
+```
+
+# Create multiple API docs
+
+```bash
+./create-doc-files.sh -t api Modal Toast
+```
+
+### Output
+
+For each component, the script creates:
+
+1. A component directory at `packages/ui-extensions/src/surfaces/admin/{type}/{componentName}/`
+2. An examples directory containing:
+   - A TypeScript example (`basic-{lowercase-name}.example.ts`)
+   - A TSX/Preact example (`basic-{lowercase-name}.example.tsx`)
+3. A documentation file (`{ComponentName}.doc.ts`) with a basic template including:
+   - Component metadata
+   - Description placeholder
+   - Example code references
+   - Category and subcategory settings
+
+The script will skip creating files that already exist to prevent overwriting existing documentation.

--- a/packages/ui-extensions/docs/surfaces/admin/create-doc-files.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/create-doc-files.sh
@@ -1,76 +1,74 @@
 #!/bin/bash
 
-# Validate surface argument
-surface="$1"
-
-echo "surface: $surface"
-
-if [ "$surface" = "admin" ] || [ "$surface" = "checkout" ]; then
-  echo "Scaffolding docs for ${surface}"
-else
-  echo "ERR: No surface argument provided. Please provide a surface argument (admin or checkout)."
-  exit 1
+# Check if at least one component name is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 [-t type] component_name1 [component_name2 ...]"
+    echo "  -t: Type of documentation (api or components, default: components)"
+    exit 1
 fi
 
-# Make this an input to the script
-components_dir="src/surfaces/${surface}/components"
-# components_dir="./packages/ui-extensions/src/surfaces/${surface}/components"
+# Parse arguments
+type="components"  # default value
+while getopts "t:" opt; do
+    case $opt in
+        t) type="$OPTARG"
+           if [[ "$type" != "components" && "$type" != "api" ]]; then
+               echo "Error: type must be either 'components' or 'api'"
+               exit 1
+           fi
+           ;;
+        \?) echo "Invalid option -$OPTARG"
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND-1))
 
-# components_dir="./packages/ui-extensions/src/surfaces/${surface}/api"
 
-addExamples() {
-    folder=$1
-    if [ -d "${folder}/examples" ]; then
-      example_folder_path="${folder}/examples"
-      examples=("$example_folder_path"/*)
+echo "Scaffolding ${type} docs for admin"
 
-      if [ ${#examples[@]} -eq 1 ] && [[ ${examples[0]} == *"basic"* ]]; then
-        echo ""
-        return
-      fi
+base_dir="./packages/ui-extensions/src/surfaces/admin/${type}"
 
-constructed_string="examples: {
-    description: '',
-    examples: [
-"
-      for example_file in "${examples[@]}"; do
-        example_name=$(basename "$example_file" ".example.tsx")
-        # Skip files starting with "basic-"
-        if [[ $example_name == basic-* ]]; then
-          continue
-        fi
-        constructed_string+="      {
-        description: 'TODO: add description',
-        image: '${example_name}.png',
-        codeblock: {
-          tabs: [
-            {
-              title: 'Preact',
-              code: '${example_file}',
-              language: 'typescript',
-            },
-          ],
-          title: 'TODO: add example title',
-        },
-      },"$'\n'
-        done
-        constructed_string+="    ],
-  },"
-      echo "$constructed_string"
+for componentName in "$@"; do
+    # Create component directory
+    folder="${base_dir}/${componentName}"
+    mkdir -p "$folder"
+
+    examples_dir="${folder}/examples"
+    mkdir -p "$examples_dir"
+    
+    docs_file="${folder}/${componentName}.doc.ts"
+    lowercaseComponentName=$(echo "$componentName" | sed -E 's/([a-z])([A-Z])/\1-\2/g' | tr '[:upper:]' '[:lower:]')
+
+     # Create TypeScript example file
+    ts_example="${examples_dir}/basic-${lowercaseComponentName}.example.ts"
+    if [ ! -f "$ts_example" ]; then
+        cat << EOF > "$ts_example"
+export default function extension() {
+  const ${componentName} = document.createElement('s-${lowercaseComponentName}');
+  // Add your s-${componentName} implementation here
+  document.body.appendChild(${componentName});
+};
+EOF
+        echo "Created TS example file for ${componentName}"
     fi
+
+    # Create TSX example file
+    tsx_example="${examples_dir}/basic-${lowercaseComponentName}.example.tsx"
+    if [ ! -f "$tsx_example" ]; then
+        cat << EOF > "$tsx_example"
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default function extension() {
+  render(<s-${lowercaseComponentName} />, document.body);
 }
+EOF
+        echo "Created TSX example file for ${componentName}"
+    fi
 
-for folder in "$components_dir"/*; do
-    if [ -d "$folder" ]; then
-        if [[ $folder == shared ]]; then
-          continue
-        fi
-        componentName=$(basename "$folder")
-        docs_file="${folder}/${componentName}.doc.ts"
-
-                if [ ! -f "$docs_file" ]; then
-          lowercaseComponentName=$(echo "$componentName" | tr '[:upper:]' '[:lower:]')
-          cat > "$docs_file" << EOF
+    if [ ! -f "$docs_file" ]; then
+        cat << EOF > "$docs_file"
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
@@ -78,7 +76,7 @@ const data: ReferenceEntityTemplateSchema = {
   description: '${componentName} is used to ...',
   requires: '',
   thumbnail: '${lowercaseComponentName}-thumbnail.png',
-  isVisualComponent: true,
+  isVisualComponent: $(if [ "$type" = "components" ]; then echo "true"; else echo "false"; fi),
   type: '',
   definitions: [
     {
@@ -87,13 +85,18 @@ const data: ReferenceEntityTemplateSchema = {
       type: '${componentName}',
     },
   ],
-  category: 'Components',
-  subCategory: 'Feedback',
+  category: '$(if [ "$type" = "components" ]; then echo "Components"; else echo "API"; fi)',
+  subCategory: '$(if [ "$type" = "components" ]; then echo "Feedback"; else echo ""; fi)',
   defaultExample: {
     image: '${lowercaseComponentName}-default.png',
     codeblock: {
       title: 'TODO: add example title',
       tabs: [
+        {
+          title: 'Preact',
+          code: './examples/basic-${lowercaseComponentName}.example.tsx',
+          language: 'jsx',
+        },
         {
           title: 'JS',
           code: './examples/basic-${lowercaseComponentName}.example.ts',
@@ -102,12 +105,13 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
-  $(addExamples "$folder")
   related: [],
 };
 
 export default data;
 EOF
-        fi
+        echo "Created documentation file for ${componentName}"
+    else
+        echo "Documentation file for ${componentName} already exists"
     fi
 done

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -3,7 +3,6 @@
   "version": "2025.7.0",
   "scripts": {
     "docs:admin": "bash ./docs/surfaces/admin/build-docs.sh",
-    "gen-docs:admin": "bash ./docs/surfaces/admin/create-doc-files.sh \"admin\"",
     "docs:checkout": "bash ./docs/surfaces/checkout/build-docs.sh",
     "docs:point-of-sale": "bash ./docs/surfaces/point-of-sale/build-docs.sh",
     "docs:customer-account": "bash ./docs/surfaces/customer-account/build-docs.sh"


### PR DESCRIPTION
### Background
This pull request includes several changes to the `ui-extensions` package, focusing on improving the documentation scaffolding process. The most important changes include updating the `scaffold-docs:admin` script in `package.json`, adding a detailed `ReadMe.md` for the `create-doc-files.sh` script, and enhancing the `create-doc-files.sh` script to support more flexible documentation generation.

### Documentation Improvements:

* [`packages/ui-extensions/docs/surfaces/admin/ReadMe.md`](diffhunk://#diff-88ade86aad935017ad4ee61549799f60f9ff48ff350057eb2a55cdad6293a8beR1-R62): Added a detailed `ReadMe.md` file explaining the usage, options, arguments, examples, and output of the `create-doc-files.sh` script.

### Script Enhancements:

* [`packages/ui-extensions/docs/surfaces/admin/create-doc-files.sh`](diffhunk://#diff-d102c4aaf0fa12672cfdeccd3a4534bcd140d3fa975bac153bf28c43fb78d648L3-R79): Enhanced the script to check for at least one component name, parse arguments for documentation type, and scaffold documentation files accordingly. The script now supports creating both component and API documentation.

### Configuration Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31-R31): Updated the `scaffold-docs:admin` script to remove the hardcoded "admin" argument, allowing for more flexible usage.

### Template Adjustments:

* [`packages/ui-extensions/docs/surfaces/admin/create-doc-files.sh`](diffhunk://#diff-d102c4aaf0fa12672cfdeccd3a4534bcd140d3fa975bac153bf28c43fb78d648L90-R99): Modified the `ReferenceEntityTemplateSchema` to dynamically set `category`, `subCategory`, and `isVisualComponent` based on the documentation type. [[1]](diffhunk://#diff-d102c4aaf0fa12672cfdeccd3a4534bcd140d3fa975bac153bf28c43fb78d648L90-R99) [[2]](diffhunk://#diff-d102c4aaf0fa12672cfdeccd3a4534bcd140d3fa975bac153bf28c43fb78d648L105-R115)


[Quick video on updates](https://share.descript.com/view/pnvDIgXPxA7)