### PR TITLE
[Customer][EXT] add company location to customer account Standard API

### DIFF
--- a/.changeset/gorgeous-lizards-ring.md
+++ b/.changeset/gorgeous-lizards-ring.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add purchasingCompany.location to customer account Standard API.

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/authenticated-account.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/authenticated-account.test.tsx
@@ -9,20 +9,17 @@ import {mount, createMockStatefulRemoteSubscribable} from './mount';
 
 function createMockCustomer() {
   return {
-    id: `gid://shopify/Customer/${faker.datatype.number({
-      min: 1,
-      precision: 1,
-    })}`,
+    id: `gid://shopify/Customer/${faker.number.int({min: 1})}`,
   };
 }
 
 function createMockPurchasingCompany() {
   return {
     company: {
-      id: `gid://shopify/Company/${faker.datatype.number({
-        min: 1,
-        precision: 1,
-      })}`,
+      id: `gid://shopify/Company/${faker.number.int({min: 1})}`,
+    },
+    location: {
+      id: `gid://shopify/CompanyLocation/${faker.number.int({min: 1})}`,
     },
   };
 }
@@ -60,7 +57,9 @@ describe('account Hooks', () => {
       );
       expect(purchasingCompany).toBeDefined();
       expect(purchasingCompany.company.id).toBeDefined();
+      expect(purchasingCompany.location.id).toBeDefined();
       expect(value.company.id).toBe(purchasingCompany.company.id);
+      expect(value.location.id).toBe(purchasingCompany.location.id);
     });
   });
 });

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -369,11 +369,23 @@ export interface PurchasingCompany {
    * Include information of the company of the logged in business customer.
    */
   company: Company;
+
+  /**
+   * Include information of the company location of the logged in business customer.
+   */
+  location?: CompanyLocation;
 }
 
 export interface Company {
   /**
    * Company ID.
+   */
+  id: string;
+}
+
+export interface CompanyLocation {
+  /**
+   * Company location ID.
    */
   id: string;
 }


### PR DESCRIPTION
### Background

part of https://github.com/shop/issues-customer-accounts-and-login/issues/587

> As a 3P developer, I can access the current company location of a customer, so I can implement location-specific logic in my extension blocks.


### Solution

Data will be provided by PR here https://github.com/shop/world/pull/28145

We will add company location to `api.authenticatedAccount.purchasingCompany` in unstable.

### 🎩

[see this PR](https://github.com/shop/world/pull/28145)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
