### PR TITLE
docs/sort component type members descending

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -82,11 +82,13 @@ const transformJson = async (filePath, isExtensions) => {
         if (definition.typeDefinitions) {
           Object.values(definition.typeDefinitions).forEach((typeDef) => {
             if (typeDef.members && Array.isArray(typeDef.members)) {
-              typeDef.members.forEach((member) => {
-                // eslint-disable-next-line no-prototype-builtins
-                if (member.hasOwnProperty('isOptional')) return;
-                member.isOptional = true;
-              });
+              typeDef.members
+                .sort((first, second) => first.name.localeCompare(second.name))
+                .forEach((member) => {
+                  // eslint-disable-next-line no-prototype-builtins
+                  if (member.hasOwnProperty('isOptional')) return;
+                  member.isOptional = true;
+                });
             }
           });
         }


### PR DESCRIPTION
Sort doc-gen type definition members in alphabetical descending order when running 
`yarn docs:admin` 

Before:
![Screenshot 2025-04-10 at 1 54 25 pm](https://github.com/user-attachments/assets/2b4e9ecf-bd94-4d9a-8b66-0f53ed1b8fae)

After:
![Screenshot 2025-04-10 at 1 53 50 pm](https://github.com/user-attachments/assets/8c74665b-9f22-4ff5-b123-662a5dda1eb0)
