### PR TITLE
updating script to push to app_home instead of app_bridge

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -136,7 +136,7 @@ const transformJson = async (filePath, isExtensions) => {
   if (!isExtensions && shopifyDevExists) {
     const shopifyDevDocs = path.join(
       shopifyDevDBPath,
-      'app_bridge/generated_docs_data.json',
+      'app_home/generated_docs_data.json',
     );
     const shopifyDevDocsContent = await fs.readFile(shopifyDevDocs, 'utf8');
     const shopifyDevDocsDocsParsed = JSON.parse(
@@ -202,9 +202,9 @@ const generateExtensionsDocs = async () => {
 };
 
 const generateAppBridgeDocs = async () => {
-  console.log('Building App Bridge docs');
+  console.log('Building App Home docs');
 
-  const outputDir = `${docsGeneratedRelativePath}/app_bridge`;
+  const outputDir = `${docsGeneratedRelativePath}/app_home`;
   const scripts = [
     `yarn tsc --project ${docsRelativePath}/${tsconfigAppBridge} --moduleResolution node  --target esNext  --module CommonJS`,
     `yarn generate-docs --input ./${srcRelativePath} --typesInput ./${srcRelativePath} --output ./${outputDir}`,


### PR DESCRIPTION
This pull request updates the `build-docs.mjs` script to reflect a naming change from "App Bridge" to "App Home" in the documentation generation process. Below are the key changes:

### Updates to file paths and content parsing:
* Updated the file path for the generated documentation data from `'app_bridge/generated_docs_data.json'` to `'app_home/generated_docs_data.json'`. (`[packages/ui-extensions/docs/surfaces/admin/build-docs.mjsL139-R139](diffhunk://#diff-7dac1bc0a9dbced945371a5d597b4a32746f7e694855108122496b047b4ba565L139-R139)`)

### Updates to logging and output directory:
* Changed the console log message from "Building App Bridge docs" to "Building App Home docs". (`[packages/ui-extensions/docs/surfaces/admin/build-docs.mjsL205-R207](diffhunk://#diff-7dac1bc0a9dbced945371a5d597b4a32746f7e694855108122496b047b4ba565L205-R207)`)
* Updated the output directory path from `app_bridge` to `app_home` for the generated documentation. (`[packages/ui-extensions/docs/surfaces/admin/build-docs.mjsL205-R207](diffhunk://#diff-7dac1bc0a9dbced945371a5d597b4a32746f7e694855108122496b047b4ba565L205-R207)`)