### PR TITLE
Fix Direct API access example for POS UI Extensions

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/direct-api-access/direct-api-access.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/direct-api-access/direct-api-access.ts
@@ -5,11 +5,12 @@ import {
   POSBlockRow,
   DirectApiRequestBody,
 } from '@shopify/ui-extensions/point-of-sale';
+import type {DirectApiRequestBody} from '@shopify/ui-extensions/point-of-sale';
 
 async function mutateMetafield(productId: number) {
   const requestBody: DirectApiRequestBody = {
     query: `
-        mutation MetafieldsSet($metafields: [MetafieldsSetInput!]!) { 
+        mutation MetafieldsSet($metafields: [MetafieldsSetInput!]!) {
           metafieldsSet(metafields: $metafields) {
             metafields {
               key

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/direct-api-access/direct-api-access.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/direct-api-access/direct-api-access.tsx
@@ -4,14 +4,14 @@ import {
   Text,
   POSBlock,
   POSBlockRow,
-  DirectApiRequestBody,
 } from '@shopify/ui-extensions-react/point-of-sale';
+import type {DirectApiRequestBody} from '@shopify/ui-extensions-react/point-of-sale';
 import {useEffect, useState} from 'react';
 
 async function mutateMetafield(productId: number) {
   const requestBody: DirectApiRequestBody = {
     query: `
-        mutation MetafieldsSet($metafields: [MetafieldsSetInput!]!) { 
+        mutation MetafieldsSet($metafields: [MetafieldsSetInput!]!) {
           metafieldsSet(metafields: $metafields) {
             metafields {
               key


### PR DESCRIPTION
### Background

This PR addresses an issue with the `DirectApiRequestBody` import in the Point of Sale UI extensions examples.

### Solution

Fixed the import of `DirectApiRequestBody` in both TypeScript and React examples by:
- Moving `DirectApiRequestBody` from a regular import to a type-only import
- Using the proper `import type` syntax to ensure it's only used for type checking

This change ensures proper type usage without importing unnecessary runtime code.

### 🎩

- Verified that the examples still compile correctly
- Confirmed that the GraphQL mutation formatting is consistent

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation