### PR TITLE
update api version for unstable

### DIFF
--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -25,6 +25,7 @@ export type ApiVersion =
   | '2024-10'
   | '2025-01'
   | '2025-04'
+  | '2025-07'
   | 'unstable';
 
 /**


### PR DESCRIPTION
### Background

customer account web need this in unstable:

![image](https://github.com/user-attachments/assets/76616f89-729d-41a7-9d01-56376d20f52c)

same with this 
https://github.com/Shopify/ui-extensions/blob/548bead3ed9c43a53b2c1fef279b0e6b8b794b75/packages/ui-extensions/src/shared.ts#L14-L15