### PR TITLE
Update category for new components

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/create-doc-files.js
+++ b/packages/ui-extensions/docs/surfaces/admin/create-doc-files.js
@@ -86,7 +86,7 @@ import shared from './shared';
 
 const data: ReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Experimental Components',
+  category: 'Polaris web components',
 };
 
 export default data;


### PR DESCRIPTION
This pull request updates the categorization of documentation for UI extensions to reflect the correct component type.

Documentation update:

* [`packages/ui-extensions/docs/surfaces/admin/create-doc-files.js`](diffhunk://#diff-5579600413a4a1d5df93180f51b783d4c85af930a1704c2dc3e70698ca6913d2L89-R89): Changed the `category` field in the `data` object from `'Experimental Components'` to `'Polaris web components'` to align with the updated classification of the components.