### PR TITLE
Add docs for customer account privacy api

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/customer-privacy.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/customer-privacy.doc.ts
@@ -1,0 +1,74 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {
+  CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION,
+  REQUIRES_PROTECTED_CUSTOMER_DATA,
+} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Customer Privacy',
+  description:
+    "The API for interacting with a customer's privacy consent. It is similar to the [Customer Privacy API in storefront](/docs/api/customer-privacy).",
+  isVisualComponent: false,
+  requires: REQUIRES_PROTECTED_CUSTOMER_DATA,
+  category: 'APIs',
+  type: 'API',
+  definitions: [
+    {
+      title: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.title,
+      description: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.description,
+      type: 'Docs_Standard_CustomerPrivacyApi',
+    },
+    {
+      title: 'useCustomerPrivacy',
+      description:
+        'Returns the current customer privacy settings and metadata and re-renders your component if the customer privacy settings change.',
+      type: 'UseCustomerPrivacyGeneratedType',
+    },
+  ],
+  defaultExample: {
+    codeblock: {
+      title: 'Read Customer Privacy',
+      tabs: [
+        {
+          code: '../examples/apis/customer-privacy.example.tsx',
+          language: 'jsx',
+          title: 'React',
+        },
+        {
+          code: '../examples/apis/customer-privacy.example.ts',
+          language: 'js',
+          title: 'JavaScript',
+        },
+      ],
+    },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description: `
+        You can apply changes to customer consent by using the \`applyTrackingConsentChanges\` API.
+        
+> Note: Requires the [\`customer_privacy\` capability](/docs/api/customer-account-ui-extensions/configuration#collect-buyer-consent) to be set to \`true\`.`,
+        codeblock: {
+          title: 'Use a Sheet to manage customer privacy consent',
+          tabs: [
+            {
+              code: '../examples/apis/sheet-consent-banner-with-form.example.tsx',
+              language: 'jsx',
+              title: 'React',
+            },
+            {
+              code: '../examples/apis/sheet-consent-banner-with-form.example.ts',
+              language: 'js',
+              title: 'JavaScript',
+            },
+          ],
+        },
+      },
+    ],
+  },
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-privacy.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-privacy.example.ts
@@ -1,0 +1,45 @@
+import {extension} from '@shopify/ui-extensions/customer-account';
+
+// 1. Choose an extension target
+export default extension(
+  'customer-account.order-status.block.render',
+  (root, {customerPrivacy}) => {
+    const {
+      visitorConsent: {
+        analytics,
+        marketing,
+        preferences,
+        saleOfData,
+      },
+    } = customerPrivacy.current;
+
+    // 2. Use consent values
+    console.log('initialValues');
+    console.log('analytics', analytics);
+    console.log('marketing', marketing);
+    console.log('preferences', preferences);
+    console.log('saleOfData', saleOfData);
+
+    // 3. Update component state when customerPrivacy changes
+    customerPrivacy.subscribe((value) => {
+      if (!value) {
+        return;
+      }
+
+      const {
+        visitorConsent: {
+          analytics,
+          marketing,
+          preferences,
+          saleOfData,
+        },
+      } = value;
+
+      console.log('updatedValues');
+      console.log('analytics', analytics);
+      console.log('marketing', marketing);
+      console.log('preferences', preferences);
+      console.log('saleOfData', saleOfData);
+    });
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-privacy.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-privacy.example.tsx
@@ -1,0 +1,29 @@
+import {useState} from 'react';
+import {
+  reactExtension,
+  useCustomerPrivacy,
+} from '@shopify/ui-extensions-react/customer-account';
+
+// 1. Choose an extension target
+export default reactExtension(
+  'customer-account.order-status.block.render',
+  () => <Extension />,
+);
+
+function Extension() {
+  // 2. Subscribe to customer privacy consent values
+  const {
+    visitorConsent: {
+      analytics,
+      marketing,
+      preferences,
+      saleOfData,
+    },
+  } = useCustomerPrivacy();
+
+  // 3. Use consent values
+  console.log('analytics', analytics);
+  console.log('marketing', marketing);
+  console.log('preferences', preferences);
+  console.log('saleOfData', saleOfData);
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/sheet-consent-banner-with-form.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/sheet-consent-banner-with-form.example.ts
@@ -1,0 +1,298 @@
+import {
+  BlockStack,
+  Button,
+  Checkbox,
+  extension,
+  Form,
+  Grid,
+  Link,
+  Modal,
+  Sheet,
+  TextBlock,
+} from '@shopify/ui-extensions/customer-account';
+import type {VisitorConsent} from '@shopify/ui-extensions/customer-account';
+// 1. Choose an extension target
+export default extension(
+  'customer-account.footer.render-after',
+  (
+    root,
+    {
+      applyTrackingConsentChange,
+      customerPrivacy,
+      ui,
+    },
+  ) => {
+    const sheetId = 'sheet-consent';
+    const modalId = 'modal-consent';
+
+    let showBanner =
+      customerPrivacy.current.shouldShowBanner;
+
+    const formValues: VisitorConsent = {
+      analytics: undefined,
+      marketing: undefined,
+      preferences: undefined,
+      saleOfData: undefined,
+    };
+
+    // 2. Subscribe to customer privacy consent values and update component state when customerPrivacy changes
+    customerPrivacy.subscribe((value) => {
+      if (!value) {
+        return;
+      }
+
+      showBanner = value.shouldShowBanner;
+
+      const {
+        visitorConsent: {
+          analytics,
+          marketing,
+          preferences,
+          saleOfData,
+        },
+      } = value;
+
+      formValues.analytics =
+        value.visitorConsent.analytics;
+      formValues.marketing =
+        value.visitorConsent.marketing;
+      formValues.preferences =
+        value.visitorConsent.preferences;
+      formValues.saleOfData =
+        value.visitorConsent.saleOfData;
+
+      analyticsCheckbox.updateProps({
+        checked: analytics,
+      });
+      marketingCheckbox.updateProps({
+        checked: marketing,
+      });
+      preferencesCheckbox.updateProps({
+        checked: preferences,
+      });
+      saleOfDataCheckbox.updateProps({
+        checked: saleOfData,
+      });
+    });
+
+    // 3. Set up event handlers
+    const handleConsentChange = async (
+      visitorConsent?: VisitorConsent,
+    ) => {
+      const result =
+        await applyTrackingConsentChange({
+          ...(visitorConsent
+            ? visitorConsent
+            : formValues),
+          type: 'changeVisitorConsent',
+        });
+
+      // Check if operation was successful
+      if (result.type === 'success') {
+        ui.overlay.close(modalId);
+        ui.overlay.close(sheetId);
+      } else {
+        // Handle failure case here
+      }
+    };
+
+    // 4. Create consent preferences form
+    const analyticsCheckbox =
+      root.createComponent(
+        Checkbox,
+        {
+          checked: formValues.analytics,
+          onChange: (checked: boolean) => {
+            formValues.analytics = checked;
+          },
+        },
+        'Analytics',
+      );
+
+    const marketingCheckbox =
+      root.createComponent(
+        Checkbox,
+        {
+          checked: formValues.marketing,
+          onChange: (checked: boolean) => {
+            formValues.marketing = checked;
+          },
+        },
+        'Marketing',
+      );
+
+    const preferencesCheckbox =
+      root.createComponent(
+        Checkbox,
+        {
+          checked: formValues.preferences,
+          onChange: (checked: boolean) => {
+            formValues.preferences = checked;
+          },
+        },
+        'Preferences',
+      );
+
+    const saleOfDataCheckbox =
+      root.createComponent(
+        Checkbox,
+        {
+          checked: formValues.saleOfData,
+          onChange: (checked: boolean) => {
+            formValues.saleOfData = checked;
+          },
+        },
+        'Sale of data',
+      );
+
+    const consentFormSubmitButton =
+      root.createComponent(
+        Button,
+        {accessibilityRole: 'submit'},
+        'Save',
+      );
+
+    const consentForm = root.createComponent(
+      Form,
+      {
+        onSubmit: () => handleConsentChange(),
+      },
+    );
+
+    const consentFormBlockStack =
+      root.createComponent(BlockStack);
+
+    const consentFormGrid = root.createComponent(
+      Grid,
+      {
+        spacing: 'base',
+      },
+    );
+
+    consentFormGrid.appendChild(
+      analyticsCheckbox,
+    );
+    consentFormGrid.appendChild(
+      marketingCheckbox,
+    );
+    consentFormGrid.appendChild(
+      preferencesCheckbox,
+    );
+    consentFormGrid.appendChild(
+      saleOfDataCheckbox,
+    );
+    consentFormGrid.appendChild(
+      consentFormSubmitButton,
+    );
+
+    consentFormBlockStack.appendChild(
+      consentFormGrid,
+    );
+    consentFormBlockStack.appendChild(
+      consentFormSubmitButton,
+    );
+    consentForm.appendChild(
+      consentFormBlockStack,
+    );
+
+    // 5. Create modal to display consent form
+    const modalFragment = root.createFragment();
+
+    const modal = root.createComponent(
+      Modal,
+      {
+        id: modalId,
+        padding: true,
+      },
+      [consentForm],
+    );
+
+    modalFragment.appendChild(modal);
+
+    const declineButton = root.createComponent(
+      Button,
+      {
+        kind: 'secondary',
+        onPress: () =>
+          handleConsentChange({
+            analytics: false,
+            marketing: false,
+            preferences: false,
+            saleOfData: false,
+          }),
+      },
+      'I decline',
+    );
+
+    const acceptButton = root.createComponent(
+      Button,
+      {
+        kind: 'secondary',
+        onPress: () =>
+          handleConsentChange({
+            analytics: true,
+            marketing: true,
+            preferences: true,
+            saleOfData: true,
+          }),
+      },
+      'I agree',
+    );
+
+    const settingsButton = root.createComponent(
+      Button,
+      {
+        kind: 'plain',
+        overlay: modalFragment,
+      },
+      'Settings',
+    );
+
+    const primaryActionFragment =
+      root.createFragment();
+
+    primaryActionFragment.appendChild(
+      declineButton,
+    );
+    primaryActionFragment.appendChild(
+      acceptButton,
+    );
+
+    const secondaryActionFragment =
+      root.createFragment();
+
+    secondaryActionFragment.appendChild(
+      settingsButton,
+    );
+
+    // 6. Create sheet to display privacy consent banner
+    const sheet = root.createComponent(
+      Sheet,
+      {
+        id: sheetId,
+        defaultOpen: showBanner,
+        accessibilityLabel:
+          'A sheet that collects privacy consent preferences',
+        primaryAction: primaryActionFragment,
+        secondaryAction: secondaryActionFragment,
+      },
+      [
+        root.createComponent(
+          TextBlock,
+          undefined,
+          [
+            'This website uses cookies to ensure you get the best experience on our website test.',
+            ' ',
+            root.createComponent(
+              Link,
+              undefined,
+              'Privacy Policy',
+            ),
+          ],
+        ),
+      ],
+    );
+
+    root.appendChild(sheet);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/sheet-consent-banner-with-form.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/sheet-consent-banner-with-form.example.tsx
@@ -1,0 +1,191 @@
+import {useState} from 'react';
+import {
+  reactExtension,
+  BlockStack,
+  Button,
+  Checkbox,
+  Form,
+  Grid,
+  Link,
+  Modal,
+  Sheet,
+  TextBlock,
+  useApi,
+  useCustomerPrivacy,
+} from '@shopify/ui-extensions-react/customer-account';
+
+import type {VisitorConsent} from '@shopify/ui-extensions/customer-account';
+
+export default reactExtension(
+  'customer-account.footer.render-after',
+  () => <Extension />,
+);
+
+function Extension() {
+  const {applyTrackingConsentChange, ui} =
+    useApi();
+
+  const {
+    shouldShowBanner,
+    visitorConsent: {
+      analytics,
+      marketing,
+      preferences,
+      saleOfData,
+    },
+  } = useCustomerPrivacy();
+
+  const [
+    consentFormValues,
+    setConsentFormValues,
+  ] = useState({
+    analytics,
+    marketing,
+    preferences,
+    saleOfData,
+  });
+
+  const sheetId = 'sheet-consent';
+  const modalId = 'modal-consent';
+
+  const getCheckboxOnChangeHandler = (
+    key: string,
+  ) => {
+    return function (checked: boolean) {
+      setConsentFormValues({
+        ...consentFormValues,
+        [key]: checked,
+      });
+    };
+  };
+
+  const handleConsentChange = async (
+    visitorConsent?: VisitorConsent,
+  ) => {
+    try {
+      const result =
+        await applyTrackingConsentChange({
+          ...(visitorConsent
+            ? visitorConsent
+            : consentFormValues),
+          type: 'changeVisitorConsent',
+        });
+
+      // Check if operation was successful
+      if (result.type === 'success') {
+        ui.overlay.close(modalId);
+        ui.overlay.close(sheetId);
+      } else {
+        // Handle failure case here
+      }
+    } catch (error) {
+      // Handle error case here
+    }
+  };
+
+  const consentFormMarkup = (
+    <Form onSubmit={() => handleConsentChange()}>
+      <BlockStack>
+        <Grid spacing="base">
+          <Checkbox
+            id="marketing"
+            checked={consentFormValues.marketing}
+            onChange={getCheckboxOnChangeHandler(
+              'marketing',
+            )}
+          >
+            Marketing
+          </Checkbox>
+          <Checkbox
+            id="analytics"
+            checked={consentFormValues.analytics}
+            onChange={getCheckboxOnChangeHandler(
+              'analytics',
+            )}
+          >
+            Analytics
+          </Checkbox>
+          <Checkbox
+            id="preferences"
+            checked={
+              consentFormValues.preferences
+            }
+            onChange={getCheckboxOnChangeHandler(
+              'preferences',
+            )}
+          >
+            Preferences
+          </Checkbox>
+          <Checkbox
+            id="saleOfData"
+            checked={consentFormValues.saleOfData}
+            onChange={getCheckboxOnChangeHandler(
+              'saleOfData',
+            )}
+          >
+            Sale of data
+          </Checkbox>
+        </Grid>
+        <Button accessibilityRole="submit">
+          Save
+        </Button>
+      </BlockStack>
+    </Form>
+  );
+
+  return (
+    <Sheet
+      id={sheetId}
+      accessibilityLabel="A sheet that collects privacy consent preferences"
+      defaultOpen={shouldShowBanner}
+      primaryAction={
+        <>
+          <Button
+            kind="secondary"
+            onPress={() =>
+              handleConsentChange({
+                analytics: false,
+                marketing: false,
+                preferences: false,
+                saleOfData: false,
+              })
+            }
+          >
+            I decline
+          </Button>
+          <Button
+            kind="secondary"
+            onPress={() =>
+              handleConsentChange({
+                analytics: true,
+                marketing: true,
+                preferences: true,
+                saleOfData: true,
+              })
+            }
+          >
+            I agree
+          </Button>
+        </>
+      }
+      secondaryAction={
+        <Button
+          kind="plain"
+          overlay={
+            <Modal id={modalId} padding>
+              {consentFormMarkup}
+            </Modal>
+          }
+        >
+          Settings
+        </Button>
+      }
+    >
+      <TextBlock>
+        This website uses cookies to ensure you
+        get the best experience on our website.{' '}
+        <Link>Privacy Policy</Link>
+      </TextBlock>
+    </Sheet>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/configuration.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/configuration.doc.ts
@@ -117,6 +117,7 @@ Defines the [capabilities](/docs/api/customer-account-ui-extensions/apis/extensi
 |---|---|
 | [\`api_access\`](#api-access) | Allows your extension to query the Storefront API.
 | [\`network_access\`](#network-access) | Allows your extension make external network calls.
+| [\`collect_buyer_consent\`](#collect-buyer-consent) | Allows your extension to collect buyer consent for specific policies such as SMS marketing.
     `,
       codeblock: {
         title: 'Capabilities',
@@ -268,6 +269,30 @@ Your extension can pass a [session token](/docs/api/customer-account-ui-extensio
 `,
         },
       ],
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'collect-buyer-consent',
+      title: 'Collect buyer consent',
+      sectionContent:
+        'If your extension utilizes the [Customer Privacy API](/docs/api/customer-account-ui-extensions/apis/customer-privacy) to collecting buyer consent, you must first declare that capability in your configuration file.',
+      sectionSubContent: [
+        {
+          title: 'Customer Privacy',
+          sectionContent:
+            "In order to collect customer privacy consent, you'll need to add `customer_privacy = true` in your toml configuration. This will let you use our [Customer Privacy API](/docs/api/customer-account-ui-extensions/apis/customer-privacy).",
+        },
+      ],
+      codeblock: {
+        title: 'Collect buyer consent',
+        tabs: [
+          {
+            title: 'shopify.extension.toml',
+            code: './examples/configuration/collect-buyer-consent.example.toml',
+            language: 'toml',
+          },
+        ],
+      },
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/configuration/collect-buyer-consent.example.toml
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/configuration/collect-buyer-consent.example.toml
@@ -1,9 +1,5 @@
 # ...
 
-[extensions.capabilities]
-api_access = true
-network_access = true
-
 [extensions.capabilities.collect_buyer_consent]
 customer_privacy = true
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -73,6 +73,9 @@ export interface Docs_Standard_SettingsApi
 export interface Docs_Standard_StorageApi
   extends Pick<StandardApi<any>, 'storage'> {}
 
+export interface Docs_Standard_CustomerPrivacyApi
+  extends Pick<StandardApi<any>, 'customerPrivacy'> {}
+
 export interface Docs_Standard_UIApi extends Pick<StandardApi<any>, 'ui'> {}
 
 export interface Docs_Standard_QueryApi


### PR DESCRIPTION
### Background

Add docs for customer account privacy api. 

### 🎩

https://shopify-dev.doc.brian-shen.us.spin.dev/docs/api/customer-account-ui-extensions/unstable/apis/customer-privacy

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
