### PR TITLE
Add announcement api to announcement targets

### DIFF
--- a/.changeset/neat-insects-run.md
+++ b/.changeset/neat-insects-run.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add announcement api to announcement targets

--- a/packages/ui-extensions/src/surfaces/checkout/api/announcement/announcement.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/announcement/announcement.ts
@@ -1,0 +1,7 @@
+export interface Announcement {
+  announcement: {
+    close(): void;
+    addEventListener(type: 'close', cb: () => void): void;
+    removeEventListener(type: 'close', cb: () => void): void;
+  };
+}

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -24,6 +24,7 @@ import type {
   AllowedComponents,
   AnyComponentExcept,
 } from './shared';
+import {Announcement} from './api/announcement/announcement';
 
 /**
  * A UI extension will register for one or more extension targets using `shopify.extend()`.
@@ -652,7 +653,8 @@ export interface RenderExtensionTargets {
    */
   'purchase.thank-you.announcement.render': RenderExtension<
     OrderConfirmationApi &
-      StandardApi<'purchase.thank-you.announcement.render'>,
+      StandardApi<'purchase.thank-you.announcement.render'> &
+      Announcement,
     AnyComponent
   >;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/api/announcement/announcement.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/announcement/announcement.ts
@@ -1,0 +1,7 @@
+export interface Announcement {
+  announcement: {
+    close(): void;
+    addEventListener(type: 'close', cb: () => void): void;
+    removeEventListener(type: 'close', cb: () => void): void;
+  };
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -11,6 +11,7 @@ import {
   FulfillmentApi,
   ReturnApi,
 } from './api/standard-api/standard-api';
+import {Announcement} from './api/announcement/announcement';
 
 type Components = typeof import('./components');
 
@@ -95,7 +96,8 @@ export interface OrderStatusExtensionTargets {
    */
   'customer-account.order-status.announcement.render': RenderExtension<
     OrderStatusApi<'customer-account.order-status.announcement.render'> &
-      StandardApi<'customer-account.order-status.announcement.render'>,
+      StandardApi<'customer-account.order-status.announcement.render'> &
+      Announcement,
     AnyComponent
   >;
   'customer-account.order.page.render': RenderExtension<
@@ -126,7 +128,8 @@ export interface CustomerAccountExtensionTargets {
     AllComponents
   >;
   'customer-account.order-index.announcement.render': RenderExtension<
-    StandardApi<'customer-account.order-index.announcement.render'>,
+    StandardApi<'customer-account.order-index.announcement.render'> &
+      Announcement,
     AllComponents
   >;
   'customer-account.profile.block.render': RenderExtension<
@@ -134,7 +137,7 @@ export interface CustomerAccountExtensionTargets {
     AllComponents
   >;
   'customer-account.profile.announcement.render': RenderExtension<
-    StandardApi<'customer-account.profile.announcement.render'>,
+    StandardApi<'customer-account.profile.announcement.render'> & Announcement,
     AllComponents
   >;
   'customer-account.profile.addresses.render-after': RenderExtension<


### PR DESCRIPTION
### Background

Add announcement api to announcement targets so that
- extensions can call `api.close` to close the extension 
- extension can know when the extension is closed

UI-API-DESIGN side PR https://github.com/Shopify/ui-api-design/pull/1107 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
