### PR TITLE
fix navigation hook

### DIFF
--- a/.changeset/thirty-buttons-happen.md
+++ b/.changeset/thirty-buttons-happen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+fix `useNavigationCurrentEntry` hook returning stale value

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/live-navigation.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/live-navigation.ts
@@ -7,20 +7,27 @@ import {useEffect, useReducer} from 'preact/hooks';
 export function useNavigationCurrentEntry<
   Target extends RenderCustomerAccountFullPageExtensionTarget = RenderCustomerAccountFullPageExtensionTarget,
 >(): NavigationHistoryEntry {
-  const {currentEntry, removeEventListener, addEventListener} =
-    useApi<Target>().navigation;
+  const navigation = useApi<Target>().navigation;
 
-  const [entry, update] = useReducer(() => currentEntry, currentEntry);
+  const [entry, update] = useReducer(
+    () => navigation.currentEntry,
+    navigation.currentEntry,
+  );
 
   useEffect(() => {
-    if (!currentEntry || !removeEventListener || !addEventListener) {
+    if (
+      !navigation ||
+      !navigation.currentEntry ||
+      !navigation.removeEventListener ||
+      !navigation.addEventListener
+    ) {
       throw new Error(
         'useNavigationCurrentEntry must be used in an extension with the customer-account.page.render or customer-account.order.page.render target only',
       );
     }
-    addEventListener('currententrychange', update);
-    return () => removeEventListener('currententrychange', update);
-  }, [addEventListener, currentEntry, removeEventListener]);
+    navigation.addEventListener('currententrychange', update);
+    return () => navigation.removeEventListener('currententrychange', update);
+  }, [navigation]);
 
   return entry;
 }


### PR DESCRIPTION
Fixes `useNavigationCurrentEntry` returning stale values
See https://github.com/Shopify/ui-extensions/pull/2927/files#r2101046001 for more context

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
