### PR TITLE
Backfill doc changes to POS Extension 2025-01 (v2)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/PrintPreview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/PrintPreview.doc.ts
@@ -6,14 +6,18 @@ const generateCodeBlockForPrintPreview = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'PrintPreview',
-  description: `A component that displays a preview of a printable document. Use this component to let users review documents before printing.`,
+  description: `
+  A component that displays a preview of a printable document. 
+  > Note:
+  > This component must be a direct child of the Screen component and cannot be nested inside any other component.`,
   isVisualComponent: true,
   type: 'component',
   thumbnail: 'print-preview-thumbnail.png',
   definitions: [
     {
       title: 'PrintPreview',
-      description: 'Renders a preview of a printable document',
+      description:
+        'Renders a preview of a printable document. This component must a direct child of the Screen component.',
       type: 'PrintPreviewProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Stack.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Stack.doc.ts
@@ -21,7 +21,7 @@ const generateCodeBlockForStack = (title: string, fileName: string) => {
 const data: ReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
-    'A container for other components that allows them to be stacked horizontally or vertically. When building complex UIs, this will be your primary building block.',
+    'A container for other components that allows them to be stacked horizontally or vertically. When building complex UIs, this will be your primary building block. Stacks always wrap the content to the next column or row.',
   isVisualComponent: true,
   type: 'component',
   definitions: [

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.npm.bash
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.npm.bash
@@ -9,5 +9,5 @@ npm update react@^18.2.0
 npm update @types/react@^18.2.0
 
 # 4. Install the new packages
-npm install @shopify/ui-extensions@2024.4
-npm install @shopify/ui-extensions-react@2024.4
+npm install @shopify/ui-extensions@2025.1
+npm install @shopify/ui-extensions-react@2025.1

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.yarn.bash
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/setup.yarn.bash
@@ -9,5 +9,5 @@ yarn upgrade react@^18.2.0
 yarn upgrade @types/react@^18.2.0
 
 # 4. Install the new packages
-yarn add @shopify/ui-extensions@2024.4
-yarn add @shopify/ui-extensions-react@2024.4
+yarn add @shopify/ui-extensions@2025.1
+yarn add @shopify/ui-extensions-react@2025.1

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/shopify.extension.toml
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/migrating/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-04"
+api_version = "2025-01"
 
 [[extensions]]
 type = "ui_extension"

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/migrating.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/migrating.doc.ts
@@ -86,7 +86,7 @@ Migrate your \`shopify.extension.toml\` file to reflect the [new syntax](https:/
 - Specify which \`api_version\` you are using at the top of the file (above \`[[extensions]]\`). This will let POS know which version of the \`ui-extensions\` package you're using.
 
 > Note:
-> \`api_version\` needs to be declared in a \`yyyy-mm\` format. If you are using \`@shopify/ui-extensions\` version \`2024.4\` for example, you must declare your \`api_version\` as 2024-04. The patch is irrelevant to \`api_version\`.
+> \`api_version\` needs to be declared in a \`yyyy-mm\` format. If you are using \`@shopify/ui-extensions\` version \`2025.1\` for example, you must declare your \`api_version\` as 2025-01. The patch is irrelevant to \`api_version\`.
 
 - Declare each extension target and file path in \`shopify.extension.toml\`
       `,


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/temp-project-mover-Archetypically-20250612104008/issues/202

TL;DR: We have only been updating the `unstable` branch in this repo and manually copying the changes to the stable docs in the shopify-dev repo. Backfilling changes to allow for new automation to be used.

#### Why v2

In the first [PR](https://github.com/Shopify/ui-extensions/pull/2965) I missed some changes.

### Solution

1. Cherry pick in:
   - https://github.com/Shopify/ui-extensions/pull/2568
2. Fix regression to referencing 2024-04 in the examples and clarification regarding the stack

### 🎩

1. Checkout this code
3. `yarn docs:point-of-sale 2025-01`
4. At this point you can observe the diff with the docs currently published.
5. In shopfy-dev, run `dev s`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation