### PR TITLE
Add Cart Line Item extensions

### DIFF
--- a/.changeset/red-sloths-tap.md
+++ b/.changeset/red-sloths-tap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Introduce Manage Cart Line Item extension targets

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
@@ -1,0 +1,55 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateCodeBlockForCartLineItemApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'cart-line-item-api', fileName);
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Cart Line Item API',
+  description: `
+The Cart Line Item API provides an extension with data about the current Cart Line Item.
+
+#### Supporting targets
+- ${TargetLink.PosCartLineItemDetailsActionMenuItemRender}
+- ${TargetLink.PosCartLineItemDetailsActionRender}
+- ${TargetLink.PosCartLineItemDetailsBlockRender}
+`,
+  isVisualComponent: false,
+  type: 'APIs',
+  definitions: [
+    {
+      title: 'CartLineItemApi',
+      description: '',
+      type: 'CartLineItemApi',
+    },
+  ],
+  examples: {
+    description: 'Examples of using the Cart Line Item API.',
+    examples: [
+      {
+        codeblock: generateCodeBlockForCartLineItemApi(
+          'Retrieve the ID of the cart line item.',
+          'id',
+        ),
+      },
+    ],
+  },
+  category: 'APIs',
+  related: [
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsActionMenuItemRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-action-menu-item-render',
+    },
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsActionRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-action-render',
+    },
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsBlockRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-block-render',
+    },
+  ],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-line-item-api/id.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-line-item-api/id.ts
@@ -1,0 +1,26 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.cart.line-item-details.action.render',
+  (root, api) => {
+    const navigator = root.createComponent(Navigator);
+    const screen = root.createComponent(Screen, {
+      name: 'CartLineItemApi',
+      title: 'Cart Line Item Api',
+    });
+    const scrollView = root.createComponent(ScrollView);
+    const text = root.createComponent(Text);
+
+    text.append(`Cart Line Item ID: ${api.cartLineItem.id}`);
+    scrollView.append(text);
+    screen.append(scrollView);
+    navigator.append(screen);
+    root.append(navigator);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-line-item-api/id.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-line-item-api/id.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import {
+  Text,
+  Screen,
+  ScrollView,
+  Navigator,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.cart.line-item-details.action.render'>();
+  return (
+    <Navigator>
+      <Screen name="CartLineItemApi" title="Cart Line Item Api">
+        <ScrollView>
+          <Text>{`Cart Line Item ID: ${api.cartLineItem.id}`}</Text>
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension(
+  'pos.cart.line-item-details.action.render',
+  () => <Modal />,
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-action-menu-item-render.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-action-menu-item-render.ts
@@ -1,0 +1,14 @@
+import {Button, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.cart.line-item-details.action.menu-item.render',
+  (root, api) => {
+    const button = root.createComponent(Button, {
+      onPress: () => {
+        api.action.presentModal();
+      },
+    });
+
+    root.append(button);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-action-menu-item-render.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-action-menu-item-render.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {
+  reactExtension,
+  Button,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const ButtonComponent = () => {
+  const api = useApi<'pos.cart.line-item-details.action.menu-item.render'>();
+
+  return <Button onPress={() => api.action.presentModal()} />;
+};
+
+export default reactExtension(
+  'pos.cart.line-item-details.action.menu-item.render',
+  () => <ButtonComponent />,
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-action-render.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-action-render.ts
@@ -1,0 +1,26 @@
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.cart.line-item-details.action.render',
+  (root, api) => {
+    const navigator = root.createComponent(Navigator);
+    const screen = root.createComponent(Screen, {
+      name: 'CartLineItem',
+      title: 'Cart Line Item',
+    });
+    const scrollView = root.createComponent(ScrollView);
+    const text = root.createComponent(Text);
+
+    text.append(`Title for this line item: ${api.cartLineItem.title}`);
+    scrollView.append(text);
+    screen.append(scrollView);
+    navigator.append(screen);
+    root.append(navigator);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-action-render.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-action-render.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import {
+  Text,
+  Screen,
+  ScrollView,
+  Navigator,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.cart.line-item-details.action.render'>();
+  return (
+    <Navigator>
+      <Screen name="CartLineItem" title="Cart Line Item">
+        <ScrollView>
+          <Text>{`Title for this line item: ${api.cartLineItem.title}`}</Text>
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension(
+  'pos.cart.line-item-details.action.render',
+  () => <Modal />,
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-block-render.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-block-render.ts
@@ -1,0 +1,31 @@
+import {
+  POSBlock,
+  Text,
+  POSBlockRow,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.cart.line-item-details.block.render',
+  (root, api) => {
+    const block = root.createComponent(POSBlock, {
+      action: {title: 'Open action', onPress: api.action.presentModal},
+    });
+
+    const mainText = root.createComponent(Text);
+    mainText.append('This is a block extension');
+
+    const subtitleText = root.createComponent(Text);
+    subtitleText.append(`Title for this line item: ${api.cartLineItem.title}`);
+
+    const blockMainRow = root.createComponent(POSBlockRow);
+    blockMainRow.append(mainText);
+
+    const blockSubtitleRow = root.createComponent(POSBlockRow);
+    blockSubtitleRow.append(subtitleText);
+    block.append(blockMainRow);
+    block.append(blockSubtitleRow);
+
+    root.append(block);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-block-render.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-cart-line-item-details-block-render.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import {
+  Text,
+  useApi,
+  reactExtension,
+  POSBlock,
+  POSBlockRow,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Block = () => {
+  const api = useApi<'pos.cart.line-item-details.block.render'>();
+  return (
+    <POSBlock action={{title: 'Open action', onPress: api.action.presentModal}}>
+      <POSBlockRow>
+        <Text>{'This is a block extension'}</Text>
+        <Text>{`Title for this line item: ${api.cartLineItem.title}`}</Text>
+      </POSBlockRow>
+    </POSBlock>
+  );
+};
+
+export default reactExtension('pos.cart.line-item-details.block.render', () => (
+  <Block />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-menu-item-render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-menu-item-render.doc.ts
@@ -1,0 +1,32 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: ExtensionTargetType.PosCartLineItemDetailsActionMenuItemRender,
+  description:
+    'A static extension target that renders as a menu item on the cart line item details screen',
+  defaultExample: {
+    codeblock: generateCodeBlock(
+      'Cart Line Item details action menu item',
+      'targets',
+      'pos-cart-line-item-details-action-menu-item-render',
+    ),
+  },
+  category: 'Targets',
+  subCategory: 'Cart line item details',
+  isVisualComponent: false,
+  related: [
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsActionRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-action-render',
+    },
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsBlockRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-block-render',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-render.doc.ts
@@ -1,0 +1,32 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: ExtensionTargetType.PosCartLineItemDetailsActionRender,
+  description:
+    'A full-screen extension target that renders when a `pos.cart.line-item-details.action.render` target calls for it',
+  defaultExample: {
+    codeblock: generateCodeBlock(
+      'Cart Line Item details action',
+      'targets',
+      'pos-cart-line-item-details-action-render',
+    ),
+  },
+  category: 'Targets',
+  subCategory: 'Cart line item details',
+  isVisualComponent: false,
+  related: [
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsActionMenuItemRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-action-menu-item-render',
+    },
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsBlockRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-block-render',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-block-render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-block-render.doc.ts
@@ -1,0 +1,32 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: ExtensionTargetType.PosCartLineItemDetailsBlockRender,
+  description:
+    'Renders a custom section within cart manage line item details screen',
+  defaultExample: {
+    codeblock: generateCodeBlock(
+      'Block',
+      'targets',
+      'pos-cart-line-item-details-block-render',
+    ),
+  },
+  category: 'Targets',
+  subCategory: 'Cart line item details',
+  isVisualComponent: false,
+  related: [
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsActionMenuItemRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-action-menu-item-render',
+    },
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsActionRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-action-render',
+    },
+  ],
+  type: 'Target',
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
@@ -21,6 +21,9 @@ export enum ExtensionTargetType {
   PosCashTrackingSessionCompleteObserve = 'pos.cash-tracking-session-complete.event.observe',
   PosCartUpdateObserve = 'pos.cart-update.event.observe',
   PosReceiptFooterBlockRender = 'pos.receipt-footer.block.render',
+  PosCartLineItemDetailsActionMenuItemRender = 'pos.cart.line-item-details.action.menu-item.render',
+  PosCartLineItemDetailsActionRender = 'pos.cart.line-item-details.action.render',
+  PosCartLineItemDetailsBlockRender = 'pos.cart.line-item-details.block.render',
 }
 
 export enum TargetLink {
@@ -46,4 +49,7 @@ export enum TargetLink {
   PosCashTrackingSessionCompleteObserve = '[pos.cash-tracking-session-complete.event.observe](/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-complete-event-observe)',
   PosCartUpdateObserve = '[pos.cart-update.event.observe](/docs/api/pos-ui-extensions/targets/cart-details/pos-cart-update-event-observe)',
   PosReceiptFooterBlockRender = '[pos.receipt-footer.block.render](/docs/api/pos-ui-extensions/targets/receipts/pos-receipt-footer-block-render)',
+  PosCartLineItemDetailsActionMenuItemRender = '[pos.cart.line-item-details.action.menu-item.render](/docs/api/pos-ui-extensions/targets/cart-details/pos-cart-line-item-details-action-menu-item-render)',
+  PosCartLineItemDetailsActionRender = '[pos.cart.line-item-details.action.render](/docs/api/pos-ui-extensions/targets/cart-details/pos-cart-line-item-details-action-render)',
+  PosCartLineItemDetailsBlockRender = '[pos.cart.line-item-details.block.render](/docs/api/pos-ui-extensions/targets/cart-details/pos-cart-line-item-details-block-render)',
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -5,6 +5,8 @@ export type {
   LineItemDiscountType,
 } from './render/api/cart-api/cart-api';
 
+export type {CartLineItemApi} from './render/api/cart-line-item-api/cart-line-item-api';
+
 export type {
   ActionApi,
   ActionApiContent,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cart-line-item-api/cart-line-item-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cart-line-item-api/cart-line-item-api.ts
@@ -1,0 +1,11 @@
+import type {LineItem} from '../../../types/cart';
+
+/**
+ * Access to the selected line item in the merchant’s current cart.
+ */
+export interface CartLineItemApi {
+  /**
+   * The selected line item in the merchant’s current cart.
+   */
+  cartLineItem: LineItem;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -3,6 +3,7 @@ import type {
   ActionApi,
   ActionTargetApi,
   CartApi,
+  CartLineItemApi,
   CustomerApi,
   DraftOrderApi,
   ProductApi,
@@ -134,6 +135,27 @@ export interface ExtensionTargets {
       CartApi &
       CustomerApi &
       ActionApi,
+    BlockComponents
+  >;
+  'pos.cart.line-item-details.action.menu-item.render': RenderExtension<
+    StandardApi<'pos.cart.line-item-details.action.menu-item.render'> &
+      ActionApi &
+      CartApi &
+      CartLineItemApi,
+    ActionComponents
+  >;
+  'pos.cart.line-item-details.action.render': RenderExtension<
+    ActionTargetApi<'pos.cart.line-item-details.action.render'> &
+      ActionApi &
+      CartApi &
+      CartLineItemApi,
+    BasicComponents
+  >;
+  'pos.cart.line-item-details.block.render': RenderExtension<
+    StandardApi<'pos.cart.line-item-details.block.render'> &
+      ActionApi &
+      CartApi &
+      CartLineItemApi,
     BlockComponents
   >;
   'pos.receipt-footer.block.render': RenderExtension<


### PR DESCRIPTION
### Background

This PR introduces new extension targets for the Cart Manage Line Item screen. You can access this screen by adding an item to the cart and selecting that line item.

![Simulator Screenshot - iPad (10th generation) - 2025-04-24 at 10 40 46](https://github.com/user-attachments/assets/a9c1a91e-1a2f-4dda-a02f-24cc4b939eb9)

These targets enable developers to provide additional context and actions directly within this screen.

### shopify-dev
The accompanying [shopify-dev PR](https://github.com/Shopify/shopify-dev/pull/56600).

### Solution

Extensions using these new targets can access the associated `LineItem` directly through the `CartLineItemApi`:

```
const api = useApi<'pos.cart.line-item-details.block.render'>();
const uuid = api.cartLineItem.uuid;
```

The LineItem available in the `CartLineItemApi` class is available in [cart.ts](https://github.com/Shopify/ui-extensions/blob/unstable/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts#L29).

### 🎩

To test these changes, use an extension specifically targeting the new extension points. Internally, we provide an [example extension](https://github.com/Shopify/manage-line-item-extension) for this purpose.

Example usage:

```
import React from 'react';
import {
  Text,
  reactExtension,
  POSBlock,
  useApi,
  POSBlockRow,
} from '@shopify/ui-extensions-react/point-of-sale';

const ManageLineItemBlock = () => {
  const api = useApi<'pos.cart.line-item-details.block.render'>();

  return (
    <POSBlock>
      <POSBlockRow>
        <Text>Line item UUID: {api.cartLineItem.uuid}</Text>
      </POSBlockRow>
    </POSBlock>
  );
};

export default reactExtension(
  'pos.cart.line-item-details.block.render',
  () => <ManageLineItemBlock />,
);
```

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
