### PR TITLE
Add appearance to documentation

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -126,7 +126,12 @@ export interface Docs_Menu_Button_Action
 export interface Docs_OrderActionMenu_Button
   extends Pick<
     ButtonProps,
-    'onPress' | 'loading' | 'loadingLabel' | 'disabled' | 'accessibilityLabel'
+    | 'onPress'
+    | 'loading'
+    | 'loadingLabel'
+    | 'disabled'
+    | 'accessibilityLabel'
+    | 'appearance'
   > {
   /**
    * Destination URL to link to.


### PR DESCRIPTION
## Problem
<!-- What problem is being addressed? -->
<!-- Link to Github issue, if applicable. Prepend 'Closes ' to an issue URL to automatically close it when this PR is merged. --> Original Issue: https://github.com/shop/world/pull/67201

## Solution
<img width="581" alt="Screenshot 2025-06-06 at 11 07 20 AM" src="https://github.com/user-attachments/assets/f883ccd2-4292-4374-8367-ba533f38dc3d" />
