### PR TITLE
Add onBlur prop to SearchBar

### DIFF
--- a/.changeset/itchy-forks-lay.md
+++ b/.changeset/itchy-forks-lay.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+SearchBar - add onBlur handler

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/SearchBar/SearchBar.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/SearchBar/SearchBar.ts
@@ -18,6 +18,10 @@ export interface SearchBarProps {
    */
   onFocus?: () => void;
   /**
+   * A callback when focus is removed.
+   */
+  onBlur?: () => void;
+  /**
    * Whether the text can be changed.
    */
   editable?: boolean;


### PR DESCRIPTION
### Background

Related to issue #[54912](https://github.com/Shopify/temp-project-mover-Archetypically-20250612104008/issues/76). **Problem:** The SearchBar component had an `onFocus` callback without a matching `onBlur`, which created potential UX issues.

TLDR:
- Expose `onBlur` prop to `SearchBar`
- Part of cross-repo change:
    - This PR needs to be merged before these PRs:
        - [pos-e2e-ui-extension PR Shopify/pos-next-react-native#144](https://github.com/Shopify/pos-e2e-ui-extension/pull/144)
        - [pos-next-react-native PR Shopify/pos-next-react-native#61908](https://github.com/Shopify/pos-next-react-native/pull/61908)
 
### Details
|Before|After|
|--|--|
| <img width="469" alt="image" src="https://github.com/user-attachments/assets/96be88ac-475f-4f0a-bcc3-59c751e9ef63" />|<img width="469" alt="image" src="https://github.com/user-attachments/assets/27f35829-aee1-4f62-afcc-2ffd998e16b3"/>|
   
### Solution
- Adds `onBlur` to the `SearchBarProps` interface to expose the existing blur functionality from the underlying `InputField` component. This completes the onFocus/onBlur pair.

### 🎩

1. Update `package.json` to use unstable-snap in your ui extension
2. Checkout the  [pos-next-react-native PR Shopify/pos-next-react-native#61908](https://github.com/Shopify/pos-next-react-native/pull/61908), use tophat or checkout and run POS locally
3. Checkout [ui-extensions PR Shopify/pos-next-react-native#2926](https://github.com/Shopify/ui-extensions/pull/2926) and run 'shopify app dev'
4. Run `dev extension [url from Developer Console]` on POS
5. Go to SearchBar Screen and test onBlur (paired with onFocus so switches from True to False and back while focusing or blurring)

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
