### PR TITLE
Fix `EventExtensionTargets` output type

### DIFF
--- a/.changeset/wise-plants-pay.md
+++ b/.changeset/wise-plants-pay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+updated event target EventExtensionTargets output type.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/targets.ts
@@ -9,14 +9,16 @@ import {CartUpdateEventData} from './data/CartUpdateEventData';
 export interface EventExtensionTargets {
   'pos.transaction-complete.event.observe': (
     data: TransactionCompleteData,
-  ) => BaseOutput;
+  ) => Promise<BaseOutput>;
   'pos.cash-tracking-session-start.event.observe': (
     data: CashTrackingSessionStartData,
-  ) => BaseOutput;
+  ) => Promise<BaseOutput>;
   'pos.cash-tracking-session-complete.event.observe': (
     data: CashTrackingSessionCompleteData,
-  ) => BaseOutput;
-  'pos.cart-update.event.observe': (data: CartUpdateEventData) => BaseOutput;
+  ) => Promise<BaseOutput>;
+  'pos.cart-update.event.observe': (
+    data: CartUpdateEventData,
+  ) => Promise<BaseOutput>;
 }
 
 export type EventExtensionTarget = keyof EventExtensionTargets;


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/temp-project-mover-Archetypically-20250612122555/issues/26

### Solution

Output for event targets should be a `Promise` as intended.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
