### PR TITLE
fix snapit by using new postinstall script

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -16,14 +16,12 @@ jobs:
 
       - uses: ./.github/workflows/actions/prepare
 
-      - name: Exit pre mode
-        run: yarn changeset:exit-pre-mode
-
       - name: Create snapshot
-        uses: Shopify/snapit@main
+        uses: Shopify/snapit@allow-post-install-script
         env:
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
-          build_script: yarn snapit:prepare
+          post_install_script: yarn changeset:exit-pre-mode
+          build_script: yarn build
           comment_command: /snapit

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "scaffold-docs:admin": "./packages/ui-extensions/docs/surfaces/admin/create-doc-files.sh \"admin\"",
     "test": "loom test",
     "type-check": "loom type-check",
-    "snapit:prepare": "yarn changeset:exit-pre-mode && yarn build",
     "changeset:exit-pre-mode": "test -f .changeset/pre.json && jq -e '.mode == \"pre\"' .changeset/pre.json > /dev/null && yarn changeset pre exit || true"
   },
   "devDependencies": {


### PR DESCRIPTION
Snapit does its own checkout so running anything before doesn't work.

We're using the new post_install_script which runs right after dependency install and before snapit calls `changeset version` (which breaks when pre mode is on)

https://github.com/Shopify/snapit/pull/31