### PR TITLE
[2025-10]Move analytics api from osp api to standard api in customer account ui extension.

### DIFF
--- a/.changeset/bright-spiders-jam.md
+++ b/.changeset/bright-spiders-jam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Move analytics api from osp api to standard api in customer account ui extension.

--- a/packages/ui-extensions/src/surfaces/customer-account/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api.ts
@@ -66,6 +66,7 @@ export type {
   Company,
   Customer,
   SessionToken,
+  Analytics,
   ApplyTrackingConsentChangeType,
   CustomerPrivacy,
   TrackingConsentChangeResult,

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -185,11 +185,6 @@ export type AuthenticationState = 'fully_authenticated' | 'pre_authenticated';
 
 export interface OrderStatusApi<Target extends ExtensionTarget> {
   /**
-   * Methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
-   */
-  analytics: Analytics;
-
-  /**
    * Gift Cards that have been applied to the order.
    */
   appliedGiftCards: StatefulRemoteSubscribable<AppliedGiftCard[]>;
@@ -950,13 +945,6 @@ export interface StoreCreditAccount {
    * The current balance of the Store Credit Account.
    */
   balance: Money;
-}
-
-export interface Analytics {
-  /**
-   * Publish method to emit analytics events to [Web Pixels](https://shopify.dev/docs/apps/marketing).
-   */
-  publish(name: string, data: {[key: string]: unknown}): Promise<boolean>;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -437,6 +437,50 @@ export interface SessionToken {
   get(): Promise<string>;
 }
 
+export interface Analytics {
+  /**
+   * Publish method to emit analytics events to [Web Pixels](https://shopify.dev/docs/apps/marketing).
+   */
+  publish(name: string, data: Record<string, unknown>): Promise<boolean>;
+
+  /**
+   * A method for capturing details about a visitor on the online store.
+   */
+  visitor(data: {email?: string; phone?: string}): Promise<VisitorResult>;
+}
+/**
+ * Represents a visitor result.
+ */
+export type VisitorResult = VisitorSuccess | VisitorError;
+
+/**
+ * Represents a successful visitor result.
+ */
+export interface VisitorSuccess {
+  /**
+   * Indicates that the visitor information was validated and submitted.
+   */
+  type: 'success';
+}
+
+/**
+ * Represents an unsuccessful visitor result.
+ */
+export interface VisitorError {
+  /**
+   * Indicates that the visitor information is invalid and wasn't submitted.
+   * Examples are using the wrong data type or missing a required property.
+   */
+  type: 'error';
+
+  /**
+   * A message that explains the error. This message is useful for debugging.
+   * It's **not** localized, and therefore should not be presented directly
+   * to the buyer.
+   */
+  message: string;
+}
+
 export interface AllowedProcessing {
   /**
    * Can collect customer analytics about how the shop was used and interactions made on the shop.

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -9,6 +9,7 @@ import {
   StorefrontApiVersion,
   Ui,
   SessionToken,
+  Analytics,
   CustomerPrivacy,
   ApplyTrackingConsentChangeType,
 } from '../shared';
@@ -78,6 +79,11 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * See [session token examples](https://shopify.dev/docs/api/customer-account-ui-extensions/apis/session-token#examples) for more information.
    */
   sessionToken: SessionToken;
+
+  /**
+   * Methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
+   */
+  analytics: Analytics;
 
   /**
    * The settings matching the settings definition written in the


### PR DESCRIPTION
### Background
Currently, `analytics` api only exists on order status targets. We will make it available on all customer account extension targets in 2025-10 rc.
Resolves: https://github.com/shop/issues-signals/issues/2167

### what have been changed:
1. Move analytics api from osp api to standard api in customer account ui extension.
2. In analytics api, add a new field named `analytics.visitor`

### Solution

Add `analytics` api on customer account standard api, similar as checkout: https://github.com/Shopify/ui-extensions/blob/unstable/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts#L492-L495

Checkout dev docs: https://shopify.dev/docs/api/checkout-ui-extensions/2025-07/apis/analytics

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
