### PR TITLE
Remove preact file to fix build

### DIFF
--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -45,9 +45,6 @@
       ],
       "pos.*": [
         "./build/ts/surfaces/point-of-sale/targets/pos.*.d.ts"
-      ],
-      "point-of-sale/preact": [
-        "./build/ts/surfaces/point-of-sale/preact.d.ts"
       ]
     }
   },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/preact.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/preact.ts
@@ -1,3 +1,0 @@
-// This file serves as a side-effect import to ensure POS component types are loaded
-// when using preact with POS extensions
-import './components';


### PR DESCRIPTION
### Background

Currently, if you try to build 2025-10-rc, it will fail due to the preact.ts file. We dont need this.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
