### PR TITLE
POS: adds receipt header block target

### DIFF
--- a/.changeset/hip-seas-change.md
+++ b/.changeset/hip-seas-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Adds pos.receipt-header.block.render extension target

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -185,6 +185,10 @@ export interface ExtensionTargets {
     {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
     ReceiptComponents
   >;
+  'pos.receipt-header.block.render': RenderExtension<
+    {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
+    ReceiptComponents
+  >;
 }
 
 export type ExtensionTarget = keyof ExtensionTargets;


### PR DESCRIPTION
### Background

Adds the changes from https://github.com/Shopify/ui-extensions/pull/3053 to unstable so that we can use them for POS compliance work, where we depend on the unstable version of the ui-extensions package to allow partners to work more quickly.

Related to https://github.com/shop/issues-retail/issues/15599.