### PR TITLE
add 2025-10 version type and update doc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/configure-example.example.toml
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/configure-example.example.toml
@@ -1,4 +1,4 @@
-api_version = "2025-07"
+api_version = "2025-10"
 
 [[extensions]]
 name = "My customer account ui extension"

--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -12,7 +12,8 @@ export type ApiVersion =
   | '2025-01'
   | '2025-04'
   | 'unstable'
-  | '2025-07';
+  | '2025-07'
+  | '2025-10';
 
 /**
  * The capabilities an extension has access to.


### PR DESCRIPTION
Fixes https://github.com/Shopify/temp-project-mover-Archetypically-20250512095102/issues/198 
1. add 2025-10 version type
2. update doc exmaple's reference
