### PR TITLE
Ship one column component layout pages to all components

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -238,7 +238,7 @@ try {
 
   await fs.rm(tempComponentDefs);
 } catch (error) {
-  console.error(error);
+  console.error(error.toString());
   console.log(error.stdout.toString());
   console.log(error.stderr.toString());
   process.exit(1);

--- a/packages/ui-extensions/src/docs/shared/components/Abbreviation.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Abbreviation.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Abbreviation',
   description:
     'Displays abbreviated text or acronyms, revealing their full meaning or additional context through a tooltip on hover or focus. Use to clarify shortened terms, initialisms, or technical language without interrupting the reading flow.',
   category: 'Polaris web components',
   subCategory: 'Titles and text',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Badge.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Badge.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Badge',
   description:
     "Use `s-badge` to inform merchants of the status of an object or of an action that's been taken.",
   category: 'Polaris web components',
   subCategory: 'Titles and text',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Banner.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Banner.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Banner',
   description:
     'Highlights important information or required actions prominently within the interface. Use to communicate statuses, provide feedback, or draw attention to critical updates.',
   category: 'Polaris web components',
   subCategory: 'Feedback',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Box.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Box.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Box',
   description:
     'A generic container that provides a flexible alternative for custom designs not achievable with existing components. Use it to apply styling such as backgrounds, padding, or borders, or to nest and group other components. The contents of Box always maintain their natural size, making it especially useful within layout components that would otherwise stretch their children.',
   category: 'Polaris web components',
   subCategory: 'Structure',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Button.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Button.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Button',
   description:
     'Triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use Button to let users perform specific tasks or initiate interactions throughout the interface. Buttons can also function as links, guiding users to internal or external destinations.',
   category: 'Polaris web components',
   subCategory: 'Actions',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Checkbox.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Checkbox.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Checkbox',
   description:
     'Use `s-checkbox` when you want to provide users with a clear selection option, such as for agreeing to terms and conditions or selecting multiple options from a list.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'ChoiceList',
   description:
     'Use `s-choice-list` to present multiple options to merchants. Choice lists can present options with either radio buttons for single selection or checkboxes for multiple selection.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Clickable.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Clickable.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Clickable',
   description:
     'The `s-clickable` component is an escape hatch for when `s-button` and `s-link` are not sufficient to create an interactive element.',
   category: 'Polaris web components',
   subCategory: 'Actions',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/ClipboardItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ClipboardItem.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'ClipboardItem',
   description:
     'Enables copying text to the user’s clipboard. Use alongside Button or Link components to let users easily copy content. `<s-clipboard-item>` doesn’t render visually.',
   category: 'Polaris web components',
   subCategory: 'utilities',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'DatePicker',
   description:
     'Use a date picker to allow merchants to select a date or a date range.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Divider.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Divider.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Divider',
   description:
     'Use `s-divider` to create a clear visual separation between different elements in your user interface.',
   category: 'Polaris web components',
   subCategory: 'Structure',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/DropZone.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DropZone.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'DropZone',
   description:
     'Lets users upload files through drag-and-drop functionality into a designated area on a page, or by activating a button.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/EmailField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/EmailField.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'EmailField',
   description:
     'Use `s-email-field` to allow merchants to input email addresses. This component provides built-in email validation and appropriate keyboard settings.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Form.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Form.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Form',
   description:
     'Wraps one or more form controls and enables implicit submission, letting users submit the form from any input by pressing “Enter.” Unlike the HTML form element, this component doesn’t automatically submit data via HTTP. You must register a `submit` event to handle form submission in JavaScript.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Grid.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Grid.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Grid',
   description:
     'Use `s-grid` to organize your content in a matrix of rows and columns and make responsive layouts for pages. Grid follows the same pattern as the [CSS grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout).',
   category: 'Polaris web components',
   subCategory: 'Structure',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Heading.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Heading.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Heading',
   description:
     'Renders hierarchical titles to communicate the structure and organization of page content. Heading levels adjust automatically based on nesting within parent Section components, ensuring a meaningful and accessible page outline.',
   category: 'Polaris web components',
   subCategory: 'Titles and text',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Icon.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Icon.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Icon',
   description:
     'Renders a graphic symbol to visually communicate core parts of the product and available actions. Icons can act as wayfinding tools to help users quickly understand their location within the interface and common interaction patterns.',
   category: 'Polaris web components',
   subCategory: 'Media',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Image.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Image.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Image',
   description:
     'Embeds an image within the interface and controls its presentation. Use to visually illustrate concepts, showcase products, or support user tasks and interactions.',
   category: 'Polaris web components',
   subCategory: 'Media',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Link.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Link.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Link',
   description:
     'Makes text interactive, allowing users to navigate to other pages or perform specific actions. Supports standard URLs, custom protocols, and navigation within Shopify or app pages.',
   category: 'Polaris web components',
   subCategory: 'Actions',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/ListItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ListItem.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'ListItem',
   description:
     'Represents a single item within an unordered or ordered list. Use only as a child of `s-unordered-list` or `s-ordered-list` components.',
   category: 'Polaris web components',
   subCategory: 'Structure',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/MoneyField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/MoneyField.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'MoneyField',
   description:
     'Use `s-money-field` when you need to collect monetary values from merchants. It provides appropriate formatting and validation for currency amounts.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/NumberField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/NumberField.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'NumberField',
   description:
     'Use `s-number-field` when you need to collect numerical input from merchants. It provides appropriate keyboard settings and validation for numerical values.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/OrderedList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/OrderedList.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'OrderedList',
   description:
     'Displays a numbered list of related items in a specific sequence. Use to present step-by-step instructions, ranked items, or procedures where order matters.',
   category: 'Polaris web components',
   subCategory: 'Structure',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Page.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Page.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Page',
   description:
     ' Use `s-page` as the main container for placing content in your app. Page comes with preset layouts and automatically adds spacing between elements.',
   category: 'Polaris web components',
   subCategory: 'Structure',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Paragraph',
   description:
     'Displays a block of text, and can contain inline elements such as buttons, links, or emphasized text. Use to present standalone blocks of content, as opposed to inline text.',
   category: 'Polaris web components',
   subCategory: 'Titles and text',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/PasswordField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PasswordField.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'PasswordField',
   description:
     'Use `s-password-field` when you need to collect sensitive information from merchants.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/PaymentIcon.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PaymentIcon.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'PaymentIcon',
   description:
     'Displays icons representing payment methods. Use to visually communicate available or saved payment options clearly',
   category: 'Polaris web components',
   subCategory: 'Media',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Progress.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Progress.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Progress',
   description:
     'Displays an indicator showing the completion status of a task. Use to visually communicate progress in either determinate (known percentage) or indeterminate (unknown duration) states.',
   category: 'Polaris web components',
   subCategory: 'Feedback',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/QRCode.ts
+++ b/packages/ui-extensions/src/docs/shared/components/QRCode.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'QRCode',
   description:
     'Displays a scannable QR code representing data such as URLs or text. Use to let users quickly access information by scanning with a smartphone or other device.',
   category: 'Polaris web components',
   subCategory: 'Other',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/SearchField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/SearchField.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'SearchField',
   description:
     'Use a search field to allow merchants to search for a specific item or search term. Search fields provide a single-line input area for collecting string values from users.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Section.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Section.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Section',
   description:
     'Use `s-section` to organize your page content. Sections have defined styling, and will display differently depending on how deeply they are nested in the page.',
   category: 'Polaris web components',
   subCategory: 'Structure',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Select.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Select.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Select',
   description:
     '`s-select` lets merchants choose one option from an options menu. Consider `s-select` when you have 4 or more options, to avoid cluttering the interface.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Spinner.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Spinner.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Spinner',
   description:
     'Displays an animated indicator showing users that content or actions are loading. Use to communicate ongoing processes, such as fetching data from a server. For loading states on buttons, use the “loading” property on the Button component instead.',
   category: 'Polaris web components',
   subCategory: 'Feedback',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Stack.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Stack.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Stack',
   description:
     'Organizes elements horizontally or vertically along the block or inline axis. Use to structure layouts, group related components, or control spacing between elements.',
   category: 'Polaris web components',
   subCategory: 'Structure',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Switch.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Switch.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Switch',
   description:
     'Use `s-switch` when you want to provide users with a clear selection option, such as toggling options on/off.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Table.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Table.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Table',
   description:
     'Use `s-table` to organize and display data in a tabular format. Tables help merchants view, analyze, and compare data. By default the `s-table` renders as a list on mobile devices and a table on desktop devices.',
   category: 'Polaris web components',
   subCategory: 'Structure',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Text.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Text.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Text',
   description:
     'Displays inline text with specific visual styles or tones. Use to emphasize or differentiate words or phrases within a Paragraph or other block-level components.',
   category: 'Polaris web components',
   subCategory: 'Titles and text',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/TextArea.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextArea.ts
@@ -1,12 +1,15 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'TextArea',
   description:
     'Use `s-text-area` when you need to collect longer text content from merchants. Text areas allow for multiple lines of text and automatically expand to fit the content.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/TextField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextField.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'TextField',
   description:
     'Lets users enter or edit text within a single-line input. Use to collect short, free-form information from users.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Time.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Time.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'Time',
   description:
     'Represents a specific point or duration in time. Use to display dates, times, or durations clearly and consistently. May include a machine-readable `datetime` attribute for improved accessibility and functionality.',
   category: 'Polaris web components',
   subCategory: 'Titles and text',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/URLField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/URLField.ts
@@ -1,11 +1,14 @@
-import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'URLField',
   description: 'Use a URLField when you need to collect URLs from merchants.',
   category: 'Polaris web components',
   subCategory: 'Forms',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/components/UnorderedList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/UnorderedList.ts
@@ -1,12 +1,15 @@
-import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
+import {
+  type SharedReferenceEntityTemplateSchema,
+  globalShared,
+} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
+  ...globalShared,
   name: 'UnorderedList',
   description:
     'Displays a bulleted list of related items. Use to present collections of items or options where the sequence isn’t critical.',
   category: 'Polaris web components',
   subCategory: 'Structure',
-  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/docs-type.ts
+++ b/packages/ui-extensions/src/docs/shared/docs-type.ts
@@ -2,5 +2,17 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 export type SharedReferenceEntityTemplateSchema = Pick<
   ReferenceEntityTemplateSchema,
-  'name' | 'description' | 'category' | 'subCategory' | 'related'
+  | 'name'
+  | 'description'
+  | 'category'
+  | 'subCategory'
+  | 'related'
+  | 'isVisualComponent'
+  | 'isOneColumnLayout'
 >;
+
+export const globalShared = {
+  related: [],
+  isVisualComponent: true,
+  isOneColumnLayout: true,
+};

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Badge';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/badge.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Banner';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/banner.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   subSections: [
     {
       title: 'Outside of a section',

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Box';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/box.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   subSections: [
     {
       title: 'Useful for',

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Button';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/button.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Checkbox';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/checkbox.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/choicelist.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/clickable.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
@@ -5,8 +5,6 @@ const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/datepicker.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'DatePicker',

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.doc.ts
@@ -13,8 +13,6 @@ const data: AdminReferenceEntityTemplateSchema = {
     },
   ],
   thumbnail: '/assets/templated-apis-screenshots/admin/components/divider.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/emailfield.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
@@ -5,8 +5,6 @@ const data: ReferenceEntityTemplateSchema = {
   ...shared,
   category: 'Polaris web components',
   thumbnail: '/assets/templated-apis-screenshots/admin/components/form.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
@@ -21,8 +21,6 @@ const data: AdminReferenceEntityTemplateSchema = {
     },
   ],
   thumbnail: '/assets/templated-apis-screenshots/admin/components/grid.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Heading';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/heading.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   subSections: [
     {
       title: 'Useful for',

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Icon';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/icon.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Image';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/image.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   subSections: [
     {
       title: 'Useful for',

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Link';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/link.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/moneyfield.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/numberfield.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/ordered-list.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   defaultExample: {
     image: 'ordered-list-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
@@ -5,9 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   requires: '',
   thumbnail: '/assets/templated-apis-screenshots/admin/components/page.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
-  type: 'component',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/paragraph.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   subSections: [
     {
       title: 'Useful for',

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/passwordfield.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/searchfield.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'SearchField',

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
@@ -3,8 +3,6 @@ import sharedContent from '../../../../docs/shared/components/Section';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/section.png',
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Select';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/select.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Spinner';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/spinner.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Stack';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/stack.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   subSections: [
     {
       title: 'Useful for',

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Switch';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/switch.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Table';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/table.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Text';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/text.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   subSections: [
     {
       title: 'Useful for',

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/TextArea';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/textarea.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/textfield.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'TextField',

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -4,8 +4,6 @@ import sharedContent from '../../../../docs/shared/components/URLField';
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/urlfield.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   definitions: [
     {
       title: 'URLField',

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
@@ -5,8 +5,6 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/unordered-list.png',
-  isVisualComponent: true,
-  isOneColumnLayout: true,
   defaultExample: {
     image: 'unordered-list-default.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation/Abbreviation.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation/Abbreviation.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Abbreviation';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  isVisualComponent: true,
   thumbnail: 'abbreviation-thumbnail.png',
-  requires: '',
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Banner';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  isVisualComponent: true,
   thumbnail: 'banner-thumbnail.png',
-  requires: '',
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Box/Box.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Box';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  isVisualComponent: true,
   thumbnail: 'box-thumbnail.png',
-  requires: '',
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Button/Button.doc.ts
@@ -4,9 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Button';
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: 'button-thumbnail.png',
-  requires: '',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem/ClipboardItem.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem/ClipboardItem.doc.ts
@@ -3,9 +3,7 @@ import sharedContent from '../../../../docs/shared/components/ClipboardItem';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  requires: '',
   isVisualComponent: false,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/DropZone/DropZone.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DropZone/DropZone.doc.ts
@@ -4,9 +4,6 @@ import sharedContent from '../../../../docs/shared/components/DropZone';
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: 'dropzone-thumbnail.png',
-  requires: '',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.doc.ts
@@ -4,9 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Form';
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: 'form-thumbnail.png',
-  requires: '',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.doc.ts
@@ -4,9 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Heading';
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: 'heading-thumbnail.png',
-  requires: '',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.doc.ts
@@ -4,9 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Icon';
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: 'icon-thumbnail.png',
-  requires: '',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.doc.ts
@@ -4,9 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Image';
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: 'image-thumbnail.png',
-  requires: '',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Link';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  requires: '',
-  isVisualComponent: true,
   thumbnail: 'link-thumbnail.png',
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/OrderedList/OrderedList.doc.ts
@@ -4,10 +4,7 @@ import listItemSharedContent from '../../../../docs/shared/components/ListItem';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  isVisualComponent: true,
   thumbnail: 'orderedlist-thumbnail.png',
-  requires: '',
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Paragraph/Paragraph.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Paragraph/Paragraph.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Paragraph';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  requires: '',
   thumbnail: 'paragraph-thumbnail.png',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.doc.ts
@@ -4,9 +4,6 @@ import sharedContent from '../../../../docs/shared/components/PaymentIcon';
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: 'paymenticon-thumbnail.png',
-  requires: '',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Progress/Progress.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Progress/Progress.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Progress';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  requires: '',
-  isVisualComponent: true,
   thumbnail: 'progress-thumbnail.png',
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/QRCode';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  requires: '',
-  isVisualComponent: true,
   thumbnail: 'qrcode-thumbnail.png',
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Spinner';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  requires: '',
   thumbnail: 'spinner-thumbnail.png',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Stack/Stack.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Stack';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  isVisualComponent: true,
   thumbnail: 'stack-thumbnail.png',
-  requires: '',
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Text/Text.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Text';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  requires: '',
   thumbnail: 'text-thumbnail.png',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/TextField';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  requires: '',
   thumbnail: 'textfield-thumbnail.png',
-  isVisualComponent: true,
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Time/Time.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Time/Time.doc.ts
@@ -3,10 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Time';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  isVisualComponent: true,
   thumbnail: 'time-thumbnail.png',
-  requires: '',
-  type: '',
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList/UnorderedList.doc.ts
@@ -4,10 +4,7 @@ import listItemSharedContent from '../../../../docs/shared/components/ListItem';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  isVisualComponent: true,
   thumbnail: 'unorderedlist-thumbnail.png',
-  requires: '',
-  type: '',
   definitions: [
     {
       title: 'Properties',


### PR DESCRIPTION
This PR: 
- [x] Adds better error messaging with `error.toString()`
- [x] Adds a `globalShared` for shared docs for every component
- [x] Moves   `related: [],  isVisualComponent: true,  isOneColumnLayout: true,` to `globalShared`. By doing this we change checkout components to use the new one column layout for component docs.
- [x] Removes `requires: '', type: '',` from checkout component docs

TODO
- [ ] Double check the clipboard component can override the `isVisualComponent: true` value