### PR TITLE
Add slot definitions for shopify.dev docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -3648,6 +3648,8 @@ declare abstract class PreactCustomElement extends BaseClass$1 {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;
@@ -3727,6 +3729,9 @@ declare const tagName$K = 's-banner';
 export interface ReactProps$K
   extends Partial<BannerProps>,
     Pick<BannerProps$1, 'id'> {
+  /**
+   * The secondary actions to display at the bottom of the banner. Only a maximum of two `s-button` components are allowed.
+   */
   secondaryActions?: ComponentChild;
   onDismiss?: ((event: CallbackEvent<typeof tagName$K>) => void) | null;
   onAfterHide?: ((event: CallbackEvent<typeof tagName$K>) => void) | null;
@@ -4358,6 +4363,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
   get isContentEditable(): boolean;
   /** @private */
   formResetCallback(): void;
+  /** @private */
+  connectedCallback(): void;
   constructor(renderImpl: RenderImpl);
 }
 
@@ -4912,6 +4919,9 @@ export interface PageProps extends Required<Pick<PageProps$1, 'inlineSize'>> {
 
 declare const tagName$p = 's-page';
 export interface ReactProps$p extends Partial<PageProps> {
+  /**
+   * The content to display in the aside section of the page.
+   */
   aside?: ComponentChild;
 }
 
@@ -5332,6 +5342,9 @@ declare const tagName$g = 's-table';
 export interface ReactProps$g
   extends Partial<TableProps>,
     Pick<TableProps$1, 'id' | 'onNextPage' | 'onPreviousPage'> {
+  /**
+   * Additional filters to display in the table. For example, the `s-search-field` component can be used to filter the table data.
+   */
   filters?: ComponentChild;
 }
 
@@ -5645,6 +5658,9 @@ export interface ReactProps$8
   extends Partial<Omit<TextFieldProps, 'accessory'>>,
     Pick<TextFieldProps$1, 'id'>,
     FieldReactProps<typeof tagName$8> {
+  /**
+   * The accessory to display in the text field.
+   */
   accessory?: ComponentChild;
 }
 
@@ -5750,7 +5766,13 @@ declare const tagName$5 = 's-admin-action';
 export interface ReactProps$5
   extends Partial<AdminActionProps>,
     Pick<AdminActionProps$1, 'id'> {
+  /**
+   * The primary action to display in the admin action.
+   */
   primaryAction: ComponentChild;
+  /**
+   * The secondary actions to display in the admin action.
+   */
   secondaryActions: ComponentChild;
 }
 
@@ -6035,3 +6057,42 @@ export {
   URLField,
   UnorderedList,
 };
+
+export interface BannerSlots {
+  /**
+   * The secondary actions to display at the bottom of the banner. Only a maximum of two `s-button` components are allowed.
+   */
+  'secondary-actions'?: HTMLElement;
+}
+
+export interface PageSlots {
+  /**
+   * The content to display in the aside section of the page.
+   */
+  aside?: HTMLElement;
+}
+
+export interface TableSlots {
+  /**
+   * Additional filters to display in the table. For example, the `s-search-field` component can be used to filter the table data.
+   */
+  filters?: HTMLElement;
+}
+
+export interface TextFieldSlots {
+  /**
+   * The accessory to display in the text field.
+   */
+  accessory?: HTMLElement;
+}
+
+export interface AdminActionSlots {
+  /**
+   * The primary action to display in the admin action.
+   */
+  'primary-action': HTMLElement;
+  /**
+   * The secondary actions to display in the admin action.
+   */
+  'secondary-actions': HTMLElement;
+}

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
@@ -14,7 +14,13 @@ declare const tagName = 's-admin-action';
 export interface ReactProps
   extends Partial<AdminActionProps>,
     Pick<AdminActionProps$1, 'id'> {
+  /**
+   * The primary action to display in the admin action.
+   */
   primaryAction: ComponentChild;
+  /**
+   * The secondary actions to display in the admin action.
+   */
   secondaryActions: ComponentChild;
 }
 
@@ -51,6 +57,8 @@ declare abstract class PreactCustomElement extends BaseClass {
     ...options
   }: RenderImpl);
 
+  /** @private */
+  setAttribute(name: string, value: string): void;
   /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.doc.ts
@@ -14,6 +14,11 @@ const data: ReferenceEntityTemplateSchema = {
       description: '',
       type: 'AdminActionProps',
     },
+    {
+      title: 'Slots',
+      description: '',
+      type: 'AdminActionSlots',
+    },
   ],
   category: 'Components',
   subCategory: 'Other',

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
@@ -49,6 +49,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
@@ -49,6 +49,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
@@ -77,6 +77,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
@@ -33,6 +33,9 @@ declare const tagName = 's-banner';
 export interface ReactProps
   extends Partial<BannerProps>,
     Pick<BannerProps$1, 'id'> {
+  /**
+   * The secondary actions to display at the bottom of the banner. Only a maximum of two `s-button` components are allowed.
+   */
   secondaryActions?: ComponentChild;
   onDismiss?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   onAfterHide?: ((event: CallbackEvent<typeof tagName>) => void) | null;
@@ -71,6 +74,8 @@ declare abstract class PreactCustomElement extends BaseClass {
     ...options
   }: RenderImpl);
 
