### PR TITLE
add customer account order status announcement render target

### DIFF
--- a/.changeset/curly-cherries-beg.md
+++ b/.changeset/curly-cherries-beg.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+add customer account order status announcement render target

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -90,6 +90,14 @@ export interface OrderStatusExtensionTargets {
       StandardApi<'customer-account.order-status.cart-line-list.render-after'>,
     AnyComponent
   >;
+  /**
+   * A static extension target that renders an extension in a prominent and noticeable area of the **Order status** page.
+   */
+  'customer-account.order-status.announcement.render': RenderExtension<
+    OrderStatusApi<'customer-account.order-status.announcement.render'> &
+      StandardApi<'customer-account.order-status.announcement.render'>,
+    AnyComponent
+  >;
   'customer-account.order.page.render': RenderExtension<
     OrderStatusApi<'customer-account.order.page.render'> &
       Omit<StandardApi<'customer-account.order.page.render'>, 'navigation'> &


### PR DESCRIPTION
### Background

add customer account order status announcement render target to unstable version. 

RC version will come later. 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
