### PR TITLE
fix vanillaJS version of global types for customer accounts

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction.d.ts
@@ -5,13 +5,9 @@ export interface CustomerAccountActionProps {
   heading: string;
 }
 
-declare class CustomerAccountActionComponent
-  extends HTMLElement
-  implements CustomerAccountActionProps {}
-
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-customer-account-action']: CustomerAccountActionComponent;
+    ['s-customer-account-action']: HTMLElement & CustomerAccountActionProps;
   }
 }
 

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup.d.ts
@@ -6,13 +6,9 @@ export interface ImageGroupProps {
   totalItems?: number;
 }
 
-declare class ImageGroupComponent
-  extends HTMLElement
-  implements ImageGroupProps {}
-
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-image-group']: ImageGroupComponent;
+    ['s-image-group']: HTMLElement & ImageGroupProps;
   }
 }
 

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
@@ -10,11 +10,9 @@ export interface PageProps {
   subheading?: string;
 }
 
-declare class PageComponent extends HTMLElement implements PageProps {}
-
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-page']: PageComponent;
+    ['s-page']: HTMLElement & PageProps;
   }
 }
 

--- a/packages/ui-extensions/src/surfaces/customer-account/components/PolicyModal.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/PolicyModal.d.ts
@@ -25,13 +25,9 @@ export interface PolicyModalProps {
   type: PolicyType;
 }
 
-declare class PolicyModalComponent
-  extends HTMLElement
-  implements PolicyModalProps {}
-
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-policy-modal']: PolicyModalComponent;
+    ['s-policy-modal']: HTMLElement & PolicyModalProps;
   }
 }
 


### PR DESCRIPTION
### Background

preact version works perfect, but we have some type issue for vanillaJS version. Now we declare correct types for the components.

<img width="755" alt="Screenshot 2025-04-15 at 3 49 21 PM" src="https://github.com/user-attachments/assets/9b52bdb0-4374-4470-af26-59f00a38a0f0" />

The vanillaJS can get all the props now. 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
