### PR TITLE
export customer privacy types and hook

### DIFF
--- a/.changeset/slimy-chefs-promise.md
+++ b/.changeset/slimy-chefs-promise.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-react': patch
+'@shopify/ui-extensions': patch
+---
+
+export customer privacy types and hooks

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/customer-privacy.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/customer-privacy.ts
@@ -1,0 +1,25 @@
+import type {
+  CustomerPrivacy,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the current customer privacy settings and metadata and
+ * re-renders your component if the customer privacy settings change.
+ */
+export function useCustomerPrivacy<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): CustomerPrivacy {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('customerPrivacy' in api)) {
+    throw new ExtensionHasNoFieldError('customerPrivacy', extensionTarget);
+  }
+
+  return useSubscription(useApi<Target>().customerPrivacy);
+}

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/index.ts
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/index.ts
@@ -43,3 +43,4 @@ export {
 } from './authenticated-account';
 
 export {useAuthenticationState} from './authentication-state';
+export {useCustomerPrivacy} from './customer-privacy';

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/customer-privacy.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/customer-privacy.test.tsx
@@ -1,0 +1,38 @@
+import {useCustomerPrivacy} from '..';
+import type {CustomerPrivacy} from '@shopify/ui-extensions/customer-account';
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useCustomerPrivacy', () => {
+  it('returns customer privacy from api', () => {
+    const customerPrivacyValue: CustomerPrivacy = {
+      allowedProcessing: {
+        analytics: false,
+        marketing: false,
+        preferences: false,
+        saleOfData: false,
+      },
+      visitorConsent: {
+        analytics: undefined,
+        marketing: undefined,
+        preferences: undefined,
+        saleOfData: undefined,
+      },
+      shouldShowBanner: false,
+      saleOfDataRegion: false,
+      region: undefined,
+      metafields: [],
+    };
+
+    const {value} = mount.hook(() => useCustomerPrivacy(), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        customerPrivacy:
+          createMockStatefulRemoteSubscribable(customerPrivacyValue),
+      },
+    });
+
+    expect(value).toStrictEqual(customerPrivacyValue);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api.ts
@@ -66,6 +66,14 @@ export type {
   Company,
   Customer,
   SessionToken,
+  ApplyTrackingConsentChangeType,
+  CustomerPrivacy,
+  TrackingConsentChangeResult,
+  TrackingConsentChangeResultError,
+  TrackingConsentMetafield,
+  TrackingConsentMetafieldChange,
+  VisitorConsent,
+  VisitorConsentChange,
 } from './api/shared';
 
 export type {CartLineItemApi} from './api/cart-line/cart-line-item';


### PR DESCRIPTION
### Background

export customer privacy types and hook

Part 2 of https://github.com/Shopify/temp-project-mover-Archetypically-20250318092846/issues/4 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
