### PR TITLE
Add more listener registration context to Handling Events docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
@@ -97,8 +97,8 @@ const data: LandingTemplateSchema = {
     {
       type: 'Generic',
       title: 'Handling events',
-      sectionContent:
-        'Handling events in admin extensions are the same as you would handle them in a web app. You can use the `addEventListener` method to listen for events on the components or use the `on[event]` prop to listen for events from the components.',
+      sectionContent: `Handling events in UI extensions are the same as you would handle them in a web app. You can use the \`addEventListener\` method to listen for events on the components or use the \`on[event]\` property to listen for events from the components.
+        \n\nWhen using Preact, event handlers can be registered by passing props beginning with \`on\`, and the event handler name is case-insensitive. For example, the JSX \`<s-button onClick={fn}>\` registers fn as a "click" event listener on the button.`,
       anchorLink: 'handling-events',
       codeblock: {
         title: 'Handling events',
@@ -115,9 +115,13 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       title: 'Using Forms',
       sectionContent: `When building a Block extension you may use the [Form component](https://shopify.dev/docs/api/admin-extensions/latest/components/forms/form) to integrate with the contextual save bar of the resource page. The Form component provides a way to manage form state and submit data to your app's backend or directly to Shopify using Direct API access.\n\nWhenever an input field is changed, the Form component will automatically update the dirty state of the resource page. When the form is submitted or reset the relevant callback in the form component will get triggered.\n\nUsing this, you can control what defines a component to be dirty by utilizing the Input's defaultValue property.\n\nRules:\n\n- When the defaultValue is set, the component will be considered dirty if the value of the input is different from the defaultValue.You may update the defaultValue when the form is submitted to reset the dirty state of the form.\n\n- When the defaultValue is not set, the component will be considered dirty if the value of the input is different from the initial value or from the last dynamic update to the input's value that wasn't triggered by user input.
+<<<<<<< HEAD
 
         Note: In order to trigger the dirty state, each input must have a name attribute.
         `,
+=======
+        Note: In order to trigger the dirty state, each input must have a name attribute.`,
+>>>>>>> 532c26b42 (add more event listener registration context to Handling Events)
       anchorLink: 'using-forms',
       codeblock: {
         title: "Trigger the Form's dirty state",

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
@@ -98,7 +98,7 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       title: 'Handling events',
       sectionContent: `Handling events in UI extensions are the same as you would handle them in a web app. You can use the \`addEventListener\` method to listen for events on the components or use the \`on[event]\` property to listen for events from the components.
-        \n\nWhen using Preact, event handlers can be registered by passing props beginning with \`on\`, and the event handler name is case-insensitive. For example, the JSX \`<s-button onClick={fn}>\` registers fn as a "click" event listener on the button.`,
+        \n\nWhen using Preact, event handlers can be registered by passing props beginning with \`on\`, and the event handler name is case-insensitive. For example, the JSX \`<s-button onClick={fn}>\` registers \`fn\` as a "click" event listener on the button.`,
       anchorLink: 'handling-events',
       codeblock: {
         title: 'Handling events',
@@ -115,13 +115,9 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       title: 'Using Forms',
       sectionContent: `When building a Block extension you may use the [Form component](https://shopify.dev/docs/api/admin-extensions/latest/components/forms/form) to integrate with the contextual save bar of the resource page. The Form component provides a way to manage form state and submit data to your app's backend or directly to Shopify using Direct API access.\n\nWhenever an input field is changed, the Form component will automatically update the dirty state of the resource page. When the form is submitted or reset the relevant callback in the form component will get triggered.\n\nUsing this, you can control what defines a component to be dirty by utilizing the Input's defaultValue property.\n\nRules:\n\n- When the defaultValue is set, the component will be considered dirty if the value of the input is different from the defaultValue.You may update the defaultValue when the form is submitted to reset the dirty state of the form.\n\n- When the defaultValue is not set, the component will be considered dirty if the value of the input is different from the initial value or from the last dynamic update to the input's value that wasn't triggered by user input.
-<<<<<<< HEAD
 
         Note: In order to trigger the dirty state, each input must have a name attribute.
         `,
-=======
-        Note: In order to trigger the dirty state, each input must have a name attribute.`,
->>>>>>> 532c26b42 (add more event listener registration context to Handling Events)
       anchorLink: 'using-forms',
       codeblock: {
         title: "Trigger the Form's dirty state",

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/using-polaris-web-components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/using-polaris-web-components.doc.ts
@@ -145,8 +145,8 @@ const data: LandingTemplateSchema = {
     {
       type: 'Generic',
       title: 'Handling events',
-      sectionContent:
-        'Handling events in UI extensions are the same as you would handle them in a web app. You can use the `addEventListener` method to listen for events on the components or use the `on[event]` property to listen for events from the components.',
+      sectionContent: `Handling events in UI extensions are the same as you would handle them in a web app. You can use the \`addEventListener\` method to listen for events on the components or use the \`on[event]\` property to listen for events from the components.
+        \n\nWhen using Preact, event handlers can be registered by passing props beginning with \`on\`, and the event handler name is case-insensitive. For example, the JSX \`<s-button onClick={fn}>\` registers fn as a "click" event listener on the button.`,
       anchorLink: 'handling-events',
       codeblock: {
         title: 'Handling events',

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/using-polaris-web-components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/using-polaris-web-components.doc.ts
@@ -146,7 +146,7 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       title: 'Handling events',
       sectionContent: `Handling events in UI extensions are the same as you would handle them in a web app. You can use the \`addEventListener\` method to listen for events on the components or use the \`on[event]\` property to listen for events from the components.
-        \n\nWhen using Preact, event handlers can be registered by passing props beginning with \`on\`, and the event handler name is case-insensitive. For example, the JSX \`<s-button onClick={fn}>\` registers fn as a "click" event listener on the button.`,
+        \n\nWhen using Preact, event handlers can be registered by passing props beginning with \`on\`, and the event handler name is case-insensitive. For example, the JSX \`<s-button onClick={fn}>\` registers \`fn\` as a "click" event listener on the button.`,
       anchorLink: 'handling-events',
       codeblock: {
         title: 'Handling events',

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/using-polaris-web-components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/using-polaris-web-components.doc.ts
@@ -145,8 +145,8 @@ const data: LandingTemplateSchema = {
     {
       type: 'Generic',
       title: 'Handling events',
-      sectionContent:
-        'Handling events in UI extensions are the same as you would handle them in a web app. You can use the `addEventListener` method to listen for events on the components or use the `on[event]` property to listen for events from the components.',
+      sectionContent: `Handling events in UI extensions are the same as you would handle them in a web app. You can use the \`addEventListener\` method to listen for events on the components or use the \`on[event]\` property to listen for events from the components.
+        \n\nWhen using Preact, event handlers can be registered by passing props beginning with \`on\`, and the event handler name is case-insensitive. For example, the JSX \`<s-button onClick={fn}>\` registers fn as a "click" event listener on the button.`,
       anchorLink: 'handling-events',
       codeblock: {
         title: 'Handling events',

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/using-polaris-web-components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/using-polaris-web-components.doc.ts
@@ -146,7 +146,7 @@ const data: LandingTemplateSchema = {
       type: 'Generic',
       title: 'Handling events',
       sectionContent: `Handling events in UI extensions are the same as you would handle them in a web app. You can use the \`addEventListener\` method to listen for events on the components or use the \`on[event]\` property to listen for events from the components.
-        \n\nWhen using Preact, event handlers can be registered by passing props beginning with \`on\`, and the event handler name is case-insensitive. For example, the JSX \`<s-button onClick={fn}>\` registers fn as a "click" event listener on the button.`,
+        \n\nWhen using Preact, event handlers can be registered by passing props beginning with \`on\`, and the event handler name is case-insensitive. For example, the JSX \`<s-button onClick={fn}>\` registers \`fn\` as a "click" event listener on the button.`,
       anchorLink: 'handling-events',
       codeblock: {
         title: 'Handling events',


### PR DESCRIPTION
## TLDR

The **Handling Events** [section](https://shopify.dev/docs/api/admin-extensions/2025-10-rc#handling-events) should have a second paragraph that explains roughly how to register listeners with Preact.

Closes https://github.com/Shopify/admin-ui-foundations/issues/2928

## Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
