### PR TITLE
Update Admin Extensions Category from `Components` to `Polaris Web Components`

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Action Extension API',
   description:
-    'This API is available to all action extension types. Refer to the [tutorial](/docs/apps/admin/admin-actions-and-blocks/build-an-admin-action) for more information. Note that the [`AdminAction`](/docs/api/admin-extensions/components/other/adminaction) component is required to build Admin action extensions.',
+    'This API is available to all action extension types. Refer to the [tutorial](/docs/apps/admin/admin-actions-and-blocks/build-an-admin-action) for more information. Note that the [`AdminAction`](/docs/api/admin-extensions/polaris-web-components/other/adminaction) component is required to build Admin action extensions.',
   isVisualComponent: false,
   type: 'API',
   definitions: [

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Print Action Extension API',
   description:
-    'This API is available to all print action extension types. Note that the [`AdminPrintAction`](/docs/api/admin-extensions/components/other/adminprintaction) component is required to build admin print action extensions.',
+    'This API is available to all print action extension types. Note that the [`AdminPrintAction`](/docs/api/admin-extensions/polaris-web-components/other/adminprintaction) component is required to build admin print action extensions.',
   isVisualComponent: false,
   type: 'API',
   definitions: [

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.doc.ts
@@ -39,7 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       type: 'component',
       name: 'AdminBlock',
-      url: '/docs/api/admin-extensions/components/other/adminblock',
+      url: '/docs/api/admin-extensions/polaris-web-components/other/adminblock',
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.doc.ts
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'AdminActionSlots',
     },
   ],
-  category: 'Components',
+  category: 'Polaris web components',
   subCategory: 'Other',
   defaultExample: {
     image: 'adminaction-default.png',

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'AdminBlockProps',
     },
   ],
-  category: 'Components',
+  category: 'Polaris web components',
   subCategory: 'Other',
   defaultExample: {
     image: 'adminblock-default.png',

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.doc.ts
@@ -34,7 +34,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       type: 'component',
       name: 'Adminaction',
-      url: '/docs/api/admin-extensions/components/other/adminaction',
+      url: '/docs/api/admin-extensions/polaris-web-components/other/adminaction',
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'AdminPrintActionProps',
     },
   ],
