### PR TITLE
[2025-10]Export visitor result type on customer account ui extension

### DIFF
--- a/.changeset/grumpy-hornets-battle.md
+++ b/.changeset/grumpy-hornets-battle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Export visitor result type on customer account ui extension

--- a/packages/ui-extensions/src/surfaces/customer-account/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api.ts
@@ -75,6 +75,9 @@ export type {
   TrackingConsentMetafieldChange,
   VisitorConsent,
   VisitorConsentChange,
+  VisitorResult,
+  VisitorSuccess,
+  VisitorError,
 } from './api/shared';
 
 export type {CartLineItemApi} from './api/cart-line/cart-line-item';


### PR DESCRIPTION
### Background
Export visitor result type on customer account ui extension. They are introduced [in this PR
](https://github.com/Shopify/ui-extensions/pull/3074/files#diff-349e34e8b49a0561cbdbcda13981e056f71b2bd11f24dd2490e0eced51c472c0R465)
### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
