### PR TITLE
Revert "Added navigateToNativeScreen function to Navigation API"

### DIFF
--- a/.changeset/pink-schools-accept.md
+++ b/.changeset/pink-schools-accept.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': minor
----
-
-Added a navigateToPosScreen option in the Navigation API

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -31,8 +31,6 @@ export type {LocaleApi, LocaleApiContent} from './api/locale-api/locale-api';
 export type {
   NavigationApiContent,
   NavigationApi,
-  PosScreen,
-  PosScreenParams,
 } from './api/navigation-api/navigation-api';
 
 export type {OrderApiContent, OrderApi} from './api/order-api/order-api';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -11,12 +11,6 @@ export interface NavigationApiContent {
 
   /** Dismisses the extension. */
   dismiss(): void;
-
-  /**
-   * Navigate to a POS screen. Screens will present in a modal.
-   * @param screen takes in a POS screen name and its parameters
-   */
-  navigateToPosScreen(screen: PosScreen): void;
 }
 
 /**
@@ -25,21 +19,3 @@ export interface NavigationApiContent {
 export interface NavigationApi {
   navigation: NavigationApiContent;
 }
-
-/**
- * The different POS screens and their parameters
- */
-export interface PosScreenParams {
-  productDetails: {productId: number; variantId?: number};
-  orderDetails: {orderId: number};
-  customerDetails: {customerId: number};
-  staffDetails: {staffId: number};
-  draftOrderDetails: {draftOrderId: number};
-}
-
-export type PosScreen = {
-  [K in keyof PosScreenParams]: {
-    screenName: K;
-    params: PosScreenParams[K];
-  };
-}[keyof PosScreenParams];


### PR DESCRIPTION
Reverts Shopify/ui-extensions#3014.

We are changing the function to be called open(url: string | URL) instead due to new design decisions.