### PR TITLE
use `main` branch for snapit again

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: ./.github/workflows/actions/prepare
 
       - name: Create snapshot
-        uses: Shopify/snapit@allow-post-install-script
+        uses: Shopify/snapit@main
         env:
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
https://github.com/Shopify/snapit/pull/31 has been merged so we can go back to using the main branch of snapit