### PR TITLE
Add refunds data to reprint receipt input data

### DIFF
--- a/.changeset/nervous-forks-mix.md
+++ b/.changeset/nervous-forks-mix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add `refunds` and `currentQuantity` fields to Receipt Reprint LineItems

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -97,6 +97,8 @@ export type {
   Address,
 } from './types/cart';
 
+export type {OrderLineItem, LineItemRefund} from './types/order';
+
 export type {DirectApiRequestBody} from './types/direct-api-request-body';
 
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
@@ -1,7 +1,7 @@
 import {BaseTransactionComplete} from '../../types/base-transaction-complete';
-import {LineItem} from '../../types/cart';
+import {OrderLineItem} from '../../types/order';
 
 export interface ReprintReceiptData extends BaseTransactionComplete {
   transactionType: 'Reprint';
-  lineItems: LineItem[];
+  lineItems: OrderLineItem[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/order.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/order.ts
@@ -1,0 +1,12 @@
+import {LineItem} from './cart';
+
+export interface LineItemRefund {
+  createdAt: string;
+  quantity: number;
+}
+
+export interface OrderLineItem extends LineItem {
+  // Number of remaining goods
+  currentQuantity: number;
+  refunds?: LineItemRefund[];
+}


### PR DESCRIPTION
### Background

Part 1/2 of https://github.com/shop/issues-retail/issues/2961

### Solution

Add `refunded` fields to LineItems for reprint event

I defined a new OrderLineItems extends LineItems interface to be safe and not to add non-optional field to all usages of LineItems (which is a part of Cart API, and Cart API does not deal with refunds)

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
