### PR TITLE
fix customer account link to checkout components

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/categories/components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/categories/components.doc.ts
@@ -14,7 +14,7 @@ const data: CategoryTemplateSchema = {
           type: 'blocks',
           name: 'Checkout components',
           subtitle: 'More components',
-          url: '/docs/api/checkout-ui-extensions/components',
+          url: '/docs/api/checkout-ui-extensions/polaris-web-components',
         },
       ],
     },


### PR DESCRIPTION
### Background

fix the link on components page on customer account. It should go to  checkout polaris web component instead of component.  

<img width="1095" alt="Screenshot 2025-05-15 at 12 36 02 PM" src="https://github.com/user-attachments/assets/21139beb-f25a-4721-85bf-3566cb1b3efd" />


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
