### PR TITLE
Added canNavigateToPosScreen function to Navigation API

### DIFF
--- a/.changeset/fair-news-dance.md
+++ b/.changeset/fair-news-dance.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Update StorageError interface

--- a/.changeset/forty-files-relax.md
+++ b/.changeset/forty-files-relax.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added an open function to the Navigation API to allow for navigation to POS native pages

--- a/.changeset/hot-suits-marry.md
+++ b/.changeset/hot-suits-marry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added canNavigateToPosScreen function to the Navigation API

--- a/.changeset/khaki-numbers-sneeze.md
+++ b/.changeset/khaki-numbers-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add shopify email template category

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -47,6 +47,12 @@ The Cart API enables UI Extensions to manage and interact with POS cart contents
       },
       {
         codeblock: generateCodeBlockForCartApi(
+          'Check editable state of the cart',
+          'check-cart-editable',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
           'Apply a cart level discount',
           'apply-cart-discount',
         ),

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/check-cart-editable.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/check-cart-editable.ts
@@ -1,0 +1,16 @@
+import {Cart, Tile, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.home.tile.render', (root, api) => {
+  const tile = root.createComponent(Tile, {
+    title: 'My App',
+    enabled: api.cart.subscribable.initial.editable ?? true,
+  });
+
+  api.cart.subscribable.subscribe((newCart: Cart) => {
+    tile.updateProps({
+      enabled: newCart.editable ?? true
+    });
+  });
+
+  root.append(tile);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/check-cart-editable.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/check-cart-editable.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {
+  reactExtension,
+  Tile,
+  useApi,
+  useCartEditable,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const SmartGridTile = () => {
+  const editable = useCartEditable();
+
+  return <Tile title="My App" enabled={editable} />;
+};
+
+export default reactExtension('pos.home.tile.render', () => <SmartGridTile />);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -44,6 +44,8 @@ const data: LandingTemplateSchema = {
 - Added optional \`taxLines\` property to [ShippingLine](/docs/api/pos-ui-extensions/targets/post-transaction/pos-transaction-complete-event-observe#transactioncompletedata-propertydetail-transaction) interface.
 - Added optional \`onBlur\` handler to [SearchBar](/docs/api/pos-ui-extensions/components/searchbar) component.
 - Added optional \`tone\` property to [Icon](/docs/api/pos-ui-extensions/components/icon) component and expanded \`name\` and \`size\` options.
+- Added optional \`editable\` property to \`Cart\` interface.
+- Added \`useCartEditable\` hook to access the cart's editable state.
 
 ### Developer Preview
 

--- a/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InternalCustomerSegmentTemplate/InternalCustomerSegmentTemplate.ts
@@ -58,6 +58,7 @@ export type CustomerSegmentTemplateCategory =
   | 'reEngageCustomers'
   | 'abandonedCheckout'
   | 'purchaseBehaviour'
+  | 'shopifyEmail'
   | 'location';
 
 /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -124,5 +124,4 @@ export type {
 export type {CountryCode} from './types/country-code';
 
 export type {Session} from './types/session';
-export type {Storage} from './types/storage';
-export {StorageError} from './types/storage';
+export type {Storage, StorageError} from './types/storage';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cart-api/cart-api.ts
@@ -30,19 +30,17 @@ export interface CartApiContent {
   subscribable: RemoteSubscribable<Cart>;
 
   /** Bulk update the cart
+   *
    * @param cartState the cart state to set
    * @returns the updated cart
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   bulkCartUpdate(cartState: CartUpdateInput): Promise<Cart>;
 
   /** Apply a cart level discount
+   *
    * @param type the type of discount applied (example: 'Percentage')
    * @param title the title attributed with the discount
    * @param amount the percentage or fixed monetary amount deducted with the discount. Pass in `undefined` if using discount codes.
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   applyCartDiscount(
     type: CartDiscountType,
@@ -52,98 +50,83 @@ export interface CartApiContent {
 
   /**
    * Add a code discount to the cart
-   * @param code the code for the discount to add to the cart
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param code the code for the discount to add to the cart
    */
   addCartCodeDiscount(code: string): Promise<void>;
 
   /**
    * Remove the cart discount
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   removeCartDiscount(): Promise<void>;
 
   /**
    * Remove all cart and line item discounts
-   * @param disableAutomaticDiscounts Whether or not automatic discounts should be enabled after removing the discounts.
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param disableAutomaticDiscounts Whether or not automatic discounts should be enabled after removing the discounts.
    */
   removeAllDiscounts(disableAutomaticDiscounts: boolean): Promise<void>;
 
   /**
    * Clear the cart
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   clearCart(): Promise<void>;
 
   /**
    * Set the customer in the cart
-   * @param customer the customer object to add to the cart
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param customer the customer object to add to the cart
    */
   setCustomer(customer: Customer): Promise<void>;
 
   /**
    * Remove the current customer from the cart
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   removeCustomer(): Promise<void>;
 
   /**
    * Add a custom sale to the cart
+   *
    * @param customSale the custom sale object to add to the cart
    * @returns {string} the uuid of the line item added
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   addCustomSale(customSale: CustomSale): Promise<string>;
 
   /**
    * Add a line item by variant ID to the cart
+   *
    * @param variantId the product variant's numeric ID to add to the cart
    * @param quantity the number of this variant to add to the cart
    * @returns {string} the uuid of the line item added
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   addLineItem(variantId: number, quantity: number): Promise<string>;
 
   /**
    * Remove the line item at this uuid from the cart
-   * @param uuid the uuid of the line item that should be removed
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param uuid the uuid of the line item that should be removed
    */
   removeLineItem(uuid: string): Promise<void>;
 
   /**
    * Adds custom properties to the cart
-   * @param properties the custom key to value object to attribute to the cart
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param properties the custom key to value object to attribute to the cart
    */
   addCartProperties(properties: Record<string, string>): Promise<void>;
 
   /**
    * Removes the specified cart properties
-   * @param keys the collection of keys to be removed from the cart properties
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param keys the collection of keys to be removed from the cart properties
    */
   removeCartProperties(keys: string[]): Promise<void>;
 
   /**
    * Adds custom properties to the specified line item
+   *
    * @param uuid the uuid of the line item to which the properties should be stringd
    * @param properties the custom key to value object to attribute to the line item
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   addLineItemProperties(
     uuid: string,
@@ -152,9 +135,8 @@ export interface CartApiContent {
 
   /**
    * Adds custom properties to multiple line items at the same time.
-   * @param lineItemProperties the collection of custom line item properties to apply to their respective line items.
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param lineItemProperties the collection of custom line item properties to apply to their respective line items.
    */
   bulkAddLineItemProperties(
     lineItemProperties: SetLineItemPropertiesInput[],
@@ -162,21 +144,19 @@ export interface CartApiContent {
 
   /**
    * Removes the specified line item properties
+   *
    * @param uuid the uuid of the line item to which the properties should be removed
    * @param keys the collection of keys to be removed from the line item properties
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   removeLineItemProperties(uuid: string, keys: string[]): Promise<void>;
 
   /**
    * Add a discount on a line item to the cart
+   *
    * @param uuid the uuid of the line item that should receive a discount
    * @param type the type of discount applied (example: 'Percentage')
    * @param title the title attributed with the discount
    * @param amount the percentage or fixed monetary amount deducted with the discout
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   setLineItemDiscount(
     uuid: string,
@@ -187,9 +167,8 @@ export interface CartApiContent {
 
   /**
    * Set line item discounts to multiple line items at the same time.
-   * @param lineItemDiscounts a map of discounts to add. They key is the uuid of the line item you want to add the discount to. The value is the discount input.
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param lineItemDiscounts a map of discounts to add. They key is the uuid of the line item you want to add the discount to. The value is the discount input.
    */
   bulkSetLineItemDiscounts(
     lineItemDiscounts: SetLineItemDiscountInput[],
@@ -197,18 +176,16 @@ export interface CartApiContent {
 
   /**
    * Sets an attributed staff to all line items in the cart.
-   * @param staffId the ID of the staff. Providing undefined will clear the attributed staff from all line items.
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param staffId the ID of the staff. Providing undefined will clear the attributed staff from all line items.
    */
   setAttributedStaff(staffId: number | undefined): Promise<void>;
 
   /**
    * Sets an attributed staff to a specific line items in the cart.
+   *
    * @param staffId the ID of the staff. Providing undefined will clear the attributed staff on the line item.
    * @param lineItemUuid the UUID of the line item.
-   *
-   * @throws CartNotEditableError if the cart is not currently editable.
    */
   setAttributedStaffToLineItem(
     staffId: number | undefined,
@@ -217,33 +194,29 @@ export interface CartApiContent {
 
   /**
    * Remove all discounts from a line item
-   * @param uuid the uuid of the line item whose discounts should be removed
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param uuid the uuid of the line item whose discounts should be removed
    */
   removeLineItemDiscount(uuid: string): Promise<void>;
 
   /**
    * Add an address to the customer (Customer must be present)
-   * @param address the address object to add to the customer in cart
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param address the address object to add to the customer in cart
    */
   addAddress(address: Address): Promise<void>;
 
   /**
    * Delete an address from the customer (Customer must be present)
-   * @param addressId the address ID to delete
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param addressId the address ID to delete
    */
   deleteAddress(addressId: number): Promise<void>;
 
   /**
    * Update the default address for the customer (Customer must be present)
-   * @param addressId the address ID to set as the default address
    *
-   * @throws CartNotEditableError if the cart is not currently editable.
+   * @param addressId the address ID to set as the default address
    */
   updateDefaultAddress(addressId: number): Promise<void>;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cart-api/errors.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cart-api/errors.ts
@@ -4,6 +4,8 @@ type CartApiMethods = Omit<CartApiContent, 'subscribable'>;
 
 /**
  * An error thrown when an attempt to edit the cart is made while it is not editable.
+ *
+ * @deprecated the cart will now throw a generic `Error`
  */
 export class CartNotEditableError extends Error {
   constructor(

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/navigation-api/navigation-api.ts
@@ -11,6 +11,39 @@ export interface NavigationApiContent {
 
   /** Dismisses the extension. */
   dismiss(): void;
+
+  /**
+   * Open POS screens. Resource screens open in a modal. Tabs close all modals before navigating to the tab.
+   * Available screens:
+   * - `gid://shopify/Product/<productId>` to open product details.
+   * - `gid://shopify/ProductVariant/<variantId>` to open product details for variant.
+   * - `gid://shopify/Customer/<customerId>` to open customer details.
+   * - `gid://shopify/Order/<orderId>` to open order details.
+   * - `gid://shopify/DraftOrder/<draftOrderId>` to open draft order details.
+   * - `gid://shopify/StaffMember/<staffMemberId>` to open staff details.
+   * - `pos://home-tab` to open the home tab.
+   * - `pos://cart-tab` to open the cart tab. Opens home tab on tablets.
+   * - `pos://products-tab` to open the products tab.
+   * - `pos://orders-tab` to open the orders tab.
+   * - `pos://customers-tab` to open the customers tab. Available only on tablets, and throws error on phones.
+   * - `pos://more-tab` to open the more tab.
+   *
+   * @example
+   * // Open product details screen for product id 123
+   * openUrl('gid://shopify/Product/123');
+   *
+   * @example
+   * // Open home tab
+   * openUrl('pos://home-tab');
+   *
+   * @example
+   * // Open home tab
+   * openUrl(new URL('pos://home-tab'));
+   *
+   * @param url - The POS screen to open
+   * @returns A promise that resolves when the POS screen is opened, rejects when an error occurs like an unsupported GID or POS screen.
+   */
+  open(url: string | URL): Promise<void>;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/navigation-api/navigation-api.ts
@@ -44,6 +44,13 @@ export interface NavigationApiContent {
    * @returns A promise that resolves when the POS screen is opened, rejects when an error occurs like an unsupported GID or POS screen.
    */
   open(url: string | URL): Promise<void>;
+
+  /**
+   * Check if a POS screen can be opened with `open` due to staff permissions and the current location's plan.
+   * @param url - The POS screen to check
+   * @returns A boolean indicating if the POS screen can be opened
+   */
+  canOpen(url: string | URL): boolean;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -1,12 +1,8 @@
-export class StorageError extends Error {
-  public name = 'StorageError';
-  constructor(
-    public code: 'RecordsCount' | 'RecordSize' | 'KeyType' | 'KeySize',
-    message: string,
-  ) {
-    super(message);
-  }
+export interface StorageError extends Error {
+  name: 'StorageError';
+  code: 'RecordsCount' | 'RecordSize' | 'KeyType' | 'KeySize';
 }
+
 export interface Storage<
   BaseStorageTypes extends Record<string, any> = Record<string, unknown>,
 > {
@@ -16,6 +12,7 @@ export interface Storage<
    * @param key - The key to set the value for.
    * @param value - The value to set for the key.
    * Can be any primitive type supported by `JSON.stringify`.
+   * @throws Error when the API version is lower than 2025-04.
    * @throws StorageError when:
    *    the extension exceeds its allotted storage limit.
    *    the value exceeds its allotted storage limit.
@@ -35,6 +32,7 @@ export interface Storage<
    * @param key - The key to get the value for.
    * @returns The value of the key.
    * If no value for the key exists, the resolved value is undefined.
+   * @throws Error when the API version is lower than 2025-04.
    * @throws StorageError when the key is not a string or exceeds its allotted size.
    */
   get<
@@ -46,12 +44,14 @@ export interface Storage<
 
   /**
    * Clears the storage.
+   * @throws Error when the API version is lower than 2025-04.
    */
   clear: () => Promise<void>;
 
   /**
    * Deletes a key from the storage.
    *
+   * @throws Error when the API version is lower than 2025-04.
    * @param key - The key to delete.
    */
   delete<
@@ -64,6 +64,7 @@ export interface Storage<
   /**
    * Gets all the keys and values in the storage.
    *
+   * @throws Error when the API version is lower than 2025-04.
    * @returns An array containing all the keys and values in the storage.
    */
   entries<


### PR DESCRIPTION
### Background

Resolves https://github.com/shop/issues-retail/issues/8397. This PR will be merged alongside [this PR](https://github.com/Shopify/pos-next-react-native/pull/63208).

### Solution

Added the canNavigateToPosScreen function to the Navigation API to allow partners to check whether or not they can navigate to said screen.

### 🎩

- Please follow the tophat instructions in [this PR](https://github.com/Shopify/pos-next-react-native/pull/63208)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
