### PR TITLE
use the block api again for the discount settings api

### DIFF
--- a/.changeset/spotty-stingrays-learn.md
+++ b/.changeset/spotty-stingrays-learn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Make DiscountFunctionSettingsApi extend BlockExtensionApi

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.ts
@@ -1,4 +1,4 @@
-import type {StandardApi} from '../standard/standard';
+import type {BlockExtensionApi} from '../block/block';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
 import {ApplyMetafieldChange} from './metafields';
@@ -6,7 +6,7 @@ import {DiscountFunctionSettingsData} from './launch-options';
 
 export interface DiscountFunctionSettingsApi<
   ExtensionTarget extends AnyExtensionTarget,
-> extends StandardApi<ExtensionTarget> {
+> extends Omit<BlockExtensionApi<ExtensionTarget>, 'data'> {
   /**
    * Applies a change to the discount function settings.
    */


### PR DESCRIPTION
Fixes https://github.com/Shopify/core-issues/issues/86367

### Background

A previous PR [removed](https://github.com/Shopify/ui-extensions/pull/2534/files#diff-55908e8943f1758521361e707861ccb27d15eba6117eb064fc60c10aba1dc2c7L103) the `BlockExtensionApi` on the discount API. The effect was that on the typescript side, the `resourcePicker`, `picker` and `navigate` aren't available anymore. Although, this block extension point has access to the block api, but just reshaped the `data` it sends. 

### Solution

Extend `BlockExtensionApi` which extends `StandardApi`, but adds `resourcePicker`, `picker` and `navigate` to the client. They are already available, but it is not satisfying typescript. I `Omit<BlockExtensionApi, 'data'>` to use custom data like we already do. 

