### PR TITLE
Add `taxLines` property to `ShippingLine` interface

### DIFF
--- a/.changeset/slimy-candles-beam.md
+++ b/.changeset/slimy-candles-beam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+add optional `shippingLines.taxLines` property.

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -64,8 +64,9 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Added optional \`currency\` property to \`Discount\` interface.
 - Added \`executedAt\` property to \`BaseTransactionComplete\` interface.
 - Added optional \`exchangeId\` and \`returnId\` property to \`ReturnTransactionData\` interface.
-- Added optional \`onBlur\` handler to \`SearchBar\` component.
 - Added required \`variantId\` property to \`ProductApi\` interface.
+- Added optional \`taxLines\` property to \`ShippingLine\` interface.
+- Added optional \`onBlur\` handler to \`SearchBar\` component.
 
   `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/shipping-line.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/shipping-line.ts
@@ -1,9 +1,11 @@
 import type {Money} from './money';
+import type {TaxLine} from './tax-line';
 
 export interface ShippingLine {
   handle?: string;
   price: Money;
   title?: string;
+  taxLines?: TaxLine[];
 }
 
 export interface CalculatedShippingLine extends ShippingLine {


### PR DESCRIPTION
### Background

Part of, https://github.com/Shopify/temp-project-mover-Archetypically-20250612122555/issues/106

### Solution

- Add optional `taxLines` property to `ShippingLine` interface.
- Add to version notes under `2025-07`.

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
