### PR TITLE
fix card links on 2025-10-rc page

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
@@ -34,13 +34,13 @@ const data: LandingTemplateSchema = {
         {
           subtitle: 'Reference',
           name: 'View a list of available extension targets',
-          url: '/docs/api/admin-extensions/api/extension-targets',
+          url: '/docs/api/admin-extensions/2025-10-rc/extension-targets',
           type: 'app',
         },
         {
           subtitle: 'Network Features',
           name: 'Learn about the network features available to admin extensions',
-          url: '/docs/api/admin-extensions/api/network-features',
+          url: '/docs/api/admin-extensions/2025-10-rc/network-features',
           type: 'globe',
         },
         {


### PR DESCRIPTION
### Background

Closes https://github.com/shop/issues-appui/issues/823 

Fixes broken links on admin-extensions rc page cards.

### Solution

Fix links in static page cards section to include version

![fixed_link](https://github.com/user-attachments/assets/b3a43cd3-67d4-48f0-b289-64679860a784)


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
