### PR TITLE
Correct datepicker category

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.ab.doc.ts
@@ -3,7 +3,7 @@ import shared from './shared';
 
 const data: ReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;


### PR DESCRIPTION
This was put in the wrong category and has been fixed up. "Experimental components" doesn't live anywhere else.