### PR TITLE
Deprecate min and max props in NumberField component

### DIFF
--- a/.changeset/silent-yaks-beam.md
+++ b/.changeset/silent-yaks-beam.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-react': minor
+---
+
+NumberField - deprecate min and max props

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -74,6 +74,7 @@ Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more i
 - Added optional \`tone\` property to \`Icon\` component and expanded \`name\` and \`size\` options.
 - Deprecated \`'minor'\`, \`'major'\`, \`'spot'\`, \`'caption'\`, \`'badge'\` as values for the \`size\` prop in the [Icon](/docs/api/pos-ui-extensions/components/icon) component. Use \`'s'\`, \`'m'\`, \`'l'\`, \`'xl'\` instead.
 - Deprecated \`'arrow'\`, \`'available-at-other-locations'\`, \`'collections'\`, \`'connectivity-warning'\`, \`'delivery'\`, \`'home'\`, \`'image-placeholder'\`, \`'internet'\`, \`'menu'\`, \`'orders'\`, \`'products'\`, \`'shipment'\` as values for the \`name\` prop in the [Icon](/docs/api/pos-ui-extensions/components/icon) component. See the available icon list names in the \`name\` prop documentation.
+- Deprecated \`max\` and \`min\` props in the [NumberField](/docs/api/pos-ui-extensions/components/numberfield) component. Implement validation logic instead.
 
 **Developer Preview**:
   - Introduced a [Storage API](/docs/api/pos-ui-extensions/apis/storage-api). The Storage API gives the UI Extension access to store data on the POS device that the extension is running on.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/NumberField/NumberField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/NumberField/NumberField.ts
@@ -8,7 +8,13 @@ import type {InputProps} from '../shared/InputField';
  */
 export interface NumberFieldProps extends InputProps {
   inputMode?: 'decimal' | 'numeric';
+  /**
+   * @deprecated Implement validation logic instead. This prop will be removed in 2025-10.
+   */
   max?: number;
+  /**
+   * @deprecated Implement validation logic instead. This prop will be removed in 2025-10.
+   */
   min?: number;
 }
 


### PR DESCRIPTION
### Background

Resolves part of [issue #1999](https://github.com/shop/issues-retail/issues/1999)

Deprecating `min` and `max` props in the NumberField component because they are (and have been) non-functional.

### Solution
- Adds deprecation notice for `min` and `max` props 

<img src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/aQSCLikeEHKP71ewIlF3/da6bcd76-508f-4d74-9afa-2fda85247842.png" width=400>

### 🎩
- See [pos-next-react-native #62931](https://app.graphite.dev/github/pr/Shopify/pos-next-react-native/62931) for tophat instructions

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation