### PR TITLE
Add context for should-render api

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -2,7 +2,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ShouldRender API',
-  description: 'This API is available to all shouldRender extension types.',
+  description:
+    'This API controls the render state of an admin action extension. Learn more in the <a href="https://shopify.dev/docs/apps/build/admin/actions-blocks/hide-extensions?extension=react#hide-an-admin-action">admin extensions tutorial</a>.',
   isVisualComponent: false,
   type: 'API',
   definitions: [


### PR DESCRIPTION
### Background

Addresses https://github.com/Shopify/shopify-dev-feedback/issues/7591

Adds some context to the should-render api docs.

![Screenshot 2025-06-10 at 5 00 57 PM](https://github.com/user-attachments/assets/186d2e92-b5f5-4678-afa6-e7b0a1a9aa4e)


### Solution

The [shouldRender API doc](https://shopify.dev/docs/api/admin-extensions/2025-01/api/target-apis/shouldrender-api) isn't clear on its own. This PR adds a link to the admin extensions tutorial. 

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
