### PR TITLE
Add Swtich documentation

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.ab.doc.ts
@@ -1,0 +1,9 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import shared from './shared';
+
+const data: ReferenceEntityTemplateSchema = {
+  ...shared,
+  category: 'Polaris web components',
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
@@ -1,0 +1,9 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import shared from './shared';
+
+const data: ReferenceEntityTemplateSchema = {
+  ...shared,
+  category: 'Components',
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/default.html
@@ -1,0 +1,4 @@
+<s-switch
+  label="Enable feature"
+  details="Ensure all criteria are met before enabling"
+></s-switch>

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/shared.ts
@@ -1,22 +1,22 @@
 const shared = {
-  name: 'Checkbox',
+  name: 'Switch',
   description:
-    'Use `s-checkbox` when you want to provide users with a clear selection option, such as for agreeing to terms and conditions or selecting multiple options from a list.',
-  thumbnail: 'checkbox-thumbnail.png',
+    'Use `s-switch` when you want to provide users with a clear selection option, such as toggling options on/off.',
+  thumbnail: 'switch-thumbnail.png',
   isVisualComponent: true,
   definitions: [
     {
       title: 'Properties',
       description: '',
-      type: 'Checkbox',
+      type: 'Switch',
     },
   ],
   subCategory: 'Forms',
   related: [
     {
       type: 'component',
-      name: 'Switch',
-      url: '/docs/api/admin-extensions/components/forms/switch',
+      name: 'Checkbox',
+      url: '/docs/api/admin-extensions/components/forms/checkbox',
     },
     {
       type: 'component',
@@ -30,7 +30,7 @@ const shared = {
     },
   ],
   defaultExample: {
-    image: 'checkbox-default.png',
+    image: 'sw-default.png',
     codeblock: {
       title: '',
       tabs: [


### PR DESCRIPTION
### Background

Adds the Switch component docs to shopify.dev

### 🎩 Tophat

In order to work on the documentation for Polaris 2025 you will need 3 repos checked out.

* Shopify/shopify-dev branch `polaris-docs-2025`
* Shopify/extensibility branch `main`
* Shopify/ui-extensions branch `add-switch-docs`

After checking out the above repos run `dev up && dev server` in `shopify-dev`. Now you should have a local copy of the docs running. 

### Switch in Docs

<img width="1798" alt="Screenshot 2025-04-18 at 10 54 13 AM" src="https://github.com/user-attachments/assets/1f2e24d3-7921-4859-9dc6-463ead7ef160" />

https://github.com/user-attachments/assets/04eb8c51-9347-4cb8-b904-a1bdec19ec66

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
