### PR TITLE
Add new TYP target: purchase.thank-you.announcment.render

### DIFF
--- a/.changeset/clever-olives-hang.md
+++ b/.changeset/clever-olives-hang.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add Checkout Thank You page announcement extension target

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.thank-you.announcement.render/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.thank-you.announcement.render/default.example.ts
@@ -1,0 +1,71 @@
+import {
+  BlockStack,
+  Button,
+  InlineStack,
+  Link,
+  Modal,
+  TextField,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/checkout';
+
+export default extension(
+  'purchase.thank-you.announcement.render',
+  (root, {shop}) => {
+    const modalFragment = root.createFragment();
+    modalFragment.appendChild(
+      root.createComponent(
+        Modal,
+        {
+          title:
+            'Tell us about your shopping experience',
+          padding: true,
+        },
+        [
+          root.createComponent(
+            BlockStack,
+            undefined,
+            [
+              root.createComponent(
+                Text,
+                undefined,
+                `We'd love to hear about your shopping experience at ${shop.name}`,
+              ),
+              root.createComponent(TextField, {
+                multiline: 4,
+                label:
+                  'How can we make your shopping experience better?',
+              }),
+              root.createComponent(
+                Button,
+                undefined,
+                'Submit',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    root.appendChild(
+      root.createComponent(
+        InlineStack,
+        undefined,
+        [
+          root.createComponent(
+            Text,
+            undefined,
+            'Check our latest offers',
+          ),
+          root.createComponent(
+            Link,
+            {
+              overlay: modalFragment,
+            },
+            'Fill out the survey',
+          ),
+        ],
+      ),
+    );
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.thank-you.announcement.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/purchase.thank-you.announcement.render/default.example.tsx
@@ -1,0 +1,51 @@
+import {
+  BlockStack,
+  Button,
+  InlineStack,
+  Link,
+  Modal,
+  reactExtension,
+  TextField,
+  Text,
+  useApi,
+} from '@shopify/ui-extensions-react/checkout';
+
+// 1. Choose an extension target
+export default reactExtension(
+  'purchase.thank-you.announcement.render',
+  () => <Extension />,
+);
+
+function Extension() {
+  // 2. Use the extension API to gather context from the shop
+  const {shop} = useApi();
+
+  // 3. Render a UI
+  return (
+    <InlineStack>
+      <Text>Check our latest offers</Text>
+      <Link
+        overlay={
+          <Modal
+            title="Tell us about your shopping experience"
+            padding
+          >
+            <BlockStack>
+              <Text>
+                We'd love to hear about your
+                shopping experience at {shop.name}
+              </Text>
+              <TextField
+                multiline={4}
+                label="How can we make your shopping experience better?"
+              ></TextField>
+              <Button>Submit</Button>
+            </BlockStack>
+          </Modal>
+        }
+      >
+        Fill out the survey
+      </Link>
+    </InlineStack>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
@@ -152,6 +152,7 @@ export function getExamples(
     ...createExample('purchase.thank-you.footer.render-after/default'),
     ...createExample('purchase.checkout.chat.render/default'),
     ...createExample('purchase.thank-you.chat.render/default'),
+    ...createExample('purchase.thank-you.announcement.render/default'),
     'analytics-publish': {
       description:
         'You can publish analytics events to the Shopify analytics frameworks and they will be propagated to all web pixels on the page.',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.announcement.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.announcement.render.doc.ts
@@ -1,0 +1,16 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {getExample, getLinksByTag, THANK_YOU_API} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'purchase.thank-you.announcment.render',
+  description: `A static extension target that is rendered on top of the **Thank you page** as a dismissable announcement.`,
+  defaultExample: getExample('purchase.thank-you.announcement.render/default', [
+    'jsx',
+    'js',
+  ]),
+  related: getLinksByTag('targets'),
+  ...THANK_YOU_API,
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -647,6 +647,14 @@ export interface RenderExtensionTargets {
     OrderConfirmationApi & StandardApi<'purchase.thank-you.chat.render'>,
     AllowedComponents<'Chat'>
   >;
+  /**
+   * A static extension target that is rendered on top of the **Thank you page** as a dismissable announcement.
+   */
+  'purchase.thank-you.announcement.render': RenderExtension<
+    OrderConfirmationApi &
+      StandardApi<'purchase.thank-you.announcement.render'>,
+    AnyComponent
+  >;
 }
 
 export interface RunnableExtensionTargets {


### PR DESCRIPTION
Part of shop/issues-checkout#5935

### Background

This PR adds a new extension target for the Thank You page, allowing developers to render dismissable announcements at the top of the page.

### Solution

Added a new extension target called `purchase.thank-you.announcement.render` that renders a dismissable announcement on the Thank You page. This provides developers with another way to communicate important information to customers after they complete their purchase.

The implementation includes:
- Adding the target definition to the `RenderExtensionTargets` interface
- Creating documentation for the new target
- Adding example implementations in both JS and React (TSX) formats
- Updating the helper docs to include the new examples

### 🎩

- Create a new extension using the `purchase.thank-you.announcement.render` target
- Complete a checkout flow to verify the announcement appears correctly on the Thank You page
- Verify the announcement is dismissable

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation