### PR TITLE
Add `executedAt`, `returnId`, `exchangeId` to transaction complete event target

### DIFF
--- a/.changeset/gold-students-remember.md
+++ b/.changeset/gold-students-remember.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+add `executedAt`, `exchangeId`, `returnId` to transaction complete event interface.

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -61,6 +61,8 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 
 - Added required \`posVersion\` property to \`Session\` interface.
 - Added optional \`currency\` property to \`Discount\` interface.
+- Added \`executedAt\` property to \`BaseTransactionComplete\` interface.
+- Added optional \`exchangeId\` and \`returnId\` property to \`ReturnTransactionData\` interface.
 
   `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
@@ -3,5 +3,7 @@ import {LineItem} from '../../types/cart';
 
 export interface ReturnTransactionData extends BaseTransactionComplete {
   transactionType: 'Return';
+  returnId?: number;
+  exchangeId?: number;
   lineItems: LineItem[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
@@ -17,4 +17,5 @@ export interface BaseTransactionComplete {
   balanceDue: Money;
   shippingLines?: ShippingLine[];
   taxLines?: TaxLine[];
+  executedAt: string;
 }


### PR DESCRIPTION
### Background

Part of, https://github.com/Shopify/temp-project-mover-Archetypically-20250612122555/issues/106

### Solution

- Add `executedAt` property for all `pos.transaction-complete.event.observe` data. (NOTE: This is the timestamp for when the target is run and may not match the timestamp for when transaction is created).
- Add optional `returnId` and `exchangeId` for Return transactions. (NOTE: `exchangeId` is when returning to gift cards).
- Add to version notes under `2025-07`.

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
