### PR TITLE
Add Avatar and Thumbnail components with documentation and examples for Admin UI Extensions

### DIFF
--- a/packages/ui-extensions/src/docs/shared/components/Avatar.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Avatar.ts
@@ -1,0 +1,12 @@
+import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+
+const data: SharedReferenceEntityTemplateSchema = {
+  name: 'Avatar',
+  description:
+    'Show a user’s profile image or initials in a compact, visual element.',
+  category: 'Polaris web components',
+  subCategory: 'Media',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/docs/shared/components/Thumbnail.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Thumbnail.ts
@@ -1,0 +1,12 @@
+import {SharedReferenceEntityTemplateSchema} from '../docs-type';
+
+const data: SharedReferenceEntityTemplateSchema = {
+  name: 'Thumbnail',
+  description:
+    'Display a small preview image representing content, products, or media.',
+  category: 'Polaris web components',
+  subCategory: 'Media',
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar/Avatar.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar/Avatar.doc.ts
@@ -1,0 +1,36 @@
+import {AdminReferenceEntityTemplateSchema} from '../../docs-types';
+import sharedContent from '../../../../docs/shared/components/Avatar';
+
+const data: AdminReferenceEntityTemplateSchema = {
+  ...sharedContent,
+  thumbnail: '/assets/templated-apis-screenshots/admin/components/avatar.png',
+  isVisualComponent: true,
+  definitions: [
+    {
+      title: 'Properties',
+      description: '',
+      type: 'Avatar',
+    },
+    {
+      title: 'Events',
+      description:
+        'Learn more about [registering events](/docs/api/app-home/using-polaris-components#event-handling).',
+      type: 'AvatarEvents',
+    },
+  ],
+  defaultExample: {
+    image: 'avatar-default.png',
+    codeblock: {
+      title: 'Code',
+      tabs: [
+        {
+          code: './examples/default.html',
+          language: 'preview',
+          layout: 'inline',
+        },
+      ],
+    },
+  },
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar/examples/default.html
@@ -1,0 +1,4 @@
+<s-avatar
+  alt="John Doe"
+  initials="JD"
+></s-avatar>

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/Thumbnail.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/Thumbnail.doc.ts
@@ -1,0 +1,37 @@
+import {AdminReferenceEntityTemplateSchema} from '../../docs-types';
+import sharedContent from '../../../../docs/shared/components/Thumbnail';
+
+const data: AdminReferenceEntityTemplateSchema = {
+  ...sharedContent,
+  thumbnail:
+    '/assets/templated-apis-screenshots/admin/components/thumbnail.png',
+  isVisualComponent: true,
+  definitions: [
+    {
+      title: 'Properties',
+      description: '',
+      type: 'Thumbnail',
+    },
+    {
+      title: 'Events',
+      description:
+        'Learn more about [registering events](/docs/api/app-home/using-polaris-components#event-handling).',
+      type: 'ThumbnailEvents',
+    },
+  ],
+  defaultExample: {
+    image: 'thumbnail-default.png',
+    codeblock: {
+      title: 'Code',
+      tabs: [
+        {
+          code: './examples/default.html',
+          language: 'preview',
+          layout: 'inline',
+        },
+      ],
+    },
+  },
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/examples/default.html
@@ -1,0 +1,4 @@
+<s-thumbnail
+  alt="White sneakers"
+  src="/assets/products/sneakers.jpg">
+</s-thumbnail>


### PR DESCRIPTION
Adds the docs `Avatar` and `Thumbnail` components

## 🎩 

```sh
git checkout add-thumbnail-and-avatar-docs
yarn docs:admin 2025-10-rc
```

Then in `shopify-dev`

```sh
dev up && dev s
```

Go to 

- [Avatar page](https://shopify-dev.myshopify.io/docs/api/app-home/polaris-web-components/media/avatar)
- [Thumbnail page](https://shopify-dev.myshopify.io/docs/api/app-home/polaris-web-components/media/thumbnail)


<img width="1800" alt="avatar" src="https://github.com/user-attachments/assets/a8a2b03c-c555-4339-b5fd-3d624a97536e" />
<img width="1800" alt="thumbnail" src="https://github.com/user-attachments/assets/fd6a89ac-06f4-44c0-91c9-0d15831fafac" />

