### PR TITLE
customer account doc -  add preact examples for components

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
@@ -36,6 +36,11 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Basic CustomerAccountAction',
       tabs: [
         {
+          title: 'Preact',
+          code: './examples/basic-CustomerAccountAction-preact.example.tsx',
+          language: 'tsx',
+        },
+        {
           title: 'JS',
           code: './examples/basic-CustomerAccountAction-js.example.ts',
           language: 'js',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-preact.example.tsx
@@ -1,0 +1,16 @@
+import {render} from 'preact';
+
+export default function extension() {
+  render(<App />, document.body);
+}
+
+function App() {
+  return (
+    <s-customer-account-action heading="Extension title">
+      Extension content
+      <s-button slot="primaryAction" onClick={() => shopify.close()}>
+        Click to close
+      </s-button>
+    </s-customer-account-action>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.doc.ts
@@ -24,6 +24,11 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Basic ImageGroup',
       tabs: [
         {
+          title: 'Preact',
+          code: './examples/basic-ImageGroup-preact.example.tsx',
+          language: 'tsx',
+        },
+        {
           title: 'JS',
           code: './examples/basic-ImageGroup-js.example.ts',
           language: 'js',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/examples/basic-ImageGroup-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/examples/basic-ImageGroup-preact.example.tsx
@@ -1,0 +1,15 @@
+import {render} from 'preact';
+
+export default function extension() {
+  render(<App />, document.body);
+}
+
+function App() {
+  return (
+    <s-image-group>
+      <s-image src="../assets/flower.jpg" />
+      <s-image src="../assets/flower.jpg" />
+      <s-image src="../assets/flower.jpg" />
+    </s-image-group>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.doc.ts
@@ -42,6 +42,11 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Basic Page',
       tabs: [
         {
+          title: 'Preact',
+          code: './examples/basic-Page-preact.example.tsx',
+          language: 'tsx',
+        },
+        {
           title: 'JS',
           code: './examples/basic-Page-js.example.ts',
           language: 'js',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-preact.example.tsx
@@ -1,0 +1,36 @@
+import {render} from 'preact';
+
+export default function extension() {
+  render(<App />, document.body);
+}
+
+function App() {
+  return (
+    <s-page heading="Order #1411" subheading="Confirmed Oct 5">
+      <s-button
+        slot="primaryAction"
+        onClick={() => console.log('Primary action')}
+      >
+        Primary action
+      </s-button>
+      <s-button
+        slot="secondaryActions"
+        onClick={() => console.log('Secondary action 1')}
+      >
+        Secondary action 1
+      </s-button>
+      <s-button
+        slot="secondaryActions"
+        onClick={() => console.log('Secondary action 2')}
+      >
+        Secondary action 2
+      </s-button>
+      <s-button
+        slot="breadcrumbActions"
+        accessibilitylabel="Button"
+        href="shopify://customer-account/orders"
+      />
+      Content
+    </s-page>
+  );
+}


### PR DESCRIPTION
### Background

customer account doc -  add preact examples for components

<img width="1394" alt="Screenshot 2025-04-21 at 11 23 31 AM" src="https://github.com/user-attachments/assets/44f565be-6f20-4cc6-a80c-a37846905ff1" />
<img width="1393" alt="Screenshot 2025-04-21 at 11 23 15 AM" src="https://github.com/user-attachments/assets/398f0b0e-cb40-4cec-9edd-eccc669cdf26" />
<img width="1421" alt="Screenshot 2025-04-21 at 11 23 23 AM" src="https://github.com/user-attachments/assets/e124fb0e-22a1-46ff-9730-cc76521f5b5d" />

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
