### PR TITLE
Polish overview of checkout APIs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/scaffolded-with-preact.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/scaffolded-with-preact.jsx
@@ -1,16 +1,20 @@
 import '@shopify/ui-extensions/preact';
-import { Fragment, render } from 'preact';
-import { useState } from 'preact/hooks';
+import {render} from 'preact';
+import {useState} from 'preact/hooks';
 
-export default function ScaffoldedWithPreact() {
-  const [count, setCount] = useState(0);  
-
-  return (
-    <Fragment>
-      <s-text>Count: {count}</s-text>
-      <s-button onClick={() => setCount(count + 1)}>Increment</s-button>
-    </Fragment>
-  );
+export default function extension() {
+  render(<Extension />, document.body);
 }
 
-render(<ScaffoldedWithPreact />, document.body);
+function Extension() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <>
+      <s-text>Count: {count}</s-text>
+      <s-button onClick={() => setCount(count + 1)}>
+        Increment
+      </s-button>
+    </>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -49,12 +49,10 @@ else
   # so we erase their contents and replace them afterwards
   echo "export {}" > src/surfaces/customer-account.ts
   echo "export {}" > src/surfaces/admin.ts
-  echo "export {}" > src/surfaces/point-of-sale.ts
   eval $COMPILE_DOCS && eval $COMPILE_STATIC_PAGES && eval $COMPILE_CATEGORIES
   build_exit=$?
   git checkout HEAD -- src/surfaces/customer-account.ts
   git checkout HEAD -- src/surfaces/admin.ts
-  git checkout HEAD -- src/surfaces/point-of-sale.ts
 fi
 
 # TODO: get generate-docs to stop requiring JS files:

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -82,11 +82,7 @@ echo
 if [ $API_VERSION == "2025-10-rc" ]
 then
   echo "**** ${API_VERSION}: prefixing generate commands with POLARIS_UNIFIED=true"
-  run_sed 's/(npm run shopify app generate extension)/POLARIS_UNIFIED=true \1/gi' \
-    ./$DOCS_PATH/generated/generated_static_pages.json
-  run_sed 's/(pnpm shopify app generate extension)/POLARIS_UNIFIED=true \1/gi' \
-    ./$DOCS_PATH/generated/generated_static_pages.json
-  run_sed 's/(yarn shopify app generate extension)/POLARIS_UNIFIED=true \1/gi' \
+  run_sed 's/(shopify app generate extension)/POLARIS_UNIFIED=true \1/gi' \
     ./$DOCS_PATH/generated/generated_static_pages.json
 else
   echo "**** ${API_VERSION}: NOT prefixing generate commands with POLARIS_UNIFIED=true"
@@ -131,3 +127,4 @@ else
   SHOPIFY_DEV_PATH="$HOME/src/github.com/Shopify/shopify-dev"
   copy_generated_docs_to_shopify_dev
 fi
+

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/configuration/default.example.toml
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/configuration/default.example.toml
@@ -1,4 +1,4 @@
-api_version = "2025-07"
+api_version = "2025-10"
 
 [[extensions]]
 type = "ui_extension"

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/configuration/extended.example.toml
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/configuration/extended.example.toml
@@ -1,4 +1,4 @@
-api_version = "2025-07"
+api_version = "2025-10"
 
 [[extensions]]
 type = "ui_extension"

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/configuration/settings.example.toml
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/configuration/settings.example.toml
@@ -1,4 +1,4 @@
-api_version = "2025-07"
+api_version = "2025-10"
 
 [[extensions]]
 type = "ui_extension"

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/extension-apis.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/extension-apis.example.tsx
@@ -1,3 +1,4 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useShippingAddress} from '@shopify/ui-extensions/checkout/preact';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/extension-targets.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/extension-targets.example.tsx
@@ -1,8 +1,10 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default function extension() {
   render(<Extension />, document.body);
 }
+
 function Extension() {
   return <s-banner>Your extension</s-banner>;
 }

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolded-with-preact.jsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolded-with-preact.jsx
@@ -1,16 +1,20 @@
 import '@shopify/ui-extensions/preact';
