### PR TITLE
[Customer][Market] 202510-rc move the country example to the top

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/localization.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/localization.doc.ts
@@ -67,25 +67,6 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'You can use the count option to get a pluralized string based on the current locale.',
-        codeblock: {
-          title: 'Translating strings with pluralization',
-          tabs: [
-            {
-              code: '../examples/apis/translate-pluralization.example.tsx',
-              language: 'jsx',
-              title: 'Preact',
-            },
-            {
-              code: '../examples/apis/translate-pluralization.locale.example.json',
-              language: 'json',
-              title: 'locales/en.default.json',
-            },
-          ],
-        },
-      },
-      {
-        description:
           'You can access the current country of a customer to implement country specific logic.',
         codeblock: {
           title: 'Getting the country of the customer',
@@ -97,6 +78,25 @@ const data: ReferenceEntityTemplateSchema = {
             },
             {
               code: '../examples/apis/localization-country.locale.example.json',
+              language: 'json',
+              title: 'locales/en.default.json',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'You can use the count option to get a pluralized string based on the current locale.',
+        codeblock: {
+          title: 'Translating strings with pluralization',
+          tabs: [
+            {
+              code: '../examples/apis/translate-pluralization.example.tsx',
+              language: 'jsx',
+              title: 'Preact',
+            },
+            {
+              code: '../examples/apis/translate-pluralization.locale.example.json',
               language: 'json',
               title: 'locales/en.default.json',
             },


### PR DESCRIPTION
## Problem

the fragment identifier of code examples is not working as expected:
[recorded video like this](https://screenshot.click/28-54-rjl80-6tn66.mp4)

* https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis/localization#examples
    * this one works fine - scroll to the right place
* https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis/localization#example-getting-the-country-of-the-customer
    * this URL does not scroll

## Solution 

We are moving the new example to the top and will link our example to `#examples` so 3p dev will see the new one directly. 

https://screenshot.click/21-46-vppkk-ygnpj.mp4 

