### PR TITLE
[Docs] Update extension examples to use anonymous default func

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/authenticated-fetch.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/authenticated-fetch.jsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/custom-authenticated-fetch.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/custom-authenticated-fetch.jsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-default-value.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-default-value.jsx
@@ -1,7 +1,7 @@
 import { render } from 'preact';
 import { useState } from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-implicit-default.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-implicit-default.jsx
@@ -1,7 +1,7 @@
 import { render } from 'preact';
 import { useState } from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/picker-email-template.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/picker-email-template.jsx
@@ -1,6 +1,6 @@
 import { render } from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/resource-picker-product.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/resource-picker-product.jsx
@@ -1,6 +1,6 @@
 import { render } from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/scaffolded-with-preact.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/scaffolded-with-preact.jsx
@@ -2,7 +2,7 @@ import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/analytics-publish.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/analytics-publish.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/analytics-visitor.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/analytics-visitor.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/api-subscribable.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/api-subscribable.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useNote} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/api.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/api.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useApi} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/attribute-values.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/attribute-values.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useAttributeValues} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/attributes/attribute-change.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/attributes/attribute-change.example.tsx
@@ -5,7 +5,7 @@ import {
   useInstructions,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/extension-banner.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/extension-banner.example.tsx
@@ -5,7 +5,7 @@ import {
   useCartLineTarget,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/page-level-error.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/page-level-error.example.tsx
@@ -4,7 +4,7 @@ import {
   useShippingAddress,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/target-native-field.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/target-native-field.example.tsx
@@ -4,7 +4,7 @@ import {
   useShippingAddress,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/attributes.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/attributes.example.tsx
@@ -4,7 +4,7 @@ import {
   useInstructions,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/cart-lines-add.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/cart-lines-add.example.tsx
@@ -4,7 +4,7 @@ import {
   useInstructions,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/delivery.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/delivery.example.tsx
@@ -4,7 +4,7 @@ import {
   useInstructions,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/discounts.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/discounts.example.tsx
@@ -4,7 +4,7 @@ import {
   useInstructions,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/metafields.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/metafields.example.tsx
@@ -4,7 +4,7 @@ import {
   useInstructions,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/notes.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-instructions/notes.example.tsx
@@ -4,7 +4,7 @@ import {
   useInstructions,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-line-item/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/cart-line-item/default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useCartLineTarget} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/checkout/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/checkout/default.example.tsx
@@ -5,7 +5,7 @@ import {
   useInstructions,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/customer-privacy/default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useCustomerPrivacy} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useTotalAmount} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/delivery-group.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/delivery-group.example.tsx
@@ -4,7 +4,7 @@ import {
   useDeliveryGroup,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/delivery-groups.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/delivery-groups.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useDeliveryGroups} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/extension-api.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/extension-api.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useExtensionApi} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/localized-fields/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/localized-fields/default.example.tsx
@@ -4,7 +4,7 @@ import {
   useLocalizedField,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/metafields/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/metafields/default.example.tsx
@@ -4,7 +4,7 @@ import {
   useCartLineTarget,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/order-confirmation/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/order-confirmation/default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useSubscription} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/payments/use-available-payment-options.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/payments/use-available-payment-options.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useAvailablePaymentOptions} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/payments/use-selected-payment-options.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/payments/use-selected-payment-options.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useSelectedPaymentOptions} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/pickup-point-list/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/pickup-point-list/default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useSubscription} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.chat.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.chat.render/default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 
 // 1. Export the extension
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.pickup-location-option-item.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.pickup-location-option-item.render-after/default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {usePickupLocationOptionTarget} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.shipping-option-item.details.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.shipping-option-item.details.render/default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useShippingOptionTarget} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.shipping-option-item.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.shipping-option-item.render-after/default.example.tsx
@@ -1,7 +1,7 @@
 import {render, Fragment} from 'preact';
 import {useShippingOptionTarget} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.shipping-option-list.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.shipping-option-list.render-after/default.example.tsx
@@ -6,7 +6,7 @@ import {
   useApplyMetafieldsChange,
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.shipping-option-list.render-before/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.checkout.shipping-option-list.render-before/default.example.tsx
@@ -6,7 +6,7 @@ import {
 } from '@shopify/ui-extensions/checkout/preact';
 import {useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.thank-you.chat.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.thank-you.chat.render/default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 
 // 1. Export the extension
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/query-default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/query-default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/query-fetch.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/query-fetch.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/session-token.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/session-token.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/settings-access.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/settings-access.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useSettings} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/shipping-option-item/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/shipping-option-item/default.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useShippingOptionTarget} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/storage.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/storage.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/subscription.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/subscription.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useSubscription} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/translate-pluralization.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/translate-pluralization.example.tsx
@@ -2,7 +2,7 @@
 import {render} from 'preact';
 import {useTranslate} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/translate.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/translate.example.tsx
@@ -2,7 +2,7 @@
 import {render} from 'preact';
 import {useTranslate} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/clipboarditem-qrcode.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/clipboarditem-qrcode.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const bitcoinAddress =
     '14qViLJfdGaP4EeHnDyJbEGQysnCpwk3gd';
   const qrCodeContent = `bitcoin:${bitcoinAddress}`;

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/clipboarditem-qrcode.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/clipboarditem-qrcode.example.tsx
@@ -1,7 +1,7 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   const bitcoinAddress =
     '14qViLJfdGaP4EeHnDyJbEGQysnCpwk3gd';
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/qrcode-fill-size.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/qrcode-fill-size.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const box = document.createElement('s-box');
   box.setAttribute('max-inline-size', '300');
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/qrcode-fill-size.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/qrcode-fill-size.example.tsx
@@ -1,7 +1,7 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(
     <s-box maxInlineSize={300}>
       <s-qrcode

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/qrcode-image.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/qrcode-image.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const qrCode =
     document.createElement('s-qrcode');
   qrCode.setAttribute(

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/qrcode-image.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/ui-components/qrcode-image.example.tsx
@@ -1,7 +1,7 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(
     <>
       <s-qrcode

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/error-handling/sentry.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/error-handling/sentry.example.tsx
@@ -22,7 +22,7 @@ self.addEventListener('error', (error) => {
 });
 
 // Your normal extension code.
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/extension-apis.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/extension-apis.example.tsx
@@ -2,7 +2,7 @@ import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useShippingAddress} from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/extension-targets.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/extension-targets.example.tsx
@@ -1,7 +1,7 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/form-default-value.jsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/form-default-value.jsx
@@ -1,7 +1,7 @@
 import { render } from 'preact';
 import { useState } from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/form-implicit-default.jsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/form-implicit-default.jsx
@@ -1,7 +1,7 @@
 import { render } from 'preact';
 import { useState } from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolded-with-preact.jsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/scaffolded-with-preact.jsx
@@ -2,7 +2,7 @@ import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/ui-components.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/ui-components.example.tsx
@@ -1,7 +1,7 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/apis-new.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/apis-new.tsx
@@ -4,7 +4,7 @@ import {
   useAttributeValues
 } from '@shopify/ui-extensions/checkout/preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/components-new.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/components-new.tsx
@@ -1,7 +1,7 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/attribute-values.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/attribute-values.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account-company-and-location.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account-company-and-location.example.tsx
@@ -1,7 +1,7 @@
 /* See the locales/en.default.json tab for the translation keys and values for this example */
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/cart-line-item.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/cart-line-item.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const target = shopify.target;
 
   const text = document.createElement('s-text');

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/cart-line-item.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/cart-line-item.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-account-api-fetch.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-account-api-fetch.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const getCustomerNameQuery = {
     query: `query {
       customer {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-account-api-fetch.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-account-api-fetch.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-privacy.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-privacy.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const visitorConsent =
     shopify.customerPrivacy.current
       .visitorConsent || {};

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-privacy.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-privacy.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/localization-country.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/localization-country.example.tsx
@@ -1,7 +1,7 @@
 /* See the locales/en.default.json tab for the translation keys and values for this example */
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query-fetch.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query-fetch.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const apiVersion = 'unstable';
   const getProductsQuery = {
     query: `query ($first: Int!) {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query-fetch.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query-fetch.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   shopify
     .query(
       `query ($first: Int!) {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/require-login.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/require-login.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const button =
     document.createElement('s-button');
   button.textContent = 'Report an issue';

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/require-login.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/require-login.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/session-token.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/session-token.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   async function queryApi() {
     // Request a new (or cached) session token from Shopify
     const token =

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/session-token.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/session-token.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/settings-access.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/settings-access.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const banner =
     document.createElement('s-banner');
   banner.textContent =

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/settings-access.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/settings-access.example.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate-pluralization.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate-pluralization.example.ts
@@ -1,5 +1,5 @@
 /* See the locales/en.default.json tab for the translation keys and values for this example */
-export default function extension() {
+export default async () => {
   const points = 10000;
   const formattedPoints =
     shopify.i18n.formatNumber(points);

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate-pluralization.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate-pluralization.example.tsx
@@ -1,7 +1,7 @@
 /* See the locales/en.default.json tab for the translation keys and values for this example */
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate.example.ts
@@ -1,5 +1,5 @@
 /* See the locales/en.default.json tab for the translation keys and values for this example */
-export default function extension() {
+export default async () => {
   const welcomeMsg = shopify.i18n.translate(
     'welcomeMessage',
   );

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate.example.tsx
@@ -1,7 +1,7 @@
 /* See the locales/en.default.json tab for the translation keys and values for this example */
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/default-js.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/default-js.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const button =
     document.createElement('s-button');
   button.textContent = 'Navigate to orders path';

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/default-preact.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/default-preact.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-apis-js.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-apis-js.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const banner =
     document.createElement('s-banner');
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-apis-preact.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-apis-preact.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-targets-js.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-targets-js.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const banner =
     document.createElement('s-banner');
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-targets-preact.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-targets-preact.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/form-default-value.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/form-default-value.jsx
@@ -1,7 +1,7 @@
 import { render } from 'preact';
 import { useState } from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/form-implicit-default.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/form-implicit-default.jsx
@@ -1,7 +1,7 @@
 import { render } from 'preact';
 import { useState } from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/ui-components-js.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/ui-components-js.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const stack = document.createElement('s-stack');
 
   const image = document.createElement('s-image');

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/ui-components-preact.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/ui-components-preact.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/examples/default.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/examples/default.tsx
@@ -1,7 +1,7 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(
     <s-admin-print-action src="https://example.com"></s-admin-print-action>,
     document.body,

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-js.example.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-js.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const accountAction = document.createElement('s-customer-account-action');
 
   const closeButton = document.createElement('s-button');

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-preact.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/examples/basic-ImageGroup-js.example.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/examples/basic-ImageGroup-js.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const imageGroup = document.createElement('s-image-group');
   const firstImage = document.createElement('s-image');
   firstImage.src = '../assets/flower.jpg';

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/examples/basic-ImageGroup-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/examples/basic-ImageGroup-preact.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-js.example.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-js.example.ts
@@ -1,4 +1,4 @@
-export default function extension() {
+export default async () => {
   const page = document.createElement('s-page');
 
   const primaryAction = document.createElement('s-button');

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-preact.example.tsx
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<App />, document.body);
 }
 


### PR DESCRIPTION
## TLDR

Replace named `default` `extension` function with anonymous `default` function

```diff
- export default function extension() {
+ export default async () => {
```

Closes https://github.com/Shopify/admin-ui-foundations/issues/2931

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
