### PR TITLE
Fix forms

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-default-value.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-default-value.jsx
@@ -17,7 +17,10 @@ function Extension() {
   return (
     <s-admin-block title="My Block Extension">
       <s-form
-        onSubmit={() => console.log('submit', {textValue, numberValue})}
+        onSubmit={(event) => {
+          event.waitUntil(fetch('app:save/data'));
+          console.log('submit', {textValue, numberValue});
+        }
         onReset={() => console.log('automatically reset values')}
       >
         <s-stack direction="block" gap="base">

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-implicit-default.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-implicit-default.jsx
@@ -19,7 +19,10 @@ function App({text, number}) {
   return (
     <s-admin-block title="My Block Extension">
       <s-form
-        onSubmit={() => console.log('submit', {textValue, numberValue})}
+        onSubmit={(event) => {
+          event.waitUntil(fetch('app:data/save'));
+          console.log('submit', {textValue, numberValue});
+        }
         onReset={() => console.log('automatically reset values')}
       >
         <s-stack direction="block" gap="base">


### PR DESCRIPTION
This pull request updates form submission handlers in two example files to include asynchronous data saving using the `event.waitUntil` method. This ensures that data-saving operations are completed before the form submission process finishes.

### Updates to form submission handlers:

* [`packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-default-value.jsx`](diffhunk://#diff-197bc911da82b1259ff6ea2861f298fc56789d22c32abfb154b99e9a133a3d41L20-R23): Modified the `onSubmit` handler to call `event.waitUntil(fetch('app:save/data'))`, ensuring that the data-saving operation is executed asynchronously during form submission.

* [`packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-implicit-default.jsx`](diffhunk://#diff-2c045f28cad7a94d24b668bae398fade0c48ca33ef7575e146aa23b1cce636e8L22-R25): Updated the `onSubmit` handler to use `event.waitUntil(fetch('app:data/save'))` for asynchronous data saving during form submission.