### PR TITLE
Export storage API interfaces

### DIFF
--- a/.changeset/loud-kings-matter.md
+++ b/.changeset/loud-kings-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Export storage API interfaces and update Storage.entries return type

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -76,6 +76,8 @@ export type {
   SessionApi,
 } from './render/api/session-api/session-api';
 
+export type {StorageApi} from './render/api/storage-api/storage-api';
+
 export type {
   ShowToastOptions,
   ToastApiContent,
@@ -122,3 +124,5 @@ export type {
 export type {CountryCode} from './types/country-code';
 
 export type {Session} from './types/session';
+export type {Storage} from './types/storage';
+export {StorageError} from './types/storage';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/data.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/data.ts
@@ -1,4 +1,5 @@
 export type {BaseData} from './event/data/BaseData';
+export type {BaseApi} from './event/data/BaseApi';
 export type {ReprintReceiptData} from './event/data/ReprintReceiptData';
 export type {TransactionCompleteData} from './event/data/TransactionCompleteData';
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseApi.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseApi.ts
@@ -1,0 +1,3 @@
+import {StorageApi} from '../../render/api/storage-api/storage-api';
+
+export type BaseApi = StorageApi;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseData.ts
@@ -1,10 +1,8 @@
 import type {ConnectivityState, Device, Session} from '../../../point-of-sale';
-import {Storage} from '../../types/storage';
 
 export interface BaseData {
   connectivity: ConnectivityState;
   device: Device;
   locale: string;
   session: Session;
-  storage?: Storage;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/CartUpdateEventData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/CartUpdateEventData.ts
@@ -1,6 +1,7 @@
 import {BaseData} from './BaseData';
 import {Cart} from '../../api';
+import {BaseApi} from './BaseApi';
 
-export interface CartUpdateEventData extends BaseData {
+export interface CartUpdateEventData extends BaseData, BaseApi {
   cart: Cart;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/CashTrackingSessionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/CashTrackingSessionData.ts
@@ -1,13 +1,14 @@
 import {BaseData} from './BaseData';
+import {BaseApi} from './BaseApi';
 
-export interface CashTrackingSessionStartData extends BaseData {
+export interface CashTrackingSessionStartData extends BaseData, BaseApi {
   cashTrackingSessionStart: {
     id: number;
     openingTime: string;
   };
 }
 
-export interface CashTrackingSessionCompleteData extends BaseData {
+export interface CashTrackingSessionCompleteData extends BaseData, BaseApi {
   cashTrackingSessionComplete: {
     id: number;
     openingTime: string;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/TransactionCompleteData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/TransactionCompleteData.ts
@@ -2,8 +2,9 @@ import {BaseData} from './BaseData';
 import type {SaleTransactionData} from './SaleTransactionData';
 import type {ExchangeTransactionData} from './ExchangeTransactionData';
 import type {ReturnTransactionData} from './ReturnTransactionData';
+import {BaseApi} from './BaseApi';
 
-export interface TransactionCompleteData extends BaseData {
+export interface TransactionCompleteData extends BaseData, BaseApi {
   transaction:
     | SaleTransactionData
     | ReturnTransactionData

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -1,6 +1,11 @@
-export interface StorageExceededError extends Error {
-  name: 'StorageExceededError';
-  code: 'RecordsCount' | 'RecordSize';
+export class StorageError extends Error {
+  public name = 'StorageError';
+  constructor(
+    public code: 'RecordsCount' | 'RecordSize' | 'KeyType' | 'KeySize',
+    message: string,
+  ) {
+    super(message);
+  }
 }
 export interface Storage<
   BaseStorageTypes extends Record<string, any> = Record<string, unknown>,
@@ -11,8 +16,10 @@ export interface Storage<
    * @param key - The key to set the value for.
    * @param value - The value to set for the key.
    * Can be any primitive type supported by `JSON.stringify`.
-   * @throws StorageExceededError if the extension exceeds its allotted storage limit.
-   * @throws StorageExceededError if value exceeds its allotted storage limit.
+   * @throws StorageError when:
+   *    the extension exceeds its allotted storage limit.
+   *    the value exceeds its allotted storage limit.
+   *    the key is not a string or exceeds its allotted size.
    */
   set<
     StorageTypes extends BaseStorageTypes = BaseStorageTypes,
@@ -28,6 +35,7 @@ export interface Storage<
    * @param key - The key to get the value for.
    * @returns The value of the key.
    * If no value for the key exists, the resolved value is undefined.
+   * @throws StorageError when the key is not a string or exceeds its allotted size.
    */
   get<
     StorageTypes extends BaseStorageTypes = BaseStorageTypes,
@@ -56,10 +64,10 @@ export interface Storage<
   /**
    * Gets all the keys and values in the storage.
    *
-   * @returns An iterator containing all the keys and values in the storage.
+   * @returns An array containing all the keys and values in the storage.
    */
   entries<
     StorageTypes extends BaseStorageTypes = BaseStorageTypes,
     Keys extends keyof StorageTypes = keyof StorageTypes,
-  >(): Promise<IterableIterator<[Keys, StorageTypes[Keys]]>>;
+  >(): Promise<[Keys, StorageTypes[Keys]][]>;
 }


### PR DESCRIPTION
### Background

Export Storage API interface to use it in POS App

Also, update `entries` method to return Array instead of  IterableIterator, since Worker serializer can't serialize Iterators

Refactor Storage API (do not include it as a part of BaseData, create new BaseAPI)
We need it for a better POS App experience. BaseData does not depend on extension, but APIs do
https://github.com/Shopify/pos-next-react-native/pull/58468#discussion_r2105079430

### Solution



### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
