### PR TITLE
pick disabled prop for customer account opage secondary action

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -108,7 +108,7 @@ export interface Docs_Page_Button_PrimaryAction
 export interface Docs_Page_Button_SecondaryAction
   extends Pick<
     ButtonProps,
-    'onClick' | 'loading' | 'accessibilityLabel' | 'href'
+    'onClick' | 'loading' | 'disabled' | 'accessibilityLabel' | 'href'
   > {}
 
 export interface Docs_Page_Button_BreadcrumbAction


### PR DESCRIPTION
### Background

Fix https://github.com/Shopify/temp-project-mover-Archetypically-20250512095102/issues/208 

pick `disabled` prop for customer account page secondary action

<img width="743" alt="Screenshot 2025-04-25 at 10 39 33 AM" src="https://github.com/user-attachments/assets/b45e7a74-21b2-4be6-8841-ee1619d3c646" />




### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
