### PR TITLE
Fix image props

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.ts
@@ -42,7 +42,7 @@ enum ProductStatus {
   Draft = 'DRAFT',
 }
 
-interface Image {
+interface ResourceImage {
   id: string;
   altText?: string;
   originalSrc: string;
@@ -74,7 +74,7 @@ interface Collection extends Resource {
   descriptionHtml: string;
   handle: string;
   id: string;
-  image?: Image | null;
+  image?: ResourceImage | null;
   productsAutomaticallySortedCount: number;
   productsCount: number;
   productsManuallySortedCount: number;
@@ -104,7 +104,7 @@ interface ProductVariant extends Resource {
     serviceName: string;
     type: FulfillmentServiceType;
   };
-  image?: Image | null;
+  image?: ResourceImage | null;
   inventoryItem: {id: string};
   inventoryManagement: ProductVariantInventoryManagement;
   inventoryPolicy: ProductVariantInventoryPolicy;
@@ -128,7 +128,7 @@ interface Product extends Resource {
   descriptionHtml: string;
   handle: string;
   hasOnlyDefaultVariant: boolean;
-  images: Image[];
+  images: ResourceImage[];
   options: {
     id: string;
     name: string;


### PR DESCRIPTION
Closes https://github.com/Shopify/admin-ui-foundations/issues/2430

The Admin types are built across API and Components. If there are overlapping types it chooses one and not the other. This is a temporary fix to ensure the docs are right.

We should throw an error and say there are duplicate types on build or hash the types so they can have the same names (will likely suck for docs though).