+  /** @private */
+  setAttribute(name: string, value: string): void;
   /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/shared.ts
@@ -26,6 +26,11 @@ Banners placed inside a section will have styles applied contextually. They're u
       description: '',
       type: 'Banner',
     },
+    {
+      title: 'Slots',
+      description: '',
+      type: 'BannerSlots',
+    },
   ],
   subCategory: 'Feedback',
   related: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
@@ -138,6 +138,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
@@ -108,6 +108,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
@@ -46,6 +46,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
@@ -61,6 +61,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
@@ -69,6 +69,8 @@ declare abstract class PreactCustomElement extends BaseClass$1 {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
@@ -175,6 +175,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
@@ -53,6 +53,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
@@ -46,6 +46,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;
@@ -179,6 +181,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
   get isContentEditable(): boolean;
   /** @private */
   formResetCallback(): void;
+  /** @private */
+  connectedCallback(): void;
   constructor(renderImpl: RenderImpl);
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
@@ -66,6 +66,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
@@ -159,6 +159,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
@@ -58,6 +58,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
@@ -61,6 +61,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
@@ -186,6 +186,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
@@ -85,6 +85,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
@@ -48,6 +48,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
@@ -46,6 +46,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;
@@ -179,6 +181,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
   get isContentEditable(): boolean;
   /** @private */
   formResetCallback(): void;
+  /** @private */
+  connectedCallback(): void;
   constructor(renderImpl: RenderImpl);
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
@@ -46,6 +46,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;
@@ -179,6 +181,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
   get isContentEditable(): boolean;
   /** @private */
   formResetCallback(): void;
+  /** @private */
+  connectedCallback(): void;
   constructor(renderImpl: RenderImpl);
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
@@ -50,6 +50,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
@@ -48,6 +48,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
@@ -48,6 +48,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page.d.ts
@@ -14,6 +14,9 @@ export interface PageProps extends Required<Pick<PageProps$1, 'inlineSize'>> {
 
 declare const tagName = 's-page';
 export interface ReactProps extends Partial<PageProps> {
+  /**
+   * The content to display in the aside section of the page.
+   */
   aside?: ComponentChild;
 }
 
@@ -50,6 +53,8 @@ declare abstract class PreactCustomElement extends BaseClass {
     ...options
   }: RenderImpl);
 
+  /** @private */
+  setAttribute(name: string, value: string): void;
   /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
@@ -18,6 +18,11 @@ const data: AdminReferenceEntityTemplateSchema = {
       description: 'Use as the outer wrapper of a page',
       type: 'Page',
     },
+    {
+      title: 'Slots',
+      description: '',
+      type: 'PageSlots',
+    },
   ],
   category: 'Polaris web components',
   subCategory: 'Structure',

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
@@ -63,6 +63,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
@@ -46,6 +46,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;
@@ -179,6 +181,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
   get isContentEditable(): boolean;
   /** @private */
   formResetCallback(): void;
+  /** @private */
+  connectedCallback(): void;
   constructor(renderImpl: RenderImpl);
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
@@ -42,6 +42,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;
@@ -175,6 +177,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
   get isContentEditable(): boolean;
   /** @private */
   formResetCallback(): void;
