### PR TITLE
Add optional onBlur handler to SearchBar component

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -63,6 +63,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Added optional \`currency\` property to \`Discount\` interface.
 - Added \`executedAt\` property to \`BaseTransactionComplete\` interface.
 - Added optional \`exchangeId\` and \`returnId\` property to \`ReturnTransactionData\` interface.
+- Added optional \`onBlur\` handler to \`SearchBar\` component.
 
   `,
     },


### PR DESCRIPTION
### Background

Related to issue #[54912](https://github.com/Shopify/temp-project-mover-Archetypically-20250612104008/issues/76)

### Solution

Updating documentation to accompany exposing the `onBlur` prop to `SearchBar`.

<img src="https://github.com/user-attachments/assets/a5945850-beef-4c6f-aa4f-9a2a778ffcaa" alt="" width="500">

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
