### PR TITLE
Update navigateToPosScreen for tabs navigation

### DIFF
--- a/.changeset/poor-icons-clean.md
+++ b/.changeset/poor-icons-clean.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Adds POS tabs to the navigateToPosScreen API

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/navigation-api/navigation-api.ts
@@ -11,6 +11,13 @@ export interface NavigationApiContent {
 
   /** Dismisses the extension. */
   dismiss(): void;
+
+  /**
+   * Navigate to a POS screen. Screens will present in a modal. Tabs will close all open modals and navigate to the tab.
+   * An error will be thrown if the screen is not available on the current device (Ex. cart tab is only available on phones and not tablets).
+   * @param screen takes in a POS screen name and its parameters
+   */
+  navigateToPosScreen(screen: PosScreen): Promise<void>;
 }
 
 /**
@@ -19,3 +26,40 @@ export interface NavigationApiContent {
 export interface NavigationApi {
   navigation: NavigationApiContent;
 }
+
+/**
+ * The different POS screens and their parameters.
+ */
+export interface PosScreenParams {
+  /** Product details screen */
+  productDetails: {productId: number; variantId?: number};
+  /** Order details screen */
+  orderDetails: {orderId: number};
+  /** Customer details screen */
+  customerDetails: {customerId: number};
+  /** Staff details screen */
+  staffDetails: {staffId: number};
+  /** Draft order details screen */
+  draftOrderDetails: {draftOrderId: number};
+  /** Home tab */
+  homeTab: undefined;
+  /** Cart tab. On tablets, this will open the home tab. */
+  cartTab: undefined;
+  /** Products tab */
+  productsTab: undefined;
+  /** Orders tab */
+  ordersTab: undefined;
+  /** Customers tab. Only available on tablets and not phones. An error will be thrown if used on a phone. */
+  customersTab: undefined;
+  /** Staff tab */
+  staffTab: undefined;
+  /** More tab */
+  moreTab: undefined;
+}
+
+export type PosScreen = {
+  [K in keyof PosScreenParams]: {
+    screenName: K;
+    params: PosScreenParams[K];
+  };
+}[keyof PosScreenParams];


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-retail/issues/8201

This updates the `navigateToPosScreen` API so that we can also navigate to tabs in POS like Home/Cart.

Currently, this PR is off `unstable` branch so we can create a snapshot for the [pos-next-react-native changes](https://github.com/Shopify/pos-next-react-native/pull/63259) to point to while `2025-10-rc` is not yet ready.

### Solution

This is the API interface update, and should have enough comments to describe the pos screens and when we would throw an error.

Note: We have a task for this shopify-dev documentation and a PR will be up shortly once all our changes are ready.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation