### PR TITLE
add customer account profile and order index announcement render

### DIFF
--- a/.changeset/poor-mayflies-bathe.md
+++ b/.changeset/poor-mayflies-bathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+add customer account profile and order index announcement render

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -125,8 +125,16 @@ export interface CustomerAccountExtensionTargets {
     StandardApi<'customer-account.order-index.block.render'>,
     AllComponents
   >;
+  'customer-account.order-index.announcement.render': RenderExtension<
+    StandardApi<'customer-account.order-index.announcement.render'>,
+    AllComponents
+  >;
   'customer-account.profile.block.render': RenderExtension<
     StandardApi<'customer-account.profile.block.render'>,
+    AllComponents
+  >;
+  'customer-account.profile.announcement.render': RenderExtension<
+    StandardApi<'customer-account.profile.announcement.render'>,
     AllComponents
   >;
   'customer-account.profile.addresses.render-after': RenderExtension<


### PR DESCRIPTION
### Background

Add 2 more targets for customer account
- `customer-account.profile.announcement.render`
- `customer-account.order-index.announcement.render` 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
