### PR TITLE
Allow key props for customer accounts components in extensions 

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction.d.ts
@@ -1,3 +1,5 @@
+import {BaseElementPropsWithChildren} from './shared';
+
 export interface CustomerAccountActionProps {
   /**
    * Sets the heading of the Action container.
@@ -16,14 +18,11 @@ declare global {
 }
 
 declare module 'preact' {
-  interface BaseProps {
-    children?: preact.ComponentChildren;
-    slot?: Lowercase<string>;
-  }
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace createElement.JSX {
     interface IntrinsicElements {
-      ['s-customer-account-action']: BaseProps & CustomerAccountActionProps;
+      ['s-customer-account-action']: BaseElementPropsWithChildren<CustomerAccountActionElement> &
+        CustomerAccountActionProps;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup.d.ts
@@ -1,3 +1,5 @@
+import {BaseElementPropsWithChildren} from './shared';
+
 export interface ImageGroupProps {
   /**
    * Indicates the total number of items that could be displayed in the image group.
@@ -15,13 +17,11 @@ declare global {
 }
 
 declare module 'preact' {
-  interface BaseProps {
-    children?: preact.ComponentChildren;
-  }
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace createElement.JSX {
     interface IntrinsicElements {
-      ['s-image-group']: BaseProps & ImageGroupProps;
+      ['s-image-group']: BaseElementPropsWithChildren<ImageGroupElement> &
+        ImageGroupProps;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
@@ -1,3 +1,5 @@
+import {BaseElementPropsWithChildren} from './shared';
+
 export interface PageProps {
   /**
    * The main page heading
@@ -19,14 +21,10 @@ declare global {
 }
 
 declare module 'preact' {
-  interface BaseProps {
-    children?: preact.ComponentChildren;
-    slot?: Lowercase<string>;
-  }
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace createElement.JSX {
     interface IntrinsicElements {
-      ['s-page']: BaseProps & PageProps;
+      ['s-page']: BaseElementPropsWithChildren<PageElement> & PageProps;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/shared.ts
@@ -12,3 +12,20 @@ export type Size =
   | 'large'
   | 'extraLarge'
   | 'fill';
+
+export interface BaseElementProps<TClass = HTMLElement> {
+  // Assigns a unique key to this element.
+  key?: preact.Key;
+  // Assigns a ref (generally from `useRef()`) to this element.
+  ref?: preact.Ref<TClass>;
+  // Assigns this element to a parent's slot.
+  slot?: Lowercase<string>;
+}
+
+/**
+ * Used when an element has children.
+ */
+export interface BaseElementPropsWithChildren<TClass = HTMLElement>
+  extends BaseElementProps<TClass> {
+  children?: preact.ComponentChildren;
+}


### PR DESCRIPTION
**Description**
Using the `key` and `ref` props on our elements with preact

Introduce two new type interfaces to standardize prop typing for Preact components:
- `BaseElementProps`: for elements without children, providing `key`, `ref`, and `slot` attributes.
- `BaseElementPropsWithChildren`: extends `BaseElementProps` to include the `children` attribute.

These interfaces replace previously duplicated `BaseProps` interfaces that were defined in individual component files, establishing a consistent and reusable typing approach across all components.

Similar to Checkout: https://github.com/shop/world/pull/64309


## Overview
This PR adds support for key props in customer accounts components within UI extensions, enhancing the ability to uniquely identify and manage components in the customer account interface.

## Changes
- Added support for key props in customer account components
- Implemented changes across multiple customer account components including:
  - CustomerAccountAction
  - Page
  - ImageGroup

## Technical Details
- Modified component interfaces to support key props
- Updated type definitions to ensure proper TypeScript support
- Maintained compatibility with existing customer account extension targets

## Impact
This change improves component identification and management in customer account extensions, which is particularly important for:
- Dynamic component rendering
- Component state management
- Performance optimization through proper key usage
- Better debugging and development experience

## Testing
The changes have been tested with:
- Customer account extension targets
- Various component configurations
- TypeScript type checking