### PR TITLE
Documenting support for POS direct API 2025-07

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/pos-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/pos-overview.doc.ts
@@ -79,7 +79,7 @@ const data: LandingTemplateSchema = {
         {
           title: 'Note',
           type: 'info',
-          sectionContent: `App Authentication is available as of POS version 10.2.0 for extensions targeting \`unstable\`. This feature will be available for all extensions targeting stable API versions in the future.`,
+          sectionContent: `App Authentication is available as of POS version 10.6.0 for extensions targeting \`2025-07\` or later. This feature will be available for all extensions targeting stable API versions in the future.`,
         },
       ],
       sectionContent:
@@ -108,7 +108,7 @@ const data: LandingTemplateSchema = {
         {
           title: 'Note',
           type: 'info',
-          sectionContent: `Direct API access is available as of POS version 10.2.0 for extensions targeting \`unstable\`. This feature will be available for all extensions targeting stable API versions in the future.`,
+          sectionContent: `Direct API access is available as of POS version 10.6.0 for extensions targeting \`2025-07\` or later. This feature will be available for all extensions targeting stable API versions in the future.`,
         },
         {
           title: 'Access scopes',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -36,6 +36,7 @@ const data: LandingTemplateSchema = {
 
 ### Features
 
+- Added support for [Direct API access](/docs/api/pos-ui-extensions#direct-api-access), and [authenticated requests](/docs/api/pos-ui-extensions#app-authentication).
 - Added required \`posVersion\` property to [Session](/docs/api/pos-ui-extensions/apis/session-api) interface.
 - Added optional \`currency\` property to [Discount](/docs/api/pos-ui-extensions/apis/cart-line-item-api#cartlineitemapi-propertydetail-cartlineitem) interface.
 - Added \`executedAt\` property to [BaseTransactionComplete](/docs/api/pos-ui-extensions/targets/receipts/pos-receipt-footer-block-render#transactioncompletewithreprintdata-propertydetail-transaction) interface.


### PR DESCRIPTION
### Background
We were missing the doc updates for Direct API in version 2025-07. This adds the documentation to the pos overview page like we see in the unstable. It also updates the versioning static page.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩
- I will generate the code for the shopify-dev repo after this merges, by using the GH action. For now, just read the documentation that's being added and make sure it's under the correct header

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
