### PR TITLE
Adding a customer account remote dom migration doc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10-rc.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10-rc.doc.ts
@@ -53,7 +53,7 @@ const data: LandingTemplateSchema = {
           url: '/docs/api/checkout-ui-extensions/2025-10-rc/upgrading-to-2025-10',
         },
       ],
-    }
+    },
   ],
 };
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10-rc.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10-rc.doc.ts
@@ -1,0 +1,60 @@
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
+
+// Order of data shape mimics visual structure of page
+// Anything in an array can have multiple objects
+
+const data: LandingTemplateSchema = {
+  title: 'Upgrading to 2025-10',
+  description: `This guide describes how to upgrade your customer account UI extension to API version \`2025-10\`.`,
+  // The id for the page that is used for routing. If this documentation is for a primary landing page, confirm the id matches the reference name.
+  id: 'upgrading-to-2025-10-rc',
+  sections: [
+    {
+      type: 'Generic',
+      anchorLink: 'migrating-to-polaris-web-components',
+      title: 'Migrating to Polaris web components',
+      sectionContent:
+        'Set the API version to `2025-10` in `shopify.extension.toml` to use the new Polaris UI framework (still in early preview). Use the comparison table below to see what Polaris web components are available today and how they map to legacy components.',
+      sectionNotice: [
+        {
+          title: 'Early access preview',
+          sectionContent: `These components are an early access preview of the [Polaris](https://shopify.dev/beta/next-gen-dev-platform/polaris) UI framework. We do not recommend migrating your production customer account UI extension to Polaris until the release is stable. However, now is a great time to explore this new version to begin mapping our your migration.`,
+          type: 'info',
+        },
+      ],
+    },
+    {
+      type: 'Markdown',
+      anchorLink: 'mapping-legacy-components-to-polaris-web',
+      title: 'Mapping Legacy components to Polaris web',
+      sectionContent: `
+|   **Legacy Component**   |   **Polaris Web Component**   |   **Migration Notes**   |
+| :----------------------: | :-------------------------------: | :---------------------: |
+|   \`Avatar\`                |   \`Avatar\`                                               |   Coming soon.                         |
+|   \`Card\`                  |  [Section](/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/section)                                             |   Available today.                     |
+|   \`CustomerAccountAction\`  |  [CustomerAccountAction](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/customeraccountaction)   |   Available today.       |
+|   \`ImageGroup\`            |  [ImageGroup](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/imagegroup)                         |   Available today.       |
+|   \`Menu\`                  |  \`Menu\`                                                      |   Coming soon.       |
+|   \`Page\`                  |  [Page](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/page)    |   Available today. |
+|   \`ResourceItem\`          |                                        |   Coming soon.  |
+`,
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'additional-components',
+      title: 'Additional components',
+      sectionContent:
+        'In addition to the components above, you can also use Polaris web components in the Checkout library to build customer account UI extensions.',
+      sectionCard: [
+        {
+          type: 'blocks',
+          name: 'Checkout components',
+          subtitle: 'More Polaris web components',
+          url: '/docs/api/checkout-ui-extensions/2025-10-rc/upgrading-to-2025-10',
+        },
+      ],
+    }
+  ],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10-rc.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10-rc.doc.ts
@@ -18,7 +18,9 @@ const data: LandingTemplateSchema = {
       sectionNotice: [
         {
           title: 'Early access preview',
-          sectionContent: `These components are an early access preview of the [Polaris](https://shopify.dev/beta/next-gen-dev-platform/polaris) UI framework. We do not recommend migrating your production customer account UI extension to Polaris until the release is stable. However, now is a great time to explore this new version to begin mapping our your migration.`,
+          sectionContent: `This is an early access preview of the [Polaris](https://shopify.dev/beta/next-gen-dev-platform/polaris) UI framework. We will be adding more components over time, so please refer to the comparison table below to see which components are currently available, which ones are coming soon, and how they correspond to their legacy versions.
+
+We advise against migrating your production customer account UI extension to Polaris until the release is stable. However, this is a great opportunity to explore the new version and start planning your migration.`,
           type: 'info',
         },
       ],


### PR DESCRIPTION
## Description
Adds an "Upgrading to 2025-10" page to customer account UI docs that includes a table displaying a list of Remote UI components, their migration status and Remote DOM equivalent. Does not include common migration patterns (to be added later).

## 🎩TopHat Instructions
- Run shopify-dev and ui-extensions locally on the 2025-10-rc branch
- Run the following command to generate the docs: yarn docs:customer-account 2025-10-rc
- Open the [generated link](https://shopify-dev.myshopify.io/docs/api/customer-account-ui-extensions) and navigate to the [Upgrading to 2025-10 page](https://shopify-dev.myshopify.io/docs/api/customer-account-ui-extensions/2025-10-rc/upgrading-to-2025-10-rc)

## Areas to Focus on
Please pay attention to the "migration notes" for each component and feel free to suggest better notes for each component.
I could not find a design system for colours we use in our docs so I used arbitrary colours in a colorKeyword() function to highlight the availability for each component.
