### PR TITLE
Move from experimental to polaris

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -134,7 +134,7 @@ const transformJson = async (filePath, isExtensions) => {
     );
 
     const filteredDocs = shopifyDevDocsDocsParsed.filter(
-      (entry) => entry.category !== 'Experimental Components',
+      (entry) => entry.category !== 'Polaris web components',
     );
 
     // Combine arrays with shopify dev docs first, followed by new data

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.ab.doc.ts
@@ -5,7 +5,7 @@ import shared from './shared';
 // @ts-ignore
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/Box.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/Box.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/Image.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/Image.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/Link.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/Link.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.ab.doc.ts
@@ -4,7 +4,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
@@ -15,7 +15,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Page',
     },
   ],
-  category: 'Experimental Components',
+  category: 'Polaris web components',
   subCategory: 'Structure',
   related: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/Section.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/Section.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/Table.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/Table.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/Text.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/Text.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.ab.doc.ts
@@ -4,7 +4,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;


### PR DESCRIPTION
This pull request focuses on updating the categorization of various components in the admin surface of the `ui-extensions` package. The main changes involve reclassifying components from the 'Experimental Components' category to the 'Polaris web components' category. Additionally, it includes a minor update to the documentation build process to filter out the 'Polaris web components' category.

### Component Categorization Updates:
* Updated the category of multiple components from 'Experimental Components' to 'Polaris web components' in their respective documentation files. This change affects components such as `Badge`, `Banner`, `Box`, `Button`, `Checkbox`, `ChoiceList`, `Clickable`, `Divider`, `EmailField`, `Grid`, `Heading`, `Icon`, `Image`, `Link`, `MoneyField`, `NumberField`, `OrderedList`, `Page`, and `Paragraph`. [[1]](diffhunk://#diff-ff8c91b44175478fd23008a9ba8c4cbb309eca38d9ff9017bb9495b384d2b1e2L6-R6) [[2]](diffhunk://#diff-6dcaa05e6d271489194e2087ab2c2dc11b1df0336bd9d61ea89606c659e08373L8-R8) [[3]](diffhunk://#diff-9220b4d716475b8172b30e591db7e81a59fc7a0d1d3c299d67639efa2fbaee16L7-R7) [[4]](diffhunk://#diff-e6e86056d667eb268589db5b72cc5861b7d898a22c7dc8307c4443c8909b0f50L18-R18)

### Documentation Build Process Update:
* Modified the `transformJson` function in `build-docs.mjs` to filter out entries with the category 'Polaris web components' in addition to 'Experimental Components'.