### PR TITLE
Remove the unsupported section from the versions page

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -15,30 +15,6 @@ const data: LandingTemplateSchema = {
   sections: [
     {
       type: 'Generic',
-      anchorLink: 'compatibility-policy',
-      title: 'Compatibility Policy',
-      sectionContent: '',
-      sectionNotice: [
-        {
-          title: 'End of Compatibility Plan',
-          type: 'Warning',
-          sectionContent: `
-          To ensure the best possible ongoing POS UI Extension development experience, starting in April 2025, we will end compatibility for versions on a one-year rolling basis. This means that POS will no longer run extensions using removed versions. This table details the end of compatibility schedule.
-
-|released version|removed versions|
-|---:|---|
-|2025-04|1.0.0, 1.0.1, 1.1.2, 1.2.0, 1.3.0, 1.4.0, 1.5.1, 1.6.0, 1.7.0, 2024-04|
-|2025-07|2024-07|
-|2025-10|2024-10|
-|2026-01|2025-01|
-|2026-04|2025-04|
-
-Refer to the [migration guide](/docs/api/pos-ui-extensions/migrating) for more information.`,
-        },
-      ],
-    },
-    {
-      type: 'Generic',
       anchorLink: '2024101',
       title: '2024.10.1',
       sectionContent: `

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -19,7 +19,6 @@ const data: LandingTemplateSchema = {
       title: '2024.10.1',
       sectionContent: `
 - Added in POS version: 9.22.0
-- Removed in POS version: N/A
 - Release day: 11/11/2024.
 
 ## Important Fixes
@@ -49,7 +48,6 @@ const data: LandingTemplateSchema = {
       title: '2024.10',
       sectionContent: `
 - Added in POS version: 9.19.0
-- Removed in POS version: N/A
 - Release day: 10/1/2024.
 
 ## Important Fixes
@@ -86,7 +84,6 @@ const data: LandingTemplateSchema = {
       title: '2024.07',
       sectionContent: `
 - Added in POS version: 9.15.0
-- Removed in POS version: N/A
 - Release day: 08/14/2024.
 
 ## Important Fixes
@@ -130,7 +127,6 @@ const data: LandingTemplateSchema = {
       ],
       sectionContent: `
 - Added in POS version: 9.11
-- Removed in POS version: 9.31.0
 - Release day: 06/10/2024.
 
 ### Features


### PR DESCRIPTION
### Background

We stopped ending support for older versions in POS.

### Solution

Remove the section suggesting we would end support.

### 🎩

See companion PR: https://github.com/Shopify/shopify-dev/pull/60045

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
