### PR TITLE
Add toast api on standard api

### DIFF
--- a/.changeset/warm-pans-wash.md
+++ b/.changeset/warm-pans-wash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add toast api on customer accounts standard api

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -150,9 +150,6 @@ export interface Docs_Standard_CustomerPrivacyApi
 
 export interface Docs_Standard_UIApi extends Pick<StandardApi<any>, 'ui'> {}
 
-export interface Docs_Standard_ToastApi
-  extends Pick<StandardApi<any>, 'toast'> {}
-
 export interface Docs_Standard_QueryApi
   extends Pick<StandardApi<any>, 'query'> {}
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -150,6 +150,9 @@ export interface Docs_Standard_CustomerPrivacyApi
 
 export interface Docs_Standard_UIApi extends Pick<StandardApi<any>, 'ui'> {}
 
+export interface Docs_Standard_ToastApi
+  extends Pick<StandardApi<any>, 'toast'> {}
+
 export interface Docs_Standard_QueryApi
   extends Pick<StandardApi<any>, 'query'> {}
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -394,6 +394,24 @@ export interface CompanyLocation {
 
 export interface Ui {
   /**
+   * The Toast API displays a non-disruptive message that displays at the bottom
+   * of the interface to provide quick, at-a-glance feedback on the outcome
+   * of an action.
+   *
+   * How to use:
+   *
+   * - Use toasts to confirm successful actions.
+   *
+   * - Aim for two words.
+   *
+   * - Use noun + past tense verb format. For example, \`Changes saved\`.
+   *
+   * For errors, or information that needs to persist on the page, use a [banner](/docs/api/checkout-ui-extensions/unstable/components/feedback/banner) component.
+   */
+  toast: {
+    show(content: string): void;
+  };
+  /**
    * Refresh data so the surrounding information on the page is updated. The `content` string will appear in a toast message after refresh, to confirm the action was successful.
    *
    * To request access to this API:

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -394,24 +394,6 @@ export interface CompanyLocation {
 
 export interface Ui {
   /**
-   * The Toast API displays a non-disruptive message that displays at the bottom
-   * of the interface to provide quick, at-a-glance feedback on the outcome
-   * of an action.
-   *
-   * How to use:
-   *
-   * - Use toasts to confirm successful actions.
-   *
-   * - Aim for two words.
-   *
-   * - Use noun + past tense verb format. For example, \`Changes saved\`.
-   *
-   * For errors, or information that needs to persist on the page, use a [banner](/docs/api/checkout-ui-extensions/unstable/components/feedback/banner) component.
-   */
-  toast: {
-    show(content: string): void;
-  };
-  /**
    * Refresh data so the surrounding information on the page is updated. The `content` string will appear in a toast message after refresh, to confirm the action was successful.
    *
    * To request access to this API:
@@ -651,4 +633,11 @@ export interface TrackingConsentChangeResultError {
    * to the buyer.
    */
   message: string;
+}
+
+export interface ToastApiResult {
+  hide: () => void;
+}
+export interface ToastApi {
+  show: (content: string) => ToastApiResult;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -12,6 +12,7 @@ import {
   Analytics,
   CustomerPrivacy,
   ApplyTrackingConsentChangeType,
+  ToastApi,
 } from '../shared';
 
 import type {ExtensionTarget} from '../../extension-targets';
@@ -100,6 +101,23 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * Methods to interact with the extension's UI.
    */
   ui: Ui;
+
+  /**
+   * The Toast API displays a non-disruptive message that displays at the bottom
+   * of the interface to provide quick, at-a-glance feedback on the outcome
+   * of an action.
+   *
+   * How to use:
+   *
+   * - Use toasts to confirm successful actions.
+   *
+   * - Aim for two words.
+   *
+   * - Use noun + past tense verb format. For example, \`Changes saved\`.
+   *
+   * For errors, or information that needs to persist on the page, use a [banner](/docs/api/checkout-ui-extensions/unstable/components/feedback/banner) component.
+   */
+  toast: ToastApi;
 
   navigation: StandardExtensionNavigation;
 


### PR DESCRIPTION
### Background

Partially fixes https://github.com/shop/issues-checkout/issues/6460

### Solution

Added a toast api on standard api itself

### 🎩

Im just adding the type and nothing else for now. 

Will update docs and remove toast from ui in a follow up once implementation is complete in the host

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
