### PR TITLE
Update POS post-exchange and post-return target examples

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -8,6 +8,8 @@ const generateCodeBlockForStorageApi = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Storage API',
   description: `The Storage API allows fetching, setting, updating, and clearing an extension's data from the POS local storage.
+  - An extension can store up to 100 entries.
+  - The maximum size for a key is ~1 KB, and for a value is ~1 MB.
   - If a target (such as \`pos.home.tile.render\`) is disabled or removed, the extension data remains.
   - All stored extension data that has not been updated for a month is cleared automatically after that period.
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-exchange-post-action-render.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-exchange-post-action-render.tsx
@@ -15,7 +15,7 @@ const ExchangeAction = () => {
     <Navigator>
       <Screen name="ExchangeDetails" title="Exchange Details">
         <ScrollView>
-          <Text>{`Exchange ID: ${api.exchange.id}`}</Text>
+          <Text>{`Order ID: ${api.order.id}`}</Text>
         </ScrollView>
       </Screen>
     </Navigator>

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-exchange-post-block-render.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-exchange-post-block-render.ts
@@ -14,7 +14,7 @@ export default extension('pos.exchange.post.block.render', (root, api) => {
   mainText.append('Exchange block extension');
 
   const subtitleText = root.createComponent(Text);
-  subtitleText.append(`Exchange ID: ${api.exchange.id}`);
+  subtitleText.append(`Order ID: ${api.order.id}`);
 
   const blockMainRow = root.createComponent(POSBlockRow);
   blockMainRow.append(mainText);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-exchange-post-block-render.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-exchange-post-block-render.tsx
@@ -19,7 +19,7 @@ const ExchangeBlock = () => {
     >
       <POSBlockRow>
         <Text>{'Exchange block extension'}</Text>
-        <Text>{`Exchange ID: ${api.exchange.id}`}</Text>
+        <Text>{`Order ID: ${api.order.id}`}</Text>
       </POSBlockRow>
     </POSBlock>
   );

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-return-post-action-render.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-return-post-action-render.ts
@@ -15,7 +15,7 @@ export default extension('pos.return.post.action.render', (root, api) => {
   const scrollView = root.createComponent(ScrollView);
   const text = root.createComponent(Text);
 
-  text.append(`Return ID: ${api.return.id}`);
+  text.append(`Order ID: ${api.order.id}`);
   scrollView.append(text);
   screen.append(scrollView);
   navigator.append(screen);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-return-post-action-render.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-return-post-action-render.tsx
@@ -15,7 +15,7 @@ const ReturnAction = () => {
     <Navigator>
       <Screen name="ReturnDetails" title="Return Details">
         <ScrollView>
-          <Text>{`Return ID: ${api.return.id}`}</Text>
+          <Text>{`Order ID: ${api.order.id}`}</Text>
         </ScrollView>
       </Screen>
     </Navigator>

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-return-post-block-render.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-return-post-block-render.ts
@@ -14,7 +14,7 @@ export default extension('pos.return.post.block.render', (root, api) => {
   mainText.append('Return block extension');
 
   const subtitleText = root.createComponent(Text);
-  subtitleText.append(`Return ID: ${api.return.id}`);
+  subtitleText.append(`Order ID: ${api.order.id}`);
 
   const blockMainRow = root.createComponent(POSBlockRow);
   blockMainRow.append(mainText);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-return-post-block-render.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-return-post-block-render.tsx
@@ -16,7 +16,7 @@ const ReturnBlock = () => {
     >
       <POSBlockRow>
         <Text>{'Return block extension'}</Text>
-        <Text>{`Return ID: ${api.return.id}`}</Text>
+        <Text>{`Order ID: ${api.order.id}`}</Text>
       </POSBlockRow>
     </POSBlock>
   );


### PR DESCRIPTION
### Background

Added more details for Storage API and fix code examples.

### Solution

- Update `pos.exchange.post.action.render`, `pos.exchange.post.block.render`, `pos.return.post.action.render`, `pos.return.post.block.render` code examples.
- Add details for Storage API.

### 🎩

- See https://github.com/Shopify/shopify-dev/pull/59589

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
