### PR TITLE
Add QueryContainer to StandardComponents type union

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/StandardComponents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/StandardComponents.ts
@@ -24,6 +24,7 @@ export type StandardComponents =
   | 'OrderedList'
   | 'Paragraph'
   | 'PasswordField'
+  | 'QueryContainer'
   | 'Section'
   | 'Select'
   | 'Spinner'


### PR DESCRIPTION
### Background

QueryContainer was not added to the StandardComponents.ts file, causing types to not be registered for code in 3p extension apps. 

### Solution

Add `QueryContainer` string literal to the  StandardComponents type union in packages/ui-extensions/src/surfaces/admin/components/StandardComponents.ts

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
