### PR TITLE
59278: Add pos version to session api

### DIFF
--- a/.changeset/little-forks-attack.md
+++ b/.changeset/little-forks-attack.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add posVersionNumber to session api

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -55,6 +55,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 
 ### Features
 
+- Added required \`posVersion\` property to \`Session\` interface.
 - Added optional \`currency\` property to \`Discount\` interface.
   `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/session.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/session.ts
@@ -31,4 +31,9 @@ export interface Session {
    * The currency code associated with the location currently in on POS.
    */
   currency: CurrencyCode;
+
+  /**
+   * The POS version.
+   */
+  posVersion: string;
 }


### PR DESCRIPTION
### Background

Relates to https://github.com/Shopify/temp-project-mover-Archetypically-20250612104008/issues/147

### Solution

Add posVersionNumber to session type

### 🎩


Update ui-extensions to 0.0.0-snapshot-20250514204734 in pos-react-native
In extension, useApi().session.currentSession.posVersionNumber

https://github.com/user-attachments/assets/ac666f96-ffe9-4f9c-bebe-1cea7cdefedb

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
