### PR TITLE
Updating target limits on 2025-07

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/configuration.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/configuration.doc.ts
@@ -59,6 +59,7 @@ You can configure more than one type of extension within a configuration file.
 
 Along with the \`target\`, Shopify needs to know which code to execute for it. You specify the path to your code file by using the  \`module\` property.
 
+Each target has a limit of three active extensions. Once three extensions have been added to a specific target, the option will be deactivated for merchants.
 
       `,
       accordionContent: [


### PR DESCRIPTION
### Background

Currently [the docs for extension targets](https://shopify.dev/docs/api/checkout-ui-extensions/2024-04/configuration#targets) don't inform devs that targets have limitations, leading to confusion and poor dev experience. See slack convo here: https://shopify.slack.com/archives/C01FT69928K/p1744110562588039

See associated issue here: https://github.com/shop/issues-checkout/issues/3475

### Solution

This PR adds info regarding the limitations which are currently not documented:

![](https://screenshot.click/01-49-eb4vn-yfmz6.png)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation

