### PR TITLE
remove all remote-ui api examples for customer account

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/customer-account-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/customer-account-api.doc.ts
@@ -6,30 +6,30 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   category: 'APIs',
   type: 'API',
-  examples: {
-    description: '',
-    examples: [
-      {
-        description: `
-        You can access the [Customer Account GraphQL API](/docs/api/customer) using the global \`fetch()\`.`,
-        codeblock: {
-          title: 'Accessing the Customer Account API with fetch()',
-          tabs: [
-            {
-              code: '../examples/apis/customer-account-api-fetch.example.tsx',
-              language: 'jsx',
-              title: 'React',
-            },
-            {
-              code: '../examples/apis/customer-account-api-fetch.example.ts',
-              language: 'js',
-              title: 'JavaScript',
-            },
-          ],
-        },
-      },
-    ],
-  },
+  // examples: {
+  //   description: '',
+  //   examples: [
+  //     {
+  //       description: `
+  //       You can access the [Customer Account GraphQL API](/docs/api/customer) using the global \`fetch()\`.`,
+  //       codeblock: {
+  //         title: 'Accessing the Customer Account API with fetch()',
+  //         tabs: [
+  //           {
+  //             code: '../examples/apis/customer-account-api-fetch.example.tsx',
+  //             language: 'jsx',
+  //             title: 'React',
+  //           },
+  //           {
+  //             code: '../examples/apis/customer-account-api-fetch.example.ts',
+  //             language: 'js',
+  //             title: 'JavaScript',
+  //           },
+  //         ],
+  //       },
+  //     },
+  //   ],
+  // },
   related: [
     {
       name: 'GraphQL Customer Account API',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/customer-privacy.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/customer-privacy.doc.ts
@@ -25,49 +25,49 @@ const data: ReferenceEntityTemplateSchema = {
     //   type: 'UseCustomerPrivacyGeneratedType',
     // },
   ],
-  defaultExample: {
-    codeblock: {
-      title: 'Read Customer Privacy',
-      tabs: [
-        {
-          code: '../examples/apis/customer-privacy.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/apis/customer-privacy.example.ts',
-          language: 'js',
-          title: 'JavaScript',
-        },
-      ],
-    },
-  },
-  examples: {
-    description: '',
-    examples: [
-      {
-        description: `
-        You can apply changes to customer consent by using the \`applyTrackingConsentChanges\` API.
-        
-> Note: Requires the [\`customer_privacy\` capability](/docs/api/customer-account-ui-extensions/configuration#collect-buyer-consent) to be set to \`true\`.`,
-        codeblock: {
-          title: 'Use a Sheet to manage customer privacy consent',
-          tabs: [
-            {
-              code: '../examples/apis/sheet-consent-banner-with-form.example.tsx',
-              language: 'jsx',
-              title: 'React',
-            },
-            {
-              code: '../examples/apis/sheet-consent-banner-with-form.example.ts',
-              language: 'js',
-              title: 'JavaScript',
-            },
-          ],
-        },
-      },
-    ],
-  },
+  //   defaultExample: {
+  //     codeblock: {
+  //       title: 'Read Customer Privacy',
+  //       tabs: [
+  //         {
+  //           code: '../examples/apis/customer-privacy.example.tsx',
+  //           language: 'jsx',
+  //           title: 'React',
+  //         },
+  //         {
+  //           code: '../examples/apis/customer-privacy.example.ts',
+  //           language: 'js',
+  //           title: 'JavaScript',
+  //         },
+  //       ],
+  //     },
+  //   },
+  //   examples: {
+  //     description: '',
+  //     examples: [
+  //       {
+  //         description: `
+  //         You can apply changes to customer consent by using the \`applyTrackingConsentChanges\` API.
+
+  // > Note: Requires the [\`customer_privacy\` capability](/docs/api/customer-account-ui-extensions/configuration#collect-buyer-consent) to be set to \`true\`.`,
+  //         codeblock: {
+  //           title: 'Use a Sheet to manage customer privacy consent',
+  //           tabs: [
+  //             {
+  //               code: '../examples/apis/sheet-consent-banner-with-form.example.tsx',
+  //               language: 'jsx',
+  //               title: 'React',
+  //             },
+  //             {
+  //               code: '../examples/apis/sheet-consent-banner-with-form.example.ts',
+  //               language: 'js',
+  //               title: 'JavaScript',
+  //             },
+  //           ],
+  //         },
+  //       },
+  //     ],
+  //   },
   related: [],
 };
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/localization.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/localization.doc.ts
@@ -45,57 +45,57 @@ const data: ReferenceEntityTemplateSchema = {
     //   type: 'UseTranslateGeneratedType',
     // },
   ],
-  defaultExample: {
-    codeblock: {
-      title: 'Translating strings',
-      tabs: [
-        {
-          code: '../examples/apis/translate.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/apis/translate.example.ts',
-          language: 'js',
-          title: 'JavaScript',
-        },
-        {
-          code: '../examples/apis/translate.locale.example.json',
-          language: 'json',
-          title: 'locales/en.default.json',
-        },
-      ],
-    },
-  },
-  examples: {
-    description: '',
-    examples: [
-      {
-        description:
-          'You can use the count option to get a pluralized string based on the current locale.',
-        codeblock: {
-          title: 'Translating strings with pluralization',
-          tabs: [
-            {
-              code: '../examples/apis/translate-pluralization.example.tsx',
-              language: 'jsx',
-              title: 'React',
-            },
-            {
-              code: '../examples/apis/translate-pluralization.example.ts',
-              language: 'js',
-              title: 'JavaScript',
-            },
-            {
-              code: '../examples/apis/translate-pluralization.locale.example.json',
-              language: 'json',
-              title: 'locales/en.default.json',
-            },
-          ],
-        },
-      },
-    ],
-  },
+  // defaultExample: {
+  //   codeblock: {
+  //     title: 'Translating strings',
+  //     tabs: [
+  //       {
+  //         code: '../examples/apis/translate.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/apis/translate.example.ts',
+  //         language: 'js',
+  //         title: 'JavaScript',
+  //       },
+  //       {
+  //         code: '../examples/apis/translate.locale.example.json',
+  //         language: 'json',
+  //         title: 'locales/en.default.json',
+  //       },
+  //     ],
+  //   },
+  // },
+  // examples: {
+  //   description: '',
+  //   examples: [
+  //     {
+  //       description:
+  //         'You can use the count option to get a pluralized string based on the current locale.',
+  //       codeblock: {
+  //         title: 'Translating strings with pluralization',
+  //         tabs: [
+  //           {
+  //             code: '../examples/apis/translate-pluralization.example.tsx',
+  //             language: 'jsx',
+  //             title: 'React',
+  //           },
+  //           {
+  //             code: '../examples/apis/translate-pluralization.example.ts',
+  //             language: 'js',
+  //             title: 'JavaScript',
+  //           },
+  //           {
+  //             code: '../examples/apis/translate-pluralization.locale.example.json',
+  //             language: 'json',
+  //             title: 'locales/en.default.json',
+  //           },
+  //         ],
+  //       },
+  //     },
+  //   ],
+  // },
   related: [],
 };
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/navigation.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/navigation.doc.ts
@@ -34,65 +34,65 @@ const data: ReferenceEntityTemplateSchema = {
     //   type: 'UseNavigationCurrentEntryGeneratedType',
     // },
   ],
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Navigation example',
-      tabs: [
-        {
-          code: '../examples/navigation/default-react.example.tsx',
-          language: 'React',
-          title: 'React',
-        },
-        {
-          code: '../examples/navigation/default-js.example.ts',
-          language: 'js',
-          title: 'js',
-        },
-      ],
-    },
-  },
-  examples: {
-    description: 'Navigation api examples',
-    examples: [
-      {
-        codeblock: {
-          title: 'Listening for navigation current entry events',
-          tabs: [
-            {
-              code: '../examples/navigation/event-listeners.example.tsx',
-              language: 'jsx',
-              title: 'React',
-            },
-          ],
-        },
-      },
-      {
-        codeblock: {
-          title: 'Using the live current entry value in a full-page extension',
-          tabs: [
-            {
-              code: '../examples/navigation/use-current-entry.example.tsx',
-              language: 'jsx',
-              title: 'React',
-            },
-          ],
-        },
-      },
-      {
-        codeblock: {
-          title: 'Navigating to customer account native order index page',
-          tabs: [
-            {
-              code: '../examples/navigation/navigating-to-customer-account-page.example.tsx',
-              language: 'jsx',
-              title: 'React',
-            },
-          ],
-        },
-      },
-    ],
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Navigation example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/navigation/default-react.example.tsx',
+  //         language: 'React',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/navigation/default-js.example.ts',
+  //         language: 'js',
+  //         title: 'js',
+  //       },
+  //     ],
+  //   },
+  // },
+  // examples: {
+  //   description: 'Navigation api examples',
+  //   examples: [
+  //     {
+  //       codeblock: {
+  //         title: 'Listening for navigation current entry events',
+  //         tabs: [
+  //           {
+  //             code: '../examples/navigation/event-listeners.example.tsx',
+  //             language: 'jsx',
+  //             title: 'React',
+  //           },
+  //         ],
+  //       },
+  //     },
+  //     {
+  //       codeblock: {
+  //         title: 'Using the live current entry value in a full-page extension',
+  //         tabs: [
+  //           {
+  //             code: '../examples/navigation/use-current-entry.example.tsx',
+  //             language: 'jsx',
+  //             title: 'React',
+  //           },
+  //         ],
+  //       },
+  //     },
+  //     {
+  //       codeblock: {
+  //         title: 'Navigating to customer account native order index page',
+  //         tabs: [
+  //           {
+  //             code: '../examples/navigation/navigating-to-customer-account-page.example.tsx',
+  //             language: 'jsx',
+  //             title: 'React',
+  //           },
+  //         ],
+  //       },
+  //     },
+  //   ],
+  // },
   related: [
     {
       name: 'StandardApi',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/attributes.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/attributes.doc.ts
@@ -27,18 +27,18 @@ const data: ReferenceEntityTemplateSchema = {
     //   type: 'UseAttributeValuesGeneratedType',
     // },
   ],
-  defaultExample: {
-    codeblock: {
-      title: 'Attribute values',
-      tabs: [
-        {
-          code: '../../examples/apis/attribute-values.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   codeblock: {
+  //     title: 'Attribute values',
+  //     tabs: [
+  //       {
+  //         code: '../../examples/apis/attribute-values.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
 };
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/cart-lines.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/cart-lines.doc.ts
@@ -36,23 +36,23 @@ const data: ReferenceEntityTemplateSchema = {
     //   type: 'UseTargetGeneratedType',
     // },
   ],
-  defaultExample: {
-    codeblock: {
-      title: '',
-      tabs: [
-        {
-          code: '../../examples/apis/cart-line-item.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../../examples/apis/cart-line-item.example.ts',
-          language: 'js',
-          title: 'JavaScript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   codeblock: {
+  //     title: '',
+  //     tabs: [
+  //       {
+  //         code: '../../examples/apis/cart-line-item.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../../examples/apis/cart-line-item.example.ts',
+  //         language: 'js',
+  //         title: 'JavaScript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
 };
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/require-login.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/require-login.doc.ts
@@ -24,29 +24,29 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'growth',
     },
   ],
-  examples: {
-    description: '',
-    examples: [
-      {
-        description: 'Call requireLogin before triggering an action',
-        codeblock: {
-          title: 'Call requireLogin before triggering an action',
-          tabs: [
-            {
-              code: '../../examples/apis/require-login.example.tsx',
-              language: 'jsx',
-              title: 'React',
-            },
-            {
-              code: '../../examples/apis/require-login.example.ts',
-              language: 'js',
-              title: 'JavaScript',
-            },
-          ],
-        },
-      },
-    ],
-  },
+  // examples: {
+  //   description: '',
+  //   examples: [
+  //     {
+  //       description: 'Call requireLogin before triggering an action',
+  //       codeblock: {
+  //         title: 'Call requireLogin before triggering an action',
+  //         tabs: [
+  //           {
+  //             code: '../../examples/apis/require-login.example.tsx',
+  //             language: 'jsx',
+  //             title: 'React',
+  //           },
+  //           {
+  //             code: '../../examples/apis/require-login.example.ts',
+  //             language: 'js',
+  //             title: 'JavaScript',
+  //           },
+  //         ],
+  //       },
+  //     },
+  //   ],
+  // },
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/query.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/query.doc.ts
@@ -15,51 +15,51 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Docs_Standard_QueryApi',
     },
   ],
-  defaultExample: {
-    description: `
-    You can access the [Storefront GraphQL API](/docs/api/storefront) via the \`query()\` helper function.
-    Ensure your extension can use this API by [enabling the \`api_access\` capability](/docs/api/customer-account-ui-extensions/configuration#api-access).`,
-    codeblock: {
-      title: 'Access the Storefront API with query',
-      tabs: [
-        {
-          code: '../examples/apis/query.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/apis/query.example.ts',
-          language: 'js',
-          title: 'JavaScript',
-        },
-      ],
-    },
-  },
-  examples: {
-    description: '',
-    examples: [
-      {
-        description: `
-        You can access the [Storefront GraphQL API](/docs/api/storefront) using global \`fetch()\`.
-        Ensure your extension can access the Storefront API via the [\`api_access\` capability](/docs/api/customer-account-ui-extensions/configuration#api-access).`,
-        codeblock: {
-          title: 'Accessing the Storefront API with fetch()',
-          tabs: [
-            {
-              code: '../examples/apis/query-fetch.example.tsx',
-              language: 'jsx',
-              title: 'React',
-            },
-            {
-              code: '../examples/apis/query-fetch.example.ts',
-              language: 'js',
-              title: 'JavaScript',
-            },
-          ],
-        },
-      },
-    ],
-  },
+  // defaultExample: {
+  //   description: `
+  //   You can access the [Storefront GraphQL API](/docs/api/storefront) via the \`query()\` helper function.
+  //   Ensure your extension can use this API by [enabling the \`api_access\` capability](/docs/api/customer-account-ui-extensions/configuration#api-access).`,
+  //   codeblock: {
+  //     title: 'Access the Storefront API with query',
+  //     tabs: [
+  //       {
+  //         code: '../examples/apis/query.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/apis/query.example.ts',
+  //         language: 'js',
+  //         title: 'JavaScript',
+  //       },
+  //     ],
+  //   },
+  // },
+  // examples: {
+  //   description: '',
+  //   examples: [
+  //     {
+  //       description: `
+  //       You can access the [Storefront GraphQL API](/docs/api/storefront) using global \`fetch()\`.
+  //       Ensure your extension can access the Storefront API via the [\`api_access\` capability](/docs/api/customer-account-ui-extensions/configuration#api-access).`,
+  //       codeblock: {
+  //         title: 'Accessing the Storefront API with fetch()',
+  //         tabs: [
+  //           {
+  //             code: '../examples/apis/query-fetch.example.tsx',
+  //             language: 'jsx',
+  //             title: 'React',
+  //           },
+  //           {
+  //             code: '../examples/apis/query-fetch.example.ts',
+  //             language: 'js',
+  //             title: 'JavaScript',
+  //           },
+  //         ],
+  //       },
+  //     },
+  //   ],
+  // },
   related: [],
 };
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/session-token.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/session-token.doc.ts
@@ -20,42 +20,42 @@ const data: ReferenceEntityTemplateSchema = {
     //   type: 'UseSessionTokenGeneratedType',
     // },
   ],
-  defaultExample: {
-    codeblock: {
-      title: 'Using a session token with fetch()',
-      tabs: [
-        {
-          code: '../examples/apis/session-token.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/apis/session-token.example.ts',
-          language: 'js',
-          title: 'JavaScript',
-        },
-      ],
-    },
-  },
-  examples: {
-    description: '',
-    examples: [
-      {
-        description:
-          "The contents of the token are signed using your shared app secret. The optional `sub` claim contains the customer's `gid` if they are logged in and your app has permission to read customer accounts. For example, a loyalty app that needs to check a customer's point balance can use the `sub` claim to verify the customer's account.",
-        codeblock: {
-          title: 'Session token claims',
-          tabs: [
-            {
-              code: '../examples/apis/session-token-jwt.example.json',
-              language: 'json',
-              title: 'Session token claims',
-            },
-          ],
-        },
-      },
-    ],
-  },
+  // defaultExample: {
+  //   codeblock: {
+  //     title: 'Using a session token with fetch()',
+  //     tabs: [
+  //       {
+  //         code: '../examples/apis/session-token.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/apis/session-token.example.ts',
+  //         language: 'js',
+  //         title: 'JavaScript',
+  //       },
+  //     ],
+  //   },
+  // },
+  // examples: {
+  //   description: '',
+  //   examples: [
+  //     {
+  //       description:
+  //         "The contents of the token are signed using your shared app secret. The optional `sub` claim contains the customer's `gid` if they are logged in and your app has permission to read customer accounts. For example, a loyalty app that needs to check a customer's point balance can use the `sub` claim to verify the customer's account.",
+  //       codeblock: {
+  //         title: 'Session token claims',
+  //         tabs: [
+  //           {
+  //             code: '../examples/apis/session-token-jwt.example.json',
+  //             language: 'json',
+  //             title: 'Session token claims',
+  //           },
+  //         ],
+  //       },
+  //     },
+  //   ],
+  // },
   related: [],
 };
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/settings.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/settings.doc.ts
@@ -21,42 +21,42 @@ const data: ReferenceEntityTemplateSchema = {
     //   type: 'UseSettingsGeneratedType',
     // },
   ],
-  defaultExample: {
-    codeblock: {
-      title: 'Accessing merchant settings',
-      tabs: [
-        {
-          code: '../examples/apis/settings-access.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/apis/settings-access.example.ts',
-          language: 'js',
-          title: 'JavaScript',
-        },
-      ],
-    },
-  },
-  examples: {
-    description: '',
-    examples: [
-      {
-        description:
-          'You can define settings that merchants can edit within the checkout editor. See [settings](/docs/api/customer-account-ui-extensions/configuration#settings-definition) for more information on how to define these.',
-        codeblock: {
-          title: 'Define merchant settings',
-          tabs: [
-            {
-              code: '../examples/apis/settings.example.toml',
-              language: 'toml',
-              title: 'shopify.extension.toml',
-            },
-          ],
-        },
-      },
-    ],
-  },
+  // defaultExample: {
+  //   codeblock: {
+  //     title: 'Accessing merchant settings',
+  //     tabs: [
+  //       {
+  //         code: '../examples/apis/settings-access.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/apis/settings-access.example.ts',
+  //         language: 'js',
+  //         title: 'JavaScript',
+  //       },
+  //     ],
+  //   },
+  // },
+  // examples: {
+  //   description: '',
+  //   examples: [
+  //     {
+  //       description:
+  //         'You can define settings that merchants can edit within the checkout editor. See [settings](/docs/api/customer-account-ui-extensions/configuration#settings-definition) for more information on how to define these.',
+  //       codeblock: {
+  //         title: 'Define merchant settings',
+  //         tabs: [
+  //           {
+  //             code: '../examples/apis/settings.example.toml',
+  //             language: 'toml',
+  //             title: 'shopify.extension.toml',
+  //           },
+  //         ],
+  //       },
+  //     },
+  //   ],
+  // },
   related: [],
 };
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/ui.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/ui.doc.ts
@@ -15,25 +15,25 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Docs_Standard_UIApi',
     },
   ],
-  examples: {
-    description: '',
-    examples: [
-      {
-        description:
-          'Here is an example of using the `Toast.show` method to display a message to the customer indicating that their action to select a pickup address was successful.',
-        codeblock: {
-          title: 'Displaying a toast',
-          tabs: [
-            {
-              code: '../examples/apis/toast-example.tsx',
-              language: 'jsx',
-              title: 'React',
-            },
-          ],
-        },
-      },
-    ],
-  },
+  // examples: {
+  //   description: '',
+  //   examples: [
+  //     {
+  //       description:
+  //         'Here is an example of using the `Toast.show` method to display a message to the customer indicating that their action to select a pickup address was successful.',
+  //       codeblock: {
+  //         title: 'Displaying a toast',
+  //         tabs: [
+  //           {
+  //             code: '../examples/apis/toast-example.tsx',
+  //             language: 'jsx',
+  //             title: 'React',
+  //           },
+  //         ],
+  //       },
+  //     },
+  //   ],
+  // },
   related: [],
 };
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.footer.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.footer.render-after.doc.ts
@@ -14,24 +14,24 @@ the footer on all customer account pages (**Order index**, **Order status**, **P
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Footer',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account footer extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.footer.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.footer.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account footer extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.footer.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.footer.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   definitions: [CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   related: [],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-index.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-index.block.render.doc.ts
@@ -9,24 +9,24 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Order index',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account order index extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order-index.block.render/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order-index.block.render/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account order index extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order-index.block.render/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order-index.block.render/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [
     {
       name: 'Placement references',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.block.render.doc.ts
@@ -13,24 +13,24 @@ const data: ReferenceEntityTemplateSchema = {
   overviewPreviewDescription:
     'A [block extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the Order Status Page.',
   subCategory: 'Order status',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account order status extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order-status.block.render/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order-status.block.render/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account order status extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.block.render/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.block.render/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [
     {
       name: 'Placement references',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.cart-line-item.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.cart-line-item.render-after.doc.ts
@@ -13,24 +13,24 @@ const data: ReferenceEntityTemplateSchema = {
   ${ORDER_STATUS_SURFACE_NOTE}
   `,
   subCategory: 'Order status',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account order status card line item extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order-status.cart-line-item.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order-status.cart-line-item.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account order status card line item extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.cart-line-item.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.cart-line-item.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   ...ORDER_STATUS_CART_LINE_ITEM_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.cart-line-list.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.cart-line-list.render-after.doc.ts
@@ -10,24 +10,24 @@ const data: ReferenceEntityTemplateSchema = {
   ${ORDER_STATUS_SURFACE_NOTE}
   `,
   subCategory: 'Order status',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account order status cart line list extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order-status.cart-line-list.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order-status.cart-line-list.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account order status cart line list extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.cart-line-list.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.cart-line-list.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   ...ORDER_STATUS_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.customer-information.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.customer-information.render-after.doc.ts
@@ -10,25 +10,25 @@ const data: ReferenceEntityTemplateSchema = {
   ${ORDER_STATUS_SURFACE_NOTE}
   `,
   subCategory: 'Order status',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title:
-        'Customer account order status customer information extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title:
+  //       'Customer account order status customer information extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   ...ORDER_STATUS_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.fulfillment-details.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.fulfillment-details.render-after.doc.ts
@@ -8,25 +8,25 @@ const data: ReferenceEntityTemplateSchema = {
     A [static extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#static-extension-targets) that renders in the delivery status card on the Order Status page. A separate delivery status card is shown for each fulfillment.
   `,
   subCategory: 'Order status',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title:
-        'Customer account order status fulfillment details extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order-status.fulfillment-details.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order-status.fulfillment-details.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title:
+  //       'Customer account order status fulfillment details extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.fulfillment-details.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.fulfillment-details.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   ...FULFILLMENT_DETAILS_APIS,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.payment-details.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.payment-details.render-after.doc.ts
@@ -8,24 +8,24 @@ const data: ReferenceEntityTemplateSchema = {
   A [static extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#static-extension-targets) that renders in the payment status section of the Order Status page.
   `,
   subCategory: 'Order status',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account order status payment status extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account order status payment status extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   ...ORDER_STATUS_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.return-details.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.return-details.render-after.doc.ts
@@ -8,24 +8,24 @@ const data: ReferenceEntityTemplateSchema = {
   A [static extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#static-extension-targets) that renders in the return status card on the Order Status page. This card only shows when a return has been requested.
   `,
   subCategory: 'Order status',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account order status return details extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order-status.return-details.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order-status.return-details.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account order status return details extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.return-details.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.return-details.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   ...ORDER_STATUS_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.unfulfilled-items.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.unfulfilled-items.render-after.doc.ts
@@ -8,25 +8,25 @@ const data: ReferenceEntityTemplateSchema = {
   A [static extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#static-extension-targets) that renders in the delivery status card for unfulfilled items on the Order Status page.
   `,
   subCategory: 'Order status',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title:
-        'Customer account order status unfulfilled details extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order-status.unfulfilled-items.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order-status.unfulfilled-items.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title:
+  //       'Customer account order status unfulfilled details extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.unfulfilled-items.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order-status.unfulfilled-items.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   ...ORDER_STATUS_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.action.menu-item.render.doc.ts
@@ -12,24 +12,24 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Order action menu',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account order menu item extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order.action.menu-item.render/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order.action.menu-item.render/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account order menu item extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order.action.menu-item.render/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order.action.menu-item.render/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   examples: {
     description: 'Additional examples for menu item extensions.',
     examples: [

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.action.render.doc.ts
@@ -18,24 +18,24 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Order action menu',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account order action extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.order.action.render/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.order.action.render/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account order action extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.order.action.render/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.order.action.render/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   definitions: [
     ORDER_ACTION_API,

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.page.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.page.render.doc.ts
@@ -20,24 +20,24 @@ A full-page extension target cannot coexist with any other targets in the same e
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Full page',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account wishlist full-page extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.page.render/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.page.render/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account wishlist full-page extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.page.render/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.page.render/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   definitions: [
     CUSTOMER_ACCOUNT_FULL_PAGE_API_DEFINITION,

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.addresses.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.addresses.render-after.doc.ts
@@ -8,24 +8,24 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (Default)',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account addresses extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.profile.addresses.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.profile.addresses.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account addresses extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.profile.addresses.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.profile.addresses.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   definitions: [CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.block.render.doc.ts
@@ -10,24 +10,24 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (Default)',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account profile extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.profile.block.render/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.profile.block.render/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account profile extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.profile.block.render/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.profile.block.render/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [
     {
       name: 'Placement references',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-details.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-details.render-after.doc.ts
@@ -8,24 +8,24 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (B2B)',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account company details extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.profile.company-details.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.profile.company-details.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account company details extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.profile.company-details.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.profile.company-details.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   definitions: [CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-addresses.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-addresses.render-after.doc.ts
@@ -11,24 +11,24 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (B2B)',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account company location addresses extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.profile.company-location-addresses.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.profile.company-location-addresses.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account company location addresses extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.profile.company-location-addresses.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.profile.company-location-addresses.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   definitions: [COMPANY_LOCATION_API, CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-payment.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-payment.render-after.doc.ts
@@ -11,24 +11,24 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (B2B)',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account company location payment extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.profile.company-location-payment.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.profile.company-location-payment.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account company location payment extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.profile.company-location-payment.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.profile.company-location-payment.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   definitions: [COMPANY_LOCATION_API, CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-staff.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-staff.render-after.doc.ts
@@ -11,24 +11,24 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (B2B)',
-  defaultExample: {
-    description: '',
-    codeblock: {
-      title: 'Customer account company location staff extension example',
-      tabs: [
-        {
-          code: '../examples/targets/customer-account.profile.company-location-staff.render-after/default.example.tsx',
-          language: 'jsx',
-          title: 'React',
-        },
-        {
-          code: '../examples/targets/customer-account.profile.company-location-staff.render-after/default.example.ts',
-          language: 'js',
-          title: 'Javascript',
-        },
-      ],
-    },
-  },
+  // defaultExample: {
+  //   description: '',
+  //   codeblock: {
+  //     title: 'Customer account company location staff extension example',
+  //     tabs: [
+  //       {
+  //         code: '../examples/targets/customer-account.profile.company-location-staff.render-after/default.example.tsx',
+  //         language: 'jsx',
+  //         title: 'React',
+  //       },
+  //       {
+  //         code: '../examples/targets/customer-account.profile.company-location-staff.render-after/default.example.ts',
+  //         language: 'js',
+  //         title: 'Javascript',
+  //       },
+  //     ],
+  //   },
+  // },
   related: [],
   definitions: [COMPANY_LOCATION_API, CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   type: 'Target',


### PR DESCRIPTION
### Background

remove all remote-ui api examples for customer account
- targets
- APIs
<img width="1737" alt="Screenshot 2025-04-21 at 9 47 39 AM" src="https://github.com/user-attachments/assets/d894b0e6-471a-4a74-bc08-59771fca9cff" />
<img width="1707" alt="Screenshot 2025-04-21 at 9 47 29 AM" src="https://github.com/user-attachments/assets/3a35ad24-5615-438d-9ab8-b3b4eea67aa4" />


the  overview page still have some, I am updating directly, will open another PR for that. 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
