### PR TITLE
Fix discount extension link from getting started

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/getting-started.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/getting-started.doc.ts
@@ -130,7 +130,7 @@ Merchants can manage their POS UI extensions across locations from the POS chann
       anchorLink: 'next-steps',
       title: 'Next steps',
       sectionContent: `
-- Follow along with an [example discount extension](/docs/api/pos-ui-extensions/example-discount-extension).
+- Follow along with an [example discount extension](/docs/apps/build/pos/build-discount-extension).
 - Explore the full [reference of Shopify retail APIs and components](/docs/api/pos-ui-extensions) that you can use for your POS UI extension.
 - Learn how to [deploy and release an app extension](/docs/apps/deployment/app-versions).
         `,


### PR DESCRIPTION
### Background

This links to a page that looks like a 404 and causes confusion
![image](https://github.com/user-attachments/assets/85ab3315-2a8d-41c2-ae3f-35e4cc65860a)

### Solution

Update to link to where our example actually lives

### 🎩

See companion PR in shopify-dev: https://github.com/Shopify/shopify-dev/pull/59139

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
