### PR TITLE
support checkout component types for customer account

### DIFF
--- a/packages/ui-extensions/buildTargetDts.ts
+++ b/packages/ui-extensions/buildTargetDts.ts
@@ -14,15 +14,17 @@ import type {
 import {Project} from 'ts-morph';
 
 function copyComponentDefinitions({
-  srcPath,
+  srcPaths,
   buildPath,
   surface,
 }: {
-  srcPath: string;
+  srcPaths: string[];
   buildPath: string;
   surface: string;
 }) {
-  const componentsSrcPath = join(srcPath, 'components');
+  const componentsSrcPaths = srcPaths.map((srcPath) =>
+    join(srcPath, 'components'),
+  );
   const componentsBuildPath = join(
     buildPath,
     `ts/surfaces/${surface}/components`,
@@ -31,23 +33,28 @@ function copyComponentDefinitions({
     mkdirSync(buildPath, {recursive: true});
   }
 
-  if (!existsSync(componentsSrcPath)) {
+  const exists = componentsSrcPaths.every((path) => existsSync(path));
+
+  if (!exists) {
     // eslint-disable-next-line no-console
     console.log('No components to copy');
     return false;
   }
 
-  const components = readdirSync(componentsSrcPath);
-  components
-    .filter((file) => {
-      return file.endsWith('d.ts');
-    })
-    .forEach((file) => {
-      copyFileSync(
-        join(componentsSrcPath, file),
-        join(componentsBuildPath, file),
-      );
-    });
+  componentsSrcPaths.forEach((componentsSrcPath) => {
+    const components = readdirSync(componentsSrcPath);
+    components
+      .filter((file) => {
+        return file.endsWith('d.ts');
+      })
+      .forEach((file) => {
+        copyFileSync(
+          join(componentsSrcPath, file),
+          join(componentsBuildPath, file),
+        );
+      });
+  });
+
   return true;
 }
 
@@ -82,20 +89,23 @@ export type GlobalThis = typeof globalThis & {
 }
 
 function processComponentDefinitions({
-  srcPath,
+  srcPaths,
   project,
   componentName,
   names,
   targetFile,
 }: {
-  srcPath: string;
+  srcPaths: string[];
   project: Project;
   componentName: string;
   names: Set<string>;
   targetFile: SourceFile;
 }) {
-  const componentSourcePath = join(srcPath, `components/${componentName}.d.ts`);
-  if (!existsSync(componentSourcePath)) {
+  const componentSourcePath = srcPaths
+    .map((srcPath) => join(srcPath, `components/${componentName}.d.ts`))
+    .find((path) => existsSync(path));
+
+  if (!componentSourcePath) {
     // eslint-disable-next-line no-console
     console.log(
       `Component ${componentName} not found in ${componentSourcePath}`,
@@ -199,13 +209,13 @@ function extractTargetComponents(
 }
 
 function createTargetDefinition({
-  srcPath,
+  srcPaths,
   buildPath,
   project,
   surface,
   target: {name, components},
 }: {
-  srcPath: string;
+  srcPaths: string[];
   buildPath: string;
   project: Project;
   surface: string;
@@ -221,7 +231,7 @@ function createTargetDefinition({
       componentName,
       names,
       targetFile,
-      srcPath,
+      srcPaths,
     });
   });
 
@@ -230,11 +240,25 @@ function createTargetDefinition({
   targetFile.saveSync();
 }
 
-export function buildTargetsDefinitions(directory: string, surface: string) {
+export function buildTargetsDefinitions(
+  directory: string,
+  surface: string,
+  additionalComponentPaths: string[] = [],
+) {
   const project = new Project();
   const buildPath = resolve(directory, 'build');
   const srcPath = resolve(directory, `src/surfaces/${surface}`);
-  const success = copyComponentDefinitions({srcPath, buildPath, surface});
+
+  const componentSrcPaths = [
+    srcPath,
+    ...additionalComponentPaths.map((path) => resolve(directory, path)),
+  ];
+  const success = copyComponentDefinitions({
+    srcPaths: componentSrcPaths,
+    buildPath,
+    surface,
+  });
+
   if (!success) {
     // eslint-disable-next-line no-console
     console.log('Failed to copy components');
@@ -248,7 +272,7 @@ export function buildTargetsDefinitions(directory: string, surface: string) {
   const targets = extractTargetComponents(sourceFile);
   targets.forEach((target) => {
     createTargetDefinition({
-      srcPath,
+      srcPaths: componentSrcPaths,
       buildPath,
       project,
       surface,

--- a/packages/ui-extensions/loom.config.ts
+++ b/packages/ui-extensions/loom.config.ts
@@ -61,6 +61,7 @@ export default createPackage((pkg) => {
             buildTargetsDefinitions(
               resolve(process.cwd(), 'packages/ui-extensions'),
               'customer-account',
+              ['src/surfaces/checkout'],
             );
             completedSurfaces.add('customer-account');
           }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/StandardComponents.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/StandardComponents.ts
@@ -1,4 +1,7 @@
+import {AnyComponent} from '../../checkout';
+
 export type StandardComponents =
+  | AnyComponent
   | 'Page'
   | 'CustomerAccountAction'
   | 'ImageGroup';


### PR DESCRIPTION
### Background

Customer account ui extensions can also use component from checkout. By default, the build only get all the components from that specific surface's source path. 

In this PR, I make the build scripts more flexible. For components, now we can specify more than 1 source paths. 

### 🎩

- Create an new customer account ui extension follow [this doc](https://docs.google.com/document/d/1hrK6JNHBi8YbEGMoaQiFQqDC8qN9dvzWVTWmHCugMDU/edit?tab=t.0#heading=h.lr188tolgi4o  )
- update extension package.json's ui-extension version to `0.0.0-snapshot-20250508171603`  ([snapshot version from this PR](https://github.com/Shopify/ui-extensions/pull/2853#issuecomment-2863758168))
- now , enjoy the checkout component types!

<img width="1164" alt="Screenshot 2025-05-08 at 1 43 03 PM" src="https://github.com/user-attachments/assets/9f0af1d8-ab90-4c18-81f3-478322316bdf" />


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
