### PR TITLE
[UI extensions]: Component missing types for targets

### DIFF
--- a/.changeset/modern-numbers-complain.md
+++ b/.changeset/modern-numbers-complain.md
@@ -2,4 +2,4 @@
 '@shopify/ui-extensions': patch
 ---
 
-TextField typing for targets
+Missing component types for targets

--- a/.changeset/modern-numbers-complain.md
+++ b/.changeset/modern-numbers-complain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+TextField typing for targets

--- a/packages/ui-extensions/src/surfaces/checkout/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/shared.ts
@@ -25,6 +25,8 @@ export type AnyComponent =
   | 'Paragraph'
   | 'PaymentIcon'
   | 'Progress'
+  | 'QRCode'
+  | 'Section'
   | 'Spinner'
   | 'Stack'
   | 'Text'

--- a/packages/ui-extensions/src/surfaces/checkout/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/shared.ts
@@ -28,6 +28,7 @@ export type AnyComponent =
   | 'Spinner'
   | 'Stack'
   | 'Text'
+  | 'TextField'
   | 'Time'
   | 'UnorderedList';
 


### PR DESCRIPTION
### TL;DR

- Added TextField types for targets.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
