### PR TITLE
Added navigateToNativeScreen function to the Navigation API

### DIFF
--- a/.changeset/pink-schools-accept.md
+++ b/.changeset/pink-schools-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added a navigateToNativeScreen option in the Navigation API

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -40,6 +40,8 @@ export type {
 export type {
   NavigationApiContent,
   NavigationApi,
+  NativeScreen,
+  NativeScreenParams,
 } from './render/api/navigation-api/navigation-api';
 
 export type {OrderApiContent, OrderApi} from './render/api/order-api/order-api';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/navigation-api/navigation-api.ts
@@ -11,6 +11,12 @@ export interface NavigationApiContent {
 
   /** Dismisses the extension. */
   dismiss(): void;
+
+  /**
+   * Navigate to a native screen
+   * @param screen takes in a native screen name and its parameters
+   */
+  navigateToNativeScreen(screen: NativeScreen): void;
 }
 
 /**
@@ -19,3 +25,21 @@ export interface NavigationApiContent {
 export interface NavigationApi {
   navigation: NavigationApiContent;
 }
+
+/**
+ * The different native screens and their parameters
+ */
+export interface NativeScreenParams {
+  productDetails: {productId: number; variantId?: number};
+  orderDetails: {orderId: number};
+  customerDetails: {customerId: number};
+  staffDetails: {staffId: number};
+  draftOrderDetails: {draftOrderId: number};
+}
+
+export type NativeScreen = {
+  [K in keyof NativeScreenParams]: {
+    screenName: K;
+    params: NativeScreenParams[K];
+  };
+}[keyof NativeScreenParams];


### PR DESCRIPTION
### Background

This is relevant to [this issue](https://github.com/shop/issues-retail/issues/1810). TLDR; we want the ability to navigate to POS native pages from extensions.

### Solution

For this PR, we are adding the navigateToNativeScreen field into the Navigation API. The rest of the implementation has been done in the pos-next-react-native repo and can be view in [this PR](https://github.com/Shopify/pos-next-react-native/pull/62879).

### 🎩

- Follow the changes in [this PR](https://github.com/Shopify/pos-next-react-native/pull/62879).

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
