### PR TITLE
[UI components]: Components changelog

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/changelog.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/changelog.doc.ts
@@ -31,14 +31,14 @@ These web components are an early access preview of the [Polaris](/beta/next-gen
 Released: June 25, 2025
 
 - Added new components:
-  - [Checkbox](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/checkbox)
-  - [EmailField](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/emailfield)
-  - [Map](/docs/api/checkout-ui-extensions/2025-10-rc/components/interactive/map)
-  - [MapMarker](/docs/api/checkout-ui-extensions/2025-10-rc/components/interactive/map#mapmarker)
-  - [Modal](/docs/api/checkout-ui-extensions/2025-10-rc/components/overlay/modal)
-  - [PhoneField](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/phonefield)
-  - [ProductThumbnail](/docs/api/checkout-ui-extensions/2025-10-rc/components/media/productthumbnail)
-  - [TextArea](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/textarea)
+  - [Checkbox](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/forms/checkbox)
+  - [EmailField](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/forms/emailfield)
+  - [Map](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/interactive/map)
+  - [MapMarker](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/interactive/map#mapmarker)
+  - [Modal](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/overlay/modal)
+  - [PhoneField](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/forms/phonefield)
+  - [ProductThumbnail](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/media/productthumbnail)
+  - [TextArea](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/forms/textarea)
 `,
     },
     {
@@ -49,28 +49,28 @@ Released: June 25, 2025
 Released: May 21, 2025
 
 - Added new components:
-  - [Abbreviation](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/abbreviation)
-  - [Banner](/docs/api/checkout-ui-extensions/2025-10-rc/components/feedback/banner)
-  - [Box](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/box)
-  - [Button](/docs/api/checkout-ui-extensions/2025-10-rc/components/actions/button)
-  - [ClipboardItem](/docs/api/checkout-ui-extensions/2025-10-rc/components/utilities/clipboarditem)
-  - [DropZone](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/dropzone)
-  - [Form](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/form)
-  - [Heading](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/heading)
-  - [Icon](/docs/api/checkout-ui-extensions/2025-10-rc/components/media/icon)
-  - [Image](/docs/api/checkout-ui-extensions/2025-10-rc/components/media/image)
-  - [Link](/docs/api/checkout-ui-extensions/2025-10-rc/components/actions/link)
-  - [ListItem](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/listitem)
-  - [OrderedList](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/orderedlist)
-  - [Paragraph](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/paragraph)
-  - [PaymentIcon](/docs/api/checkout-ui-extensions/2025-10-rc/components/media/paymenticon)
-  - [Progress](/docs/api/checkout-ui-extensions/2025-10-rc/components/feedback/progress)
-  - [QRCode](/docs/api/checkout-ui-extensions/2025-10-rc/components/other/qrcode)
-  - [Spinner](/docs/api/checkout-ui-extensions/2025-10-rc/components/feedback/spinner)
-  - [Stack](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/stack)
-  - [TextField](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/textfield)
-  - [Time](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/time)
-  - [UnorderedList](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/unorderedlist)
+  - [Abbreviation](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/titles-and-text/abbreviation)
+  - [Banner](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/feedback/banner)
+  - [Box](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/structure/box)
+  - [Button](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/actions/button)
+  - [ClipboardItem](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/utilities/clipboarditem)
+  - [DropZone](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/forms/dropzone)
+  - [Form](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/forms/form)
+  - [Heading](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/titles-and-text/heading)
+  - [Icon](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/media/icon)
+  - [Image](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/media/image)
+  - [Link](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/actions/link)
+  - [ListItem](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/structure/listitem)
+  - [OrderedList](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/structure/orderedlist)
+  - [Paragraph](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/titles-and-text/paragraph)
+  - [PaymentIcon](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/media/paymenticon)
+  - [Progress](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/feedback/progress)
+  - [QRCode](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/other/qrcode)
+  - [Spinner](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/feedback/spinner)
+  - [Stack](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/structure/stack)
+  - [TextField](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/forms/textfield)
+  - [Time](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/titles-and-text/time)
+  - [UnorderedList](/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/structure/unorderedlist)
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/changelog.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/changelog.doc.ts
@@ -1,0 +1,79 @@
+import type {LandingTemplateSchema} from '@shopify/generate-docs';
+
+const data: LandingTemplateSchema = {
+  title: 'Changelog',
+  description: `
+Stay up to date with the latest component releases, updates, and changes for Shopify checkout UI extensions.
+`,
+  id: 'changelog',
+  sections: [
+    {
+      type: 'Generic',
+      anchorLink: 'latest-releases',
+      title: 'Latest Releases',
+      sectionContent:
+        'Keep track of the most recent component updates and new releases.',
+      sectionNotice: [
+        {
+          title: 'Early access preview',
+          sectionContent: `
+These web components are an early access preview of the [Polaris](/beta/next-gen-dev-platform/polaris) UI framework. We will add more components over time.
+`,
+          type: 'info',
+        },
+      ],
+    },
+    {
+      type: 'Markdown',
+      anchorLink: 'June',
+      title: 'June 2025',
+      sectionContent: `
+Released: June 25, 2025
+
+- Added new components:
+  - [Checkbox](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/checkbox)
+  - [EmailField](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/emailfield)
+  - [Map](/docs/api/checkout-ui-extensions/2025-10-rc/components/interactive/map)
+  - [MapMarker](/docs/api/checkout-ui-extensions/2025-10-rc/components/interactive/map#mapmarker)
+  - [Modal](/docs/api/checkout-ui-extensions/2025-10-rc/components/overlay/modal)
+  - [PhoneField](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/phonefield)
+  - [ProductThumbnail](/docs/api/checkout-ui-extensions/2025-10-rc/components/media/productthumbnail)
+  - [TextArea](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/textarea)
+`,
+    },
+    {
+      type: 'Markdown',
+      anchorLink: 'May',
+      title: 'May 2025',
+      sectionContent: `
+Released: May 21, 2025
+
+- Added new components:
+  - [Abbreviation](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/abbreviation)
+  - [Banner](/docs/api/checkout-ui-extensions/2025-10-rc/components/feedback/banner)
+  - [Box](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/box)
+  - [Button](/docs/api/checkout-ui-extensions/2025-10-rc/components/actions/button)
+  - [ClipboardItem](/docs/api/checkout-ui-extensions/2025-10-rc/components/utilities/clipboarditem)
+  - [DropZone](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/dropzone)
+  - [Form](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/form)
+  - [Heading](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/heading)
+  - [Icon](/docs/api/checkout-ui-extensions/2025-10-rc/components/media/icon)
+  - [Image](/docs/api/checkout-ui-extensions/2025-10-rc/components/media/image)
+  - [Link](/docs/api/checkout-ui-extensions/2025-10-rc/components/actions/link)
+  - [ListItem](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/listitem)
+  - [OrderedList](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/orderedlist)
+  - [Paragraph](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/paragraph)
+  - [PaymentIcon](/docs/api/checkout-ui-extensions/2025-10-rc/components/media/paymenticon)
+  - [Progress](/docs/api/checkout-ui-extensions/2025-10-rc/components/feedback/progress)
+  - [QRCode](/docs/api/checkout-ui-extensions/2025-10-rc/components/other/qrcode)
+  - [Spinner](/docs/api/checkout-ui-extensions/2025-10-rc/components/feedback/spinner)
+  - [Stack](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/stack)
+  - [TextField](/docs/api/checkout-ui-extensions/2025-10-rc/components/forms/textfield)
+  - [Time](/docs/api/checkout-ui-extensions/2025-10-rc/components/titles-and-text/time)
+  - [UnorderedList](/docs/api/checkout-ui-extensions/2025-10-rc/components/structure/unorderedlist)
+`,
+    },
+  ],
+};
+
+export default data;


### PR DESCRIPTION
closes https://github.com/shop/issues-checkout/issues/6056

### TL;DR 🤖
This pull request introduces updates to the documentation for Shopify checkout UI extensions, primarily focusing on the changelog and component availability. It adds detailed changelog entries for recent component releases and updates the comparison table to reflect the current availability of components.

### Updates to Changelog Documentation: 
* Added a new `changelog.doc.ts` file to document recent component releases for Shopify checkout UI extensions, including details for May and June 2025 releases. The changelog highlights newly added components such as `Checkbox`, `EmailField`, `Map`, `Modal`, `PhoneField`, `ProductThumbnail`, and `TextArea`.

### Updates to Component Availability Table:
* Updated `upgrading-to-2025-10.doc.ts` to mark the following components as "Available today" instead of "Coming soon":
  - `Checkbox`
  - `EmailField`
  - `Map` and `MapMarker`
  - `Modal`
  - `PhoneField`
  - `ProductThumbnail`
  - `TextArea`
