### PR TITLE
Add storage API to point-of-sale extension targets base input

### DIFF
--- a/.changeset/rude-ducks-shave.md
+++ b/.changeset/rude-ducks-shave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Adds storage API to BaseData and StandardApi (should be available in all extension targets)

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseData.ts
@@ -1,8 +1,10 @@
 import type {ConnectivityState, Device, Session} from '../../../point-of-sale';
+import {Storage} from '../../types/storage';
 
 export interface BaseData {
   connectivity: ConnectivityState;
   device: Device;
   locale: string;
   session: Session;
+  storage: Storage;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/standard/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/standard/standard-api.ts
@@ -5,6 +5,7 @@ import {SessionApi} from '../session-api/session-api';
 import {ToastApi} from '../toast-api/toast-api';
 import {ProductSearchApi} from '../product-search-api/product-search-api';
 import {PrintApi} from '../print-api/print-api';
+import {StorageApi} from '../storage-api/storage-api';
 
 export type StandardApi<T> = {[key: string]: any} & {
   extensionPoint: T;
@@ -14,4 +15,5 @@ export type StandardApi<T> = {[key: string]: any} & {
   PrintApi &
   ProductSearchApi &
   DeviceApi &
-  ConnectivityApi;
+  ConnectivityApi &
+  StorageApi;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/storage-api/storage-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/storage-api/storage-api.ts
@@ -1,0 +1,5 @@
+import {Storage} from '../../../types/storage';
+
+export interface StorageApi {
+  storage: Storage;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -14,6 +14,7 @@ import type {Components} from './shared';
 import type {AnyComponentBuilder} from '../../shared';
 import type {ReprintReceiptData} from './event/data/ReprintReceiptData';
 import type {TransactionCompleteData} from './event/data/TransactionCompleteData';
+import {StorageApi} from './render/api/storage-api/storage-api';
 
 type SmartGridComponents = AnyComponentBuilder<Pick<Components, 'Tile'>>;
 type ActionComponents = AnyComponentBuilder<Pick<Components, 'Button'>>;
@@ -161,10 +162,8 @@ export interface ExtensionTargets {
   'pos.receipt-footer.block.render': RenderExtension<
     // NOTE: key/any type is cause of no arg useApi() that includes all target types.
     //   stop using useApi() with no args, instead specify the target type explicitly.
-    {[key: string]: any} & (
-      | TransactionCompleteData
-      | {transaction: ReprintReceiptData}
-    ),
+    {[key: string]: any} & StorageApi &
+      (TransactionCompleteData | {transaction: ReprintReceiptData}),
     ReceiptComponents
   >;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -1,0 +1,65 @@
+export interface StorageExceededError extends Error {
+  name: 'StorageExceededError';
+  code: 'RecordsCount' | 'RecordSize';
+}
+export interface Storage<
+  BaseStorageTypes extends Record<string, any> = Record<string, unknown>,
+> {
+  /**
+   * Sets the value of a key in the storage.
+   *
+   * @param key - The key to set the value for.
+   * @param value - The value to set for the key.
+   * Can be any primitive type supported by `JSON.stringify`.
+   * @throws StorageExceededError if the extension exceeds its allotted storage limit.
+   * @throws StorageExceededError if value exceeds its allotted storage limit.
+   */
+  set<
+    StorageTypes extends BaseStorageTypes = BaseStorageTypes,
+    Keys extends keyof StorageTypes = keyof StorageTypes,
+  >(
+    key: Keys,
+    value: StorageTypes[Keys],
+  ): Promise<void>;
+
+  /**
+   * Gets the value of a key in the storage.
+   *
+   * @param key - The key to get the value for.
+   * @returns The value of the key.
+   * If no value for the key exists, the resolved value is undefined.
+   */
+  get<
+    StorageTypes extends BaseStorageTypes = BaseStorageTypes,
+    Keys extends keyof StorageTypes = keyof StorageTypes,
+  >(
+    key: Keys,
+  ): Promise<StorageTypes[Keys] | undefined>;
+
+  /**
+   * Clears the storage.
+   */
+  clear: () => Promise<void>;
+
+  /**
+   * Deletes a key from the storage.
+   *
+   * @param key - The key to delete.
+   */
+  delete<
+    StorageTypes extends BaseStorageTypes = BaseStorageTypes,
+    Keys extends keyof StorageTypes = keyof StorageTypes,
+  >(
+    key: Keys,
+  ): Promise<boolean>;
+
+  /**
+   * Gets all the keys and values in the storage.
+   *
+   * @returns An iterator containing all the keys and values in the storage.
+   */
+  entries<
+    StorageTypes extends BaseStorageTypes = BaseStorageTypes,
+    Keys extends keyof StorageTypes = keyof StorageTypes,
+  >(): Promise<IterableIterator<[Keys, StorageTypes[Keys]]>>;
+}


### PR DESCRIPTION
### Background

Part 1/4 of https://github.com/Shopify/temp-project-mover-Archetypically-20250612122555/issues/187

Closes https://github.com/Shopify/temp-project-mover-Archetypically-20250612122555/issues/276


### Solution


Adds storage API types to allow extensions store data in POS App

Implemented API from https://github.com/Shopify/ui-api-design/pull/909

### 🎩

- ...

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation
