### PR TITLE
Remove deprecation of min and max props in NumberField

### DIFF
--- a/.changeset/famous-badgers-dance.md
+++ b/.changeset/famous-badgers-dance.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+NumberField - remove deprecation of min and max props

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/NumberField/NumberField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/NumberField/NumberField.ts
@@ -9,11 +9,11 @@ import type {InputProps} from '../shared/InputField';
 export interface NumberFieldProps extends InputProps {
   inputMode?: 'decimal' | 'numeric';
   /**
-   * @deprecated Implement validation logic instead. This prop will be removed in 2025-10.
+   * The highest decimal or integer to be accepted for the field.
    */
   max?: number;
   /**
-   * @deprecated Implement validation logic instead. This prop will be removed in 2025-10.
+   * The lowest decimal or integer to be accepted for the field.
    */
   min?: number;
 }


### PR DESCRIPTION
### Background

Related to issue [#1999](https://github.com/shop/issues-retail/issues/1999)

### Solution

We are not deprecating min and max so I updated the docs.

### 🎩



- in ui-extension terminal, run `yarn docs:point-of-sale`
- in shopify-dev, run `dev s`
- Press ctrl + T to view in browser. Navigate to https://shopify-dev.myshopify.io/docs/api/pos-ui-extensions/unstable/components/numberfield

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/aQSCLikeEHKP71ewIlF3/d1c7feac-0e7a-4792-8653-9038363866f5.png)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation