### PR TITLE
61018: fix pos.draft-order-details.block.render allowed component type

### DIFF
--- a/.changeset/gentle-bags-repair.md
+++ b/.changeset/gentle-bags-repair.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Fix pos.draft-order-details.block.render allowed component to BlockComponents

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -53,10 +53,15 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Removed in POS version: N/A
 - Release day: N/A
 
+## Important Fixes
+
+- Update pos.draft-order-details.block.render allowed components to \`BlockComponents\`.
+
 ### Features
 
 - Added required \`posVersion\` property to \`Session\` interface.
 - Added optional \`currency\` property to \`Discount\` interface.
+
   `,
     },
     {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -116,7 +116,7 @@ export interface ExtensionTargets {
       ActionApi &
       CartApi &
       DraftOrderApi,
-    ActionComponents
+    BlockComponents
   >;
   'pos.customer-details.action.menu-item.render': RenderExtension<
     StandardApi<'pos.customer-details.action.menu-item.render'> &


### PR DESCRIPTION
### Background
![image](https://github.com/user-attachments/assets/70309f98-a2c0-4b89-a9dc-baf18234d9cd)
Closes https://github.com/Shopify/pos-next-react-native/issues/60654?issue=Shopify%7Cpos-next-react-native%7C61018

### Solution
Change ActionComponents to BlockComponents

### 🎩

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
