### PR TITLE
Add comprehensive 2025-10 migration instructions for checkout

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/apis-new.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/apis-new.tsx
@@ -1,0 +1,31 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+import {
+  useAttributeValues
+} from '@shopify/ui-extensions/checkout/preact';
+
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  const [includeGift] = useAttributeValues(['includeGift']);
+  return (
+    <s-checkbox
+      checked={includeGift === 'yes'}
+      onChange={onCheckboxChange}
+      label="Include a complimentary gift"
+    />
+  );
+}
+
+async function onCheckboxChange(e) {
+  const isChecked = e.target.checked;
+
+  const result = await shopify.applyAttributeChange({
+    type: 'updateAttribute',
+    key: 'includeGift',
+    value: isChecked ? 'yes' : 'no',
+  });
+  console.log('applyAttributeChange result', result);
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/apis-old-js.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/apis-old-js.ts
@@ -1,0 +1,29 @@
+import {extension, Checkbox} from '@shopify/ui-extensions/checkout';
+
+export default extension('purchase.checkout.block.render', (root, api) => {
+  api.attributes.subscribe(() => render(root, api));
+  render(root, api);
+});
+
+function render(root, api) {
+  const includeGift = api.attributes.current.some(
+    (attribute) => attribute.key == 'includeGift' && attribute.value == 'yes',
+  );
+
+  async function onCheckboxChange(isChecked) {
+    const result = await api.applyAttributeChange({
+      type: 'updateAttribute',
+      key: 'includeGift',
+      value: isChecked ? 'yes' : 'no',
+    });
+    console.log('applyAttributeChange result', result);
+  }
+
+  root.replaceChildren(
+    root.createComponent(
+      Checkbox,
+      {checked: includeGift, onChange: onCheckboxChange},
+      'Include a complimentary gift',
+    ),
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/apis-old-react.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/apis-old-react.tsx
@@ -1,0 +1,31 @@
+import {
+  reactExtension,
+  Checkbox,
+  useAttributeValues,
+  useApplyAttributeChange,
+} from '@shopify/ui-extensions-react/checkout';
+
+export default reactExtension('purchase.checkout.block.render', () => (
+  <Extension />
+));
+
+function Extension() {
+  const [includeGift] = useAttributeValues(['includeGift']);
+  const applyAttributeChange = useApplyAttributeChange();
+
+  async function onCheckboxChange(isChecked) {
+    const result = await applyAttributeChange({
+      type: 'updateAttribute',
+      key: 'includeGift',
+      value: isChecked ? 'yes' : 'no',
+    });
+    console.log('applyAttributeChange result', result);
+  }
+
+  const checked = includeGift === 'yes';
+  return (
+    <Checkbox checked={checked} onChange={onCheckboxChange}>
+      Include a complimentary gift
+    </Checkbox>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/components-new.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/components-new.tsx
@@ -1,0 +1,15 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  return (
+    <s-stack direction="inline" gap="base">
+      <s-text-field label="Gift message"></s-text-field>
+      <s-button variant="primary">Save</s-button>
+    </s-stack>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/components-old-js.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/components-old-js.ts
@@ -1,0 +1,15 @@
+import {
+  extension,
+  InlineStack,
+  TextField,
+  Button,
+} from '@shopify/ui-extensions/checkout';
+
+export default extension('purchase.checkout.block.render', (root, _api) => {
+  root.replaceChildren(
+    root.createComponent(InlineStack, {}, [
+      root.createComponent(TextField, {label: 'Gift message'}),
+      root.createComponent(Button, {}, 'Save'),
+    ]),
+  );
+});

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/components-old-react.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/components-old-react.tsx
@@ -1,0 +1,19 @@
+import {
+  reactExtension,
+  InlineStack,
+  TextField,
+  Button,
+} from '@shopify/ui-extensions-react/checkout';
+
+export default reactExtension('purchase.checkout.block.render', () => (
+  <Extension />
+));
+
+function Extension() {
+  return (
+    <InlineStack>
+      <TextField label="Gift message" />
+      <Button>Save</Button>
+    </InlineStack>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/package-json-new.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/package-json-new.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@shopify/ui-extensions": "~2025.10.0-rc"
+  }
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/package-json-old-js.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/package-json-old-js.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@shopify/ui-extensions": "2025.4.x"
+  }
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/package-json-old-react.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/package-json-old-react.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "react": "^18.0.0",
+    "@shopify/ui-extensions": "2025.4.x",
+    "@shopify/ui-extensions-react": "2025.4.x",
+    "react-reconciler": "0.29.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0"
+  }
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/shopify.extension-new.toml
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/shopify.extension-new.toml
@@ -1,0 +1,8 @@
+api_version = "2025-10"
+
+[[extensions]]
+name = "your-extension"
+handle = "your-extension"
+type = "ui_extension"
+
+# Contents of your existing file...

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
@@ -6,26 +6,203 @@ import type {LandingTemplateSchema} from '@shopify/generate-docs';
 const data: LandingTemplateSchema = {
   title: 'Upgrading to 2025-10',
   description: `
-This guide describes how to upgrade your checkout UI extension to API version \`2025-10\`.
+This guide describes how to upgrade your checkout UI extension to API version \`2025-10\` and adopt [Polaris](/beta/next-gen-dev-platform/polaris) web components.
 `,
   // The id for the page that is used for routing. If this documentation is for a primary landing page, confirm the id matches the reference name.
   id: 'upgrading-to-2025-10',
   sections: [
     {
       type: 'Generic',
-      anchorLink: 'migrating-to-polaris-web-components',
-      title: 'Migrating to Polaris Web Components',
+      anchorLink: 'update-api-version',
+      title: 'Update API version',
       sectionContent:
-        'Set the API version to `2025-10` in `shopify.extension.toml` to use the new Polaris UI framework.',
+        'Set the API version to `2025-10` in `shopify.extension.toml` to use Polaris web components.',
       sectionNotice: [
         {
           title: 'Early access preview',
           sectionContent: `
-These web components are an early access preview of the [Polaris](https://shopify.dev/beta/next-gen-dev-platform/polaris) UI framework. We will add more components over time. 
-
-Use the comparison table below to see what Polaris web components are available today, which are coming soon, and how they map to legacy components.
-
 We do not recommend migrating your production checkout UI extension to Polaris yet. However, now is a great time to explore this new version and start thinking about what it means for your own extensions.
+`,
+          type: 'info',
+        },
+      ],
+      codeblock: {
+        title: 'shopify.extension.toml',
+        tabs: [
+          {
+            title: 'shopify.extension.toml',
+            code: './examples/upgrading-to-2025-10/shopify.extension-new.toml',
+            language: 'toml',
+          },
+        ],
+      },
+    },
+    {
+      type: 'GenericAccordion',
+      anchorLink: 'adjust-dependencies',
+      title: 'Adjust package dependencies',
+      sectionContent: `
+As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the dependencies in your \`package.json\` file and re-install.
+`,
+      accordionContent: [
+        {
+          title: 'New dependencies with Preact',
+          description: '',
+          codeblock: {
+            title: 'New dependencies with Preact',
+            tabs: [
+              {
+                title: 'package.json',
+                code: './examples/upgrading-to-2025-10/package-json-new.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous dependencies with React',
+          description: '',
+          codeblock: {
+            title: 'Previous dependencies with React',
+            tabs: [
+              {
+                title: 'package.json',
+                code: './examples/upgrading-to-2025-10/package-json-old-react.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous dependencies with JavaScript',
+          description: '',
+          codeblock: {
+            title: 'Previous dependencies with JavaScript',
+            tabs: [
+              {
+                title: 'package.json',
+                code: './examples/upgrading-to-2025-10/package-json-old-js.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      type: 'GenericAccordion',
+      anchorLink: 'migrate-api-calls',
+      title: 'Migrate API calls',
+      sectionContent:
+        'Instead of accessing APIs from a callback parameter, access them from the global `shopify` object. If you had previously been using React hooks, import those same hooks from a new Preact-specific package.',
+      accordionContent: [
+        {
+          title: 'New API calls in Preact',
+          description: '',
+          codeblock: {
+            title: 'New API calls in Preact',
+            tabs: [
+              {
+                title: 'Preact',
+                code: './examples/upgrading-to-2025-10/apis-new.tsx',
+                language: 'tsx',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous API calls in React',
+          description: '',
+          codeblock: {
+            title: 'Previous API calls in React',
+            tabs: [
+              {
+                title: 'React',
+                code: './examples/upgrading-to-2025-10/apis-old-react.tsx',
+                language: 'tsx',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous API calls in JavaScript',
+          description: '',
+          codeblock: {
+            title: 'Previous API calls in JavaScript',
+            tabs: [
+              {
+                title: 'JavaScript',
+                code: './examples/upgrading-to-2025-10/apis-old-js.ts',
+                language: 'ts',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      type: 'GenericAccordion',
+      anchorLink: 'migrate-to-polaris-web-components',
+      title: 'Migrate to Polaris web components',
+      sectionContent:
+        'Polaris web components are exposed as custom HTML elements. Update your React or JavaScript components to custom elements.',
+      accordionContent: [
+        {
+          title: 'New components in Preact',
+          description: '',
+          codeblock: {
+            title: 'New components in Preact',
+            tabs: [
+              {
+                title: 'Preact',
+                code: './examples/upgrading-to-2025-10/components-new.tsx',
+                language: 'tsx',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous components in React',
+          description: '',
+          codeblock: {
+            title: 'Previous components in React',
+            tabs: [
+              {
+                title: 'React',
+                code: './examples/upgrading-to-2025-10/components-old-react.tsx',
+                language: 'tsx',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous components in JavaScript',
+          description: '',
+          codeblock: {
+            title: 'Previous components in JavaScript',
+            tabs: [
+              {
+                title: 'JavaScript',
+                code: './examples/upgrading-to-2025-10/components-old-js.ts',
+                language: 'ts',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'polaris-web-components',
+      title: 'Polaris web components',
+      sectionContent: '',
+      sectionNotice: [
+        {
+          title: 'Early access preview',
+          sectionContent: `
+These web components are an early access preview of the [Polaris](/beta/next-gen-dev-platform/polaris) UI framework. We will add more components over time.
+
+Use the comparison table below to see which Polaris web components are available today, which are coming soon, and how they map to legacy components.
 `,
           type: 'info',
         },
@@ -34,42 +211,42 @@ We do not recommend migrating your production checkout UI extension to Polaris y
     {
       type: 'Markdown',
       anchorLink: 'mapping-legacy-components-to-polaris-web-components',
-      title: 'Mapping Legacy Components to Polaris Web Components',
+      title: 'Mapping legacy components to Polaris web components',
       sectionContent: `
 |   **Legacy&nbsp;Component**   |   **Polaris&nbsp;Web&nbsp;Component**   |   **Migration&nbsp;Notes**   |
 | :----------------------: | :-------------------------------: | :---------------------: |
-|                          |   [Abbreviation](/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/abbreviation)   |   Available today                      |
+|                          |   [Abbreviation](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/abbreviation)   |   Available today                      |
 |   \`Badge\`                  |   \`Badge\`                                               |   Coming soon                          |
-|   \`Banner\`                 |   [Banner](/api/checkout-ui-extensions/2025-10-rc/components/feedback/banner)                                              |   Available today                      |
+|   \`Banner\`                 |   [Banner](/docs/api/checkout-ui-extensions/2025-10-rc/components/feedback/banner)                                              |   Available today                      |
 |   \`BlockLayout\`            |                                                      |   Removed. Use \`Grid\`                  |
-|   \`BlockSpacer\`            |                                                      |   Removed. Use [Stack](/api/checkout-ui-extensions/2025-10-rc/components/structure/stack) with \`gap\` property          |
-|   \`BlockStack\`             |                                                      |   Removed. Use [Stack](/api/checkout-ui-extensions/2025-10-rc/components/structure/stack) with \`direction=block\`       |
-|   \`Button\`                 |   [Button](/api/checkout-ui-extensions/2025-10-rc/components/actions/button)                                              |   Available today                      |
+|   \`BlockSpacer\`            |                                                      |   Removed. Use [Stack](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/stack) with \`gap\` property          |
+|   \`BlockStack\`             |                                                      |   Removed. Use [Stack](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/stack) with \`direction=block\`       |
+|   \`Button\`                 |   [Button](/docs/api/checkout-ui-extensions/2025-10-rc/components/actions/button)                                              |   Available today                      |
 |   \`Chat\`                   |   \`Chat\`                                                |   Coming soon                          |
 |   \`Checkbox\`               |   \`Checkbox\`                                            |   Coming soon                          |
 |   \`Choice\`                 |   \`Choice\`                                              |   Coming soon                          |
 |   \`ChoiceList\`             |   \`ChoiceList\`                                          |   Coming soon                          |
-|   \`ClipboardItem\`          |   [ClipboardItem](/api/checkout-ui-extensions/2025-10-rc/components/utilities/clipboarditem)                                       |   Available today                      |
+|   \`ClipboardItem\`          |   [ClipboardItem](/docs/api/checkout-ui-extensions/2025-10-rc/components/utilities/clipboarditem)                                       |   Available today                      |
 |   \`ConsentCheckbox\`        |   \`ConsentCheckbox\`                                     |   Coming soon                          |
 |   \`ConsentPhoneField\`      |   \`ConsentPhoneField\`                                   |   Coming soon                          |
 |   \`DateField\`              |   \`DateField\`                                           |   Coming soon                          |
 |   \`DatePicker\`             |   \`DatePicker\`                                          |   Coming soon                          |
 |   \`Disclosure\`             |   \`Details\` and \`Summary\`                         |   Coming soon                          |
 |   \`Divider\`                |   \`Divider\`                                             |   Coming soon                          |
-|   \`DropZone\`               |   [DropZone](/api/checkout-ui-extensions/2025-10-rc/components/forms/dropzone)                                            |   Available today                      |
-|   \`Form\`                   |   [Form](/api/checkout-ui-extensions/2025-10-rc/components/forms/form)                                                |   Available today                      |
+|   \`DropZone\`               |   [DropZone](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/dropzone)                                            |   Available today                      |
+|   \`Form\`                   |   [Form](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/form)                                                |   Available today                      |
 |   \`Grid\`                   |   \`Grid\`                                                |   Coming soon                          |
 |   \`GridItem\`               |   \`GridItem\`                                            |   Coming soon                          |
-|   \`Heading\`                |   [Heading](/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/heading)                                             |   Available today                      |
-|   \`HeadingGroup\`           |   [Section](/api/checkout-ui-extensions/2025-10-rc/components/structure/section)                                             |   Available today                          |
-|   \`Icon\`                   |   [Icon](/api/checkout-ui-extensions/2025-10-rc/components/media/icon)                                                |   Available today                          |
-|   \`Image\`                  |   [Image](/api/checkout-ui-extensions/2025-10-rc/components/media/image)                                               |   Available today                      |
+|   \`Heading\`                |   [Heading](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/heading)                                             |   Available today                      |
+|   \`HeadingGroup\`           |   [Section](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/section)                                             |   Available today                          |
+|   \`Icon\`                   |   [Icon](/docs/api/checkout-ui-extensions/2025-10-rc/components/media/icon)                                                |   Available today                          |
+|   \`Image\`                  |   [Image](/docs/api/checkout-ui-extensions/2025-10-rc/components/media/image)                                               |   Available today                      |
 |   \`InlineLayout\`           |                                                      |   Removed. Use \`Grid\`                   |
-|   \`InlineSpacer\`           |                                                      |   Removed. Use [Stack](/api/checkout-ui-extensions/2025-10-rc/components/structure/stack)                  |
-|   \`InlineStack\`            |   \`Stack\`                                              |   Use [Stack](/api/checkout-ui-extensions/2025-10-rc/components/structure/stack) with \`direction=inline\`                  |
-|   \`Link\`                   |   [Link](/api/checkout-ui-extensions/2025-10-rc/components/actions/link)                                                |   Available today                      |
-|   \`List\`                   |   [UnorderedList](/api/checkout-ui-extensions/2025-10-rc/components/other/unorderedlist) or [OrderedList](/api/checkout-ui-extensions/2025-10-rc/components/other/orderedlist)                                         |   Available today      |
-|   \`ListItem\`               |   [ListItem](/api/checkout-ui-extensions/2025-10-rc/components/other/listitem)                                            |   Available today                      |
+|   \`InlineSpacer\`           |                                                      |   Removed. Use [Stack](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/stack)                  |
+|   \`InlineStack\`            |   \`Stack\`                                              |   Use [Stack](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/stack) with \`direction=inline\`                  |
+|   \`Link\`                   |   [Link](/docs/api/checkout-ui-extensions/2025-10-rc/components/actions/link)                                                |   Available today                      |
+|   \`List\`                   |   [UnorderedList](/docs/api/checkout-ui-extensions/2025-10-rc/components/other/unorderedlist) or [OrderedList](/docs/api/checkout-ui-extensions/2025-10-rc/components/other/orderedlist)                                         |   Available today      |
+|   \`ListItem\`               |   [ListItem](/docs/api/checkout-ui-extensions/2025-10-rc/components/other/listitem)                                            |   Available today                      |
 |   \`Map\`                    |   \`Map\`                                                 |   Coming soon                          |
 |   \`MapMarker\`              |   \`MapMarker\`                                           |   Coming soon                          |
 |   \`MapPopover\`             |   \`Popover\`                                             |   Coming soon                          |
@@ -79,7 +256,7 @@ We do not recommend migrating your production checkout UI extension to Polaris y
 |   \`Popover\`                |   \`Popover\`                                             |   Coming soon                          |
 |   \`Pressable\`              |   \`Clickable\`                                           |   Coming soon                          |
 |   \`ProductThumbnail\`       |   \`ProductThumbnail\`                                    |   Coming soon                          |
-|   \`Progress\`               |   [Progress](/api/checkout-ui-extensions/2025-10-rc/components/feedback/progress)                                            |   Available today                      |
+|   \`Progress\`               |   [Progress](/docs/api/checkout-ui-extensions/2025-10-rc/components/feedback/progress)                                            |   Available today                      |
 |   \`QRCode\`                 |   \`QRCode\`                                              |   Available today                      |
 |   \`ScrollView\`             |   \`ScrollBox\`                                           |   Coming soon                          |
 |   \`Select\`                 |   \`Select\`                                              |   Coming soon                          |
@@ -87,18 +264,18 @@ We do not recommend migrating your production checkout UI extension to Polaris y
 |   \`SkeletonImage\`          |                                                       |   Removed                                     |
 |   \`SkeletonText\`           |   \`SkeletonText\`                                                    |   Coming soon                                     |
 |   \`SkeletonTextBlock\`      |   \`SkeletonTextBlock\`                                                    |   Coming soon                                     |
-|   \`Spinner\`                |   [Spinner](/api/checkout-ui-extensions/2025-10-rc/components/feedback/spinner)                                             |   Available today                      |
+|   \`Spinner\`                |   [Spinner](/docs/api/checkout-ui-extensions/2025-10-rc/components/feedback/spinner)                                             |   Available today                      |
 |   \`Stepper\`                |   \`NumberField\`                                         |   Coming soon                      |
 |   \`Switch\`                 |   \`Switch\`                                              |   Coming soon                          |
 |   \`Tag\`                    |   \`Tag\`                                                 |   Coming soon                          |
-|   \`Text\`                   |   [Text](/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/text)                                                |   Available today                      |
-|   \`TextBlock\`              |   [Paragraph](/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/paragraph)                                         |   Available today                   |
-|   \`TextField\`              |   [TextField](/api/checkout-ui-extensions/2025-10-rc/components/forms/textfield)                                           |   Available today                      |
-|                              |   [Time](/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/time)                                                |   Available today                      |
+|   \`Text\`                   |   [Text](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/text)                                                |   Available today                      |
+|   \`TextBlock\`              |   [Paragraph](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/paragraph)                                         |   Available today                   |
+|   \`TextField\`              |   [TextField](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/textfield)                                           |   Available today                      |
+|                              |   [Time](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/time)                                                |   Available today                      |
 |   \`ToggleButton\`           |   \`Option\`                                         |   Coming soon                 |
 |   \`ToggleButtonGroup\`      |   \`OptionGroup\`                                         |   Coming soon            |
 |   \`Tooltip\`                |   \`Tooltip\`                                             |   Coming soon                          |
-|   \`View\`                   |   [Box](/api/checkout-ui-extensions/2025-10-rc/components/structure/box)                                                 |   Available today                      |
+|   \`View\`                   |   [Box](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/box)                                                 |   Available today                      |
 `,
     },
   ],


### PR DESCRIPTION
### Background

This makes the [upgrade guide](https://shopify.dev/docs/api/checkout-ui-extensions/2025-10-rc/upgrading-to-2025-10) more comprehensive by explaining:
* how to adjust packages
* how to adopt the `shopify` global
* where to import hooks from
* how to adopt custom elements

It **does not** explain how to adjust the `tsconfig` to get the right types. That will need to happen in a follow-up.

### 🎩

```
dev clone shopify-dev
dev up
dev server
```

```
dev clone ui-extensions
# check out this PR
dev up
yarn docs:checkout 2025-10-rc
```

<details>
<summary>📸  preview</summary>

<img width="1418" alt="Screenshot 2025-05-23 at 10 54 19 PM" src="https://github.com/user-attachments/assets/06941506-b1f5-46f8-8279-d781c1cd0d31" />

</details>


<details>
<summary>📸  preview</summary>

<img width="1416" alt="Screenshot 2025-05-23 at 10 54 35 PM" src="https://github.com/user-attachments/assets/37fab1c3-f3a8-46e5-9079-1dcf96d7c333" />

</details>


<details>
<summary>📸  preview</summary>

<img width="1416" alt="Screenshot 2025-05-23 at 10 54 53 PM" src="https://github.com/user-attachments/assets/d397ae4f-39e4-422b-86a6-48d2f09c7f0d" />

</details>


<details>
<summary>📸  preview</summary>

<img width="1417" alt="Screenshot 2025-05-23 at 10 55 23 PM" src="https://github.com/user-attachments/assets/15c30586-a9e4-4644-ad9b-c9cfe9f78211" />

</details>


<details>
<summary>📸  preview</summary>

<img width="1416" alt="Screenshot 2025-05-23 at 10 55 49 PM" src="https://github.com/user-attachments/assets/ab2e3128-0477-4ce6-be62-a7ec1c672690" />

</details>

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