-import { Fragment, render } from 'preact';
-import { useState } from 'preact/hooks';
+import {render} from 'preact';
+import {useState} from 'preact/hooks';
 
-export default function ScaffoldedWithPreact() {
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
   const [count, setCount] = useState(0);
 
   return (
-    <Fragment>
+    <>
       <s-text>Count: {count}</s-text>
-      <s-button onClick={() => setCount(count + 1)}>Increment</s-button>
-    </Fragment>
+      <s-button onClick={() => setCount(count + 1)}>
+        Increment
+      </s-button>
+    </>
   );
 }
-
-render(<ScaffoldedWithPreact />, document.body);

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolding-npm.example.bash
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolding-npm.example.bash
@@ -1,3 +1,0 @@
-npm init @shopify/app@latest
-cd your-app
-npm run shopify app generate extension

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolding-pnpm.example.bash
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolding-pnpm.example.bash
@@ -1,3 +1,0 @@
-pnpm create @shopify/app
-cd your-app
-pnpm shopify app generate extension

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolding-yarn.example.bash
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolding-yarn.example.bash
@@ -1,3 +1,0 @@
-yarn create @shopify/app
-cd your-app
-yarn shopify app generate extension

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolding.example.bash
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolding.example.bash
@@ -1,0 +1,11 @@
+# create an app if you don't already have one:
+shopify app init --name my-app
+
+# navigate to your app's root directory:
+cd my-app
+
+# generate a new extension:
+shopify app generate extension
+
+# follow the steps to create a new
+# extension in ./extensions.

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/ui-components.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/ui-components.example.tsx
@@ -1,3 +1,4 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default function extension() {

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
@@ -21,31 +21,13 @@ const data: LandingTemplateSchema = {
       anchorLink: 'scaffolding-extension',
       title: 'Scaffolding an extension',
       sectionContent:
-        'Use Shopify CLI to [generate a new extension](/apps/tools/cli/commands#generate-extension) in the directory of your app.',
-      sectionCard: [
-        {
-          name: 'Getting started video',
-          subtitle: 'Watch',
-          url: 'https://www.youtube.com/watch?v=jr_AIUDUSMw',
-          type: 'youtube',
-        },
-      ],
+        'Use the Shopify CLI to [generate a new extension](/apps/tools/cli/commands#generate-extension) in the directory of your app.',
       codeblock: {
         title: 'Scaffolding',
         tabs: [
           {
-            title: 'npm',
-            code: './examples/scaffolding-npm.example.bash',
-            language: 'bash',
-          },
-          {
-            title: 'yarn',
-            code: './examples/scaffolding-yarn.example.bash',
-            language: 'bash',
-          },
-          {
-            title: 'pnpm',
-            code: './examples/scaffolding-pnpm.example.bash',
+            title: 'CLI',
+            code: './examples/scaffolding.example.bash',
             language: 'bash',
           },
         ],
@@ -77,7 +59,7 @@ const data: LandingTemplateSchema = {
         Static extension targets are tied to core checkout features like contact information, shipping methods, and order summary line items.
         Block extension targets can be displayed at any point in the checkout process and will always render regardless of which checkout features are available.
         An example is a field to capture order notes from the customer.
-        \n\nExtension UIs are rendered using [remote UI](https://github.com/Shopify/remote-dom/tree/remote-ui),
+        \nExtension UIs are rendered using [remote DOM](https://github.com/Shopify/remote-dom/),
         a fast and secure environment for custom [(non-DOM)](#security) UIs.`,
       sectionCard: [
         {
@@ -92,7 +74,7 @@ const data: LandingTemplateSchema = {
         title: 'Extension targets',
         tabs: [
           {
-            title: 'React',
+            title: 'Preact',
             code: './examples/extension-targets.example.tsx',
             language: 'tsx',
           },
@@ -144,7 +126,7 @@ const data: LandingTemplateSchema = {
         title: 'Extension APIs',
         tabs: [
           {
-            title: 'React',
+            title: 'Preact',
             code: './examples/extension-apis.example.tsx',
             language: 'tsx',
           },
@@ -177,7 +159,7 @@ const data: LandingTemplateSchema = {
         title: 'UI components',
         tabs: [
           {
-            title: 'React',
+            title: 'Preact',
             code: './examples/ui-components.example.tsx',
             language: 'tsx',
           },
@@ -244,10 +226,10 @@ Checkout UI extensions don't have access to the DOM and can't return DOM nodes. 
       title: 'Resources',
       resources: [
         {
-          name: 'remote-ui',
+          name: 'remote-dom',
           subtitle:
             'Learn more about the underlying technology that powers checkout UI extensions.',
-          url: 'https://github.com/Shopify/remote-dom/tree/remote-ui',
+          url: 'https://github.com/Shopify/remote-dom/',
           type: 'gitHub',
         },
         {

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
@@ -38,7 +38,7 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       title: 'Scaffolded with Preact',
       sectionContent:
-        'UI Extensions are scaffolded with Preact by default. This means that you can use Preact patterns and principles within your extension.',
+        'UI Extensions are scaffolded with [Preact](https://preactjs.com/) by default. This means that you can use Preact patterns and principles within your extension.',
       anchorLink: 'scaffolded-with-preact',
       codeblock: {
         title: 'Scaffolded with Preact',
@@ -185,7 +185,7 @@ Checkout UI extensions are a safe and secure way to customize the appearance and
           sectionContent: `
 You can't override the CSS for UI components. The checkout UI will always render the merchant's own branding as shown in the image in the UI components section above.
 
-Checkout UI extensions don't have access to the DOM and can't return DOM nodes. They can't return \`<div>\` elements, for example. Building an arbitrary tree of HTML and loading additional scripts using script tags are also not supported.
+Checkout UI extensions don't have access to the real checkout DOM and can't render arbitrary HTML such as \`<div>\` elements or \`<script>\` tags, etc. They can only render custom HTML elements provided by Shopify.
 `,
           type: 'info',
         },

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/using-polaris-web-components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/using-polaris-web-components.doc.ts
@@ -114,8 +114,8 @@ const data: LandingTemplateSchema = {
             tabs: [
               {
                 title: 'JavaScript',
-                code: './examples/properties-vs-attributes-jsx-props.js',
-                language: 'javascript',
+                code: './examples/properties-vs-attributes-jsx-props.ts',
+                language: 'ts',
               },
             ],
             title: 'Pseudocode',

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/using-polaris-web-components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/using-polaris-web-components.doc.ts
@@ -107,15 +107,15 @@ const data: LandingTemplateSchema = {
           initialLanguage: '',
         },
         {
-          title: 'How JSX properties are aspplied',
+          title: 'How JSX properties are applied',
           description:
             "When using Polaris web components in JSX, the framework determines how to apply your props based on whether the element has a matching property name.\n\nIf the element has a property with the exact same name as your prop, the value is set as a property. Otherwise, it's applied as an attribute. Here's how this works in pseudocode:",
           codeblock: {
             tabs: [
               {
                 title: 'JavaScript',
-                code: './examples/properties-vs-attributes-jsx-props.ts',
-                language: 'ts',
+                code: './examples/properties-vs-attributes-jsx-props.js',
+                language: 'javascript',
               },
             ],
             title: 'Pseudocode',


### PR DESCRIPTION
### Background

Apply fixes for https://shopify.dev/docs/api/checkout-ui-extensions/2025-10-rc

### Solution

* Re-applied fixes from `checkout-web` that got lost in a merge: simpler scaffolding, corrected version number in examples. See https://github.com/shop/world/pull/56814
* Fixed scaffolded with Preact example which wasn't working (in both Checkout and Admin). I also removed `Fragment` to make it more idiomatic.
* Added preact side-effect imports to overview example code for future-proofing
* Fix incorrect info about working with the DOM

### 🎩

```
yarn docs:checkout 2025-10-rc
```

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
