### PR TITLE
Fio/brute force remove required

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-ab-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-ab-docs.sh
@@ -178,6 +178,9 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
+echo "Adding isOptional: true to members that don't have it..."
+node ./remove-required.js "$GENERATED_DOCS_JSON"
+
 if [ -d $SHOPIFY_DEV_PATH ]; then
   mkdir -p $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/app_bridge
 

--- a/packages/ui-extensions/docs/surfaces/admin/build-ab-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-ab-docs.sh
@@ -179,7 +179,7 @@ if [ $sed_exit -ne 0 ]; then
 fi
 
 echo "Adding isOptional: true to members that don't have it..."
-node ./remove-required.js "$GENERATED_DOCS_JSON"
+node "$(dirname "$0")/remove-required.js" "$GENERATED_DOCS_JSON"
 
 if [ -d $SHOPIFY_DEV_PATH ]; then
   mkdir -p $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/app_bridge

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
@@ -167,6 +167,10 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
+GENERATED_DOCS_JSON="./$DOCS_PATH/generated/generated_docs_data.json"
+echo "Adding isOptional: true to members that don't have it..."
+node "$(dirname "$0")/remove-required.js" "$GENERATED_DOCS_JSON"
+
 if [ -d $SHOPIFY_DEV_PATH ]; then
   mkdir -p $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/admin_extensions/$API_VERSION
   cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/admin_extensions/$API_VERSION

--- a/packages/ui-extensions/docs/surfaces/admin/remove-required.js
+++ b/packages/ui-extensions/docs/surfaces/admin/remove-required.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-undef, no-console */
+const fs = require('fs');
+
+const generatedDocsPath = process.argv[1];
+const data = JSON.parse(fs.readFileSync(generatedDocsPath, 'utf8'));
+
+let modified = false;
+
+data.forEach((entry) => {
+  if (entry.definitions) {
+    entry.definitions.forEach((definition) => {
+      if (definition.typeDefinitions) {
+        Object.values(definition.typeDefinitions).forEach((typeDef) => {
+          if (typeDef.members && Array.isArray(typeDef.members)) {
+            typeDef.members.forEach((member) => {
+              // eslint-disable-next-line no-prototype-builtins
+              if (member.hasOwnProperty('isOptional')) return;
+              member.isOptional = true;
+              modified = true;
+            });
+          }
+        });
+      }
+    });
+  }
+});
+
+if (modified) {
+  fs.writeFileSync(generatedDocsPath, JSON.stringify(data, null, 2));
+  console.log(
+    "Successfully added isOptional: true to members that didn't have it.",
+  );
+} else {
+  console.log(
+    'No changes needed. All members already have isOptional property.',
+  );
+}
+
+/* eslint-enable no-undef, no-console */

--- a/packages/ui-extensions/docs/surfaces/admin/remove-required.js
+++ b/packages/ui-extensions/docs/surfaces/admin/remove-required.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef, no-console */
 const fs = require('fs');
 
-const generatedDocsPath = process.argv[1];
+const generatedDocsPath = process.argv[2];
 const data = JSON.parse(fs.readFileSync(generatedDocsPath, 'utf8'));
 
 let modified = false;


### PR DESCRIPTION
This pull request includes changes to the `packages/ui-extensions/docs/surfaces/admin` directory to add an `isOptional` property to members in the generated documentation that do not already have it. The changes involve updating the build scripts and adding a new script to handle this modification.

Key changes include:

### Build Script Updates:
* [`packages/ui-extensions/docs/surfaces/admin/build-ab-docs.sh`](diffhunk://#diff-a4042519e57f2e9e8c7c8858aed3e84f63415dcc544c122a3224154c55c945e4R181-R183): Added a command to run the new `remove-required.js` script to add `isOptional: true` to members that don't have it.
* [`packages/ui-extensions/docs/surfaces/admin/build-docs.sh`](diffhunk://#diff-1695c603d38e9e8e1b2799055288f03cdb983b75010831f98f8616e52adb951cR162-R164): Similar to the previous script, added a command to run the `remove-required.js` script.

### New Script Addition:
* [`packages/ui-extensions/docs/surfaces/admin/remove-required.js`](diffhunk://#diff-f4c4d20b4b7d274a5e0a6aab8cb2e51c9d909cbcd4964431b214ec7482791a35R1-R39): Created a new script that reads the generated documentation JSON, checks for members without the `isOptional` property, and adds it if missing. The script logs the outcome and writes the modified data back to the file.