### PR TITLE
ignore native html props for customer account elements

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
@@ -5,22 +5,25 @@ export interface CustomerAccountActionProps {
   heading: string;
 }
 
-declare class CustomerAccountActionComponent
-  extends HTMLElement
-  implements CustomerAccountActionProps {}
+export interface CustomerAccountActionElement
+  extends HTMLElement,
+    CustomerAccountActionProps {}
 
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-customer-account-action']: CustomerAccountActionComponent;
+    ['s-customer-account-action']: CustomerAccountActionElement;
   }
 }
 
 declare module 'preact' {
+  interface BaseProps {
+    children?: preact.ComponentChildren;
+    slot?: Lowercase<string>;
+  }
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace createElement.JSX {
     interface IntrinsicElements {
-      ['s-customer-account-action']: HTMLAttributes<HTMLElement> &
-        CustomerAccountActionProps;
+      ['s-customer-account-action']: BaseProps & CustomerAccountActionProps;
     }
   }
 }
@@ -33,21 +36,22 @@ export interface ImageGroupProps {
   totalItems?: number;
 }
 
-declare class ImageGroupComponent
-  extends HTMLElement
-  implements ImageGroupProps {}
+export interface ImageGroupElement extends HTMLElement, ImageGroupProps {}
 
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-image-group']: ImageGroupComponent;
+    ['s-image-group']: ImageGroupElement;
   }
 }
 
 declare module 'preact' {
+  interface BaseProps {
+    children?: preact.ComponentChildren;
+  }
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace createElement.JSX {
     interface IntrinsicElements {
-      ['s-image-group']: HTMLAttributes<HTMLElement> & ImageGroupProps;
+      ['s-image-group']: BaseProps & ImageGroupProps;
     }
   }
 }
@@ -64,65 +68,23 @@ export interface PageProps {
   subheading?: string;
 }
 
-declare class PageComponent extends HTMLElement implements PageProps {}
+export interface PageElement extends HTMLElement, PageProps {}
 
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-page']: PageComponent;
+    ['s-page']: PageElement;
   }
 }
 
 declare module 'preact' {
+  interface BaseProps {
+    children?: preact.ComponentChildren;
+    slot?: Lowercase<string>;
+  }
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace createElement.JSX {
     interface IntrinsicElements {
-      ['s-page']: HTMLAttributes<HTMLElement> & PageProps;
-    }
-  }
-}
-
-type PolicyType = 'refund';
-
-// The interface is duplicated in the `ui-extensions-react` package because it no longer can be imported
-// More on the PR: https://github.com/Shopify/ui-extensions/pull/1399
-export interface PolicyModalProps {
-  /**
-   * Whether the modal should be rendered.
-   * Modal is a controlled component, so you must keep the state of the `open` prop yourself.
-   */
-  open: boolean;
-  /**
-   * Callback when either the close button, the backdrop, or the `escape` key is pressed.
-   * `onClose` is only called while the modal is open and attempts to be closed,
-   * not when it exits the viewport.
-   * You’ll usually want to use this callback to set the `open` prop to `false`.
-   */
-  onClose: () => void;
-  /**
-   * A title rendered as a `Heading` at the top of the modal.
-   */
-  title: string;
-  /**
-   * Type of policy to render.
-   */
-  type: PolicyType;
-}
-
-declare class PolicyModalComponent
-  extends HTMLElement
-  implements PolicyModalProps {}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    ['s-policy-modal']: PolicyModalComponent;
-  }
-}
-
-declare module 'preact' {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace createElement.JSX {
-    interface IntrinsicElements {
-      ['s-policy-modal']: HTMLAttributes<HTMLElement> & PolicyModalProps;
+      ['s-page']: BaseProps & PageProps;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction.d.ts
@@ -5,18 +5,25 @@ export interface CustomerAccountActionProps {
   heading: string;
 }
 
+export interface CustomerAccountActionElement
+  extends HTMLElement,
+    CustomerAccountActionProps {}
+
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-customer-account-action']: HTMLElement & CustomerAccountActionProps;
+    ['s-customer-account-action']: CustomerAccountActionElement;
   }
 }
 
 declare module 'preact' {
+  interface BaseProps {
+    children?: preact.ComponentChildren;
+    slot?: Lowercase<string>;
+  }
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace createElement.JSX {
     interface IntrinsicElements {
-      ['s-customer-account-action']: HTMLAttributes<HTMLElement> &
-        CustomerAccountActionProps;
+      ['s-customer-account-action']: BaseProps & CustomerAccountActionProps;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup.d.ts
@@ -6,17 +6,22 @@ export interface ImageGroupProps {
   totalItems?: number;
 }
 
+export interface ImageGroupElement extends HTMLElement, ImageGroupProps {}
+
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-image-group']: HTMLElement & ImageGroupProps;
+    ['s-image-group']: ImageGroupElement;
   }
 }
 
 declare module 'preact' {
+  interface BaseProps {
+    children?: preact.ComponentChildren;
+  }
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace createElement.JSX {
     interface IntrinsicElements {
-      ['s-image-group']: HTMLAttributes<HTMLElement> & ImageGroupProps;
+      ['s-image-group']: BaseProps & ImageGroupProps;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
@@ -10,17 +10,23 @@ export interface PageProps {
   subheading?: string;
 }
 
+export interface PageElement extends HTMLElement, PageProps {}
+
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-page']: HTMLElement & PageProps;
+    ['s-page']: PageElement;
   }
 }
 
 declare module 'preact' {
+  interface BaseProps {
+    children?: preact.ComponentChildren;
+    slot?: Lowercase<string>;
+  }
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace createElement.JSX {
     interface IntrinsicElements {
-      ['s-page']: HTMLAttributes<HTMLElement> & PageProps;
+      ['s-page']: BaseProps & PageProps;
     }
   }
 }


### PR DESCRIPTION
ignore native html props for customer account elements

no title anymore:
<img width="862" alt="Screenshot 2025-05-14 at 11 13 21 AM" src="https://github.com/user-attachments/assets/102a3174-9c26-4301-b06c-3154f6ec67c7" />

heading is still here:
<img width="846" alt="Screenshot 2025-05-14 at 11 14 03 AM" src="https://github.com/user-attachments/assets/3771faf5-780b-40ba-9c7b-193155555330" />


Vanilla JS version
<img width="1122" alt="Screenshot 2025-05-15 at 1 23 45 PM" src="https://github.com/user-attachments/assets/3f21f2cc-05dd-4118-af97-fa633093513d" />


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
