### PR TITLE
Add child component to parent component docs for admin surface

### DIFF
--- a/packages/ui-extensions/src/docs/shared/components/Choice.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Choice.ts
@@ -1,0 +1,12 @@
+import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+
+const data: SharedReferenceEntityTemplateSchema = {
+  name: 'Choice',
+  description:
+    'Create options that let users select one or multiple items from a list of choices.',
+  category: 'Polaris web components',
+  subCategory: 'Forms',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/docs/shared/components/GridItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/GridItem.ts
@@ -1,0 +1,11 @@
+import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+
+const data: SharedReferenceEntityTemplateSchema = {
+  name: 'GridItem',
+  description: 'Display content within a single item of a grid layout.',
+  category: 'Polaris web components',
+  subCategory: 'Structure',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/docs/shared/components/TableBody.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableBody.ts
@@ -1,0 +1,12 @@
+import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+
+const data: SharedReferenceEntityTemplateSchema = {
+  name: 'TableBody',
+  description:
+    'Define the main content area of a table, containing rows and cells that display data.',
+  category: 'Polaris web components',
+  subCategory: 'Structure',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/docs/shared/components/TableCell.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableCell.ts
@@ -1,0 +1,11 @@
+import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+
+const data: SharedReferenceEntityTemplateSchema = {
+  name: 'TableCell',
+  description: 'Display data within a cell in a table row.',
+  category: 'Polaris web components',
+  subCategory: 'Structure',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/docs/shared/components/TableHeader.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableHeader.ts
@@ -1,0 +1,11 @@
+import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+
+const data: SharedReferenceEntityTemplateSchema = {
+  name: 'TableHeader',
+  description: 'Display column names at the top of a table.',
+  category: 'Polaris web components',
+  subCategory: 'Structure',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/docs/shared/components/TableHeaderRow.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableHeaderRow.ts
@@ -1,0 +1,12 @@
+import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+
+const data: SharedReferenceEntityTemplateSchema = {
+  name: 'TableHeaderRow',
+  description:
+    'Define a header row in a table, displaying column names and enabling sorting.',
+  category: 'Polaris web components',
+  subCategory: 'Structure',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/docs/shared/components/TableRow.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableRow.ts
@@ -1,0 +1,11 @@
+import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+
+const data: SharedReferenceEntityTemplateSchema = {
+  name: 'TableRow',
+  description: 'Display a row of data within the body of a table.',
+  category: 'Polaris web components',
+  subCategory: 'Structure',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
@@ -1,5 +1,6 @@
 import {AdminReferenceEntityTemplateSchema} from '../../docs-types';
 import sharedContent from '../../../../docs/shared/components/ChoiceList';
+import choiceSharedContent from '../../../../docs/shared/components/Choice';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
@@ -11,6 +12,11 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Properties',
       description: '',
       type: 'ChoiceList',
+    },
+    {
+      title: choiceSharedContent.name,
+      description: choiceSharedContent.description,
+      type: 'Choice',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
@@ -1,5 +1,6 @@
 import {AdminReferenceEntityTemplateSchema} from '../../docs-types';
 import sharedContent from '../../../../docs/shared/components/Grid';
+import gridItemSharedContent from '../../../../docs/shared/components/GridItem';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
@@ -27,6 +28,11 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Properties',
       description: '',
       type: 'Grid',
+    },
+    {
+      title: gridItemSharedContent.name,
+      description: gridItemSharedContent.description,
+      type: 'GridItem',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
@@ -1,11 +1,19 @@
 import {AdminReferenceEntityTemplateSchema} from '../../docs-types';
 import sharedContent from '../../../../docs/shared/components/OrderedList';
+import listItemSharedContent from '../../../../docs/shared/components/ListItem';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/ordered-list.png',
   isVisualComponent: true,
+  definitions: [
+    {
+      title: listItemSharedContent.name,
+      description: listItemSharedContent.description,
+      type: 'ListItem',
+    },
+  ],
   defaultExample: {
     image: 'ordered-list-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
@@ -1,6 +1,12 @@
 import {AdminReferenceEntityTemplateSchema} from '../../docs-types';
 import sharedContent from '../../../../docs/shared/components/Table';
 
+import tableBodySharedContent from '../../../../docs/shared/components/TableBody';
+import tableCellSharedContent from '../../../../docs/shared/components/TableCell';
+import tableHeaderSharedContent from '../../../../docs/shared/components/TableHeader';
+import tableHeaderRowSharedContent from '../../../../docs/shared/components/TableHeaderRow';
+import tableRowSharedContent from '../../../../docs/shared/components/TableRow';
+
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/table.png',
@@ -21,6 +27,31 @@ const data: AdminReferenceEntityTemplateSchema = {
       description:
         'Learn more about [registering events](/docs/api/app-home/using-polaris-components#event-handling).',
       type: 'TableEvents',
+    },
+    {
+      title: tableBodySharedContent.name,
+      description: tableBodySharedContent.description,
+      type: 'TableBody',
+    },
+    {
+      title: tableCellSharedContent.name,
+      description: tableCellSharedContent.description,
+      type: 'TableCell',
+    },
+    {
+      title: tableHeaderSharedContent.name,
+      description: tableHeaderSharedContent.description,
+      type: 'TableHeader',
+    },
+    {
+      title: tableHeaderRowSharedContent.name,
+      description: tableHeaderRowSharedContent.description,
+      type: 'TableHeaderRow',
+    },
+    {
+      title: tableRowSharedContent.name,
+      description: tableRowSharedContent.description,
+      type: 'TableRow',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
@@ -1,11 +1,19 @@
 import {AdminReferenceEntityTemplateSchema} from '../../docs-types';
 import sharedContent from '../../../../docs/shared/components/UnorderedList';
+import listItemSharedContent from '../../../../docs/shared/components/ListItem';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/unordered-list.png',
   isVisualComponent: true,
+  definitions: [
+    {
+      title: listItemSharedContent.name,
+      description: listItemSharedContent.description,
+      type: 'ListItem',
+    },
+  ],
   defaultExample: {
     image: 'unordered-list-default.png',
     codeblock: {


### PR DESCRIPTION
This pull request introduces new shared component documentation for several Polaris web components and integrates these shared definitions into existing admin component documentation. The changes enhance the reuse and consistency of component descriptions across the codebase.

Closes https://github.com/Shopify/admin-ui-foundations/issues/2849


https://github.com/user-attachments/assets/4783c5b9-79f9-401f-96a7-cb928bc0abb5


### New Shared Component Documentation:

* Added shared documentation for the following components, each encapsulated in its own file:
  - `Choice` (`Choice.ts`): Describes the choice component for selecting options.
  - `GridItem` (`GridItem.ts`): Represents a single item in a grid layout.
  - `TableBody`, `TableCell`, `TableHeader`, `TableHeaderRow`, and `TableRow` (`TableBody.ts`, `TableCell.ts`, `TableHeader.ts`, `TableHeaderRow.ts`, `TableRow.ts`): Define various table-related components for structuring and displaying tabular data. [[1]](diffhunk://#diff-abcbc01094760d8972a629b62ca7a5398d593a340ae60b7aed85515b1372da9dR1-R12) [[2]](diffhunk://#diff-5ecbc2a23caa456d914579364e9574e5799ada644c136b1773ab74aa94983945R1-R12) [[3]](diffhunk://#diff-175e8a21d1ffcba024a3e90d5b086d5eb48a0cd17d0217191889f2405e981e02R1-R11) [[4]](diffhunk://#diff-f08ea22e8aa100b096410a010508c6b96c22fcc5becce3bacc3c87fdf92dcc09R1-R12) [[5]](diffhunk://#diff-d9861f37346e242b6337a2436d58dd171884ae73a8a35d02f5537a8bbe8c8332R1-R12)

### Integration into Admin Component Documentation:

* Enhanced admin component documentation by incorporating shared definitions:
  - [`ChoiceList.doc.ts`](diffhunk://#diff-0aa44870299dafe40aee07eea418b622096c35ab3351837a6521f7e524d67127R3): Added `Choice` as a related definition. [[1]](diffhunk://#diff-0aa44870299dafe40aee07eea418b622096c35ab3351837a6521f7e524d67127R3) [[2]](diffhunk://#diff-0aa44870299dafe40aee07eea418b622096c35ab3351837a6521f7e524d67127R17-R21)
  - [`Grid.doc.ts`](diffhunk://#diff-35dff23864e65c8824b366481902e1c1349bd02bd58442e2c81ebd7b7eb85849R3): Added `GridItem` as a related definition. [[1]](diffhunk://#diff-35dff23864e65c8824b366481902e1c1349bd02bd58442e2c81ebd7b7eb85849R3) [[2]](diffhunk://#diff-35dff23864e65c8824b366481902e1c1349bd02bd58442e2c81ebd7b7eb85849R33-R37)
  - `OrderedList.doc.ts` and `UnorderedList.doc.ts`: Added `ListItem` as a related definition. [[1]](diffhunk://#diff-c0cb51117d699e20ad35bc1346194202df5e7f29ae7d7590e7d2167832d295c3R3-R17) [[2]](diffhunk://#diff-ff0d48f22c20f78170eec3c93b5c5228ee2673d27dce70b1a9aeed0538a7b35dR3-R17)
  - [`Table.doc.ts`](diffhunk://#diff-a09445e5ca96d277ae83bcc90d000a503c16e85d5c0aef036b63f64a4056ccabR4-R9): Added `TableBody`, `TableCell`, `TableHeader`, `TableHeaderRow`, and `TableRow` as related definitions. [[1]](diffhunk://#diff-a09445e5ca96d277ae83bcc90d000a503c16e85d5c0aef036b63f64a4056ccabR4-R9) [[2]](diffhunk://#diff-a09445e5ca96d277ae83bcc90d000a503c16e85d5c0aef036b63f64a4056ccabR32-R56)