### PR TITLE
Use 2025.10.0 in 2025-10-rc branch

### DIFF
--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/ui-extensions",
-  "version": "2025.7.0",
+  "version": "2025.10.0",
   "scripts": {
     "docs:admin": "node ./docs/surfaces/admin/build-docs.mjs",
     "docs:checkout": "bash ./docs/surfaces/checkout/build-docs.sh",


### PR DESCRIPTION
This changes the version number to `2025.10.0` for the release candidate.