### PR TITLE
Remove `[component]` badge from titles

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -240,17 +240,24 @@ const generateAppBridgeDocs = async () => {
   );
 };
 
-if (existsSync(generatedDocsPath)) {
-  await fs.rm(generatedDocsPath, {recursive: true});
-}
-await fs.copyFile(componentDefs, tempComponentDefs);
-await replaceFileContent(
-  tempComponentDefs,
-  /typeof globalThis\.HTMLElement/g,
-  'any',
-);
-await generateExtensionsDocs();
-await generateAppBridgeDocs();
-await copyGeneratedToShopifyDev();
+try {
+  if (existsSync(generatedDocsPath)) {
+    await fs.rm(generatedDocsPath, {recursive: true});
+  }
+  await fs.copyFile(componentDefs, tempComponentDefs);
+  await replaceFileContent(
+    tempComponentDefs,
+    /typeof globalThis\.HTMLElement/g,
+    'any',
+  );
+  await generateExtensionsDocs();
+  await generateAppBridgeDocs();
+  await copyGeneratedToShopifyDev();
 
-await fs.rm(tempComponentDefs);
+  await fs.rm(tempComponentDefs);
+} catch (error) {
+  console.error(error);
+  console.log(error.stdout.toString());
+  console.log(error.stderr.toString());
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/admin/create-doc-files.js
+++ b/packages/ui-extensions/docs/surfaces/admin/create-doc-files.js
@@ -55,10 +55,8 @@ componentNames.forEach((componentName) => {
   const sharedContent = `const shared = {
   name: '${componentName}',
   description: '${componentName} is used to ...',
-  requires: '',
   thumbnail: '${lowercaseComponentName}-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: '${componentName}',

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Badge',
   description:
     "Use `s-badge` to inform merchants of the status of an object or of an action that's been taken.",
-  requires: '',
   thumbnail: 'badge-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Banner',
   description:
     'Use `s-banner` to communicate important status updates or indicate that there are important actions that users must take. \n\n You can use banners both as a standalone component on a page or inside of a `s-section`. Banners will automatically update their deisgn to match the context in which they are used.',
-  requires: '',
   thumbnail: 'banner-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Box',
   description:
     'Use `s-box` as your foundational structural element for composing UI. It can be styled using predefined tokens. Use it to build your layout. \n\n Box is useful for wrapping and isolating content with specific styling, such as background color, border or padding. It can also help nest other components. In general, avoid using Box as a layout element. Instead, rely on [`s-stack`](/docs/api/app-home/polaris-web-components/structure/stack) and [`s-grid`](/docs/api/app-home/polaris-web-components/structure/grid) for layout.',
-  requires: '',
   thumbnail: 'box-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Button',
   description:
     'Use `s-button` when you want to provide users the ability to perform specific actions, like saving data.',
-  requires: '',
   thumbnail: 'button-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Checkbox',
   description:
     'Use `s-checkbox` when you want to provide users with a clear selection option, such as for agreeing to terms and conditions or selecting multiple options from a list.',
-  requires: '',
   thumbnail: 'checkbox-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'ChoiceList',
   description:
     'Use `s-choice-list` to present multiple options to merchants. Choice lists can present options with either radio buttons for single selection or checkboxes for multiple selection.',
-  requires: '',
   thumbnail: 'choicelist-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Clickable',
   description:
     'Use `s-clickable` to make elements interactive. This component provides consistent keyboard navigation and accessibility features for clickable elements.',
-  requires: '',
   thumbnail: 'clickable-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Divider',
   description:
     'Use `s-divider` to create a clear visual separation between different elements in your user interface. Use dividers to separate related, but distinct information within sections.',
-  requires: '',
   thumbnail: 'divider-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'EmailField',
   description:
     'Use `s-email-field` to allow merchants to input email addresses. This component provides built-in email validation and appropriate keyboard settings.',
-  requires: '',
   thumbnail: 'emailfield-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Grid',
   description:
     'Use `s-grid` to create responsive layouts with consistent spacing. Grid follows the same pattern as the [CSS grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout). Grid helps organize content into columns and rows with proper alignment and spacing. \n\n Grid does not include any padding by default. If you need padding around your grid, use `base` to apply the default padding. Grid will allow children to overflow unless template rows/columns are properly set.',
-  requires: '',
   thumbnail: 'grid-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Heading',
   description:
     'Use `s-heading` to display a title, similar to the h1-h6 tags in HTML. `s-heading` will automatically update its design based on how deeply it is nested within `s-section` components.',
-  requires: '',
   thumbnail: 'heading-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Icon',
   description:
     'Use `s-icon` to render an icon from a predefined list. Choose the one that suits your needs.',
-  requires: '',
   thumbnail: 'icon-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Image',
   description:
     'Use `s-image` when you want to display an image. \n\n When using images or illustrations in your app, ensure that they add clarity and clearly direct merchants to the next step. Make sure to use high-resolution images to ensure a professional, high-quality experience.',
-  requires: '',
   thumbnail: 'image-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Link',
   description:
     '`s-link` is an interactive component that directs users to a specified URL. It even supports custom protocols.',
-  requires: '',
   thumbnail: 'link-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'MoneyField',
   description:
     'Use `s-money-field` when you need to collect monetary values from merchants. It provides appropriate formatting and validation for currency amounts.',
-  requires: '',
   thumbnail: 'moneyfield-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'NumberField',
   description:
     'Use `s-number-field` when you need to collect numerical input from merchants. It provides appropriate keyboard settings and validation for numerical values.',
-  requires: '',
   thumbnail: 'numberfield-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'OrderedList',
   description:
     '`s-ordered-list` displays a set of related text-only content beginning with a number.',
-  requires: '',
   thumbnail: 'ordered-list-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Paragraph',
   description:
     'Use `s-paragraph` to display a block of text similar to the `<p>` tag in HTML.',
-  requires: '',
   thumbnail: 'paragraph-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'PasswordField',
   description:
     'Use `s-password-field` when you need to collect sensitive information from merchants.',
-  requires: '',
   thumbnail: 'password-field-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Section',
   description:
     "`s-section` is a structural component that allows thematic and logical grouping of content. You should use sections as the primary container for all of your app's content. Nest sections to progressively group information. \n\n Section's visual style is contextual and controlled by Shopify. In the admin, at the top level of nesting, sections render as cards. Nested further, they render as the appropriate container for related information within a card. The sections header property will automatically use the correct heading level for the section's content based on the level of nesting. \n\n Section provides default vertical white space to children, so using Stack and Grid are not necessary unless building a complex layout.",
-  requires: '',
   thumbnail: 'section-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Select',
   description:
     '`s-select` lets merchants choose one option from an options menu. Consider `s-select` when you have 4 or more options, to avoid cluttering the interface.',
-  requires: '',
   thumbnail: 'select-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Spinner',
   description:
     'Use `s-spinner` to let merchants know that content is being loaded. For loading states on buttons, use the loading prop on the Button component instead.',
-  requires: '',
   thumbnail: 'spinner-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Stack',
   description:
     "`s-stack` structures layout elements along the [block or inline axes](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow) of the page. It is useful for organizing buttons, creating layouts that adjust to screen size, and controlling spacing between elements.\n\nIt's important to note that Stack does not include any padding by default. If you need padding around your stacked elements, use `base` to apply the default padding. When spacing becomes limited, Stack will always wrap children to a new line.\n\nWhen using `s-stack`, use smaller gaps between small elements and larger gaps between big ones. Maintain a consistent spacing in stacks across all pages of your app.",
-  requires: '',
   thumbnail: 'stack-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Table',
   description:
     'Use `s-table` to organize and display data in a grid format. Tables help merchants view, analyze, and compare data.',
-  requires: '',
   thumbnail: 'table-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'Text',
   description:
     'Use `s-text` to render inline text with different visual styles.',
-  requires: '',
   thumbnail: 'text-thumbnail.png',
   isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'TextArea',
   description:
     'Use `s-text-area` when you need to collect longer text content from merchants. Text areas allow for multiple lines of text and automatically expand to fit the content.',
-  requires: '',
   thumbnail: 'textarea-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'TextField',
   description:
     'Use a text field to allow merchants to enter or edit text. Text fields provide a single-line input area for collecting string values from users.',
-  requires: '',
   thumbnail: 'textfield-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'TextField',

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/shared.ts
@@ -1,10 +1,8 @@
 const shared = {
   name: 'URLField',
   description: 'Use a URLField when you need to collect URLs from merchants.',
-  requires: '',
   thumbnail: 'urlfield-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'URLField',

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/shared.ts
@@ -2,10 +2,8 @@ const shared = {
   name: 'UnorderedList',
   description:
     'UnorderedList displays a set of related text-only content beginning with a bullet.',
-  requires: '',
   thumbnail: 'unordered-list-thumbnail.png',
   isVisualComponent: true,
-  type: 'component',
   definitions: [
     {
       title: 'UnorderedList',


### PR DESCRIPTION
This is unnecessary as the IA tells developers these are components.

| Before | After |
| --- | --- |
| ![Screenshot 2025-04-11 at 10 23 55](https://github.com/user-attachments/assets/19bc9c12-6786-4891-9134-0c853fdaf9e5) | ![Screenshot 2025-04-11 at 10 24 02](https://github.com/user-attachments/assets/e88cde20-541d-4430-8469-a064ba1d4ded) |