### PR TITLE
Remove related links from Admin docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/shared.ts
@@ -8,6 +8,7 @@ const shared = {
       type: 'Badge',
     },
   ],
+  related: [],
   defaultExample: {
     image: 'badge-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/shared.ts
@@ -47,13 +47,7 @@ const shared = {
     },
   ],
   subCategory: 'Feedback',
-  related: [
-    {
-      type: 'component',
-      name: 'Badge',
-      url: '/docs/api/admin-extensions/polaris-web-components/feedback/badge',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'banner-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/shared.ts
@@ -22,23 +22,7 @@ const shared = {
     },
   ],
   subCategory: 'Structure',
-  related: [
-    {
-      type: 'component',
-      name: 'Stack',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/stack',
-    },
-    {
-      type: 'component',
-      name: 'Grid',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/grid',
-    },
-    {
-      type: 'component',
-      name: 'Section',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/section',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'box-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/shared.ts
@@ -18,18 +18,7 @@ const shared = {
     },
   ],
   subCategory: 'Actions',
-  related: [
-    {
-      type: 'component',
-      name: 'Clickable',
-      url: '/docs/api/admin-extensions/polaris-web-components/actions/clickable',
-    },
-    {
-      type: 'component',
-      name: 'Link',
-      url: '/docs/api/admin-extensions/polaris-web-components/actions/link',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'button-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/shared.ts
@@ -12,23 +12,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'Switch',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/switch',
-    },
-    {
-      type: 'component',
-      name: 'Select',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/select',
-    },
-    {
-      type: 'component',
-      name: 'ChoiceList',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/choice-list',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'checkbox-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/shared.ts
@@ -13,18 +13,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'Select',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/select',
-    },
-    {
-      type: 'component',
-      name: 'Checkbox',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/checkbox',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'choicelist-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable/shared.ts
@@ -19,18 +19,7 @@ const shared = {
     },
   ],
   subCategory: 'Actions',
-  related: [
-    {
-      type: 'component',
-      name: 'Button',
-      url: '/docs/api/admin-extensions/polaris-web-components/actions/button',
-    },
-    {
-      type: 'component',
-      name: 'Link',
-      url: '/docs/api/admin-extensions/polaris-web-components/actions/link',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'clickable-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/shared.ts
@@ -21,18 +21,7 @@ const shared = {
     },
   ],
   subCategory: 'Structure',
-  related: [
-    {
-      type: 'component',
-      name: 'Section',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/section',
-    },
-    {
-      type: 'component',
-      name: 'Stack',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/stack',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'divider-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/shared.ts
@@ -13,18 +13,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'TextField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
-    },
-    {
-      type: 'component',
-      name: 'TextArea',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/textarea',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'emailfield-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid/shared.ts
@@ -29,18 +29,7 @@ const shared = {
     },
   ],
   subCategory: 'Structure',
-  related: [
-    {
-      type: 'component',
-      name: 'Box',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/box',
-    },
-    {
-      type: 'component',
-      name: 'Stack',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/stack',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'grid-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/shared.ts
@@ -38,13 +38,7 @@ const shared = {
     },
   ],
   subCategory: 'Titles and text',
-  related: [
-    {
-      type: 'component',
-      name: 'Text',
-      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/text',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'heading-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/shared.ts
@@ -12,13 +12,7 @@ const shared = {
     },
   ],
   subCategory: 'Media',
-  related: [
-    {
-      type: 'component',
-      name: 'Image',
-      url: '/docs/api/admin-extensions/polaris-web-components/media/image',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'icon-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/shared.ts
@@ -33,13 +33,7 @@ const shared = {
     },
   ],
   subCategory: 'Media',
-  related: [
-    {
-      type: 'component',
-      name: 'Icon',
-      url: '/docs/api/admin-extensions/polaris-web-components/media/icon',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'image-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/shared.ts
@@ -18,13 +18,7 @@ const shared = {
     },
   ],
   subCategory: 'Actions',
-  related: [
-    {
-      type: 'component',
-      name: 'Button',
-      url: '/docs/api/admin-extensions/polaris-web-components/actions/button',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'link-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/shared.ts
@@ -13,18 +13,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'NumberField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/numberfield',
-    },
-    {
-      type: 'component',
-      name: 'TextField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'moneyfield-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/shared.ts
@@ -13,18 +13,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'TextField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
-    },
-    {
-      type: 'component',
-      name: 'MoneyField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/moneyfield',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'numberfield-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/shared.ts
@@ -6,18 +6,7 @@ const shared = {
     '/assets/templated-apis-screenshots/admin/components/ordered-list.png',
   isVisualComponent: true,
   subCategory: 'Structure',
-  related: [
-    {
-      type: 'component',
-      name: 'UnorderedList',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/unordered-list',
-    },
-    {
-      type: 'component',
-      name: 'Text',
-      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/text',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'ordered-list-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/shared.ts
@@ -32,13 +32,7 @@ const shared = {
     },
   ],
   subCategory: 'Titles and text',
-  related: [
-    {
-      type: 'component',
-      name: 'Heading',
-      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/heading',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'paragraph-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/shared.ts
@@ -13,18 +13,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'TextField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
-    },
-    {
-      type: 'component',
-      name: 'EmailField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/emailfield',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'password-field-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField/shared.ts
@@ -14,23 +14,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'TextField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
-    },
-    {
-      type: 'component',
-      name: 'EmailField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/emailfield',
-    },
-    {
-      type: 'component',
-      name: 'NumberField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/numberfield',
-    },
-  ],
+  related: [],
   defaultExample: {
     codeblock: {
       title: 'Code',

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/shared.ts
@@ -30,23 +30,7 @@ const shared = {
     },
   ],
   subCategory: 'Structure',
-  related: [
-    {
-      type: 'component',
-      name: 'Box',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/box',
-    },
-    {
-      type: 'component',
-      name: 'Stack',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/stack',
-    },
-    {
-      type: 'component',
-      name: 'Heading',
-      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/heading',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'section-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/shared.ts
@@ -12,18 +12,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'ChoiceList',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/choice-list',
-    },
-    {
-      type: 'component',
-      name: 'Checkbox',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/checkbox',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'select-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner/shared.ts
@@ -12,13 +12,7 @@ const shared = {
     },
   ],
   subCategory: 'Feedback',
-  related: [
-    {
-      type: 'component',
-      name: 'Button',
-      url: '/docs/api/admin-extensions/polaris-web-components/actions/button',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'spinner-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack/shared.ts
@@ -35,18 +35,7 @@ const shared = {
     },
   ],
   subCategory: 'Structure',
-  related: [
-    {
-      type: 'component',
-      name: 'Box',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/box',
-    },
-    {
-      type: 'component',
-      name: 'Grid',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/grid',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'stack-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/shared.ts
@@ -12,23 +12,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'Checkbox',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/checkbox',
-    },
-    {
-      type: 'component',
-      name: 'Select',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/select',
-    },
-    {
-      type: 'component',
-      name: 'ChoiceList',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/choice-list',
-    },
-  ],
+  related: [],
   defaultExample: {
     codeblock: {
       title: 'Code',

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/shared.ts
@@ -23,13 +23,7 @@ const shared = {
     },
   ],
   subCategory: 'Structure',
-  related: [
-    {
-      type: 'component',
-      name: 'Grid',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/grid',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'table-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/shared.ts
@@ -30,13 +30,7 @@ const shared = {
     },
   ],
   subCategory: 'Titles and text',
-  related: [
-    {
-      type: 'component',
-      name: 'Heading',
-      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/heading',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'text-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/shared.ts
@@ -12,13 +12,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'TextField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'textarea-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/shared.ts
@@ -19,23 +19,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'TextArea',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/textarea',
-    },
-    {
-      type: 'component',
-      name: 'EmailField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/emailfield',
-    },
-    {
-      type: 'component',
-      name: 'NumberField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/numberfield',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'text-field-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/shared.ts
@@ -11,18 +11,7 @@ const shared = {
     },
   ],
   subCategory: 'Forms',
-  related: [
-    {
-      type: 'component',
-      name: 'TextField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/textfield',
-    },
-    {
-      type: 'component',
-      name: 'EmailField',
-      url: '/docs/api/admin-extensions/polaris-web-components/forms/emailfield',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'urlfield-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/shared.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/shared.ts
@@ -6,18 +6,7 @@ const shared = {
     '/assets/templated-apis-screenshots/admin/components/unordered-list.png',
   isVisualComponent: true,
   subCategory: 'Structure',
-  related: [
-    {
-      type: 'component',
-      name: 'OrderedList',
-      url: '/docs/api/admin-extensions/polaris-web-components/structure/ordered-list',
-    },
-    {
-      type: 'component',
-      name: 'Text',
-      url: '/docs/api/admin-extensions/polaris-web-components/titles-and-text/text',
-    },
-  ],
+  related: [],
   defaultExample: {
     image: 'unordered-list-default.png',
     codeblock: {


### PR DESCRIPTION
Closes https://github.com/Shopify/admin-ui-foundations/issues/2853

### Background

The Admin renders these documentation pages on App Home and Admin Extensions pages. The issue we have is that related links pointing only to Admin Extensions which pulls developers from App Home to that section. We could fix this but when reviewing this problem @AaronSpringut mentioned we could remove the related links all together.

### Solution

Remove related links.

