### PR TITLE
fix snapshot

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -16,11 +16,14 @@ jobs:
 
       - uses: ./.github/workflows/actions/prepare
 
+      - name: Exit pre mode
+        run: yarn changeset:exit-pre-mode
+
       - name: Create snapshot
         uses: Shopify/snapit@main
         env:
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
-          build_script: yarn build; yarn changeset:exit-pre-mode
+          build_script: yarn build
           comment_command: /snapit


### PR DESCRIPTION
Previous version failed https://github.com/Shopify/ui-extensions/actions/runs/15140884965/job/42564360513

I think something is off with how the snapit action consumes the `build_script`.

Let's just add a previous step where we exit the mode