+  /** @private */
+  connectedCallback(): void;
   constructor(renderImpl: RenderImpl);
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
@@ -57,6 +57,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
@@ -46,6 +46,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
@@ -52,6 +52,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
@@ -153,6 +153,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch.d.ts
@@ -47,6 +47,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
@@ -26,6 +26,9 @@ declare const tagName = 's-table';
 export interface ReactProps
   extends Partial<TableProps>,
     Pick<TableProps$1, 'id' | 'onNextPage' | 'onPreviousPage'> {
+  /**
+   * Additional filters to display in the table. For example, the `s-search-field` component can be used to filter the table data.
+   */
   filters?: ComponentChild;
 }
 
@@ -69,6 +72,8 @@ declare abstract class PreactCustomElement extends BaseClass {
     ...options
   }: RenderImpl);
 
+  /** @private */
+  setAttribute(name: string, value: string): void;
   /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/shared.ts
@@ -10,6 +10,11 @@ const shared = {
       description: '',
       type: 'Table',
     },
+    {
+      title: 'Slots',
+      description: '',
+      type: 'TableSlots',
+    },
   ],
   subCategory: 'Structure',
   related: [

--- a/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
@@ -48,6 +48,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
@@ -48,6 +48,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
@@ -54,6 +54,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
@@ -48,6 +48,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
@@ -48,6 +48,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
@@ -74,6 +74,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
@@ -46,6 +46,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;
@@ -179,6 +181,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
   get isContentEditable(): boolean;
   /** @private */
   formResetCallback(): void;
+  /** @private */
+  connectedCallback(): void;
   constructor(renderImpl: RenderImpl);
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
@@ -42,6 +42,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;
@@ -175,6 +177,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
   get isContentEditable(): boolean;
   /** @private */
   formResetCallback(): void;
+  /** @private */
+  connectedCallback(): void;
   constructor(renderImpl: RenderImpl);
 }
 
@@ -193,6 +197,9 @@ export interface ReactProps
   extends Partial<Omit<TextFieldProps, 'accessory'>>,
     Pick<TextFieldProps$1, 'id'>,
     FieldReactProps<typeof tagName> {
+  /**
+   * The accessory to display in the text field.
+   */
   accessory?: ComponentChild;
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/shared.ts
@@ -11,6 +11,11 @@ const shared = {
         'A text input field that allows users to enter and edit text.',
       type: 'TextField',
     },
+    {
+      title: 'Slots',
+      description: '',
+      type: 'TextFieldSlots',
+    },
   ],
   subCategory: 'Forms',
   related: [

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
@@ -46,6 +46,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;
@@ -179,6 +181,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
   get isContentEditable(): boolean;
   /** @private */
   formResetCallback(): void;
+  /** @private */
+  connectedCallback(): void;
   constructor(renderImpl: RenderImpl);
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
@@ -48,6 +48,8 @@ declare abstract class PreactCustomElement extends BaseClass {
   }: RenderImpl);
 
   /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
   attributeChangedCallback(name: string): void;
   /** @private */
   connectedCallback(): void;


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/admin-ui-foundations/issues/2745

### Solution

- Updates the admin `components.d.ts`
- Adds slot definitions for shopify.dev

<img width="1800" alt="slot-defs" src="https://github.com/user-attachments/assets/05f90a09-e48b-4b5b-9772-79c19f16367d" />

### 🎩

- Checkout branch
- Run `yarn docs:admin 2025-10-rc`
- Run `shopify-dev` locally (`dev up && dev server`)
- Visit the following pages to ensure Slot definitions are correct:
  - [AdminAction](https://shopify-dev.myshopify.io/docs/api/admin-extensions/2025-10-rc/components/other/adminaction)
  - [Banner](https://shopify-dev.myshopify.io/docs/api/app-home/polaris-web-components/feedback/banner)
  - [Table](https://shopify-dev.myshopify.io/docs/api/app-home/polaris-web-components/structure/table)
  - [TextField](https://shopify-dev.myshopify.io/docs/api/app-home/polaris-web-components/forms/textfield)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