-  category: 'Components',
+  category: 'Polaris web components',
   subCategory: 'Other',
   defaultExample: {
     image: 'adminprintaction-default.png',

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.doc.ts
@@ -34,12 +34,12 @@ const data: ReferenceEntityTemplateSchema = {
     {
       type: 'component',
       name: 'AdminAction',
-      url: '/docs/api/admin-extensions/components/other/adminaction',
+      url: '/docs/api/admin-extensions/polaris-web-components/other/adminaction',
     },
     {
       type: 'component',
       name: 'AdminBlock',
-      url: '/docs/api/admin-extensions/components/other/adminblock',
+      url: '/docs/api/admin-extensions/polaris-web-components/other/adminblock',
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/shared.ts
@@ -16,12 +16,12 @@ const shared = {
     {
       type: 'component',
       name: 'Banner',
-      url: '/docs/api/admin-extensions/components/feedback/banner',
+      url: '/docs/api/admin-extensions/polaris-web-components/feedback/banner',
     },
     {
       type: 'component',
       name: 'Text',
-      url: '/docs/api/admin-extensions/components/titles-and-text/text',
+      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/text',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/shared.ts
@@ -4,7 +4,7 @@ const shared = {
   Use \`s-banner\` to communicate important status updates or required actions that users must take. Banners will automatically adjust their design to match the context in which they are used.
 
 #### Outside of a section
-Banners placed outside of a section will display in their own card and should be located at the top of the page. 
+Banners placed outside of a section will display in their own card and should be located at the top of the page.
 They're useful for conveying messages that apply to the entire page or areas not visible within the viewport, such as validation errors further down the page.
 
 #### In a section
@@ -13,7 +13,7 @@ Banners placed inside a section will have styles applied contextually. They're u
 #### Best practices
 - Seeing these banners can be stressful, so use them sparingly to avoid overwhelming users.
 - Focus on a single piece of information or required action to avoid overwhelming users.
-- Make the message concise and scannable. Users shouldn’t need to spend a lot of time figuring out what they need to know and do. 
+- Make the message concise and scannable. Users shouldn’t need to spend a lot of time figuring out what they need to know and do.
 - Info, Warning and Critical banners should contain a call to action and clear next steps. Users should know what to do after seeing the banner.
 - Avoid banners that can't be dismissed unless the user is required to take action.
 
@@ -37,7 +37,7 @@ Banners placed inside a section will have styles applied contextually. They're u
     {
       type: 'component',
       name: 'Badge',
-      url: '/docs/api/admin-extensions/components/feedback/badge',
+      url: '/docs/api/admin-extensions/polaris-web-components/feedback/badge',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/shared.ts
@@ -1,7 +1,7 @@
 const shared = {
   name: 'Box',
   description: `
-  Use \`s-box\` to build custom interfaces with your own design language. 
+  Use \`s-box\` to build custom interfaces with your own design language.
 
   #### Useful for:
   - Creating custom designs when you can't build what you need with the existing components.
@@ -22,17 +22,17 @@ const shared = {
     {
       type: 'component',
       name: 'Stack',
-      url: '/docs/api/admin-extensions/components/structure/stack',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/stack',
     },
     {
       type: 'component',
       name: 'Grid',
-      url: '/docs/api/admin-extensions/components/structure/grid',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/grid',
     },
     {
       type: 'component',
       name: 'Section',
-      url: '/docs/api/admin-extensions/components/structure/section',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/section',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/shared.ts
@@ -16,12 +16,12 @@ const shared = {
     {
       type: 'component',
       name: 'Pressable',
-      url: '/docs/api/admin-extensions/components/actions/pressable',
+      url: '/docs/api/admin-extensions/polaris-web-components/actions/pressable',
     },
     {
       type: 'component',
       name: 'Link',
-      url: '/docs/api/admin-extensions/components/actions/link',
+      url: '/docs/api/admin-extensions/polaris-web-components/actions/link',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/shared.ts
@@ -16,17 +16,17 @@ const shared = {
     {
       type: 'component',
       name: 'Switch',
-      url: '/docs/api/admin-extensions/components/forms/switch',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/switch',
     },
     {
       type: 'component',
       name: 'Select',
-      url: '/docs/api/admin-extensions/components/forms/select',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/select',
     },
     {
       type: 'component',
       name: 'ChoiceList',
-      url: '/docs/api/admin-extensions/components/forms/choice-list',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/choice-list',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/shared.ts
@@ -16,12 +16,12 @@ const shared = {
     {
       type: 'component',
       name: 'Select',
-      url: '/docs/api/admin-extensions/components/forms/select',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/select',
     },
     {
       type: 'component',
       name: 'Checkbox',
-      url: '/docs/api/admin-extensions/components/forms/checkbox',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/checkbox',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable/shared.ts
@@ -16,12 +16,12 @@ const shared = {
     {
       type: 'component',
       name: 'Button',
-      url: '/docs/api/admin-extensions/components/actions/button',
+      url: '/docs/api/admin-extensions/polaris-web-components/actions/button',
     },
     {
       type: 'component',
       name: 'Link',
-      url: '/docs/api/admin-extensions/components/actions/link',
+      url: '/docs/api/admin-extensions/polaris-web-components/actions/link',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/shared.ts
@@ -22,12 +22,12 @@ const shared = {
     {
       type: 'component',
       name: 'Section',
-      url: '/docs/api/admin-extensions/components/structure/section',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/section',
     },
     {
       type: 'component',
       name: 'Stack',
-      url: '/docs/api/admin-extensions/components/structure/stack',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/stack',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/shared.ts
@@ -16,12 +16,12 @@ const shared = {
     {
       type: 'component',
       name: 'TextField',
-      url: '/docs/api/admin-extensions/components/forms/textfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
     },
     {
       type: 'component',
       name: 'TextArea',
-      url: '/docs/api/admin-extensions/components/forms/textarea',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/textarea',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid/shared.ts
@@ -1,14 +1,14 @@
 const shared = {
   name: 'Grid',
   description: `
-  Use \`s-grid\` to organize your content in a matrix of rows and columns and make responsive layouts for pages. Grid follows the same pattern as the [CSS grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout). 
-  
+  Use \`s-grid\` to organize your content in a matrix of rows and columns and make responsive layouts for pages. Grid follows the same pattern as the [CSS grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout).
+
   #### Useful for:
   - Organizing content into a grid-like layout with columns and rows with consistent alignment and spacing.
   - Creating responsive layouts with consistent spacing.
-  
+
   #### Considerations
-  - Grid doesn't include any padding by default. If you need padding around your grid, use \`base\` to apply the default padding. 
+  - Grid doesn't include any padding by default. If you need padding around your grid, use \`base\` to apply the default padding.
   - Grid will allow children to overflow unless template rows/columns are properly set.
   - Grid will always wrap children to a new line. If you need to control the wrapping behavior, use \`s-stack\` or \`s-box\`.
  `,
@@ -27,12 +27,12 @@ const shared = {
     {
       type: 'component',
       name: 'Box',
-      url: '/docs/api/admin-extensions/components/structure/box',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/box',
     },
     {
       type: 'component',
       name: 'Stack',
-      url: '/docs/api/admin-extensions/components/structure/stack',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/stack',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/shared.ts
@@ -10,7 +10,7 @@ const shared = {
   #### Considerations
   - The level of the heading is automatically determined by how deeply it's nested inside other components, starting from h2.
   - Default to using the \`heading\` property in \`s-section\`. The \`s-heading\` component should only be used if you need to implement a custom layout for your heading in the UI.
-  
+
   #### Best practices
   - Use short headings to make your content scannable.
   - Use plain and clear terms.
@@ -33,7 +33,7 @@ const shared = {
     {
       type: 'component',
       name: 'Text',
-      url: '/docs/api/admin-extensions/components/titles-and-text/text',
+      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/text',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/shared.ts
@@ -16,7 +16,7 @@ const shared = {
     {
       type: 'component',
       name: 'Image',
-      url: '/docs/api/admin-extensions/components/media/image',
+      url: '/docs/api/admin-extensions/polaris-web-components/media/image',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/shared.ts
@@ -1,7 +1,7 @@
 const shared = {
   name: 'Image',
   description: `
-  Use \`s-image\` to display images in your app. 
+  Use \`s-image\` to display images in your app.
 
   #### Useful for:
   - Adding illustrations and photos.
@@ -26,7 +26,7 @@ const shared = {
     {
       type: 'component',
       name: 'Icon',
-      url: '/docs/api/admin-extensions/components/media/icon',
+      url: '/docs/api/admin-extensions/polaris-web-components/media/icon',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/shared.ts
@@ -16,7 +16,7 @@ const shared = {
     {
       type: 'component',
       name: 'Button',
-      url: '/docs/api/admin-extensions/components/actions/button',
+      url: '/docs/api/admin-extensions/polaris-web-components/actions/button',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/shared.ts
@@ -16,12 +16,12 @@ const shared = {
     {
       type: 'component',
       name: 'NumberField',
-      url: '/docs/api/admin-extensions/components/forms/numberfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/numberfield',
     },
     {
       type: 'component',
       name: 'TextField',
-      url: '/docs/api/admin-extensions/components/forms/textfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
@@ -4,7 +4,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/shared.ts
@@ -16,12 +16,12 @@ const shared = {
     {
       type: 'component',
       name: 'TextField',
-      url: '/docs/api/admin-extensions/components/forms/textfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
     },
     {
       type: 'component',
       name: 'MoneyField',
-      url: '/docs/api/admin-extensions/components/forms/moneyfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/moneyfield',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/shared.ts
@@ -9,12 +9,12 @@ const shared = {
     {
       type: 'component',
       name: 'UnorderedList',
-      url: '/docs/api/admin-extensions/components/structure/unordered-list',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/unordered-list',
     },
     {
       type: 'component',
       name: 'Text',
-      url: '/docs/api/admin-extensions/components/titles-and-text/text',
+      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/text',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
@@ -3,8 +3,8 @@ import {AdminReferenceEntityTemplateSchema} from '../../docs-types';
 const data: AdminReferenceEntityTemplateSchema = {
   name: 'Page',
   description: `
-  Use \`s-page\` as the main container for placing content in your app. Page comes with preset layouts and automatically adds spacing between elements. 
-  
+  Use \`s-page\` as the main container for placing content in your app. Page comes with preset layouts and automatically adds spacing between elements.
+
   #### Useful for:
   - Creating flexible, responsive page layouts.
   `,
@@ -30,12 +30,12 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       type: 'component',
       name: 'Section',
-      url: '/docs/api/admin-extensions/components/structure/section',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/section',
     },
     {
       type: 'component',
       name: 'Box',
-      url: '/docs/api/admin-extensions/components/structure/box',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/box',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/shared.ts
@@ -29,7 +29,7 @@ const shared = {
     {
       type: 'component',
       name: 'Heading',
-      url: '/docs/api/admin-extensions/components/titles-and-text/heading',
+      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/heading',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/shared.ts
@@ -16,12 +16,12 @@ const shared = {
     {
       type: 'component',
       name: 'TextField',
-      url: '/docs/api/admin-extensions/components/forms/textfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
     },
     {
       type: 'component',
       name: 'EmailField',
-      url: '/docs/api/admin-extensions/components/forms/emailfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/emailfield',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: ReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField/shared.ts
@@ -17,17 +17,17 @@ const shared = {
     {
       type: 'component',
       name: 'TextField',
-      url: '/docs/api/admin-extensions/components/forms/textfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
     },
     {
       type: 'component',
       name: 'EmailField',
-      url: '/docs/api/admin-extensions/components/forms/emailfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/emailfield',
     },
     {
       type: 'component',
       name: 'NumberField',
-      url: '/docs/api/admin-extensions/components/forms/numberfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/numberfield',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/shared.ts
@@ -1,10 +1,10 @@
 const shared = {
   name: 'Section',
   description: `
-Use \`s-section\` to organize your page content. Sections have defined styling, and will display differently depending on how deeply they are nested in the page. 
+Use \`s-section\` to organize your page content. Sections have defined styling, and will display differently depending on how deeply they are nested in the page.
 
-- **Level 1:** Display as responsive cards with background color, rounded corners, and shadow effects. Includes outer padding that can be removed when content like \`s-table\` needs to expand to the full width of the section. 
-- **Nested sections:** Don't have any background color or effects by default. 
+- **Level 1:** Display as responsive cards with background color, rounded corners, and shadow effects. Includes outer padding that can be removed when content like \`s-table\` needs to expand to the full width of the section.
+- **Nested sections:** Don't have any background color or effects by default.
 
 #### Useful for:
 - Organizing your page in a logical structure based on nesting levels.
@@ -30,17 +30,17 @@ Use \`s-section\` to organize your page content. Sections have defined styling, 
     {
       type: 'component',
       name: 'Box',
-      url: '/docs/api/admin-extensions/components/structure/box',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/box',
     },
     {
       type: 'component',
       name: 'Stack',
-      url: '/docs/api/admin-extensions/components/structure/stack',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/stack',
     },
     {
       type: 'component',
       name: 'Heading',
-      url: '/docs/api/admin-extensions/components/titles-and-text/heading',
+      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/heading',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/shared.ts
@@ -16,12 +16,12 @@ const shared = {
     {
       type: 'component',
       name: 'ChoiceList',
-      url: '/docs/api/admin-extensions/components/forms/choice-list',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/choice-list',
     },
     {
       type: 'component',
       name: 'Checkbox',
-      url: '/docs/api/admin-extensions/components/forms/checkbox',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/checkbox',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner/shared.ts
@@ -16,7 +16,7 @@ const shared = {
     {
       type: 'component',
       name: 'Button',
-      url: '/docs/api/admin-extensions/components/actions/button',
+      url: '/docs/api/admin-extensions/polaris-web-components/actions/button',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack/shared.ts
@@ -2,17 +2,17 @@ const shared = {
   name: 'Stack',
   description: `
   Use \`s-stack\` to organize elements along the [block or inline axes](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow) of the page.
-  
+
   #### Useful for:
   - Placing items in rows or columns when sections don't work for your layout.
   - Controlling the spacing between elements.
-  
+
   #### Considerations
-  - Stack doesn't add any padding by default. If you want padding around your stacked elements, use \`base\` to apply the default padding. 
+  - Stack doesn't add any padding by default. If you want padding around your stacked elements, use \`base\` to apply the default padding.
   - When spacing becomes limited, Stack will always wrap children to a new line.
 
   #### Best practices
-  - Use smaller gaps between small elements and larger gaps between big ones. 
+  - Use smaller gaps between small elements and larger gaps between big ones.
   - Maintain consistent spacing in stacks across all pages of your app.
   `,
   thumbnail: 'stack-thumbnail.png',
@@ -29,12 +29,12 @@ const shared = {
     {
       type: 'component',
       name: 'Box',
-      url: '/docs/api/admin-extensions/components/structure/box',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/box',
     },
     {
       type: 'component',
       name: 'Grid',
-      url: '/docs/api/admin-extensions/components/structure/grid',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/grid',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: ReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/shared.ts
@@ -16,17 +16,17 @@ const shared = {
     {
       type: 'component',
       name: 'Checkbox',
-      url: '/docs/api/admin-extensions/components/forms/checkbox',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/checkbox',
     },
     {
       type: 'component',
       name: 'Select',
-      url: '/docs/api/admin-extensions/components/forms/select',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/select',
     },
     {
       type: 'component',
       name: 'ChoiceList',
-      url: '/docs/api/admin-extensions/components/forms/choice-list',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/choice-list',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/shared.ts
@@ -21,7 +21,7 @@ const shared = {
     {
       type: 'component',
       name: 'Grid',
-      url: '/docs/api/admin-extensions/components/structure/grid',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/grid',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/shared.ts
@@ -29,7 +29,7 @@ const shared = {
     {
       type: 'component',
       name: 'Heading',
-      url: '/docs/api/admin-extensions/components/titles-and-text/heading',
+      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/heading',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
@@ -4,7 +4,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/shared.ts
@@ -16,7 +16,7 @@ const shared = {
     {
       type: 'component',
       name: 'TextField',
-      url: '/docs/api/admin-extensions/components/forms/textfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/shared.ts
@@ -22,17 +22,17 @@ const shared = {
     {
       type: 'component',
       name: 'TextArea',
-      url: '/docs/api/admin-extensions/components/forms/textarea',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/textarea',
     },
     {
       type: 'component',
       name: 'EmailField',
-      url: '/docs/api/admin-extensions/components/forms/emailfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/emailfield',
     },
     {
       type: 'component',
       name: 'NumberField',
-      url: '/docs/api/admin-extensions/components/forms/numberfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/numberfield',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/shared.ts
@@ -15,12 +15,12 @@ const shared = {
     {
       type: 'component',
       name: 'TextField',
-      url: '/docs/api/admin-extensions/components/forms/textfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
     },
     {
       type: 'component',
       name: 'EmailField',
-      url: '/docs/api/admin-extensions/components/forms/emailfield',
+      url: '/docs/api/admin-extensions/polaris-web-components/forms/emailfield',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Components',
+  category: 'Polaris web components',
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/shared.ts
@@ -9,12 +9,12 @@ const shared = {
     {
       type: 'component',
       name: 'OrderedList',
-      url: '/docs/api/admin-extensions/components/structure/ordered-list',
+      url: '/docs/api/admin-extensions/polaris-web-components/structure/ordered-list',
     },
     {
       type: 'component',
       name: 'Text',
-      url: '/docs/api/admin-extensions/components/titles-and-text/text',
+      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/text',
     },
   ],
   defaultExample: {


### PR DESCRIPTION
## TLDR

For version `2025-10-rc`, this PR updates the Admin Extensions Category from `Components` to `Polaris Web Components`.

- Before: `/docs/api/admin-extensions/2025-10-rc/components/actions/choicelist`
- After: `/docs/api/admin-extensions/2025-10-rc/polaris-web-components/actions/choicelist`

Part of https://github.com/Shopify/admin-ui-foundations/issues/2763

### Background

We want to differentiate between the original Polaris components and the new Polaris web components. 

### Solution

Since Polaris web components won't be General Availability until 2025-10, this PR updates the category for version `2025-10-rc` from `components` to `polaris-web-components`. 

| Before   | After         |
| ------------- | ------------- |
| <img width="1624" alt="Screenshot 2025-05-01 at 18 20 31" src="https://github.com/user-attachments/assets/8f602c46-9c47-4bf2-8825-2a9fffd51ff2" /> | <img width="1624" alt="image" src="https://github.com/user-attachments/assets/075a7b74-970f-4f93-a439-1f68ddd02b07" /> |

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation

## References

- https://github.com/Shopify/ui-extensions/pull/2827
- https://github.com/Shopify/shopify-dev/pull/56913