### PR TITLE
Add `Thumbnail` to `StandardComponents`

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/StandardComponents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/StandardComponents.ts
@@ -38,6 +38,7 @@ export type StandardComponents =
   | 'Text'
   | 'TextArea'
   | 'TextField'
+  | 'Thumbnail'
   | 'UnorderedList'
   | 'URLField';
 


### PR DESCRIPTION
### Background

This PR adds the `Thumbnail` component to the list of standard components available in the admin UI extensions.

### Solution

The `Thumbnail` component is now included in the `StandardComponents` type, allowing developers to use it in their admin UI extensions. This component will be useful for displaying image thumbnails in the admin interface.

### 🎩

- Import and use the `Thumbnail` component in an admin UI extension
- Verify that the component renders correctly with various image sources

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation

## References

- #3023