### PR TITLE
Remove shopify.ui.overlay doc from customer accounts for now

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -394,12 +394,6 @@ export interface CompanyLocation {
 
 export interface Ui {
   /**
-   * An overlay is a contextual element on top of the main interface that provides additional information or functionality.
-   */
-  overlay: {
-    close(overlayId: string): void;
-  };
-  /**
    * The Toast API displays a non-disruptive message that displays at the bottom
    * of the interface to provide quick, at-a-glance feedback on the outcome
    * of an action.


### PR DESCRIPTION
### Background

Removes shopify.ui.overlay api for now.

Also approve https://github.com/Shopify/shopify-dev/pull/58175

### Solution

Just removed the api from the docs

### 🎩

Run `yarn run docs:customer-account 2025-10-rc` in ui-extensions in this branch

<img width="1232" alt="Screenshot 2025-06-02 at 10 35 14 AM" src="https://github.com/user-attachments/assets/1457d365-5e7f-4e27-ba2d-cc5a19ca7072" />


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
