### PR TITLE
Storage API Docs

### DIFF
--- a/.changeset/neat-ways-collect.md
+++ b/.changeset/neat-ways-collect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+add storageapi documentation

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -1,0 +1,73 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {CUSTOM_DATA} from '../helpers/helper.docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateCodeBlockForStorageApi = (title: string, fileName: string) =>
+  generateCodeBlock(title, 'storage-api', fileName);
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Storage API',
+  description: `The Storage API allows fetching, setting, updating, and clearing an extension's data from the POS local storage.
+  - If a target (such as \`pos.home.tile.render\`) is disabled or removed, the extension data remains.
+  - All stored extension data that has not been updated for a month is cleared automatically after that period.
+
+  > Note:
+  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  isVisualComponent: false,
+  type: 'APIs',
+  category: 'APIs',
+  related: [],
+  definitions: [CUSTOM_DATA('Storage', 'StorageApi')],
+  examples: {
+    description: 'Examples of using the Storage API',
+    examples: [
+      {
+        codeblock: generateCodeBlockForStorageApi(
+          'Getting a single value from storage',
+          'get',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForStorageApi(
+          'Setting a single value in storage',
+          'set',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForStorageApi(
+          'Deleting a single value from storage',
+          'delete',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForStorageApi(
+          'Clear all entries for an extension from storage',
+          'clear',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForStorageApi(
+          'Retrieve all entries for an extension from storage',
+          'entries',
+        ),
+      },
+    ],
+    exampleGroups: [
+      {
+        title: 'Use cases',
+        examples: [
+          {
+            description:
+              "In this example, we use a Smart Grid Tile to show the contents of the extension's Storage API.",
+            codeblock: generateCodeBlockForStorageApi(
+              'Debugging StorageAPI',
+              'debugging-storage-api',
+            ),
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/clear.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/clear.ts
@@ -1,0 +1,31 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  let itemCount = 0;
+
+  const tile = root.createComponent(Tile, {
+    title: 'Storage app',
+    subtitle: 'Clear example',
+    badgeValue: itemCount,
+    enabled: true,
+    onPress: async () => {
+      await api.storage.clear();
+      api.toast.show('All data cleared');
+      itemCount = 0;
+      tile.updateProps({badgeValue: itemCount});
+    },
+  });
+
+  const initializeData = async () => {
+    const count = 10;
+    for (let i = 0; i < count; i++) {
+      await api.storage.set(`key-${i}`, `value-${i}`);
+    }
+    itemCount = count;
+    tile.updateProps({badgeValue: itemCount});
+  };
+
+  initializeData();
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/clear.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/clear.tsx
@@ -1,0 +1,39 @@
+import React, {useState, useEffect} from 'react';
+import {
+  Tile,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const TileComponent = () => {
+  const api = useApi<'pos.home.tile.render'>();
+  const [itemCount, setItemCount] = useState(0);
+
+  useEffect(() => {
+    const initializeData = async () => {
+      const count = 10;
+      for (let i = 0; i < count; i++) {
+        await api.storage.set(`key-${i}`, `value-${i}`);
+      }
+      setItemCount(count);
+    };
+
+    initializeData();
+  }, [api.storage]);
+
+  return (
+    <Tile
+      title="Storage app"
+      subtitle="Clear example"
+      badgeValue={itemCount}
+      onPress={async () => {
+        await api.storage.clear();
+        api.toast.show('All data cleared');
+        setItemCount(0);
+      }}
+      enabled
+    />
+  );
+};
+
+export default reactExtension('pos.home.tile.render', () => <TileComponent />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/delete.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/delete.ts
@@ -1,0 +1,21 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'Storage app',
+    subtitle: 'Delete example',
+    enabled: true,
+    onPress: async () => {
+      await api.storage.set('key', 'A temporary value');
+      const storedData = await api.storage.get('key');
+      api.toast.show(`Current value: ${String(storedData)}`);
+      setTimeout(async () => {
+        api.storage.delete('key');
+        const storedData = (await api.storage.get('key')) ?? '';
+        api.toast.show(`Current value after deletion: ${String(storedData)}`);
+      }, 2000);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/delete.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/delete.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {
+  Tile,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const TileComponent = () => {
+  const api = useApi<'pos.home.tile.render'>();
+  return (
+    <Tile
+      title="Storage app"
+      subtitle="Delete example"
+      onPress={async () => {
+        await api.storage.set('key', 'A temporary value');
+        const storedData = await api.storage.get('key');
+        api.toast.show(`Current value: ${String(storedData)}`);
+        setTimeout(async () => {
+          api.storage.delete('key');
+          const storedData = (await api.storage.get('key')) ?? '';
+          api.toast.show(`Current value after deletion: ${String(storedData)}`);
+        }, 2000);
+      }}
+      enabled
+    />
+  );
+};
+
+export default reactExtension('pos.home.tile.render', () => <TileComponent />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/entries.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/entries.ts
@@ -1,0 +1,32 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+import type {Storage} from '@shopify/ui-extensions/point-of-sale';
+
+interface ExampleStorage {
+  attempts: number;
+  darkMode: boolean;
+  trackingId: string;
+}
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const storage: Storage<ExampleStorage> = api.storage;
+
+  const tile = root.createComponent(Tile, {
+    title: 'Storage app',
+    subtitle: 'Entries example',
+    enabled: true,
+    onPress: async () => {
+      await storage.set('attempts', 2);
+      await storage.set('darkMode', true);
+      await storage.set('trackingId', 'd6ead53c-b5f5-0b16-dabb-17081ff238c3');
+
+      const allEntries = await storage.entries();
+      const message = allEntries.length
+        ? allEntries.map(([key, value]) => `${key}: ${value}`).join(', ')
+        : 'Nothing stored';
+
+      api.toast.show(message);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/entries.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/entries.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type {Storage} from '@shopify/ui-extensions/point-of-sale';
+import {
+  Tile,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+interface ExampleStorage {
+  attempts: number;
+  darkMode: boolean;
+  trackingId: string;
+}
+
+const TileComponent = () => {
+  const api = useApi<'pos.home.tile.render'>();
+  const storage: Storage<ExampleStorage> = api.storage;
+  return (
+    <Tile
+      title="Storage app"
+      subtitle="Entries example"
+      onPress={async () => {
+        await storage.set('attempts', 2);
+        await storage.set('darkMode', true);
+        await storage.set('trackingId', 'd6ead53c-b5f5-0b16-dabb-17081ff238c3');
+
+        const allEntries = await storage.entries();
+        const message = allEntries.length
+          ? allEntries.map(([key, value]) => `${key}: ${value}`).join(', ')
+          : 'Nothing stored';
+
+        api.toast.show(message);
+      }}
+      enabled
+    />
+  );
+};
+
+export default reactExtension('pos.home.tile.render', () => <TileComponent />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/get.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/get.ts
@@ -1,0 +1,15 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'Storage app',
+    subtitle: 'Get example',
+    enabled: true,
+    onPress: async () => {
+      const storedData = await api.storage.get('key');
+      api.toast.show(String(storedData ?? ''));
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/get.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/get.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {
+  Tile,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const TileComponent = () => {
+  const api = useApi<'pos.home.tile.render'>();
+  return (
+    <Tile
+      title="Storage app"
+      subtitle="Get example"
+      onPress={async () => {
+        const storedData = await api.storage.get('key');
+        api.toast.show(String(storedData ?? ''));
+      }}
+      enabled
+    />
+  );
+};
+
+export default reactExtension('pos.home.tile.render', () => <TileComponent />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/set.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/set.ts
@@ -1,0 +1,31 @@
+import {Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+import type {Storage} from '@shopify/ui-extensions/point-of-sale';
+
+interface ExampleStorage {
+  trackingId: string;
+  someObject: Record<string, unknown>;
+  attempts: number;
+}
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const storage: Storage<ExampleStorage> = api.storage;
+
+  const tile = root.createComponent(Tile, {
+    title: 'Storage app',
+    subtitle: 'Set example',
+    enabled: true,
+    onPress: async () => {
+      await Promise.all([
+        storage.set('trackingId', 'd6ead53c-b5f5-0b16-dabb-17081ff238c3'),
+        storage.set('someObject', {
+          boolean: true,
+          numeric: 2,
+          string: 'Hello world!',
+        }),
+        storage.set('attempts', 2),
+      ]);
+    },
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/set.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/set.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import type {Storage} from '@shopify/ui-extensions/point-of-sale';
+import {
+  Tile,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+interface ExampleStorage {
+  trackingId: string;
+  someObject: Record<string, unknown>;
+  attempts: number;
+}
+
+const TileComponent = () => {
+  const api = useApi<'pos.home.tile.render'>();
+  const storage: Storage<ExampleStorage> = api.storage;
+  return (
+    <Tile
+      title="Storage app"
+      subtitle="Set example"
+      onPress={async () => {
+        await Promise.all([
+          storage.set('trackingId', 'd6ead53c-b5f5-0b16-dabb-17081ff238c3'),
+          storage.set('someObject', {
+            boolean: true,
+            numeric: 2,
+            string: 'Hello world!',
+          }),
+          storage.set('attempts', 2),
+        ]);
+      }}
+      enabled
+    />
+  );
+};
+
+export default reactExtension('pos.home.tile.render', () => <TileComponent />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -68,6 +68,8 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Added optional \`taxLines\` property to \`ShippingLine\` interface.
 - Added optional \`onBlur\` handler to \`SearchBar\` component.
 
+**Developer Preview**:
+  - Introduced a [Storage API](/docs/api/pos-ui-extensions/apis/storage-api). The Storage API gives the UI Extension access to store data on the POS device that the extension is running on.
   `,
     },
     {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/storage-api/storage-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/storage-api/storage-api.ts
@@ -1,5 +1,5 @@
 import {Storage} from '../../../types/storage';
 
 export interface StorageApi {
-  storage?: Storage;
+  storage: Storage;
 }


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/2766

### Background

Adds documentation for the POS StorageAPI.

### Solution

- Update `storage` to be non-optional.
- Add as developer preview with 5 examples.
- Update version change log.

### 🎩

See tophat steps in, https://github.com/Shopify/shopify-dev/pull/58622

Demo of some examples.

https://github.com/user-attachments/assets/6ae77c52-4b26-4147-81ee-e1d10e70bd34


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
