### PR TITLE
Add Shopify email template category

### DIFF
--- a/.changeset/khaki-numbers-sneeze.md
+++ b/.changeset/khaki-numbers-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add shopify email template category

--- a/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate.ts
@@ -58,6 +58,7 @@ export type CustomerSegmentTemplateCategory =
   | 'reEngageCustomers'
   | 'abandonedCheckout'
   | 'purchaseBehaviour'
+  | 'shopifyEmail'
   | 'location';
 
 /**


### PR DESCRIPTION
### Background

Adding a new template category for Shopify Email related templates

### Solution

To have a new segment category display in the Segmentation Templates we need to add a new category from the extensions

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
