### PR TITLE
add customer account preact hooks support for rc version

### DIFF
--- a/packages/ui-extensions/loom.config.ts
+++ b/packages/ui-extensions/loom.config.ts
@@ -21,6 +21,10 @@ export default createPackage((pkg) => {
     name: 'customer-account',
     root: './src/surfaces/customer-account.ts',
   });
+  pkg.entry({
+    name: 'customer-account/preact',
+    root: './src/surfaces/customer-account/preact/index.ts',
+  });
   // pkg.entry({name: 'point-of-sale', root: './src/surfaces/point-of-sale.ts'});
   pkg.entry({name: 'preact', root: './src/preact.ts'});
   pkg.use(

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -30,6 +30,9 @@
       ],
       "customer-account.*": [
         "./build/ts/surfaces/customer-account/targets/customer-account.*.d.ts"
+      ],
+      "customer-account/preact": [
+        "./build/ts/surfaces/customer-account/preact/index.d.ts"
       ]
     }
   },
@@ -67,6 +70,12 @@
     "./customer-account.*": {
       "default": "./build/ts/surfaces/customer-account/targets/customer-account.*.d.ts"
     },
+    "./customer-account/preact": {
+      "types": "./build/ts/surfaces/customer-account/preact/index.d.ts",
+      "esnext": "./build/esnext/surfaces/customer-account/preact/index.esnext",
+      "import": "./build/esm/surfaces/customer-account/preact/index.mjs",
+      "require": "./build/cjs/surfaces/customer-account/preact/index.js"
+    },
     "./preact": {
       "types": "./build/ts/preact.d.ts",
       "esnext": "./build/esnext/preact.esnext",
@@ -83,9 +92,11 @@
   "devDependencies": {
     "@remote-ui/async-subscription": "^2.1.16",
     "@shopify/generate-docs": "0.16.4",
-    "typescript": "^4.9.0"
+    "typescript": "^4.9.0",
+    "@faker-js/faker": "^8.4.1"
   },
   "optionalDependencies": {
+    "preact": "*",
     "@preact/signals": "*"
   },
   "publishConfig": {

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/.eslintrc.js
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  rules: {
+    // This is necessary because https://github.com/Shopify/generate-docs
+    // cannot yet infer return types.
+    '@typescript-eslint/explicit-function-return-type': 'error',
+  },
+};

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/api.ts
@@ -1,0 +1,52 @@
+import {useContext} from 'react';
+import {
+  RenderExtensionTarget,
+  ApiForRenderExtension,
+} from '@shopify/ui-extensions/customer-account';
+
+import {CustomerAccountUIExtensionError} from '../errors';
+import {ExtensionApiContext} from '../context';
+
+/**
+ * Returns the full API object that was passed in to your extension when it was created.
+ * Depending on the extension target, this object can contain different properties.
+ *
+ * For example, the `customer-account.order-status.cart-line-item.render-after` extension target will return the [CartLineDetailsApi](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cartlinedetailsapi) object.
+ * Other targets may only have access to the [StandardApi](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi) object,
+ * which contains a basic set of properties about the order.
+ *
+ * For a full list of the API available to each extension target, see the [ExtensionTargets type](https://shopify.dev/docs/api/checkout-ui-extensions/apis/extensiontargets).
+ */
+export function useApi<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): ApiForRenderExtension<Target> {
+  const api = useContext(ExtensionApiContext);
+
+  if (api == null) {
+    throw new CustomerAccountUIExtensionError(
+      'You can only call this hook when running as a customer account UI extension.',
+    );
+  }
+
+  return api as ApiForRenderExtension<Target>;
+}
+
+/**
+ * Returns the full API object that was passed in to your extension when it was created.
+ * Depending on the extension target, this object can contain different properties.
+ *
+ * For example, the `customer-account.order-status.cart-line-item.render-after` extension target will return the [CartLineDetailsApi](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cartlinedetailsapi) object.
+ * Other targets may only have access to the [StandardApi](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi) object,
+ * which contains a basic set of properties about the order.
+ *
+ * For a full list of the API available to each extension target, see the [ExtensionTargets type](https://shopify.dev/docs/api/checkout-ui-extensions/apis/extensiontargets).
+ *
+ * > Caution: This is deprecated, use `useApi` instead.
+ *
+ * @deprecated This is deprecated, use `useApi` instead.
+ */
+export function useExtensionApi<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): ApiForRenderExtension<Target> {
+  return useApi();
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/api.ts
@@ -1,11 +1,9 @@
-import {useContext} from 'react';
 import {
   RenderExtensionTarget,
   ApiForRenderExtension,
-} from '@shopify/ui-extensions/customer-account';
+} from '../extension-targets';
 
