### PR TITLE
Call Shopify CLI directly in Admin UI Extensions Getting Started

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/deploy.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/deploy.sh
@@ -2,6 +2,6 @@
 cd my-app
 
 # deploy your app and its extensions:
-npm run deploy
+shopify app deploy
 
 # follow the steps to deploy

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/getting-started.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/getting-started.sh
@@ -1,10 +1,10 @@
 # create an app if you don't already have one:
-npm init @shopify/app@latest --name my-app
+shopify app init --name my-app
 
 # navigate to your app's root directory:
 cd my-app
 
 # generate a new extension:
-npm run generate extension
+shopify app generate extension
 # follow the steps to create a new
 # extension in ./extensions.


### PR DESCRIPTION
## TLDR

Update Admin UI extensions getting started to use Shopify CLI directly instead of via npm scripts

### Solution


```diff
- npm init @shopify/app@latest --name my-app
+ shopify app init --name my-app

- npm run generate extension
+ shopify app generate extension

- npm run deploy
+ shopify app deploy
```

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
