### PR TITLE
Add `Discount.currency` optional property

### DIFF
--- a/.changeset/cool-insects-dream.md
+++ b/.changeset/cool-insects-dream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add currency property to Discount interface.

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -39,6 +39,20 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
     },
     {
       type: 'Generic',
+      anchorLink: '202507',
+      title: '2025.07',
+      sectionContent: `
+- Added in POS version: 10.6
+- Removed in POS version: N/A
+- Release day: N/A
+
+### Features
+
+- Added optional \`currency\` property to \`Discount\` interface.
+  `,
+    },
+    {
+      type: 'Generic',
       anchorLink: '202504',
       title: '2025.04',
       sectionContent: `
@@ -55,7 +69,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
   - Added support for the ${TargetLink.PosReceiptFooterBlockRender} target.
   - Introduced a [POSReceiptBlock component](/docs/api/pos-ui-extensions/components/posreceiptblock). It's the required parent component for ${TargetLink.PosReceiptFooterBlockRender} targets.
   - Introduced a [QRCode component](/docs/api/pos-ui-extensions/components/qrcode). It can be used to render a QR code in POS receipts but must be within a [POSReceiptBlock component](/docs/api/pos-ui-extensions/components/posreceiptblock).
-      `,
+  `,
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -45,6 +45,7 @@ export interface LineItem {
 
 export interface Discount {
   amount: number;
+  currency?: string;
   discountDescription?: string;
   type?: string;
 }


### PR DESCRIPTION
### Background

We should support multi-currencies. On POS, discounts can be multi-currency. Updating for `Discount` interface used by event targets.

### Solution

- Add optional `currency` type to existing `Discount` interface.
- Add to version notes under `2025-07`.
- Did not use existing [Money](https://github.com/Shopify/ui-extensions/blob/unstable/packages/ui-extensions/src/surfaces/point-of-sale/types/money.ts) or made required because it will break typing for existing users of `Discount`. Should it be a breaking change though?

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
