### PR TITLE
Update customer account slots

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
@@ -15,15 +15,15 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'CustomerAccountActionProps',
     },
     {
-      title: 'ButtonProps primaryAction',
+      title: 'ButtonSlot primary-action',
       description:
-        'Supported props for Buttons used inside CustomerAccountAction `primaryAction` prop.<br><br>`children` only support text.',
+        'Supported props for Buttons used inside CustomerAccountAction `primary-action` slot.<br><br>`children` only support text.',
       type: 'Docs_CustomerAccountAction_Button_PrimaryAction',
     },
     {
-      title: 'ButtonProps secondaryAction',
+      title: 'ButtonProps secondary-actions',
       description:
-        'Supported props for Button used inside CustomerAccountAction `secondaryAction` prop.<br><br>`children` only support text.',
+        'Supported props for Button used inside CustomerAccountAction `secondary-actions` slot.<br><br>`children` only support text.',
       type: 'Docs_CustomerAccountAction_Button_SecondaryAction',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
@@ -15,13 +15,13 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'CustomerAccountActionProps',
     },
     {
-      title: 'ButtonSlot primary-action',
+      title: 'Button slot primary-action',
       description:
         'Supported props for Buttons used inside CustomerAccountAction `primary-action` slot.<br><br>`children` only support text.',
       type: 'Docs_CustomerAccountAction_Button_PrimaryAction',
     },
     {
-      title: 'ButtonProps secondary-actions',
+      title: 'Button slot secondary-actions',
       description:
         'Supported props for Button used inside CustomerAccountAction `secondary-actions` slot.<br><br>`children` only support text.',
       type: 'Docs_CustomerAccountAction_Button_SecondaryAction',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-js.example.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-js.example.ts
@@ -3,7 +3,7 @@ export default function extension() {
 
   const closeButton = document.createElement('s-button');
   closeButton.innerHTML = 'Click to close';
-  closeButton.slot = 'primaryAction';
+  closeButton.slot = 'primary-action';
   closeButton.addEventListener('click', () => shopify.close());
 
   accountAction.append('Extension content');

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-preact.example.tsx
@@ -8,7 +8,7 @@ function App() {
   return (
     <s-customer-account-action heading="Extension title">
       Extension content
-      <s-button slot="primaryAction" onClick={() => shopify.close()}>
+      <s-button slot="primary-action" onClick={() => shopify.close()}>
         Click to close
       </s-button>
     </s-customer-account-action>

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.doc.ts
@@ -15,19 +15,19 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'PageProps',
     },
     {
-      title: 'ButtonSlot primary-action',
+      title: 'Button slot primary-action',
       description:
         'Supported props for Buttons used inside Page `primary-action` slot.<br><br>`children` only support text.',
       type: 'Docs_Page_Button_PrimaryAction',
     },
     {
-      title: 'ButtonSlot secondary-actions',
+      title: 'Button slot secondary-actions',
       description:
         'Supported props for Button used inside Page `secondary-actions` slot.<br><br>`children` are not supported.<br>Use `accessibilityLabel` instead.',
       type: 'Docs_Page_Button_SecondaryAction',
     },
     {
-      title: 'ButtonSlot breadcrumb-actions',
+      title: 'Button slot breadcrumb-actions',
       description:
         'Supported props for Button used inside Page `breadcrumb-actions` slot.<br><br>`children` are not supported.<br>Use `accessibilityLabel` instead.',
       type: 'Docs_Page_Button_BreadcrumbAction',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.doc.ts
@@ -15,21 +15,21 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'PageProps',
     },
     {
-      title: 'ButtonProps primaryAction',
+      title: 'ButtonSlot primary-action',
       description:
-        'Supported props for Buttons used inside Page `primaryAction` prop.<br><br>`children` only support text.',
+        'Supported props for Buttons used inside Page `primary-action` slot.<br><br>`children` only support text.',
       type: 'Docs_Page_Button_PrimaryAction',
     },
     {
-      title: 'ButtonProps secondaryActions',
+      title: 'ButtonSlot secondary-actions',
       description:
-        'Supported props for Button used inside Page `secondaryActions` prop.<br><br>`children` are not supported.<br>Use `accessibilityLabel` instead.',
+        'Supported props for Button used inside Page `secondary-actions` slot.<br><br>`children` are not supported.<br>Use `accessibilityLabel` instead.',
       type: 'Docs_Page_Button_SecondaryAction',
     },
     {
-      title: 'ButtonProps breadcrumbActions',
+      title: 'ButtonSlot breadcrumb-actions',
       description:
-        'Supported props for Button used inside Page `breadcrumbActions` prop.<br><br>`children` are not supported.<br>Use `accessibilityLabel` instead.',
+        'Supported props for Button used inside Page `breadcrumb-actions` slot.<br><br>`children` are not supported.<br>Use `accessibilityLabel` instead.',
       type: 'Docs_Page_Button_BreadcrumbAction',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-js.example.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-js.example.ts
@@ -3,25 +3,25 @@ export default function extension() {
 
   const primaryAction = document.createElement('s-button');
   primaryAction.innerHTML = 'Primary action';
-  primaryAction.slot = 'primaryAction';
+  primaryAction.slot = 'primary-action';
   primaryAction.addEventListener('click', () => console.log('Primary action'));
 
   const secondaryActions1 = document.createElement('s-button');
-  secondaryActions1.slot = 'secondaryActions';
+  secondaryActions1.slot = 'secondary-actions';
   secondaryActions1.textContent = 'Secondary action 1';
   secondaryActions1.addEventListener('click', () =>
     console.log('Secondary action 1'),
   );
 
   const secondaryActions2 = document.createElement('s-button');
-  secondaryActions2.slot = 'secondaryActions';
+  secondaryActions2.slot = 'secondary-actions';
   secondaryActions2.textContent = 'Secondary action 2';
   secondaryActions2.addEventListener('click', () =>
     console.log('Secondary action 2'),
   );
 
   const breadcrumbActions = document.createElement('s-button');
-  breadcrumbActions.slot = 'breadcrumbActions';
+  breadcrumbActions.slot = 'breadcrumb-actions';
   breadcrumbActions.setAttribute('accessibilitylabel', 'Button');
   breadcrumbActions.setAttribute('href', 'shopify://customer-account/orders');
 

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-preact.example.tsx
@@ -8,25 +8,25 @@ function App() {
   return (
     <s-page heading="Order #1411" subheading="Confirmed Oct 5">
       <s-button
-        slot="primaryAction"
+        slot="primary-action"
         onClick={() => console.log('Primary action')}
       >
         Primary action
       </s-button>
       <s-button
-        slot="secondaryActions"
+        slot="secondary-actions"
         onClick={() => console.log('Secondary action 1')}
       >
         Secondary action 1
       </s-button>
       <s-button
-        slot="secondaryActions"
+        slot="secondary-actions"
         onClick={() => console.log('Secondary action 2')}
       >
         Secondary action 2
       </s-button>
       <s-button
-        slot="breadcrumbActions"
+        slot="breadcrumb-actions"
         accessibilitylabel="Button"
         href="shopify://customer-account/orders"
       />


### PR DESCRIPTION
### Background

Admin recently change slots names to kebab case. We are trying to stay consistent here as well

Also see https://github.com/shop/world/pull/68252

### Solution

Updated examples and change slot names

### 🎩

1. Check out to this branch and run `yarn run docs:customer-account 2025-10-rc`
2. Go into shopify-dev `dev up` `dev s` and see the changes

<img width="1509" alt="Screenshot 2025-06-04 at 11 51 31 AM" src="https://github.com/user-attachments/assets/467aa2dc-f3c0-47be-8f2c-5fdb32b3d90b" />

<img width="1509" alt="Screenshot 2025-06-04 at 11 51 37 AM" src="https://github.com/user-attachments/assets/7da220db-2158-4116-b97e-1ded21086519" />

<img width="1509" alt="Screenshot 2025-06-04 at 11 51 45 AM" src="https://github.com/user-attachments/assets/834952f8-3c9a-47ea-8d30-29fe6b80b657" />

<img width="1509" alt="Screenshot 2025-06-04 at 11 51 50 AM" src="https://github.com/user-attachments/assets/c6ddd28c-09f5-420a-b2f5-5013ae0d650a" />



### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
