### PR TITLE
fix snapit

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -25,5 +25,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
-          build_script: yarn build
+          build_script: yarn snapit:prepare
           comment_command: /snapit

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "scaffold-docs:admin": "./packages/ui-extensions/docs/surfaces/admin/create-doc-files.sh \"admin\"",
     "test": "loom test",
     "type-check": "loom type-check",
+    "snapit:prepare": "changeset:exit-pre-mode && yarn build",
     "changeset:exit-pre-mode": "test -f .changeset/pre.json && jq -e '.mode == \"pre\"' .changeset/pre.json > /dev/null && yarn changeset pre exit || true"
   },
   "devDependencies": {


### PR DESCRIPTION
Snapit doesn't work on the local copy and instead does its own checkout. So we can't make changes to the local pre.json beforehand.