-import {CustomerAccountUIExtensionError} from '../errors';
-import {ExtensionApiContext} from '../context';
+import {CustomerAccountUIExtensionError} from './errors';
 
 /**
  * Returns the full API object that was passed in to your extension when it was created.
@@ -20,7 +18,7 @@ import {ExtensionApiContext} from '../context';
 export function useApi<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
 >(): ApiForRenderExtension<Target> {
-  const api = useContext(ExtensionApiContext);
+  const api = (globalThis as any)?.shopify as ApiForRenderExtension<Target>;
 
   if (api == null) {
     throw new CustomerAccountUIExtensionError(

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/app-metafields.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/app-metafields.ts
@@ -1,0 +1,65 @@
+import type {
+  AppMetafieldEntryTarget,
+  Metafield,
+  AppMetafieldEntry,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+import {useMemo} from 'react';
+
+import {
+  CustomerAccountUIExtensionError,
+  ExtensionHasNoFieldError,
+} from '../errors';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+interface AppMetafieldFilters {
+  id?: AppMetafieldEntryTarget['id'];
+  type?: AppMetafieldEntryTarget['type'];
+  namespace?: Metafield['namespace'];
+  key?: Metafield['key'];
+}
+
+type AppMetafieldFilterKeys = keyof AppMetafieldFilters;
+
+/**
+ * Returns the metafields configured with `shopify.ui.extension.toml`.
+ * @arg {AppMetafieldFilters} - filter the list of returned metafields
+ */
+export function useAppMetafields<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(filters: AppMetafieldFilters = {}): AppMetafieldEntry[] {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('appMetafields' in api)) {
+    throw new ExtensionHasNoFieldError('appMetafields', extensionTarget);
+  }
+
+  const appMetafields = useSubscription(api.appMetafields);
+
+  return useMemo(() => {
+    if (filters.key && !filters.namespace) {
+      throw new CustomerAccountUIExtensionError(
+        'You must pass in a namespace with a key',
+      );
+    }
+
+    const filterKeys = Object.keys(filters) as AppMetafieldFilterKeys[];
+
+    if (filterKeys.length) {
+      return appMetafields.filter((app) => {
+        return filterKeys.every((key) => {
+          if (key === 'id' || key === 'type') {
+            return app.target[key] === filters[key];
+          }
+
+          return app.metafield[key] === filters[key];
+        });
+      });
+    }
+
+    return appMetafields;
+  }, [filters, appMetafields]);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/app-metafields.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/app-metafields.ts
@@ -1,15 +1,15 @@
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
 import type {
   AppMetafieldEntryTarget,
   Metafield,
   AppMetafieldEntry,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
-import {useMemo} from 'react';
+} from '../api';
+import {useMemo} from 'preact/hooks';
 
 import {
   CustomerAccountUIExtensionError,
   ExtensionHasNoFieldError,
-} from '../errors';
+} from './errors';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/attributes.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/attributes.ts
@@ -1,0 +1,44 @@
+import type {
+  Attribute,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the proposed `attributes` applied to the checkout.
+ */
+export function useAttributes<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): Attribute[] | undefined {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('attributes' in api)) {
+    throw new ExtensionHasNoFieldError('attributes', extensionTarget);
+  }
+
+  return useSubscription(api.attributes);
+}
+
+/**
+ * Returns the values for the specified `attributes` applied to the checkout.
+ *
+ * @param keys - An array of attribute keys.
+ */
+export function useAttributeValues<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(keys: string[]): (string | undefined)[] {
+  const attributes = useAttributes<Target>();
+
+  if (!attributes?.length) {
+    return [];
+  }
+
+  return keys.map((key) => {
+    const attribute = attributes.find((attribute) => attribute.key === key);
+    return attribute?.value;
+  });
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/attributes.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/attributes.ts
@@ -1,11 +1,9 @@
-import type {
-  Attribute,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {Attribute} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the proposed `attributes` applied to the checkout.

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/authenticated-account.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/authenticated-account.ts
@@ -1,0 +1,33 @@
+import type {
+  Customer,
+  PurchasingCompany,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+/**
+ * Returns the current authenticated `Customer`.
+ *
+ * The value is `undefined` if the customer isn't authenticated.
+ */
+export function useAuthenticatedAccountCustomer<
+  Target extends RenderExtensionTarget,
+>(): Customer | undefined {
+  const account = useApi<Target>().authenticatedAccount;
+
+  return useSubscription(account.customer);
+}
+
+/**
+ * Provides information about the company of the authenticated business customer.
+ * The value is `undefined` if a business customer isn't authenticated.
+ */
+export function useAuthenticatedAccountPurchasingCompany<
+  Target extends RenderExtensionTarget,
+>(): PurchasingCompany | undefined {
+  const account = useApi<Target>().authenticatedAccount;
+
+  return useSubscription(account.purchasingCompany);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/authenticated-account.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/authenticated-account.ts
@@ -1,8 +1,5 @@
-import type {
-  Customer,
-  PurchasingCompany,
-  RenderExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderExtensionTarget} from '../extension-targets';
+import type {Customer, PurchasingCompany} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/authentication-state.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/authentication-state.ts
@@ -1,0 +1,16 @@
+import type {
+  AuthenticationState,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useSubscription} from './subscription';
+import {useApi} from './api';
+
+/**
+ * Returns authentication state of Order status page.
+ */
+export function useAuthenticationState<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): AuthenticationState {
+  return useSubscription(useApi<Target>().authenticationState);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/authentication-state.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/authentication-state.ts
@@ -1,7 +1,5 @@
-import type {
-  AuthenticationState,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {AuthenticationState} from '../api';
 
 import {useSubscription} from './subscription';
 import {useApi} from './api';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/billing-address.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/billing-address.ts
@@ -1,0 +1,33 @@
+import type {
+  MailingAddress,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {ExtensionHasNoFieldError, ScopeNotGrantedError} from '../errors';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+/**
+ * Returns 'billingAddress' specified in the order.
+ */
+export function useBillingAddress<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): MailingAddress | undefined {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('billingAddress' in api)) {
+    throw new ExtensionHasNoFieldError('billingAddress', extensionTarget);
+  }
+
+  const billingAddress = api.billingAddress;
+
+  if (!billingAddress) {
+    throw new ScopeNotGrantedError(
+      'Using billing address requires having billing address permissions granted to your app.',
+    );
+  }
+
+  return useSubscription(billingAddress);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/billing-address.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/billing-address.ts
@@ -1,9 +1,7 @@
-import type {
-  MailingAddress,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {MailingAddress} from '../api';
 
-import {ExtensionHasNoFieldError, ScopeNotGrantedError} from '../errors';
+import {ExtensionHasNoFieldError, ScopeNotGrantedError} from './errors';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/buyer-identity.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/buyer-identity.ts
@@ -1,0 +1,82 @@
+import type {
+  OrderStatusCustomer,
+  OrderStatusBuyerIdentity,
+  OrderStatusPurchasingCompany,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {ExtensionHasNoFieldError, ScopeNotGrantedError} from '../errors';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+/**
+ * Returns the current `Customer`.
+ *
+ * The value is `undefined` if the buyer isn't a known customer for this shop or if they haven't logged in yet.
+ */
+export function useCustomer<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): OrderStatusCustomer | undefined {
+  const buyerIdentity = useInternalBuyerIdentity<Target>();
+
+  return useSubscription(buyerIdentity.customer);
+}
+
+/**
+ * Returns the email address of the buyer that is interacting with the cart.
+ * The value is `undefined` if the app does not have access to customer data.
+ */
+export function useEmail<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): string | undefined {
+  const buyerIdentity = useInternalBuyerIdentity<Target>();
+
+  return useSubscription(buyerIdentity.email);
+}
+
+/**
+ * Returns the phone number of the buyer that is interacting with the cart.
+ * The value is `undefined` if the app does not have access to customer data.
+ */
+export function usePhone<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): string | undefined {
+  const buyerIdentity = useInternalBuyerIdentity<Target>();
+
+  return useSubscription(buyerIdentity.phone);
+}
+
+/**
+ * Provides information about the company and its location that the business customer
+ * is purchasing on behalf of during a B2B checkout. It includes details that can be utilized to
+ * identify both the company and its corresponding location to which the business customer belongs.
+ *
+ * The value is `undefined` if a business customer isn't logged in. This function throws an error if the app doesn't have access to customer data.
+ */
+export function usePurchasingCompany<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): OrderStatusPurchasingCompany | undefined {
+  const buyerIdentity = useInternalBuyerIdentity<Target>();
+
+  return useSubscription(buyerIdentity.purchasingCompany);
+}
+
+function useInternalBuyerIdentity<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): OrderStatusBuyerIdentity {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('buyerIdentity' in api)) {
+    throw new ExtensionHasNoFieldError('buyerIdentity', extensionTarget);
+  }
+
+  if (!api.buyerIdentity) {
+    throw new ScopeNotGrantedError(
+      'Using buyer identity requires having personal customer data permissions granted to your app.',
+    );
+  }
+
+  return api.buyerIdentity;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/buyer-identity.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/buyer-identity.ts
@@ -1,11 +1,11 @@
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
 import type {
   OrderStatusCustomer,
   OrderStatusBuyerIdentity,
   OrderStatusPurchasingCompany,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+} from '../api';
 
-import {ExtensionHasNoFieldError, ScopeNotGrantedError} from '../errors';
+import {ExtensionHasNoFieldError, ScopeNotGrantedError} from './errors';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/capabilities.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/capabilities.ts
@@ -1,0 +1,18 @@
+import type {Capability} from '@shopify/ui-extensions/customer-account';
+
+import {useSubscription} from './subscription';
+import {useApi} from './api';
+
+/**
+ * Returns a list of an extension's granted capabilities.
+ */
+export function useExtensionCapabilities(): Capability[] {
+  return useSubscription(useApi().extension.capabilities);
+}
+
+/**
+ * Returns whether or not a given capability of an extension is granted.
+ */
+export function useExtensionCapability(capability: Capability): boolean {
+  return useExtensionCapabilities().includes(capability);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/capabilities.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/capabilities.ts
@@ -1,4 +1,4 @@
-import type {Capability} from '@shopify/ui-extensions/customer-account';
+import type {Capability} from '../api';
 
 import {useSubscription} from './subscription';
 import {useApi} from './api';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/cart-lines.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/cart-lines.ts
@@ -1,0 +1,25 @@
+import type {
+  CartLine,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the current line items for the checkout, and automatically re-renders
+ * your component if line items are added, removed, or updated.
+ */
+export function useCartLines<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): CartLine[] {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('lines' in api)) {
+    throw new ExtensionHasNoFieldError('lines', extensionTarget);
+  }
+
+  return useSubscription(api.lines);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/cart-lines.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/cart-lines.ts
@@ -1,11 +1,9 @@
-import type {
-  CartLine,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {CartLine} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the current line items for the checkout, and automatically re-renders

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/checkout-settings.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/checkout-settings.ts
@@ -1,0 +1,24 @@
+import type {
+  CheckoutSettings,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the `checkoutSettings` applied to the checkout.
+ */
+export function useCheckoutSettings<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): CheckoutSettings {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('checkoutSettings' in api)) {
+    throw new ExtensionHasNoFieldError('checkoutSettings', extensionTarget);
+  }
+
+  return useSubscription(api.checkoutSettings);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/checkout-settings.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/checkout-settings.ts
@@ -1,11 +1,9 @@
-import type {
-  CheckoutSettings,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {CheckoutSettings} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the `checkoutSettings` applied to the checkout.

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/cost.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/cost.ts
@@ -1,0 +1,26 @@
+import type {
+  Money,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns a `Money` value representing the minimum a buyer can expect to pay at the current
+ * step of checkout. This value excludes amounts yet to be negotiated. For example,
+ * the information step might not have delivery costs calculated.
+ */
+export function useTotalAmount<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): Money {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('cost' in api)) {
+    throw new ExtensionHasNoFieldError('cost', extensionTarget);
+  }
+
+  return useSubscription(api.cost.totalAmount);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/cost.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/cost.ts
@@ -1,11 +1,9 @@
-import type {
-  Money,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {Money} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns a `Money` value representing the minimum a buyer can expect to pay at the current

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/country.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/country.ts
@@ -1,0 +1,26 @@
+import {
+  Country,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the country associated with either the current order on the order status page
+ * or the selected country in the customer account interface,
+ * and automatically re-renders your component if the country changes.
+ */
+export function useLocalizationCountry<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): Country | undefined {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('country' in api.localization)) {
+    throw new ExtensionHasNoFieldError('country', extensionTarget);
+  }
+
+  return useSubscription(api.localization.country);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/country.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/country.ts
@@ -1,11 +1,9 @@
-import {
-  Country,
-  RenderExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import {Country} from '../api';
+import {RenderExtensionTarget} from '../extension-targets';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the country associated with either the current order on the order status page

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/currency.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/currency.ts
@@ -1,0 +1,25 @@
+import {
+  Currency,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the currency of the checkout, and automatically re-renders
+ * your component if the currency changes.
+ */
+export function useCurrency<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): Currency {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('currency' in api.localization)) {
+    throw new ExtensionHasNoFieldError('currency', extensionTarget);
+  }
+
+  return useSubscription(api.localization.currency);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/currency.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/currency.ts
@@ -1,11 +1,9 @@
-import {
-  Currency,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {Currency} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the currency of the checkout, and automatically re-renders

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/customer-privacy.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/customer-privacy.ts
@@ -1,0 +1,25 @@
+import type {
+  CustomerPrivacy,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the current customer privacy settings and metadata and
+ * re-renders your component if the customer privacy settings change.
+ */
+export function useCustomerPrivacy<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): CustomerPrivacy {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('customerPrivacy' in api)) {
+    throw new ExtensionHasNoFieldError('customerPrivacy', extensionTarget);
+  }
+
+  return useSubscription(useApi<Target>().customerPrivacy);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/customer-privacy.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/customer-privacy.ts
@@ -1,11 +1,9 @@
-import type {
-  CustomerPrivacy,
-  RenderExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderExtensionTarget} from '../extension-targets';
+import type {CustomerPrivacy} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the current customer privacy settings and metadata and

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/discounts.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/discounts.ts
@@ -1,0 +1,43 @@
+import type {
+  CartDiscountAllocation,
+  CartDiscountCode,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the current discount codes applied to the cart, and automatically re-renders
+ * your component if discount codes are added or removed.
+ */
+export function useDiscountCodes<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): CartDiscountCode[] {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('discountCodes' in api)) {
+    throw new ExtensionHasNoFieldError('discountCodes', extensionTarget);
+  }
+
+  return useSubscription(api.discountCodes);
+}
+
+/**
+ * Returns the current discount allocations applied to the cart, and automatically re-renders
+ * your component if discount allocations changed.
+ */
+export function useDiscountAllocations<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): CartDiscountAllocation[] {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('discountAllocations' in api)) {
+    throw new ExtensionHasNoFieldError('discountAllocations', extensionTarget);
+  }
+
+  return useSubscription(api.discountAllocations);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/discounts.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/discounts.ts
@@ -1,12 +1,9 @@
-import type {
-  CartDiscountAllocation,
-  CartDiscountCode,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {CartDiscountAllocation, CartDiscountCode} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the current discount codes applied to the cart, and automatically re-renders

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/errors.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/errors.ts
@@ -1,0 +1,29 @@
+import type {ExtensionTarget} from '../extension-targets';
+
+export class CustomerAccountUIExtensionError extends Error {
+  name = 'CustomerAccountUIExtensionError';
+}
+
+export class ScopeNotGrantedError extends Error {
+  name = 'ScopeNotGrantedError';
+}
+
+export class ExtensionHasNoMethodError extends Error {
+  name = 'ExtensionHasNoMethodError';
+
+  constructor(method: string, target: ExtensionTarget) {
+    super(
+      `Cannot call '${method}()' on target '${target}'. The corresponding property was not found on the API.`,
+    );
+  }
+}
+
+export class ExtensionHasNoFieldError extends Error {
+  name = 'ExtensionHasNoFieldrror';
+
+  constructor(field: string, target: ExtensionTarget) {
+    super(
+      `Cannot access '${field}' on target '${target}'. The corresponding property was not found on the API.`,
+    );
+  }
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/extension-editor.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/extension-editor.ts
@@ -1,0 +1,10 @@
+import type {Editor} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+
+/**
+ * Returns information about the editor where the extension is being rendered.
+ */
+export function useExtensionEditor(): Editor | undefined {
+  return useApi().extension.editor;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/extension-editor.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/extension-editor.ts
@@ -1,4 +1,4 @@
-import type {Editor} from '@shopify/ui-extensions/customer-account';
+import type {Editor} from '../api';
 
 import {useApi} from './api';
 

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/extension-language.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/extension-language.ts
@@ -1,0 +1,18 @@
+import type {
+  Language,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+/**
+ * Returns the buyer's language, as supported by the extension.
+ */
+export function useExtensionLanguage<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): Language {
+  const {localization} = useApi<Target>();
+
+  return useSubscription(localization.extensionLanguage);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/extension-language.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/extension-language.ts
@@ -1,7 +1,5 @@
-import type {
-  Language,
-  RenderExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderExtensionTarget} from '../extension-targets';
+import type {Language} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/extension.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/extension.ts
@@ -1,0 +1,19 @@
+import type {Extension} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+
+/**
+ * Returns the metadata of the extension.
+ */
+export function useExtension(): Extension {
+  return useApi().extension;
+}
+
+/**
+ * Returns the metadata about the extension.
+ * > Caution: This is deprecated, use `useExtension()` instead.
+ * @deprecated Use `useExtension()` instead.
+ */
+export function useExtensionData(): Extension {
+  return useExtension();
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/extension.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/extension.ts
@@ -1,4 +1,4 @@
-import type {Extension} from '@shopify/ui-extensions/customer-account';
+import type {Extension} from '../api';
 
 import {useApi} from './api';
 

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/gift-cards.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/gift-cards.ts
@@ -1,0 +1,25 @@
+import type {
+  AppliedGiftCard,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the current gift cards applied to the cart, and automatically re-renders
+ * your component if gift cards are added or removed.
+ */
+export function useAppliedGiftCards<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): AppliedGiftCard[] {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('appliedGiftCards' in api)) {
+    throw new ExtensionHasNoFieldError('appliedGiftCards', extensionTarget);
+  }
+
+  return useSubscription(api.appliedGiftCards);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/gift-cards.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/gift-cards.ts
@@ -1,11 +1,9 @@
-import type {
-  AppliedGiftCard,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {AppliedGiftCard} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the current gift cards applied to the cart, and automatically re-renders

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/i18n.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/i18n.ts
@@ -1,0 +1,15 @@
+import {
+  I18n,
+  RenderCustomerAccountExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+import {useApi} from './api';
+
+/**
+ Returns utilities for translating content and formatting values
+    according to the current localization of the user.
+ */
+export function useI18n<
+  Target extends RenderCustomerAccountExtensionTarget = RenderCustomerAccountExtensionTarget,
+>(): I18n {
+  return useApi<Target>().i18n;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/i18n.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/i18n.ts
@@ -1,7 +1,6 @@
-import {
-  I18n,
-  RenderCustomerAccountExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderCustomerAccountExtensionTarget} from '../extension-targets';
+import type {I18n} from '../api';
+
 import {useApi} from './api';
 
 /**

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/index.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/index.ts
@@ -1,0 +1,46 @@
+export {useBillingAddress} from './billing-address';
+export {useExtensionApi, useApi} from './api';
+export {useCurrency} from './currency';
+export {useLanguage} from './language';
+export {useLocalizationCountry} from './country';
+export {useLocalizationMarket} from './market';
+export {useTimezone} from './timezone';
+export {useExtensionCapabilities, useExtensionCapability} from './capabilities';
+export {useExtensionLanguage} from './extension-language';
+export {useCheckoutSettings} from './checkout-settings';
+export {useMetafield} from './metafield';
+export {useMetafields} from './metafields';
+export {useNote} from './note';
+export {useAttributes, useAttributeValues} from './attributes';
+export {useShippingAddress} from './shipping-address';
+export {useTotalAmount} from './cost';
+export {useCartLines} from './cart-lines';
+export {useTarget} from './target';
+export {useAppMetafields} from './app-metafields';
+export {useShop} from './shop';
+export {useStorage} from './storage';
+export {useExtension, useExtensionData} from './extension';
+export {useSubscription} from './subscription';
+export {
+  useCustomer,
+  useEmail,
+  usePhone,
+  usePurchasingCompany,
+} from './buyer-identity';
+export {useTranslate} from './translate';
+export {useI18n} from './i18n';
+export {useSessionToken} from './session-token';
+export {useSettings} from './settings';
+export {useExtensionEditor} from './extension-editor';
+export {useDiscountAllocations, useDiscountCodes} from './discounts';
+export {useOrder} from './order';
+export {useAppliedGiftCards} from './gift-cards';
+export {useNavigationCurrentEntry} from './live-navigation';
+export {useNavigation} from './navigation';
+export {
+  useAuthenticatedAccountCustomer,
+  useAuthenticatedAccountPurchasingCompany,
+} from './authenticated-account';
+
+export {useAuthenticationState} from './authentication-state';
+export {useCustomerPrivacy} from './customer-privacy';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/language.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/language.ts
@@ -1,0 +1,19 @@
+import {
+  Language,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+/**
+ * Returns the current language of the checkout, and automatically re-renders
+ * your component if the language changes.
+ */
+export function useLanguage<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): Language {
+  const {localization} = useApi<Target>();
+
+  return useSubscription(localization.language);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/language.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/language.ts
@@ -1,7 +1,5 @@
-import {
-  Language,
-  RenderExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderExtensionTarget} from '../extension-targets';
+import type {Language} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/live-navigation.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/live-navigation.ts
@@ -1,0 +1,27 @@
+import {
+  NavigationHistoryEntry,
+  RenderCustomerAccountFullPageExtensionTarget,
+} from '@shopify/ui-extensions/src/surfaces/customer-account';
+import {useApi} from './api';
+import {useEffect, useReducer} from 'react';
+
+export function useNavigationCurrentEntry<
+  Target extends RenderCustomerAccountFullPageExtensionTarget = RenderCustomerAccountFullPageExtensionTarget,
+>(): NavigationHistoryEntry {
+  const {currentEntry, removeEventListener, addEventListener} =
+    useApi<Target>().navigation;
+
+  const [entry, update] = useReducer(() => currentEntry, currentEntry);
+
+  useEffect(() => {
+    if (!currentEntry || !removeEventListener || !addEventListener) {
+      throw new Error(
+        'useNavigationCurrentEntry must be used in an extension with the customer-account.page.render or customer-account.order.page.render target only',
+      );
+    }
+    addEventListener('currententrychange', update);
+    return () => removeEventListener('currententrychange', update);
+  }, [addEventListener, currentEntry, removeEventListener]);
+
+  return entry;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/live-navigation.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/live-navigation.ts
@@ -1,9 +1,8 @@
-import {
-  NavigationHistoryEntry,
-  RenderCustomerAccountFullPageExtensionTarget,
-} from '@shopify/ui-extensions/src/surfaces/customer-account';
+import type {RenderCustomerAccountFullPageExtensionTarget} from '../extension-targets';
+import type {NavigationHistoryEntry} from '../api';
+
 import {useApi} from './api';
-import {useEffect, useReducer} from 'react';
+import {useEffect, useReducer} from 'preact/hooks';
 
 export function useNavigationCurrentEntry<
   Target extends RenderCustomerAccountFullPageExtensionTarget = RenderCustomerAccountFullPageExtensionTarget,

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/market.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/market.ts
@@ -1,0 +1,25 @@
+import {
+  Market,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the market of the checkout, and automatically re-renders
+ * your component if it changes.
+ */
+export function useLocalizationMarket<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): Market | undefined {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('market' in api.localization)) {
+    throw new ExtensionHasNoFieldError('market', extensionTarget);
+  }
+
+  return useSubscription(api.localization.market);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/market.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/market.ts
@@ -1,11 +1,9 @@
-import {
-  Market,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {Market} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the market of the checkout, and automatically re-renders

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/metafield.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/metafield.ts
@@ -1,0 +1,28 @@
+import {Metafield} from '@shopify/ui-extensions/customer-account';
+
+import {CustomerAccountUIExtensionError} from '../errors';
+
+import {useMetafields} from './metafields';
+
+interface MetafieldFilter {
+  namespace: string;
+  key: string;
+}
+
+/**
+ * Returns a single filtered `Metafield` or `undefined`.
+ * @arg {MetafieldFilter} - filter the list of returned metafields to a single metafield
+ */
+export function useMetafield(filters: MetafieldFilter): Metafield | undefined {
+  const {namespace, key} = filters;
+
+  if (!namespace || !key) {
+    throw new CustomerAccountUIExtensionError(
+      'You must pass in both a namespace and key',
+    );
+  }
+
+  const metafields = useMetafields({namespace, key});
+
+  return metafields.length ? metafields[0] : undefined;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/metafield.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/metafield.ts
@@ -1,6 +1,6 @@
-import {Metafield} from '@shopify/ui-extensions/customer-account';
+import type {Metafield} from '../api';
 
-import {CustomerAccountUIExtensionError} from '../errors';
+import {CustomerAccountUIExtensionError} from './errors';
 
 import {useMetafields} from './metafields';
 

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/metafields.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/metafields.ts
@@ -1,0 +1,57 @@
+import type {
+  Metafield,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+import {useMemo} from 'react';
+
+import {
+  CustomerAccountUIExtensionError,
+  ExtensionHasNoFieldError,
+} from '../errors';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+interface MetafieldsFilters {
+  namespace: string;
+  key?: string;
+}
+
+/**
+ * Returns the current array of `metafields` applied to the checkout.
+ * You can optionally filter the list.
+ * @arg {MetafieldsFilters} - filter the list of returned metafields
+ */
+export function useMetafields<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(filters?: MetafieldsFilters): Metafield[] {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('metafields' in api)) {
+    throw new ExtensionHasNoFieldError('metafields', extensionTarget);
+  }
+
+  const metaFields = useSubscription(api.metafields);
+
+  return useMemo(() => {
+    if (filters) {
+      const {namespace, key} = filters;
+
+      if (!namespace) {
+        throw new CustomerAccountUIExtensionError(
+          'You must pass in a namespace with a key',
+        );
+      }
+
+      const filteredResults = metaFields.filter(
+        (metafield) =>
+          metafield.namespace === namespace && (!key || metafield.key === key),
+      );
+
+      return filteredResults;
+    }
+
+    return metaFields;
+  }, [filters, metaFields]);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/metafields.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/metafields.ts
@@ -1,13 +1,12 @@
-import type {
-  Metafield,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
-import {useMemo} from 'react';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {Metafield} from '../api';
+
+import {useMemo} from 'preact/hooks';
 
 import {
   CustomerAccountUIExtensionError,
   ExtensionHasNoFieldError,
-} from '../errors';
+} from './errors';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/navigation.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/navigation.ts
@@ -1,0 +1,12 @@
+import {
+  ApiForExtension,
+  RenderCustomerAccountExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+
+export function useNavigation<
+  Target extends RenderCustomerAccountExtensionTarget = RenderCustomerAccountExtensionTarget,
+>(): ApiForExtension<Target>['navigation'] {
+  return useApi<Target>().navigation;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/navigation.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/navigation.ts
@@ -1,7 +1,7 @@
-import {
-  ApiForExtension,
+import type {
   RenderCustomerAccountExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+  ApiForExtension,
+} from '../extension-targets';
 
 import {useApi} from './api';
 

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/note.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/note.ts
@@ -1,0 +1,21 @@
+import type {RenderOrderStatusExtensionTarget} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the proposed `note` applied to the checkout.
+ */
+export function useNote<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): string | undefined {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('note' in api)) {
+    throw new ExtensionHasNoFieldError('note', extensionTarget);
+  }
+
+  return useSubscription(api.note);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/note.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/note.ts
@@ -1,8 +1,8 @@
-import type {RenderOrderStatusExtensionTarget} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the proposed `note` applied to the checkout.

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/order.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/order.ts
@@ -1,0 +1,24 @@
+import {
+  Order,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {ExtensionHasNoMethodError} from '../errors';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+/**
+ * Returns the order information that's available post-checkout.
+ */
+export function useOrder<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): Order | undefined {
+  const api = useApi<Target>();
+
+  if ('order' in api) {
+    return useSubscription(api.order);
+  }
+
+  throw new ExtensionHasNoMethodError('order', (api as any).extension.target);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/order.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/order.ts
@@ -1,9 +1,7 @@
-import {
-  Order,
-  RenderExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderExtensionTarget} from '../extension-targets';
+import type {Order} from '../api';
 
-import {ExtensionHasNoMethodError} from '../errors';
+import {ExtensionHasNoMethodError} from './errors';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/session-token.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/session-token.ts
@@ -1,0 +1,23 @@
+import {
+  RenderExtensionTarget,
+  SessionToken,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Provides access to session tokens, which can be used to verify token claims on your app's server.
+ */
+export function useSessionToken<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): SessionToken {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('sessionToken' in api)) {
+    throw new ExtensionHasNoFieldError('sessionToken', extensionTarget);
+  }
+
+  return api.sessionToken;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/session-token.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/session-token.ts
@@ -1,10 +1,8 @@
-import {
-  RenderExtensionTarget,
-  SessionToken,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderExtensionTarget} from '../extension-targets';
+import type {SessionToken} from '../api';
 
 import {useApi} from './api';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Provides access to session tokens, which can be used to verify token claims on your app's server.

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/settings.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/settings.ts
@@ -1,0 +1,27 @@
+import type {
+  ExtensionSettings,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the setting values defined by the merchant for the extension.
+ */
+export function useSettings<
+  Settings extends ExtensionSettings,
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): Partial<Settings> {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('settings' in api)) {
+    throw new ExtensionHasNoFieldError('settings', extensionTarget);
+  }
+
+  const settings = useSubscription(api.settings);
+
+  return settings as Settings;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/settings.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/settings.ts
@@ -1,11 +1,9 @@
-import type {
-  ExtensionSettings,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {ExtensionSettings} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the setting values defined by the merchant for the extension.

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/shipping-address.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/shipping-address.ts
@@ -1,0 +1,33 @@
+import type {
+  MailingAddress,
+  RenderOrderStatusExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+
+import {ExtensionHasNoFieldError, ScopeNotGrantedError} from '../errors';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+/**
+ * Returns the proposed `shippingAddress` applied to the checkout.
+ */
+export function useShippingAddress<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): MailingAddress | undefined {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('shippingAddress' in api)) {
+    throw new ExtensionHasNoFieldError('shippingAddress', extensionTarget);
+  }
+
+  const shippingAddress = api.shippingAddress;
+
+  if (!shippingAddress) {
+    throw new ScopeNotGrantedError(
+      'Using shipping address requires having shipping address permissions granted to your app.',
+    );
+  }
+
+  return useSubscription(shippingAddress);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/shipping-address.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/shipping-address.ts
@@ -1,9 +1,7 @@
-import type {
-  MailingAddress,
-  RenderOrderStatusExtensionTarget,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {MailingAddress} from '../api';
 
-import {ExtensionHasNoFieldError, ScopeNotGrantedError} from '../errors';
+import {ExtensionHasNoFieldError, ScopeNotGrantedError} from './errors';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/shop.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/shop.ts
@@ -1,0 +1,23 @@
+import type {
+  RenderOrderStatusExtensionTarget,
+  Shop,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the `Shop` where the checkout is taking place.
+ */
+export function useShop<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): Shop {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('shop' in api)) {
+    throw new ExtensionHasNoFieldError('shop', extensionTarget);
+  }
+
+  return api.shop;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/shop.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/shop.ts
@@ -1,10 +1,8 @@
-import type {
-  RenderOrderStatusExtensionTarget,
-  Shop,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {Shop} from '../api';
 
 import {useApi} from './api';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the `Shop` where the checkout is taking place.

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/storage.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/storage.ts
@@ -1,0 +1,15 @@
+import type {
+  RenderExtensionTarget,
+  Storage,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+
+/**
+ * Returns the key-value `Storage` interface for the extension target.
+ */
+export function useStorage<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): Storage {
+  return useApi<Target>().storage;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/storage.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/storage.ts
@@ -1,7 +1,5 @@
-import type {
-  RenderExtensionTarget,
-  Storage,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderExtensionTarget} from '../extension-targets';
+import type {Storage} from '../api';
 
 import {useApi} from './api';
 

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/subscription.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/subscription.ts
@@ -1,0 +1,45 @@
+import {useEffect, useState} from 'react';
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+
+type Subscriber<T> = Parameters<StatefulRemoteSubscribable<T>['subscribe']>[0];
+
+/**
+ * Subscribes to the special wrapper type that all “changeable” values in the
+ * checkout use. This hook extracts the most recent value from that object,
+ * and subscribes to update the value when changes occur in the checkout.
+ *
+ * > Note:
+ * > You generally shouldn’t need to use this directly, as there are dedicated hooks
+ * > for accessing the current value of each individual resource in the checkout.
+ */
+export function useSubscription<Value>(
+  subscription: StatefulRemoteSubscribable<Value>,
+): Value {
+  const [, setValue] = useState(subscription.current);
+
+  useEffect(() => {
+    let didUnsubscribe = false;
+
+    const checkForUpdates: Subscriber<Value> = (newValue) => {
+      if (didUnsubscribe) {
+        return;
+      }
+
+      setValue(newValue);
+    };
+
+    const unsubscribe = subscription.subscribe(checkForUpdates);
+
+    // Because we're subscribing in a passive effect,
+    // it's possible for an update to occur between render and the effect handler.
+    // Check for this and schedule an update if work has occurred.
+    checkForUpdates(subscription.current);
+
+    return () => {
+      didUnsubscribe = true;
+      unsubscribe();
+    };
+  }, [subscription]);
+
+  return subscription.current;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/subscription.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/subscription.ts
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useState} from 'preact/hooks';
 import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 type Subscriber<T> = Parameters<StatefulRemoteSubscribable<T>['subscribe']>[0];

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/target.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/target.ts
@@ -1,0 +1,33 @@
+import {
+  ExtensionTarget,
+  CartLine,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+
+class ExtensionHasNoTargetError extends Error {
+  name = 'ExtensionHasNoTargetError';
+
+  constructor(target: ExtensionTarget) {
+    super(
+      `Cannot call 'useTarget()' on target '${target}'. Property 'target' is not found on api.`,
+    );
+  }
+}
+
+/**
+ * Returns the cart line the extension is attached to. This hook can only be used by extensions in the
+ * `purchase.cart-line-item.line-components.render` and `customer-account.order-status.cart-line-item.render-after`
+ * extension targets. Until version `2023-04`, this hook returned a `PresentmentCartLine` object.
+ */
+export function useTarget(): CartLine {
+  const api =
+    useApi<'customer-account.order-status.cart-line-item.render-after'>();
+
+  if (!api.target) {
+    throw new ExtensionHasNoTargetError(api.extension.target);
+  }
+
+  return useSubscription(api.target);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/target.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/target.ts
@@ -1,7 +1,5 @@
-import {
-  ExtensionTarget,
-  CartLine,
-} from '@shopify/ui-extensions/customer-account';
+import type {ExtensionTarget} from '../extension-targets';
+import type {CartLine} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/.eslintrc.js
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    '@typescript-eslint/explicit-function-return-type': 'off',
+  },
+};

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/api.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/api.test.tsx
@@ -1,0 +1,31 @@
+import {useApi} from '..';
+
+import {mount} from './mount';
+
+describe('useApi', () => {
+  it('returns api', async () => {
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+    };
+    const {value} = mount.hook(
+      () => useApi<'customer-account.order-status.block.render'>(),
+      {
+        extensionApi,
+      },
+    );
+
+    expect(value).toMatchObject(extensionApi);
+  });
+
+  it('throws when not run inside a UI extension', async () => {
+    const runner = async () => {
+      return mount.hook(() => useApi());
+    };
+
+    await expect(runner).rejects.toThrow(
+      'You can only call this hook when running as a customer account UI extension.',
+    );
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/app-metafields.test.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/app-metafields.test.ts
@@ -1,0 +1,181 @@
+import {Metafield} from '@shopify/ui-extensions/customer-account';
+import {faker} from '@faker-js/faker';
+
+import {useAppMetafields} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useAppMetafields', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createMetafield(props: Partial<Metafield> = {}): Metafield {
+    return {
+      key: `key-${faker.datatype.uuid()}`,
+      namespace: 'example-namespace',
+      value: 'example-value',
+      valueType: 'string',
+      ...props,
+    };
+  }
+
+  const productEntry = {
+    target: {id: faker.datatype.uuid(), type: 'product' as const},
+    metafield: createMetafield(),
+  };
+
+  const variantEntry = {
+    target: {id: faker.datatype.uuid(), type: 'variant' as const},
+    metafield: createMetafield(),
+  };
+
+  it('returns all app metafield entries', () => {
+    const appMetaFieldEntries = [productEntry, variantEntry];
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      appMetafields: createMockStatefulRemoteSubscribable(appMetaFieldEntries),
+    };
+
+    const {value} = mount.hook(() => useAppMetafields(), {extensionApi});
+
+    expect(value).toMatchObject(appMetaFieldEntries);
+  });
+
+  it('returns filtered app metafield entries based on type', () => {
+    const appMetaFieldEntries = [productEntry, variantEntry];
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      appMetafields: createMockStatefulRemoteSubscribable(appMetaFieldEntries),
+    };
+
+    const {value} = mount.hook(() => useAppMetafields({type: 'product'}), {
+      extensionApi,
+    });
+
+    expect(value).toMatchObject([productEntry]);
+  });
+
+  it('returns filtered app metafield entry based on id', () => {
+    const testId = faker.datatype.uuid();
+    const newEntry = {
+      target: {id: testId, type: 'product' as const},
+      metafield: createMetafield(),
+    };
+
+    const appMetaFieldEntries = [newEntry, variantEntry];
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      appMetafields: createMockStatefulRemoteSubscribable(appMetaFieldEntries),
+    };
+
+    const {value} = mount.hook(() => useAppMetafields({id: testId}), {
+      extensionApi,
+    });
+
+    expect(value).toMatchObject([newEntry]);
+  });
+
+  it('returns filtered app metafield entries based on namespace', () => {
+    const testNamespace = 'test_namespace';
+    const newEntry = {
+      target: {id: faker.datatype.uuid(), type: 'product' as const},
+      metafield: createMetafield({namespace: testNamespace}),
+    };
+
+    const appMetaFieldEntries = [newEntry, productEntry, variantEntry];
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      appMetafields: createMockStatefulRemoteSubscribable(appMetaFieldEntries),
+    };
+
+    const {value} = mount.hook(
+      () => useAppMetafields({namespace: testNamespace}),
+      {extensionApi},
+    );
+
+    expect(value).toMatchObject([newEntry]);
+  });
+
+  it('returns filtered app metafield entries based on namespace & key', () => {
+    const testNamespace = 'test_namespace';
+    const testKey = 'test_key';
+    const newEntry = {
+      target: {id: faker.datatype.uuid(), type: 'product' as const},
+      metafield: createMetafield({namespace: testNamespace, key: testKey}),
+    };
+
+    const appMetaFieldEntries = [newEntry, productEntry, variantEntry];
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      appMetafields: createMockStatefulRemoteSubscribable(appMetaFieldEntries),
+    };
+
+    const {value} = mount.hook(
+      () => useAppMetafields({namespace: testNamespace, key: testKey}),
+      {extensionApi},
+    );
+
+    expect(value).toMatchObject([newEntry]);
+  });
+
+  it('throws an error if no namespace is provided with key', () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    const appMetaFieldEntries = [productEntry, variantEntry];
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      appMetafields: createMockStatefulRemoteSubscribable(appMetaFieldEntries),
+    };
+
+    expect(() =>
+      mount.hook(() => useAppMetafields({key: 'test_key'}), {
+        extensionApi,
+      }),
+    ).toThrow('You must pass in a namespace with a key');
+  });
+
+  it('returns filtered app metafield entries based on all searchable fields', () => {
+    const testNamespace = 'test_namespace';
+    const testKey = 'test_key';
+    const testId = faker.datatype.uuid();
+
+    const newEntry = {
+      target: {id: testId, type: 'product' as const},
+      metafield: createMetafield({namespace: testNamespace, key: testKey}),
+    };
+
+    const appMetaFieldEntries = [newEntry, productEntry, variantEntry];
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      appMetafields: createMockStatefulRemoteSubscribable(appMetaFieldEntries),
+    };
+
+    const {value} = mount.hook(
+      () =>
+        useAppMetafields({
+          namespace: testNamespace,
+          key: testKey,
+          id: testId,
+          type: 'product',
+        }),
+      {extensionApi},
+    );
+
+    expect(value).toMatchObject([newEntry]);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/app-metafields.test.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/app-metafields.test.ts
@@ -1,5 +1,6 @@
-import {Metafield} from '@shopify/ui-extensions/customer-account';
 import {faker} from '@faker-js/faker';
+
+import type {Metafield} from '../../api';
 
 import {useAppMetafields} from '..';
 

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/attributes.test.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/attributes.test.ts
@@ -1,0 +1,67 @@
+import {useAttributeValues, useAttributes} from '../attributes';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('Attributes API hooks', () => {
+  describe('useAttributes', () => {
+    it('returns an empty array if no attributes are available', () => {
+      const {value} = mount.hook(() => useAttributes(), {
+        extensionApi: {
+          extension: {
+            target: 'customer-account.order-status.block.render' as const,
+          },
+          attributes: createMockStatefulRemoteSubscribable([]),
+        },
+      });
+
+      expect(value).toStrictEqual([]);
+    });
+
+    it('returns an array of attributes if available', () => {
+      const {value} = mount.hook(() => useAttributes(), {
+        extensionApi: {
+          extension: {
+            target: 'customer-account.order-status.block.render' as const,
+          },
+          attributes: createMockStatefulRemoteSubscribable([
+            {key: 'foo', value: 'bar'},
+          ]),
+        },
+      });
+
+      expect(value).toStrictEqual([{key: 'foo', value: 'bar'}]);
+    });
+  });
+
+  describe('useAttributeValues', () => {
+    it('returns an array of attribute values if available', () => {
+      const {value} = mount.hook(() => useAttributeValues(['foo']), {
+        extensionApi: {
+          extension: {
+            target: 'customer-account.order-status.block.render' as const,
+          },
+          attributes: createMockStatefulRemoteSubscribable([
+            {key: 'foo', value: 'bar'},
+          ]),
+        },
+      });
+
+      expect(value).toStrictEqual(['bar']);
+    });
+
+    it('returns an array with undefined values if a non-existent attribute is requested', () => {
+      const {value} = mount.hook(() => useAttributeValues(['foo', 'bar']), {
+        extensionApi: {
+          extension: {
+            target: 'customer-account.order-status.block.render' as const,
+          },
+          attributes: createMockStatefulRemoteSubscribable([
+            {key: 'bar', value: 'baz'},
+          ]),
+        },
+      });
+
+      expect(value).toStrictEqual([undefined, 'baz']);
+    });
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/authenticated-account.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/authenticated-account.test.tsx
@@ -1,0 +1,65 @@
+import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import {faker} from '@faker-js/faker';
+import {
+  useAuthenticatedAccountCustomer,
+  useAuthenticatedAccountPurchasingCompany,
+} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+function createMockCustomer() {
+  return {
+    id: `gid://shopify/Customer/${faker.number.int({min: 1})}`,
+  };
+}
+
+function createMockPurchasingCompany() {
+  return {
+    company: {
+      id: `gid://shopify/Company/${faker.number.int({min: 1})}`,
+    },
+    location: {
+      id: `gid://shopify/CompanyLocation/${faker.number.int({min: 1})}`,
+    },
+  };
+}
+
+function createMockHookContext(customer = {}, purchasingCompany = {}) {
+  return {
+    extensionApi: {
+      authenticatedAccount: {
+        customer: createMockStatefulRemoteSubscribable(customer),
+        purchasingCompany:
+          createMockStatefulRemoteSubscribable(purchasingCompany),
+      },
+    },
+  };
+}
+
+describe('account Hooks', () => {
+  describe('useLoggedInAccountCustomer()', () => {
+    it('returns id of the logged in customer', () => {
+      const customer = createMockCustomer();
+      const {value} = mount.hook(
+        () => useAuthenticatedAccountCustomer(),
+        createMockHookContext(customer),
+      );
+      expect(customer).toBeDefined();
+      expect(customer.id).toBeDefined();
+      expect(value.id).toBe(customer.id);
+    });
+
+    it('returns company id of which the logged in customer belongs to', () => {
+      const purchasingCompany = createMockPurchasingCompany();
+      const {value} = mount.hook(
+        () => useAuthenticatedAccountPurchasingCompany(),
+        createMockHookContext({}, purchasingCompany),
+      );
+      expect(purchasingCompany).toBeDefined();
+      expect(purchasingCompany.company.id).toBeDefined();
+      expect(purchasingCompany.location.id).toBeDefined();
+      expect(value.company.id).toBe(purchasingCompany.company.id);
+      expect(value.location.id).toBe(purchasingCompany.location.id);
+    });
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/authentication-state.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/authentication-state.test.tsx
@@ -1,0 +1,24 @@
+import {useAuthenticationState} from '..';
+import type {Extension} from '@shopify/ui-extensions/customer-account';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useAuthenticationState Hooks', () => {
+  it('returns authenticationState', () => {
+    const authenticationStateSubscribable =
+      createMockStatefulRemoteSubscribable(
+        'fully_authenticated',
+      ) as Extension['authenticationState'];
+
+    const {value} = mount.hook(useAuthenticationState, {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        authenticationState: authenticationStateSubscribable,
+      },
+    });
+    expect(value).toBeDefined();
+    expect(value).toBe('fully_authenticated');
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/billing-address.test.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/billing-address.test.ts
@@ -1,0 +1,35 @@
+import {MailingAddress} from '@shopify/ui-extensions/customer-account';
+
+import {useBillingAddress} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+import {ScopeNotGrantedError} from '../../errors';
+
+describe('useBillingAddress', () => {
+  it('returns latest billing address', async () => {
+    const address: MailingAddress = {countryCode: 'CA'};
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      billingAddress: createMockStatefulRemoteSubscribable(address),
+    };
+
+    const {value} = mount.hook(() => useBillingAddress(), {extensionApi});
+
+    expect(value).toMatchObject(address);
+  });
+
+  it('raises an exception without approval scopes granted', () => {
+    expect(() =>
+      mount.hook(() => useBillingAddress(), {
+        extensionApi: {
+          extension: {
+            target: 'customer-account.order-status.block.render' as const,
+          },
+          billingAddress: undefined,
+        },
+      }),
+    ).toThrow(ScopeNotGrantedError);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/buyer-identity-businessCustomer.test.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/buyer-identity-businessCustomer.test.ts
@@ -1,0 +1,36 @@
+import {usePurchasingCompany} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('usePurchasingCompany', () => {
+  it('returns purchasing company from the api', () => {
+    const purchasingCompany = {
+      company: {
+        id: 'gid://shopify/Company/2',
+        name: 'Company',
+        externalId: 'company-external-id',
+      },
+      location: {
+        id: 'gid://shopify/CompanyLocation/2',
+        name: 'CompanyLocation',
+        externalId: 'company-location-external-id',
+      },
+    };
+
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      buyerIdentity: {
+        purchasingCompany:
+          createMockStatefulRemoteSubscribable(purchasingCompany),
+      },
+    };
+
+    const {value} = mount.hook(() => usePurchasingCompany(), {
+      extensionApi,
+    });
+
+    expect(value).toStrictEqual(purchasingCompany);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/buyer-identity.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/buyer-identity.test.tsx
@@ -1,0 +1,165 @@
+import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import {faker} from '@faker-js/faker';
+
+import {ScopeNotGrantedError} from '../../errors';
+import {useCustomer, useEmail, usePhone} from '..';
+
+import {mount} from './mount';
+
+function createMockCustomer(customer = {}) {
+  const firstName = faker.name.firstName();
+  const lastName = faker.name.lastName();
+
+  return {
+    id: `gid://shopify/Customer/${faker.datatype.number({
+      min: 1,
+      precision: 1,
+    })}`,
+    fullName: `${firstName} ${lastName}`,
+    firstName,
+    lastName,
+    email: faker.internet.email(),
+    phone: faker.phone.number(),
+    ...customer,
+  };
+}
+
+function createEmptyContext() {
+  return {
+    extensionApi: {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      buyerIdentity: undefined,
+    },
+  };
+}
+
+function createUseEmailContext(email?: string) {
+  return createMockHookContext(email, undefined, undefined);
+}
+
+function createUseCustomerContext(customer = {}) {
+  return createMockHookContext(undefined, undefined, customer);
+}
+
+function createUsePhoneContext(phone?: string) {
+  return createMockHookContext(undefined, phone, undefined);
+}
+
+function createMockSuscribable<T>(data: T): StatefulRemoteSubscribable<T> {
+  return {
+    current: data,
+    value: data,
+    subscribe: () => () => {},
+    destroy: async () => {},
+  };
+}
+
+function createMockHookContext(email?: string, phone?: string, customer = {}) {
+  return {
+    extensionApi: {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      buyerIdentity: {
+        customer: createMockSuscribable(customer),
+        email: createMockSuscribable(email),
+        phone: createMockSuscribable(phone),
+      },
+    },
+  };
+}
+
+describe('buyerIdentity Hooks', () => {
+  describe('useCustomer()', () => {
+    it('raises an exception without CustomerPersonalData ApprovalScope', () => {
+      expect(() => {
+        mount.hook(() => useCustomer(), createEmptyContext());
+      }).toThrow(ScopeNotGrantedError);
+    });
+
+    it('returns undefined fields with CustomerPersonalData ApprovalScopes only', () => {
+      const hook = mount.hook(
+        () => useCustomer(),
+        createUseCustomerContext({
+          email: undefined,
+          phone: undefined,
+          firstName: undefined,
+          lastName: undefined,
+          fullName: undefined,
+        }),
+      );
+
+      expect(hook.current).toBeDefined();
+      expect(hook.current?.email).toBeUndefined();
+      expect(hook.current?.phone).toBeUndefined();
+      expect(hook.current?.fullName).toBeUndefined();
+      expect(hook.current?.firstName).toBeUndefined();
+      expect(hook.current?.lastName).toBeUndefined();
+    });
+
+    it('returns email, phone and name fields with all ApprovalScopes', () => {
+      const customer = createMockCustomer();
+      const hook = mount.hook(
+        () => useCustomer(),
+        createUseCustomerContext(customer),
+      );
+      expect(customer).toBeDefined();
+      expect(customer.email).toBeDefined();
+      expect(hook.current?.email).toBe(customer.email);
+      expect(customer.phone).toBeDefined();
+      expect(hook.current?.phone).toBe(customer.phone);
+      expect(customer.firstName).toBeDefined();
+      expect(hook.current?.firstName).toBe(customer.firstName);
+      expect(customer.lastName).toBeDefined();
+      expect(hook.current?.lastName).toBe(customer.lastName);
+      expect(customer.fullName).toBeDefined();
+      expect(hook.current?.fullName).toBe(customer.fullName);
+    });
+  });
+
+  describe('useEmail()', () => {
+    it('raises an exception without CustomerPersonalData ApprovalScope', () => {
+      expect(() => {
+        mount.hook(() => useEmail(), createEmptyContext());
+      }).toThrow(ScopeNotGrantedError);
+    });
+
+    it('returns undefined with CustomerPersonalData ApprovalScope only', () => {
+      const hook = mount.hook(
+        () => useEmail(),
+        createUseEmailContext(undefined),
+      );
+      expect(hook?.current).toBeUndefined();
+    });
+
+    it('returns email with CustomerPersonalData and CustomerEmail ApprovalScopes', () => {
+      const email = faker.internet.email();
+      const hook = mount.hook(() => useEmail(), createUseEmailContext(email));
+      expect(hook?.current).toBe(email);
+    });
+  });
+
+  describe('usePhone()', () => {
+    it('raises an exception without CustomerPersonalData ApprovalScope', () => {
+      expect(() => {
+        mount.hook(() => usePhone(), createEmptyContext());
+      }).toThrow(ScopeNotGrantedError);
+    });
+
+    it('returns undefined with CustomerPersonalData ApprovalScope only', () => {
+      const hook = mount.hook(
+        () => usePhone(),
+        createUsePhoneContext(undefined),
+      );
+      expect(hook?.current).toBeUndefined();
+    });
+
+    it('returns phone with CustomerPersonalData and CustomerEmail ApprovalScopes', () => {
+      const phone = faker.phone.number();
+      const hook = mount.hook(() => usePhone(), createUsePhoneContext(phone));
+      expect(hook?.current).toBe(phone);
+    });
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/capabilities.test.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/capabilities.test.ts
@@ -1,0 +1,58 @@
+import type {Extension} from '@shopify/ui-extensions/customer-account';
+
+import {useExtensionCapabilities, useExtensionCapability} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useExtensionCapabilities', () => {
+  it('returns a list of granted capabilities of the extension', () => {
+    const capabilities = ['network_access', 'block_progress'];
+
+    const capabilitiesSubscribable = createMockStatefulRemoteSubscribable(
+      capabilities,
+    ) as Extension['capabilities'];
+
+    const {value} = mount.hook(useExtensionCapabilities, {
+      extensionApi: {
+        extension: {
+          capabilities: capabilitiesSubscribable,
+        },
+      },
+    });
+
+    expect(value).toStrictEqual(capabilities);
+  });
+});
+
+describe('useExtensionCapability', () => {
+  it('returns the status of a capabilities', () => {
+    const capabilities = createMockStatefulRemoteSubscribable([
+      'network_access',
+    ]) as Extension['capabilities'];
+
+    const {value: activatedCapability} = mount.hook(
+      () => useExtensionCapability('network_access'),
+      {
+        extensionApi: {
+          extension: {
+            capabilities,
+          },
+        },
+      },
+    );
+
+    const {value: deactivatedCapability} = mount.hook(
+      () => useExtensionCapability('block_progress'),
+      {
+        extensionApi: {
+          extension: {
+            capabilities,
+          },
+        },
+      },
+    );
+
+    expect(activatedCapability).toBe(true);
+    expect(deactivatedCapability).toBe(false);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/checkout-settings.test.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/checkout-settings.test.ts
@@ -1,0 +1,30 @@
+import {CheckoutSettings} from '@shopify/ui-extensions/customer-account';
+
+import {useCheckoutSettings} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useCheckoutSettings', () => {
+  it('returns checkout settings from the api', () => {
+    const checkoutSettings = {
+      orderSubmission: 'ORDER',
+      shippingAddress: {
+        isEditable: true,
+      },
+      paymentTermsTemplate: undefined,
+    } as CheckoutSettings;
+
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      checkoutSettings: createMockStatefulRemoteSubscribable(checkoutSettings),
+    };
+
+    const {value} = mount.hook(() => useCheckoutSettings(), {
+      extensionApi,
+    });
+
+    expect(value).toStrictEqual(checkoutSettings);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/configuration.test.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/configuration.test.ts
@@ -1,0 +1,20 @@
+import {useSettings} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useSettings', () => {
+  it('returns settings from the api', () => {
+    const settings = {title: 'checkout ui'};
+
+    const {value} = mount.hook(() => useSettings(), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        settings: createMockStatefulRemoteSubscribable(settings),
+      },
+    });
+
+    expect(value).toStrictEqual(settings);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/country.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/country.test.tsx
@@ -1,0 +1,24 @@
+import {CountryCode} from '@shopify/ui-extensions/customer-account';
+
+import {useLocalizationCountry} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useLocalizationCountry', () => {
+  it('returns country from the api', () => {
+    const country: {isoCode: CountryCode} = {isoCode: 'CA'};
+
+    const {value} = mount.hook(() => useLocalizationCountry(), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        localization: {
+          country: createMockStatefulRemoteSubscribable(country),
+        },
+      },
+    });
+
+    expect(value).toStrictEqual(country);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/currency.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/currency.test.tsx
@@ -1,0 +1,24 @@
+import {CurrencyCode} from '@shopify/ui-extensions/customer-account';
+
+import {useCurrency} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useCurrency', () => {
+  it('returns currency from the api', () => {
+    const currency: {isoCode: CurrencyCode} = {isoCode: 'CAD'};
+
+    const {value} = mount.hook(() => useCurrency(), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        localization: {
+          currency: createMockStatefulRemoteSubscribable(currency),
+        },
+      },
+    });
+
+    expect(value).toStrictEqual(currency);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/customer-privacy.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/customer-privacy.test.tsx
@@ -1,0 +1,38 @@
+import {useCustomerPrivacy} from '..';
+import type {CustomerPrivacy} from '@shopify/ui-extensions/customer-account';
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useCustomerPrivacy', () => {
+  it('returns customer privacy from api', () => {
+    const customerPrivacyValue: CustomerPrivacy = {
+      allowedProcessing: {
+        analytics: false,
+        marketing: false,
+        preferences: false,
+        saleOfData: false,
+      },
+      visitorConsent: {
+        analytics: undefined,
+        marketing: undefined,
+        preferences: undefined,
+        saleOfData: undefined,
+      },
+      shouldShowBanner: false,
+      saleOfDataRegion: false,
+      region: undefined,
+      metafields: [],
+    };
+
+    const {value} = mount.hook(() => useCustomerPrivacy(), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        customerPrivacy:
+          createMockStatefulRemoteSubscribable(customerPrivacyValue),
+      },
+    });
+
+    expect(value).toStrictEqual(customerPrivacyValue);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/discounts.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/discounts.test.tsx
@@ -1,0 +1,76 @@
+import {
+  CartDiscountCode,
+  CartDiscountAllocation,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useDiscountAllocations, useDiscountCodes} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+import type {PartialExtensionApi} from './mount';
+
+describe('Discounts API hooks', () => {
+  describe('useDiscountCodes', () => {
+    it('returns the current discount codes', async () => {
+      const discountCodes: CartDiscountCode[] = [
+        {code: '20off'},
+        {code: 'free_shipping'},
+      ];
+
+      const extensionApi: PartialExtensionApi = {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        discountCodes: createMockStatefulRemoteSubscribable(discountCodes),
+      };
+
+      const {value} = mount.hook(() => useDiscountCodes(), {extensionApi});
+
+      expect(value).toBe(discountCodes);
+    });
+  });
+
+  describe('useDiscountAllocations', () => {
+    it('returns the current discount allocations', async () => {
+      const discountAllocations: CartDiscountAllocation[] = [
+        {
+          code: '20off',
+          discountedAmount: {
+            amount: 20,
+            currencyCode: 'USD',
+          },
+          type: 'code',
+        },
+        {
+          title: '10% off',
+          discountedAmount: {
+            amount: 10,
+            currencyCode: 'USD',
+          },
+          type: 'automatic',
+        },
+        {
+          title: '15% off',
+          discountedAmount: {
+            amount: 15,
+            currencyCode: 'USD',
+          },
+          type: 'custom',
+        },
+      ];
+
+      const extensionApi: PartialExtensionApi = {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        discountAllocations:
+          createMockStatefulRemoteSubscribable(discountAllocations),
+      };
+
+      const {value} = mount.hook(() => useDiscountAllocations(), {
+        extensionApi,
+      });
+
+      expect(value).toBe(discountAllocations);
+    });
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/extension-language.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/extension-language.test.tsx
@@ -1,0 +1,23 @@
+import {useExtensionLanguage} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useExtensionLanguage', () => {
+  it('returns extension language from api', () => {
+    const extensionLanguage = {isoCode: 'en-CA'};
+
+    const {value} = mount.hook(() => useExtensionLanguage(), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        localization: {
+          extensionLanguage:
+            createMockStatefulRemoteSubscribable(extensionLanguage),
+        },
+      },
+    });
+
+    expect(value).toStrictEqual(extensionLanguage);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/gift-cards.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/gift-cards.test.tsx
@@ -1,0 +1,36 @@
+import {AppliedGiftCard} from '@shopify/ui-extensions/customer-account';
+
+import {useAppliedGiftCards} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+import type {PartialExtensionApi} from './mount';
+
+describe('Gift cards API hooks', () => {
+  describe('useAppliedGiftCards', () => {
+    it('returns the current gift cards', async () => {
+      const giftCards: AppliedGiftCard[] = [
+        {
+          amountUsed: {amount: 20, currencyCode: 'USD'},
+          balance: {amount: 20, currencyCode: 'USD'},
+          lastCharacters: '1234',
+        },
+        {
+          amountUsed: {amount: 10, currencyCode: 'USD'},
+          balance: {amount: 10, currencyCode: 'USD'},
+          lastCharacters: '5678',
+        },
+      ];
+
+      const extensionApi: PartialExtensionApi = {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        appliedGiftCards: createMockStatefulRemoteSubscribable(giftCards),
+      };
+
+      const {value} = mount.hook(() => useAppliedGiftCards(), {extensionApi});
+
+      expect(value).toBe(giftCards);
+    });
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/i18n.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/i18n.test.tsx
@@ -1,0 +1,20 @@
+import {mount} from './mount';
+import {useI18n} from '..';
+
+describe('useI18n', () => {
+  it('returns the i18n utilities', () => {
+    const mock = {
+      formatNumber: jest.fn(),
+      formatDate: jest.fn(),
+      formatCurrency: jest.fn(),
+      translate: jest.fn(),
+    };
+    const {value} = mount.hook(useI18n, {
+      extensionApi: {
+        i18n: mock,
+      },
+    });
+
+    expect(value).toStrictEqual(mock);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/live-navigation.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/live-navigation.test.tsx
@@ -1,0 +1,74 @@
+import {mount} from './mount';
+import {useNavigationCurrentEntry} from '..';
+import {destroyAll} from '@quilted/react-testing';
+
+describe('useNavigationCurrentEntry', () => {
+  function createMock() {
+    return {
+      navigate: jest.fn(),
+      currentEntry: {state: jest.fn(), url: 'extension:/'},
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      updateCurrentEntry: jest.fn(),
+    };
+  }
+
+  it('returns the entry', () => {
+    const mock = createMock();
+    const {value} = mount.hook(useNavigationCurrentEntry, {
+      extensionApi: {
+        navigation: mock,
+      },
+    });
+
+    expect(value).toStrictEqual(mock.currentEntry);
+  });
+
+  it('calls addEventListener', () => {
+    const mock = createMock();
+    mount.hook(useNavigationCurrentEntry, {
+      extensionApi: {
+        navigation: mock,
+      },
+    });
+
+    expect(mock.addEventListener).toHaveBeenCalledWith(
+      'currententrychange',
+      expect.any(Function),
+    );
+  });
+
+  it('calls removeEventListener on destroy', () => {
+    const mock = createMock();
+    mount.hook(useNavigationCurrentEntry, {
+      extensionApi: {
+        navigation: mock,
+      },
+    });
+
+    destroyAll();
+
+    expect(mock.removeEventListener).toHaveBeenCalledWith(
+      'currententrychange',
+      expect.any(Function),
+    );
+  });
+
+  it('throws an error when its not a full page extension or order full page extension', async () => {
+    const mock = {
+      navigate: jest.fn(),
+    };
+
+    const runner = async () => {
+      return mount.hook(useNavigationCurrentEntry, {
+        extensionApi: {
+          navigation: mock,
+        },
+      });
+    };
+
+    await expect(runner).rejects.toThrow(
+      'useNavigationCurrentEntry must be used in an extension with the customer-account.page.render or customer-account.order.page.render target only',
+    );
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/market.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/market.test.tsx
@@ -1,0 +1,22 @@
+import {useLocalizationMarket} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useLocalizationMarket', () => {
+  it('returns market from the api', () => {
+    const market = {id: 'gid://shopify/Market/123', handle: 'apac'};
+
+    const {value} = mount.hook(() => useLocalizationMarket(), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        localization: {
+          market: createMockStatefulRemoteSubscribable(market),
+        },
+      },
+    });
+
+    expect(value).toStrictEqual(market);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/metafield.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/metafield.test.tsx
@@ -1,0 +1,112 @@
+import {faker} from '@faker-js/faker';
+import {Metafield} from '@shopify/ui-extensions/customer-account';
+
+import {useMetafield} from '..';
+
+import {createMockStatefulRemoteSubscribable, mount} from './mount';
+
+describe('useMetafields', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createMetafield(props: Partial<Metafield> = {}): Metafield {
+    return {
+      key: `key-${faker.datatype.uuid()}`,
+      namespace: `namespace-${faker.random.word}`,
+      value: `value-${faker.random.word}`,
+      valueType: 'string',
+      ...props,
+    };
+  }
+
+  function createMetafields(count = 5): Metafield[] {
+    return [...Array(count)].map(() => createMetafield());
+  }
+
+  it('returns undefined metafield', () => {
+    const metafieldCount = 10;
+
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      metafields: createMockStatefulRemoteSubscribable(
+        createMetafields(metafieldCount),
+      ),
+    };
+
+    const namespace = 'test_namespace';
+    const key = 'test_key';
+
+    const {value} = mount.hook(() => useMetafield({namespace, key}), {
+      extensionApi,
+    });
+
+    expect(value).toBeUndefined();
+  });
+
+  it('returns a filtered metafield', () => {
+    const namespace = 'test_namespace';
+    const key = 'test_key';
+    const newNamespace = createMetafield({namespace, key});
+
+    const metafields = [newNamespace, ...createMetafields()];
+
+    const {value} = mount.hook(() => useMetafield({namespace, key}), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        metafields: createMockStatefulRemoteSubscribable(metafields),
+      },
+    });
+
+    expect(value?.namespace).toStrictEqual(namespace);
+    expect(value?.key).toStrictEqual(key);
+  });
+
+  it('throws an error if no namespace is provided with key', () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      metafields: createMockStatefulRemoteSubscribable(createMetafields()),
+    };
+
+    expect(() =>
+      mount.hook(
+        () =>
+          useMetafield({
+            // @ts-expect-error: expected to fail
+            namespace: undefined,
+            key: 'test_key',
+          }),
+        {
+          extensionApi,
+        },
+      ),
+    ).toThrow('You must pass in both a namespace and key');
+  });
+
+  it('throws an error if no key is provided with namespace', () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      metafields: createMockStatefulRemoteSubscribable(createMetafields()),
+    };
+
+    const key = undefined as unknown as string;
+
+    expect(() =>
+      mount.hook(() => useMetafield({namespace: 'test_namespace', key}), {
+        extensionApi,
+      }),
+    ).toThrow('You must pass in both a namespace and key');
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/metafields.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/metafields.test.tsx
@@ -1,0 +1,136 @@
+import {faker} from '@faker-js/faker';
+import {Metafield} from '@shopify/ui-extensions/customer-account';
+
+import {useMetafields} from '..';
+
+import {createMockStatefulRemoteSubscribable, mount} from './mount';
+
+describe('useMetafields', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createMetafield(props: Partial<Metafield> = {}): Metafield {
+    return {
+      key: `key-${faker.datatype.uuid()}`,
+      namespace: `namespace-${faker.random.word}`,
+      value: `value-${faker.random.word}`,
+      valueType: 'string',
+      ...props,
+    };
+  }
+
+  function createMetafields(count = 5): Metafield[] {
+    return [...Array(count)].map(() => createMetafield());
+  }
+
+  it('returns all metafields', () => {
+    const metafieldCount = 10;
+
+    const {value} = mount.hook(() => useMetafields(), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render',
+        },
+        metafields: createMockStatefulRemoteSubscribable(
+          createMetafields(metafieldCount),
+        ),
+      },
+    });
+
+    expect(value).toHaveLength(metafieldCount);
+  });
+
+  it('returns an array of filtered metafields by namespace', () => {
+    const namespace = 'test_namespace';
+    const key = 'test_key';
+    const newNamespace = createMetafield({namespace, key});
+
+    const key2 = 'test_key2';
+    const newNamespace2 = createMetafield({namespace, key: key2});
+
+    const metafields = [newNamespace, newNamespace2, ...createMetafields()];
+
+    const {value} = mount.hook(() => useMetafields({namespace}), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render',
+        },
+        metafields: createMockStatefulRemoteSubscribable(metafields),
+      },
+    });
+
+    expect(value).toHaveLength(2);
+
+    expect(value[0].namespace).toStrictEqual(namespace);
+    expect(value[1].namespace).toStrictEqual(namespace);
+
+    expect(value[0].key).toStrictEqual(key);
+    expect(value[1].key).toStrictEqual(key2);
+  });
+
+  it('returns an array of filtered metafields by namespace and key', () => {
+    const namespace = 'test_namespace';
+    const key = 'test_key';
+    const newNamespace = createMetafield({namespace, key});
+
+    const metafields = [newNamespace, ...createMetafields()];
+
+    const {value} = mount.hook(() => useMetafields({namespace, key}), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render',
+        },
+        metafields: createMockStatefulRemoteSubscribable(metafields),
+      },
+    });
+
+    expect(value).toHaveLength(1);
+    expect(value[0].namespace).toStrictEqual(namespace);
+    expect(value[0].key).toStrictEqual(key);
+  });
+
+  it('returns an empty array if no matches are found', () => {
+    const namespace = 'test_namespace';
+    const key = 'test_key';
+
+    const metafields = createMetafields();
+
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      metafields: createMockStatefulRemoteSubscribable(metafields),
+    };
+
+    const namespaceSearch = mount.hook(() => useMetafields({namespace}), {
+      extensionApi,
+    });
+
+    const keySearch = mount.hook(() => useMetafields({namespace, key}), {
+      extensionApi,
+    });
+
+    expect(namespaceSearch.value).toHaveLength(0);
+    expect(keySearch.value).toHaveLength(0);
+  });
+
+  it('throws an error if no namespace is provided with key', () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      metafields: createMockStatefulRemoteSubscribable(createMetafields()),
+    };
+
+    const namespace = undefined as unknown as string;
+
+    expect(() =>
+      mount.hook(() => useMetafields({namespace, key: 'test_key'}), {
+        extensionApi,
+      }),
+    ).toThrow('You must pass in a namespace with a key');
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/mount.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/mount.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {createRender} from '@quilted/react-testing';
+import {
+  ApiForRenderExtension,
+  RenderExtensionTarget,
+} from '@shopify/ui-extensions/customer-account';
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+
+import {ExtensionApiContext} from '../../context';
+
+export const mount = createRender<Options, Options>({
+  context(options) {
+    return options;
+  },
+
+  render(element, {extensionApi}) {
+    return (
+      <ExtensionApiContext.Provider value={extensionApi as any}>
+        {element}
+      </ExtensionApiContext.Provider>
+    );
+  },
+});
+
+type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};
+
+export type PartialExtensionApi = DeepPartial<
+  ApiForRenderExtension<RenderExtensionTarget>
+>;
+
+interface Options {
+  extensionApi?: PartialExtensionApi;
+}
+
+export function createMockStatefulRemoteSubscribable<T>(
+  value: T,
+): StatefulRemoteSubscribable<T> {
+  const subscribable: StatefulRemoteSubscribable<T> = {
+    get current() {
+      return value;
+    },
+    subscribe: jest.fn(),
+    destroy: jest.fn(),
+  };
+
+  return subscribable;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/navigation.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/navigation.test.tsx
@@ -1,0 +1,18 @@
+import {mount} from './mount';
+import {useNavigation} from '..';
+
+describe('useNavigation', () => {
+  it('returns the navigation', () => {
+    const mock = {
+      navigate: jest.fn(),
+    };
+
+    const {value} = mount.hook(useNavigation, {
+      extensionApi: {
+        navigation: mock,
+      },
+    });
+
+    expect(value).toStrictEqual(mock);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/notes.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/notes.test.tsx
@@ -1,0 +1,19 @@
+import {useNote} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useNote', () => {
+  it('returns the current order note', async () => {
+    const note = 'the note';
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      note: createMockStatefulRemoteSubscribable(note),
+    };
+
+    const {value} = mount.hook(() => useNote(), {extensionApi});
+
+    expect(value).toBe(note);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/session-token.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/session-token.test.tsx
@@ -1,0 +1,22 @@
+import {useSessionToken} from '..';
+
+import {mount} from './mount';
+
+describe('useSessionToken', () => {
+  it('returns sessionToken from the api', () => {
+    const mockGetSessionToken = {
+      get: jest.fn(),
+    };
+
+    const {value} = mount.hook(() => useSessionToken(), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        sessionToken: mockGetSessionToken,
+      },
+    });
+
+    expect(value).toMatchObject(mockGetSessionToken);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/shipping-address.test.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/shipping-address.test.ts
@@ -1,0 +1,35 @@
+import {MailingAddress} from '@shopify/ui-extensions/customer-account';
+
+import {useShippingAddress} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+import {ScopeNotGrantedError} from '../../errors';
+
+describe('useShippingAddress', () => {
+  it('returns latest shipping address', async () => {
+    const address: MailingAddress = {countryCode: 'CA'};
+    const extensionApi = {
+      extension: {
+        target: 'customer-account.order-status.block.render' as const,
+      },
+      shippingAddress: createMockStatefulRemoteSubscribable(address),
+    };
+
+    const {value} = mount.hook(() => useShippingAddress(), {extensionApi});
+
+    expect(value).toMatchObject(address);
+  });
+
+  it('raises an exception without approval scopes granted', () => {
+    expect(() =>
+      mount.hook(() => useShippingAddress(), {
+        extensionApi: {
+          extension: {
+            target: 'customer-account.order-status.block.render' as const,
+          },
+          shippingAddress: undefined,
+        },
+      }),
+    ).toThrow(ScopeNotGrantedError);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/timezone.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/timezone.test.tsx
@@ -1,0 +1,22 @@
+import {useTimezone} from '..';
+
+import {mount, createMockStatefulRemoteSubscribable} from './mount';
+
+describe('useTimezone', () => {
+  it('returns timezone from the api', () => {
+    const timezone = 'America/New_York';
+
+    const {value} = mount.hook(() => useTimezone(), {
+      extensionApi: {
+        extension: {
+          target: 'customer-account.order-status.block.render' as const,
+        },
+        localization: {
+          timezone: createMockStatefulRemoteSubscribable(timezone),
+        },
+      },
+    });
+
+    expect(value).toStrictEqual(timezone);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/translate.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/translate.test.tsx
@@ -28,7 +28,6 @@ describe('useTranslate', () => {
 
     const simpleTranslation = [
       'Hello, ',
-      // eslint-disable-next-line react/jsx-key
       <Name />,
       ' . You are applicant #',
       1,

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/translate.test.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/translate.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import {useTranslate} from '..';
+
+import {mount} from './mount';
+
+describe('useTranslate', () => {
+  it('returns string translation', async () => {
+    const simpleTranslation = 'This is a simple string translation';
+    const translateInSandbox = jest.fn(() => simpleTranslation);
+
+    const extensionApi = {
+      i18n: {
+        translate: translateInSandbox,
+      },
+    };
+
+    const {value} = mount.hook(() => useTranslate(), {extensionApi});
+    const translate = value;
+
+    expect(translate('exampleKey')).toStrictEqual(simpleTranslation);
+  });
+
+  it('returns array with strings, numbers, and components', async () => {
+    function Name() {
+      return <p>Fred</p>;
+    }
+
+    const simpleTranslation = [
+      'Hello, ',
+      // eslint-disable-next-line react/jsx-key
+      <Name />,
+      ' . You are applicant #',
+      1,
+    ];
+    const translateInSandbox = jest.fn(() => simpleTranslation);
+
+    const extensionApi = {
+      i18n: {
+        translate: translateInSandbox,
+      },
+    };
+
+    const {value} = mount.hook(() => useTranslate(), {extensionApi});
+    const translate = value;
+
+    // Expect that a the same array is returned, with any valid components wrapped in a React.Fragment
+    expect(translate('exampleKey')).toMatchObject([
+      'Hello, ',
+      expect.objectContaining({type: Name}),
+      ' . You are applicant #',
+      1,
+    ]);
+  });
+
+  it('returns array with an element that is not a string, number, or component', async () => {
+    const simpleTranslation = ['Hello, ', undefined, ' .'];
+    const translateInSandbox = jest.fn(() => simpleTranslation);
+
+    const extensionApi = {
+      i18n: {
+        translate: translateInSandbox,
+      },
+    };
+
+    const {value} = mount.hook(() => useTranslate(), {extensionApi});
+    const translate = value;
+
+    expect(translate('exampleKey')).toStrictEqual(simpleTranslation);
+  });
+});

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/tsconfig.json
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  },
+  "include": ["./**/*"],
+  "exclude": []
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/tests/tsconfig.json
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/tests/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
-  "include": ["./**/*"],
+  "include": ["./**/*", "../**/*"],
   "exclude": []
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/timezone.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/timezone.ts
@@ -1,0 +1,25 @@
+import {
+  RenderOrderStatusExtensionTarget,
+  Timezone,
+} from '@shopify/ui-extensions/customer-account';
+
+import {useApi} from './api';
+import {useSubscription} from './subscription';
+import {ExtensionHasNoFieldError} from '../errors';
+
+/**
+ * Returns the time zone of the checkout, and automatically re-renders
+ * your component if the time zone changes.
+ */
+export function useTimezone<
+  Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,
+>(): Timezone {
+  const api = useApi<Target>();
+  const extensionTarget = api.extension.target;
+
+  if (!('timezone' in api.localization)) {
+    throw new ExtensionHasNoFieldError('timezone', extensionTarget);
+  }
+
+  return useSubscription(api.localization.timezone);
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/timezone.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/timezone.ts
@@ -1,11 +1,9 @@
-import {
-  RenderOrderStatusExtensionTarget,
-  Timezone,
-} from '@shopify/ui-extensions/customer-account';
+import type {RenderOrderStatusExtensionTarget} from '../extension-targets';
+import type {Timezone} from '../api';
 
 import {useApi} from './api';
 import {useSubscription} from './subscription';
-import {ExtensionHasNoFieldError} from '../errors';
+import {ExtensionHasNoFieldError} from './errors';
 
 /**
  * Returns the time zone of the checkout, and automatically re-renders

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/translate.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/translate.ts
@@ -1,0 +1,38 @@
+import {isValidElement, cloneElement, useCallback} from 'react';
+import type {
+  RenderExtensionTarget,
+  I18nTranslate,
+} from '@shopify/ui-extensions/customer-account';
+import type {RemoteComponentType} from '@remote-ui/types';
+
+import {useApi} from './api';
+
+/**
+ * Returns the `I18nTranslate` interface used to translate strings.
+ */
+export function useTranslate<
+  Target extends RenderExtensionTarget = RenderExtensionTarget,
+>(): I18nTranslate {
+  const {i18n} = useApi<Target>();
+
+  const translate = useCallback<I18nTranslate>(
+    (...args) => {
+      const translation = i18n.translate(...args);
+
+      if (!Array.isArray(translation)) {
+        return translation as any;
+      }
+
+      return translation.map((part, index) => {
+        if (isValidElement(part)) {
+          // eslint-disable-next-line react/no-array-index-key
+          return cloneElement(part as RemoteComponentType<any>, {key: index});
+        }
+        return part;
+      });
+    },
+    [i18n],
+  );
+
+  return translate;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/translate.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/translate.ts
@@ -1,9 +1,7 @@
-import {isValidElement, cloneElement, useCallback} from 'react';
-import type {
-  RenderExtensionTarget,
-  I18nTranslate,
-} from '@shopify/ui-extensions/customer-account';
-import type {RemoteComponentType} from '@remote-ui/types';
+import {isValidElement, cloneElement} from 'preact';
+import {useCallback} from 'preact/hooks';
+import type {RenderExtensionTarget} from '../extension-targets';
+import type {I18nTranslate} from '../api';
 
 import {useApi} from './api';
 
@@ -25,8 +23,7 @@ export function useTranslate<
 
       return translation.map((part, index) => {
         if (isValidElement(part)) {
-          // eslint-disable-next-line react/no-array-index-key
-          return cloneElement(part as RemoteComponentType<any>, {key: index});
+          return cloneElement(part, {key: index});
         }
         return part;
       });

--- a/packages/ui-extensions/yarn.lock
+++ b/packages/ui-extensions/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@faker-js/faker@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.4.1.tgz#5d5e8aee8fce48f5e189bf730ebd1f758f491451"
+  integrity sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -42,23 +47,10 @@
   dependencies:
     "@remote-ui/rpc" "^1.4.5"
 
-"@remote-ui/core@^2.2.5":
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.2.5.tgz#591a4af8137dbb5274bb7f7cd31dc78b99d4cd88"
-  integrity sha512-np+j+Bn5fWjqaOng0UQv4S48JqO/aLkKzCLR07c+PRXbxHxvMuGZeq/MuWOyTheUWhDaV2McrGDk+g/yYKQ8mA==
-  dependencies:
-    "@remote-ui/rpc" "^1.4.5"
-    "@remote-ui/types" "^1.1.3"
-
 "@remote-ui/rpc@^1.4.5":
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.4.5.tgz#20328970c314374d96fdaae1cf93aca4b47fefee"
   integrity sha512-Cr+06niG/vmE4A9YsmaKngRuuVSWKMY42NMwtZfy+gctRWGu6Wj9BWuMJg5CEp+JTkRBPToqT5rqnrg1G/Wvow==
-
-"@remote-ui/types@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@remote-ui/types/-/types-1.1.3.tgz#b2a790d5be50fb82d89d4abea9883f87f83a5a25"
-  integrity sha512-P1kN1F3p0oMgnLN8Of1Ie9am3sLvJ7nhqHH1pvzkrxqjVwhhyPVZNcwOHyUNZPKp62izhDavdrcnqrdXzVJqGA==
 
 "@shopify/generate-docs@0.16.4":
   version "0.16.4"
@@ -232,6 +224,11 @@ picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+preact@*:
+  version "10.26.5"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.26.5.tgz#7e1e998af178f139e4c7cb53f441bf2179f44ad2"
+  integrity sha512-fmpDkgfGU6JYux9teDWLhj9mKN55tyepwYbxHgQuIxbWQzgFg5vk7Mrrtfx7xRxq798ynkY4DDDxZr235Kk+4w==
 
 queue-microtask@^1.2.2:
   version "1.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,6 +1436,11 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@faker-js/faker@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.4.1.tgz#5d5e8aee8fce48f5e189bf730ebd1f758f491451"
+  integrity sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz"
@@ -5932,6 +5937,11 @@ possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
+
+preact@*:
+  version "10.26.5"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.26.5.tgz#7e1e998af178f139e4c7cb53f441bf2179f44ad2"
+  integrity sha512-fmpDkgfGU6JYux9teDWLhj9mKN55tyepwYbxHgQuIxbWQzgFg5vk7Mrrtfx7xRxq798ynkY4DDDxZr235Kk+4w==
 
 preferred-pm@^3.0.0:
   version "3.1.3"


### PR DESCRIPTION
### Background

There are 2 commits
1.  cop paste all customer account legacy hooks from unstable version so that we can make sure we will not miss any existing hooks. 
2. update the implementation and type imports a little bit to make sure it works 

### Solution

same as checkout https://github.com/Shopify/ui-extensions/pull/2764

### 🎩

Use https://github.com/Shopify/ui-extensions/pull/2777#issuecomment-2810270571

And this is how it looks like
<img width="966" alt="Screenshot 2025-04-16 at 1 55 39 PM" src="https://github.com/user-attachments/assets/a52f7130-f18c-4287-9edb-c5208f640418" />

<img width="1680" alt="Screenshot 2025-04-16 at 1 55 50 PM" src="https://github.com/user-attachments/assets/307f7386-9296-499a-98c0-a07c01f86c4f" />

```
import { render } from "preact";
import {
  useExtension,
} from "@shopify/ui-extensions/customer-account/preact";

export default function () {
  render(<Extension />, document.body);
}

function Extension() {
  const extension = useExtension();
  return (
    <s-page>
      <s-button slot="primaryAction" onClick={() => console.log("Primary action")} >PRIMARY BUTTONE</s-button>
      {JSON.stringify(extension)}
    </s-page>
  )
};

```

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
