### PR TITLE
Update docs for all components to include id prop

### DIFF
--- a/.changeset/plenty-sheep-jam.md
+++ b/.changeset/plenty-sheep-jam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Update customer account ui extensions component props to include id

--- a/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
@@ -1,6 +1,6 @@
-import {Size} from './components/shared';
+import {Size, IdProps} from './components/shared';
 
-export interface CustomerAccountActionProps {
+export interface CustomerAccountActionProps extends IdProps {
   /**
    * Sets the heading of the Action container.
    */
@@ -30,7 +30,7 @@ declare module 'preact' {
   }
 }
 
-export interface ImageGroupProps {
+export interface ImageGroupProps extends IdProps {
   /**
    * Indicates the total number of items that could be displayed in the image group.
    * It is used to determine the remaining number to show when all the available image slots have been filled.
@@ -58,7 +58,7 @@ declare module 'preact' {
   }
 }
 
-export interface PageProps {
+export interface PageProps extends IdProps {
   /**
    * The main page heading
    */
@@ -91,14 +91,7 @@ declare module 'preact' {
   }
 }
 
-interface GlobalProps {
-  /**
-   * A unique identifier for the element.
-   */
-  id?: string;
-}
-
-export interface AvatarProps extends GlobalProps {
+export interface AvatarProps extends IdProps {
   /**
    * Initials to display in the avatar.
    */

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar.d.ts
@@ -1,11 +1,4 @@
-import {BaseElementPropsWithChildren, Size} from './shared';
-
-interface GlobalProps {
-  /**
-   * A unique identifier for the element.
-   */
-  id?: string;
-}
+import {BaseElementPropsWithChildren, Size, GlobalProps} from './shared';
 
 export interface AvatarProps extends GlobalProps {
   /**

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar.d.ts
@@ -1,6 +1,6 @@
-import {BaseElementPropsWithChildren, Size, GlobalProps} from './shared';
+import {BaseElementPropsWithChildren, Size, IdProps} from './shared';
 
-export interface AvatarProps extends GlobalProps {
+export interface AvatarProps extends IdProps {
   /**
    * Initials to display in the avatar.
    */

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction.d.ts
@@ -1,6 +1,6 @@
-import {BaseElementPropsWithChildren, GlobalProps} from './shared';
+import {BaseElementPropsWithChildren, IdProps} from './shared';
 
-export interface CustomerAccountActionProps extends GlobalProps {
+export interface CustomerAccountActionProps extends IdProps {
   /**
    * Sets the heading of the Action container.
    */

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction.d.ts
@@ -1,6 +1,6 @@
-import {BaseElementPropsWithChildren} from './shared';
+import {BaseElementPropsWithChildren, GlobalProps} from './shared';
 
-export interface CustomerAccountActionProps {
+export interface CustomerAccountActionProps extends GlobalProps {
   /**
    * Sets the heading of the Action container.
    */

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup.d.ts
@@ -1,6 +1,6 @@
-import {BaseElementPropsWithChildren} from './shared';
+import {BaseElementPropsWithChildren, GlobalProps} from './shared';
 
-export interface ImageGroupProps {
+export interface ImageGroupProps extends GlobalProps {
   /**
    * Indicates the total number of items that could be displayed in the image group.
    * It is used to determine the remaining number to show when all the available image slots have been filled.

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup.d.ts
@@ -1,6 +1,6 @@
-import {BaseElementPropsWithChildren, GlobalProps} from './shared';
+import {BaseElementPropsWithChildren, IdProps} from './shared';
 
-export interface ImageGroupProps extends GlobalProps {
+export interface ImageGroupProps extends IdProps {
   /**
    * Indicates the total number of items that could be displayed in the image group.
    * It is used to determine the remaining number to show when all the available image slots have been filled.

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
@@ -1,6 +1,6 @@
-import {BaseElementPropsWithChildren, GlobalProps} from './shared';
+import {BaseElementPropsWithChildren, IdProps} from './shared';
 
-export interface PageProps extends GlobalProps {
+export interface PageProps extends IdProps {
   /**
    * The main page heading
    */

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
@@ -1,6 +1,6 @@
-import {BaseElementPropsWithChildren} from './shared';
+import {BaseElementPropsWithChildren, GlobalProps} from './shared';
 
-export interface PageProps {
+export interface PageProps extends GlobalProps {
   /**
    * The main page heading
    */

--- a/packages/ui-extensions/src/surfaces/customer-account/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/shared.ts
@@ -5,6 +5,13 @@ export interface IdProps {
   id?: string;
 }
 
+export interface GlobalProps {
+  /**
+   * A unique identifier for the element.
+   */
+  id?: string;
+}
+
 export type Size =
   | 'extraSmall'
   | 'small'

--- a/packages/ui-extensions/src/surfaces/customer-account/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/shared.ts
@@ -5,13 +5,6 @@ export interface IdProps {
   id?: string;
 }
 
-export interface GlobalProps {
-  /**
-   * A unique identifier for the element.
-   */
-  id?: string;
-}
-
 export type Size =
   | 'extraSmall'
   | 'small'

--- a/packages/ui-extensions/src/surfaces/customer-account/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/shared.ts
@@ -1,6 +1,6 @@
 export interface IdProps {
   /**
-   * A unique identifier for the component.
+   * A unique identifier for the element.
    */
   id?: string;
 }


### PR DESCRIPTION
### Background

Updates all our component props to have id. 

Implemented in these places

https://github.com/shop/world/pull/98539
https://github.com/shop/world/pull/98496
https://github.com/shop/world/pull/98206

Avatar already has id

Also review https://github.com/Shopify/shopify-dev/pull/59980

### Solution

Used the IdProps type
<img width="1293" alt="Screenshot 2025-07-09 at 12 04 14 PM" src="https://github.com/user-attachments/assets/63624e1c-72f6-4d43-aad1-a385a416bd34" />

<img width="1293" alt="Screenshot 2025-07-09 at 12 04 07 PM" src="https://github.com/user-attachments/assets/a8b90f54-5ebc-4ceb-8e3b-81a20642a2f9" />

<img width="1293" alt="Screenshot 2025-07-09 at 12 04 47 PM" src="https://github.com/user-attachments/assets/33b75423-690e-4153-b329-28c502fb478d" />

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
