### PR TITLE
Added Variant ID to ProductApi

### DIFF
--- a/.changeset/five-comics-leave.md
+++ b/.changeset/five-comics-leave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added variantId field to productApi

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -56,6 +56,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 ## Important Fixes
 
 - Update pos.draft-order-details.block.render allowed components to \`BlockComponents\`.
+- Added support for a product variant id field in the \`ProductApi\` interface.
 
 ### Features
 
@@ -64,6 +65,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Added \`executedAt\` property to \`BaseTransactionComplete\` interface.
 - Added optional \`exchangeId\` and \`returnId\` property to \`ReturnTransactionData\` interface.
 - Added optional \`onBlur\` handler to \`SearchBar\` component.
+- Added required \`variantId\` property to \`ProductApi\` interface.
 
   `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/product-api/product-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/product-api/product-api.ts
@@ -7,4 +7,8 @@ export interface ProductApiContent {
    * The unique identifier for the product.
    */
   id: number;
+  /**
+   * The unique identifier for the product variant.
+   */
+  variantId: number;
 }


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/temp-project-mover-Archetypically-20250612104008/issues/190.

### Solution

- Added the variantID field to the productApi.

### 🎩

- Refer to the pull request on the [pos-next-react-native repo](https://github.com/Shopify/pos-next-react-native/pull/62177) for tophat instructions.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
