### PR TITLE
POS Targets: adds receipt header block target

### DIFF
--- a/.changeset/hip-seas-change.md
+++ b/.changeset/hip-seas-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Adds pos.receipt-header.block.render extension target

--- a/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
@@ -187,6 +187,10 @@ export interface RenderExtensionTargets {
     {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
     ReceiptComponents
   >;
+  'pos.receipt-header.block.render': RenderExtension<
+    {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
+    ReceiptComponents
+  >;
 }
 
 export interface ExtensionTargets


### PR DESCRIPTION
### Background

A partner working on a POS compliance extension requested to target the header of the printed receipt. Therefore, we're adding an extension target so that extension blocks can be added in that spot.

Closes https://github.com/shop/issues-retail/issues/15600

### Solution

We're duplicating the existing extension footer target definition, so this is not really new code.

### Checklist

- [ ] I have updated relevant documentation
