### PR TITLE
Landing page link fix

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -34,7 +34,7 @@ const data: LandingTemplateSchema = {
         {
           subtitle: 'Reference',
           name: 'View a list of available extension targets',
-          url: '/docs/api/admin-extensions/api/extension-targets',
+          url: '/docs/api/admin-extensions/latest/api/extension-targets',
           type: 'app',
         },
         {

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -34,7 +34,7 @@ const data: LandingTemplateSchema = {
         {
           subtitle: 'Reference',
           name: 'View a list of available extension targets',
-          url: '/docs/api/admin-extensions/latest/api/extension-targets',
+          url: '/docs/api/admin-extensions/current/api/extension-targets',
           type: 'app',
         },
         {

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -34,7 +34,7 @@ const data: LandingTemplateSchema = {
         {
           subtitle: 'Reference',
           name: 'View a list of available extension targets',
-          url: '/docs/api/admin-extensions/current/api/extension-targets',
+          url: '/docs/api/admin-extensions/current/extension-targets',
           type: 'app',
         },
         {


### PR DESCRIPTION
Updates link with more robust `latest` version path.

### Background

https://github.com/Shopify/shopify-dev/issues/58377

Fixes a link on the landing page to list of Admin Extension targets. 

### Solution

I've updated the link to use ~`/latest`~ `/current` according to our [internal site variables](https://shopify.dev/internal/content-strategy/content-components/basic#site-variables) to maintain API version across reference docs.

### 🎩

- Visit https://shopify.dev/docs/api/admin-extensions/latest
- Click the Reference button in the **Overview** section (see below). This will not work. 
- Go back to https://shopify.dev/docs/api/admin-extensions/latest
- Inspect the button, and update the link within your browser to `/docs/api/admin-extensions/current/extension-targets`
- Retry the click, which will take you to the right page

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
