### PR TITLE
Add recurringDeliveries to SellingPlan

### DIFF
--- a/.changeset/eight-chicken-destroy.md
+++ b/.changeset/eight-chicken-destroy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add recurringDeliveries to SellingPlan

--- a/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
@@ -22,6 +22,11 @@ export interface SellingPlan {
    * @example 'gid://shopify/SellingPlan/1'
    */
   id: string;
+
+  /**
+   * Whether purchasing the selling plan will result in multiple deliveries.
+   */
+  recurringDeliveries: boolean;
 }
 
 export interface Attribute {

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -225,6 +225,11 @@ export interface SellingPlan {
    * @example 'gid://shopify/SellingPlan/1'
    */
   id: string;
+
+  /**
+   * Whether purchasing the selling plan will result in multiple deliveries.
+   */
+  recurringDeliveries: boolean;
 }
 
 export interface Attribute {


### PR DESCRIPTION
### Background

Add `recurringDeliveries` boolean to SellingPlan. This provides more information to checkout extensions.

### Solution

Update types.

### 🎩

- Update to `0.0.0-snapshot-20250602200457` for `@shopify/ui-extensions` and `@shopify/ui-extensions/react` in a test app
- checkout extension, reference `line.merchandise.sellingPlan.recurringDeliveries`

<img width="642" alt="Screenshot 2025-05-15 at 3 02 35 PM" src="https://github.com/user-attachments/assets/90c9cd06-0b80-45d4-9f92-d4e8c72aec69" />

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
