### PR TITLE
Added navigateToNativeScreen function to Navigation API

### DIFF
--- a/.changeset/pink-schools-accept.md
+++ b/.changeset/pink-schools-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added a navigateToPosScreen option in the Navigation API

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -31,6 +31,8 @@ export type {LocaleApi, LocaleApiContent} from './api/locale-api/locale-api';
 export type {
   NavigationApiContent,
   NavigationApi,
+  PosScreen,
+  PosScreenParams,
 } from './api/navigation-api/navigation-api';
 
 export type {OrderApiContent, OrderApi} from './api/order-api/order-api';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -11,6 +11,12 @@ export interface NavigationApiContent {
 
   /** Dismisses the extension. */
   dismiss(): void;
+
+  /**
+   * Navigate to a POS screen. Screens will present in a modal.
+   * @param screen takes in a POS screen name and its parameters
+   */
+  navigateToPosScreen(screen: PosScreen): void;
 }
 
 /**
@@ -19,3 +25,21 @@ export interface NavigationApiContent {
 export interface NavigationApi {
   navigation: NavigationApiContent;
 }
+
+/**
+ * The different POS screens and their parameters
+ */
+export interface PosScreenParams {
+  productDetails: {productId: number; variantId?: number};
+  orderDetails: {orderId: number};
+  customerDetails: {customerId: number};
+  staffDetails: {staffId: number};
+  draftOrderDetails: {draftOrderId: number};
+}
+
+export type PosScreen = {
+  [K in keyof PosScreenParams]: {
+    screenName: K;
+    params: PosScreenParams[K];
+  };
+}[keyof PosScreenParams];


### PR DESCRIPTION
### Background

This is relevant to https://github.com/shop/issues-retail/issues/1810. TLDR; we want the ability to navigate to POS native pages from extensions.

**Note:** This PR will be merged later on, when the GSD project is approved for build.

### Solution

For this PR, we are adding the navigateToNativeScreen field into the Navigation API. The rest of the implementation has been done in the pos-next-react-native repo and can be view in [this PR](https://github.com/Shopify/pos-next-react-native/pull/62879).

### 🎩

- Follow the instructions in [this PR](https://github.com/Shopify/pos-next-react-native/pull/62879).

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
