### PR TITLE
Update dismiss modal change to 9.31

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -71,7 +71,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 
 ## Important Fixes
 
-- **POS 9.30.0**:
+- **POS 9.31.0**:
 
   - Modal updated so neither swiping down nor tapping outside of modal will dismiss modal.
 


### PR DESCRIPTION
Related to https://github.com/Shopify/pos-next-react-native/pull/55454
Matching shopify-dev PR https://github.com/Shopify/shopify-dev/pull/54806

### Background

The modal change will not occur until 9.31
![image](https://github.com/user-attachments/assets/d4846d6b-cbe5-4db6-b4b9-9faf0b088af4)
