### PR TITLE
Add context for should-render api

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -2,7 +2,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ShouldRender API',
-  description: 'This API is available to all shouldRender extension types.',
+  description:
+    'This API controls the render state of an admin action extension. Learn more in the <a href="https://shopify.dev/docs/apps/build/admin/actions-blocks/hide-extensions?extension=react#hide-an-admin-action">admin extensions tutorial</a>.',
   isVisualComponent: false,
   type: 'API',
   definitions: [


### PR DESCRIPTION
### Background

Updating the should-render API description on current rc version of docs. 

Cherry-pick from [here](https://github.com/Shopify/ui-extensions/pull/2973). 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
