### PR TITLE
Add maxLength fix on POS TextField to changelog

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -75,6 +75,10 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 
 ## Important Fixes
 
+- **POS 10.3.0**:
+
+  - Fixed an issue where the \`TextField\` component failed to apply the \`maxLength\` parameter.
+
 - **POS 10.2.0**:
 
   - Fixed a sizing issue with the \`Button\` component.
@@ -106,6 +110,10 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Release day: 1/6/2025
 
 ## Important Fixes
+
+- **POS 10.3.0**:
+
+  - Fixed an issue where the \`TextField\` component failed to apply the \`maxLength\` parameter.
 
 - **POS 10.2.0**:
 
@@ -171,6 +179,10 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 
 ## Important Fixes
 
+- **POS 10.3.0**:
+
+  - Fixed an issue where the \`TextField\` component failed to apply the \`maxLength\` parameter.
+
 - **POS 10.2.0**:
 
   - Fixed a sizing issue with the \`Button\` component.
@@ -196,6 +208,10 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Release day: 10/1/2024.
 
 ## Important Fixes
+
+- **POS 10.3.0**:
+
+  - Fixed an issue where the \`TextField\` component failed to apply the \`maxLength\` parameter.
 
 - **POS 10.2.0**:
 
@@ -229,6 +245,10 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Release day: 08/14/2024.
 
 ## Important Fixes
+
+- **POS 10.3.0**:
+
+  - Fixed an issue where the \`TextField\` component failed to apply the \`maxLength\` parameter.
 
 - **POS 10.2.0**:
 
@@ -267,6 +287,12 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Added in POS version: 9.11.0
 - Removed in POS version: 9.31.0
 - Release day: 06/10/2024.
+
+## Important Fixes
+
+- **POS 10.3.0**:
+
+  - Fixed an issue where the \`TextField\` component failed to apply the \`maxLength\` parameter.
 
 ### Features
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -288,12 +288,6 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Removed in POS version: 9.31.0
 - Release day: 06/10/2024.
 
-## Important Fixes
-
-- **POS 10.3.0**:
-
-  - Fixed an issue where the \`TextField\` component failed to apply the \`maxLength\` parameter.
-
 ### Features
 
 - Added support for the ${TargetLink.PosPurchasePostActionMenuItemRender} and ${TargetLink.PosPurchasePostActionRender} targets.


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/temp-project-mover-Archetypically-20250612104008/issues/160
PR fixing the bug: https://github.com/Shopify/pos-next-react-native/pull/60021

This updates the unstable POS UI changelog to mention fixing a bug where the `maxLength` parameter of the `TextField` component was dropped for API versions 2024-04+.

### Solution

| Before  | After |
| ------------- | ------------- |
|  <img width="300" alt="image" src="https://github.com/user-attachments/assets/fafd57fc-37bd-4667-9863-6d18f6bc7de8" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/0a8076c8-d676-4ab6-8086-b5e0bc55f568" /> |



###  🎩

1. Checkout this branch/PR from the shopify-dev repo.
2. Run dev up && dev s in that repo in your IDE
3. ctrl+T to open the local instance in your browser.
4. Navigate to:
  - https://shopify-dev.myshopify.io/docs/api/pos-ui-extensions/unstable/versions
  - https://shopify-dev.myshopify.io/docs/api/pos-ui-extensions/2024-07/versions
  - https://shopify-dev.myshopify.io/docs/api/pos-ui-extensions/2024-10/versions
  - https://shopify-dev.myshopify.io/docs/api/pos-ui-extensions/2025-01/versions
  - https://shopify-dev.myshopify.io/docs/api/pos-ui-extensions/2025-04/versions

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
