### PR TITLE
Checkout: fix markdown when using lists

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Box/Box.doc.ts
@@ -32,11 +32,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best Practices',
       sectionContent: `
-        - Use \`s-box\` when you need a container that preserves the natural size of its contents.
-        - \`s-box\` is particularly useful in layout components like \`s-stack\` where you want to prevent children from stretching to fit.
-        - \`s-box\` has a \`display: block\` layout by default.
-        - Use \`s-box\` for simple container needs where you don't need the additional features of more specialized components like \`s-stack\`.
-        - Consider using \`s-box\` when you need to apply specific styling or layout properties to a group of elements without affecting their natural dimensions.
+- Use \`s-box\` when you need a container that preserves the natural size of its contents.
+- \`s-box\` is particularly useful in layout components like \`s-stack\` where you want to prevent children from stretching to fit.
+- \`s-box\` has a \`display: block\` layout by default.
+- Use \`s-box\` for simple container needs where you don't need the additional features of more specialized components like \`s-stack\`.
+- Consider using \`s-box\` when you need to apply specific styling or layout properties to a group of elements without affecting their natural dimensions.
       `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.doc.ts
@@ -32,8 +32,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best Practices',
       sectionContent: `
-        - Wrap around all form input elements.
-        - Forms can have only one submit button and it must be at the end of the form.
+- Wrap around all form input elements.
+- Forms can have only one submit button and it must be at the end of the form.
       `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.doc.ts
@@ -31,14 +31,16 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Useful for',
       type: 'Generic',
       anchorLink: 'useful-for',
-      sectionContent: `- Creating titles and subtitles for your content that are consistent across your app.
+      sectionContent: `
+- Creating titles and subtitles for your content that are consistent across your app.
 - Helping users with visual impairments navigate through content effectively using assistive technologies like screen readers.`,
     },
     {
       title: 'Considerations',
       type: 'Generic',
       anchorLink: 'considerations',
-      sectionContent: `- The level of the heading is automatically determined by how deeply it's nested inside other components, starting from h2.
+      sectionContent: `
+- The level of the heading is automatically determined by how deeply it's nested inside other components, starting from h2.
 - Default to using the \`heading\` property in components that support it (e.g. Section and Banner). The \`s-heading\` component should only be used if you need to implement a custom layout for your heading in the UI.`,
     },
     {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.doc.ts
@@ -32,8 +32,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best Practices',
       sectionContent: `
-        - Use links primarily for navigation and use buttons primarily for actions.
-        - The HTML that renders for the \`s-button\` and \`s-link\` components includes style and accessibility information. Use these components intentionally and consistently to provide a more inclusive experience for assistive technology users and a more cohesive visual experience for sighted users.
+- Use links primarily for navigation and use buttons primarily for actions.
+- The HTML that renders for the \`s-button\` and \`s-link\` components includes style and accessibility information. Use these components intentionally and consistently to provide a more inclusive experience for assistive technology users and a more cohesive visual experience for sighted users.
       `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/checkout/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/OrderedList/OrderedList.doc.ts
@@ -38,11 +38,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best Practices',
       sectionContent: `
-        - Use \`s-ordered-list\` when you need to present items in a specific sequence or order.
-        - Each item in the list should be wrapped in a \`s-list-item\` component.
-        - Keep list items concise and consistent in length when possible.
-        - Use \`s-ordered-list\` for step-by-step instructions, numbered procedures, or ranked items.
-        - Consider using \`s-ordered-list\` when the order of items is important for understanding.
+- Use \`s-ordered-list\` when you need to present items in a specific sequence or order.
+- Each item in the list should be wrapped in a \`s-list-item\` component.
+- Keep list items concise and consistent in length when possible.
+- Use \`s-ordered-list\` for step-by-step instructions, numbered procedures, or ranked items.
+- Consider using \`s-ordered-list\` when the order of items is important for understanding.
       `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.doc.ts
@@ -32,9 +32,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best Practices',
       sectionContent: `
-        - Clearly label text fields so that it’s obvious what customers should enter.
-        - Label text fields as optional when input isn’t required. For example, use the label <b>First name (optional)</b>.
-        - Don’t have optional fields pass true to the required property.
+- Clearly label text fields so that it’s obvious what customers should enter.
+- Label text fields as optional when input isn’t required. For example, use the label <b>First name (optional)</b>.
+- Don’t have optional fields pass true to the required property.
       `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList/UnorderedList.doc.ts
@@ -38,11 +38,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best Practices',
       sectionContent: `
-        - Use \`s-unordered-list\` when you need to present a list of related items or options.
-        - Each item in the list should be wrapped in a \`s-list-item\` component.
-        - Keep list items concise and consistent in length when possible.
-        - Use \`s-unordered-list\` for navigation menus, feature lists, or any collection of related items.
-        - Consider using \`s-unordered-list\` when you want to present information in a clear, scannable format.
+- Use \`s-unordered-list\` when you need to present a list of related items or options.
+- Each item in the list should be wrapped in a \`s-list-item\` component.
+- Keep list items concise and consistent in length when possible.
+- Use \`s-unordered-list\` for navigation menus, feature lists, or any collection of related items.
+- Consider using \`s-unordered-list\` when you want to present information in a clear, scannable format.
       `,
     },
   ],


### PR DESCRIPTION
Aim to fix the formatting of bulleted lists when set in markdown. Only found this in Checkout content, Admin is good.

<img width="627" alt="image" src="https://github.com/user-attachments/assets/e09adc7d-0897-476d-8e50-951a4a1c0104" />
