### PR TITLE
Added docs for Direct API and Auth API

### DIFF
--- a/.changeset/calm-lamps-brush.md
+++ b/.changeset/calm-lamps-brush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added new type for direct api

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/authenticated-fetch/authenticated-fetch.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/authenticated-fetch/authenticated-fetch.ts
@@ -1,0 +1,26 @@
+import {
+  extension,
+  POSBlock,
+  Text,
+  POSBlockRow,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.customer-details.block.render', (root, api) => {
+  const customerId = api.customer.id;
+  const infoText = root.createComponent(Text);
+  const posBlockRow = root.createComponent(POSBlockRow);
+
+  async function getLoyaltyInfo() {
+    const res = await fetch(`${URL}/api/loyalty/${customerId}`);
+    const json = await res.json();
+    infoText.replaceChildren(json.loyaltySummary);
+  }
+
+  posBlockRow.append(infoText);
+  const posBlock = root.createComponent(POSBlock);
+
+  posBlock.append(posBlockRow);
+  root.append(posBlock);
+
+  getLoyaltyInfo();
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/authenticated-fetch/authenticated-fetch.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/authenticated-fetch/authenticated-fetch.tsx
@@ -1,0 +1,34 @@
+import {
+  reactExtension,
+  useApi,
+  Text,
+  POSBlock,
+  POSBlockRow,
+} from '@shopify/ui-extensions-react/point-of-sale';
+import {useEffect, useState} from 'react';
+
+const CustomerDetailsBlock = () => {
+  const {customer} = useApi<'pos.customer-details.block.render'>();
+  const [loyaltyInfo, setLoyaltyInfo] = useState<any>();
+  useEffect(() => {
+    getLoyaltyInfo();
+  }, [customer.id]);
+
+  async function getLoyaltyInfo() {
+    const res = await fetch(`${URL}/api/loyalty/${customer.id}`);
+    const json = await res.json();
+    setLoyaltyInfo(json.loyaltySummary);
+  }
+
+  return (
+    <POSBlock>
+      <POSBlockRow>
+        <Text>{loyaltyInfo}</Text>
+      </POSBlockRow>
+    </POSBlock>
+  );
+};
+
+export default reactExtension('pos.customer-details.block.render', () => (
+  <CustomerDetailsBlock />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/direct-api-access/direct-api-access.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/direct-api-access/direct-api-access.ts
@@ -1,0 +1,97 @@
+import {
+  extension,
+  POSBlock,
+  Text,
+  POSBlockRow,
+  DirectApiRequestBody,
+} from '@shopify/ui-extensions/point-of-sale';
+
+async function mutateMetafield(productId: number) {
+  const requestBody: DirectApiRequestBody = {
+    query: `
+        mutation MetafieldsSet($metafields: [MetafieldsSetInput!]!) { 
+          metafieldsSet(metafields: $metafields) {
+            metafields {
+              key
+              namespace
+              value
+              createdAt
+              updatedAt
+            }
+          }
+        }
+      `,
+    variables: {
+      metafields: [
+        {
+          key: 'direct_api',
+          namespace: 'custom',
+          ownerId: `gid://shopify/Product/${productId}`,
+          value: 'Example Value',
+        },
+      ],
+    },
+  };
+
+  await fetch('shopify:admin/api/graphql.json', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+}
+
+async function queryProductMetafields(productId: number) {
+  const requestBody: DirectApiRequestBody = {
+    query: `
+      query GetProduct($id: ID!) {
+        product(id: $id) {
+          id
+          metafields(first: 10) {
+            edges {
+              node {
+                id
+                namespace
+                key
+                value
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables: {id: `gid://shopify/Product/${productId}`},
+  };
+  const res = await fetch('shopify:admin/api/graphql.json', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+  return res.json();
+}
+
+export default extension('pos.product-details.block.render', (root, api) => {
+  const productId = api.product.id;
+  const metafieldInfoText = root.createComponent(Text);
+  const metafieldInfoRow = root.createComponent(POSBlockRow);
+
+  const setMetafieldText = root.createComponent(Text);
+  setMetafieldText.append('Set Metafield');
+
+  const setMetafieldRow = root.createComponent(POSBlockRow, {
+    onPress: () => mutateMetafield(productId),
+  });
+
+  async function getProductInfo() {
+    const result = await queryProductMetafields(productId);
+    metafieldInfoText.replaceChildren(JSON.stringify(result, null, 2));
+  }
+
+  metafieldInfoRow.append(metafieldInfoText);
+  setMetafieldRow.append(setMetafieldText);
+
+  const posBlock = root.createComponent(POSBlock);
+
+  posBlock.append(metafieldInfoRow);
+  posBlock.append(setMetafieldRow);
+  root.append(posBlock);
+
+  getProductInfo();
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/direct-api-access/direct-api-access.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/direct-api-access/direct-api-access.tsx
@@ -1,0 +1,97 @@
+import {
+  reactExtension,
+  useApi,
+  Text,
+  POSBlock,
+  POSBlockRow,
+  DirectApiRequestBody,
+} from '@shopify/ui-extensions-react/point-of-sale';
+import {useEffect, useState} from 'react';
+
+async function mutateMetafield(productId: number) {
+  const requestBody: DirectApiRequestBody = {
+    query: `
+        mutation MetafieldsSet($metafields: [MetafieldsSetInput!]!) { 
+          metafieldsSet(metafields: $metafields) {
+            metafields {
+              key
+              namespace
+              value
+              createdAt
+              updatedAt
+            }
+          }
+        }
+      `,
+    variables: {
+      metafields: [
+        {
+          key: 'direct_api',
+          namespace: 'custom',
+          ownerId: `gid://shopify/Product/${productId}`,
+          value: 'Example Value',
+        },
+      ],
+    },
+  };
+
+  await fetch('shopify:admin/api/graphql.json', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+}
+
+async function queryProductMetafields(productId: number) {
+  const requestBody: DirectApiRequestBody = {
+    query: `
+      query GetProduct($id: ID!) {
+        product(id: $id) {
+          id
+          metafields(first: 10) {
+            edges {
+              node {
+                id
+                namespace
+                key
+                value
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables: {id: `gid://shopify/Product/${productId}`},
+  };
+  const res = await fetch('shopify:admin/api/graphql.json', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+  return res.json();
+}
+
+const ProductDetailsBlock = () => {
+  const {product} = useApi<'pos.product-details.block.render'>();
+  const [productInfo, setProductInfo] = useState<any>();
+  useEffect(() => {
+    async function getProductInfo() {
+      const result = await queryProductMetafields(product.id);
+      setProductInfo(JSON.stringify(result, null, 2));
+    }
+    getProductInfo();
+  }, [product.id]);
+
+  return (
+    <POSBlock>
+      <POSBlockRow>
+        <Text>Metafields: {productInfo}</Text>
+      </POSBlockRow>
+      <POSBlockRow onPress={() => mutateMetafield(product.id)}>
+        <Text>Set metafield</Text>
+      </POSBlockRow>
+    </POSBlock>
+  );
+};
+
+export default reactExtension('pos.product-details.block.render', () => (
+  <ProductDetailsBlock />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/pos-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/pos-overview.doc.ts
@@ -38,6 +38,18 @@ const data: LandingTemplateSchema = {
           url: '/docs/api/pos-ui-extensions/components',
           type: 'blocks',
         },
+        {
+          subtitle: 'App authentication',
+          name: "Make authenticated requests to your app's backend",
+          url: '#app-authentication',
+          type: 'tool',
+        },
+        {
+          subtitle: 'Direct API access',
+          name: 'Access the Shopify GraphQL API directly',
+          url: '#direct-api-access',
+          type: 'tool',
+        },
       ],
     },
     {
@@ -57,6 +69,73 @@ const data: LandingTemplateSchema = {
           name: 'Use the Figma UI kit to design your extension.',
           url: 'https://www.figma.com/community/file/1493617217926107705',
           type: 'star',
+        },
+      ],
+    },
+    {
+      type: 'Generic',
+      title: 'App Authentication',
+      sectionNotice: [
+        {
+          title: 'Note',
+          type: 'info',
+          sectionContent: `App Authentication is available as of POS version 10.2.0 for extensions targeting \`unstable\`. This feature will be available for all extensions targeting stable API versions in the future.`,
+        },
+      ],
+      sectionContent:
+        "POS UI extensions can also make authenticated calls to your app's backend. When you use `fetch()` to make a request to your app's configured auth domain or any of its subdomains, an `Authorization` header is automatically added with a Shopify [OpenID Connect ID Token (formerly known as a Session Token)](https://shopify.dev/docs/api/app-bridge-library/reference/id-token). There's no need to manually manage ID tokens.\n\nRelative URLs passed to `fetch()` are resolved against your app's `app_url`. This means if your app's backend is on the same domain as your `app_url`, you can make requests to it using `fetch('/path')`.\n\nIf you need to make requests to a different domain, you can use the [`session.getSessionToken()` method](/docs/api/pos-ui-extensions/apis/session-api#sessionapi-propertydetail-getsessiontoken) to retrieve the ID token and manually add it to your request headers.",
+      anchorLink: 'app-authentication',
+      codeblock: {
+        title: "Make requests to your app's backend",
+        tabs: [
+          {
+            code: '../examples/authenticated-fetch/authenticated-fetch.tsx',
+            language: 'tsx',
+            title: 'React',
+          },
+          {
+            code: '../examples/authenticated-fetch/authenticated-fetch.ts',
+            language: 'ts',
+            title: 'TS',
+          },
+        ],
+      },
+    },
+    {
+      type: 'Generic',
+      title: 'Direct API access',
+      sectionNotice: [
+        {
+          title: 'Note',
+          type: 'info',
+          sectionContent: `Direct API access is available as of POS version 10.2.0 for extensions targeting \`unstable\`. This feature will be available for all extensions targeting stable API versions in the future.`,
+        },
+      ],
+      sectionContent:
+        "You can make Shopify Admin API requests directly from your extension using the standard [web fetch API](https://developer.mozilla.org/en-US/docs/Web/API/fetch)!\n\nAny `fetch()` calls from your extension to Shopify's Admin GraphQL API are automatically authenticated by default. These calls are fast too, because Shopify handles requests directly.\n\nDirect API requests use [online access](https://shopify.dev/docs/apps/build/authentication-authorization/access-token-types/online-access-tokens) mode by default.",
+      anchorLink: 'direct-api-access',
+
+      codeblock: {
+        title: 'Query Shopify data',
+        tabs: [
+          {
+            code: '../examples/direct-api-access/direct-api-access.tsx',
+            language: 'tsx',
+            title: 'React',
+          },
+          {
+            code: '../examples/direct-api-access/direct-api-access.ts',
+            language: 'ts',
+            title: 'TS',
+          },
+        ],
+      },
+      sectionCard: [
+        {
+          name: 'Learn more about access scopes',
+          subtitle: 'Developer guide',
+          url: '/docs/api/usage/access-scopes',
+          type: 'information',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -93,6 +93,8 @@ export type {
   Address,
 } from './types/cart';
 
+export type {DirectApiRequestBody} from './types/direct-api-request-body';
+
 export type {
   ShippingLine,
   CalculatedShippingLine,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/direct-api-request-body.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/direct-api-request-body.ts
@@ -1,0 +1,13 @@
+/**
+ * Interface representing the structure of a direct API request body for GraphQL operations.
+ */
+export interface DirectApiRequestBody {
+  /**
+   * The GraphQL query or mutation string to be executed.
+   */
+  query: string;
+  /**
+   * Optional variables to be passed along with the GraphQL query.
+   */
+  variables?: Record<string, any>;
+}


### PR DESCRIPTION
### Background
This adds the unstable documentation for POS UI Extension Direct API and Auth API. It's pretty much a copy and paste from the admin-ui-extension documentation, but tailored to POS. I also made the code examples relevant to POS and our selection of block targets!

### Solution


### 🎩
- Checkout this branch/PR from the shopify-dev repo.
- Run `dev up && dev s` in that repo in your IDE
- ctrl+T to open the local instance in your browser.
- Navigate to https://shopify-dev.myshopify.io/docs/api/pos-ui-extensions/unstable#direct-api-access

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
