### PR TITLE
Export Announcement type for use externally

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout.ts
@@ -143,6 +143,7 @@ export type {
   OrderStatusApi,
 } from './checkout/api/order-status/order-status';
 export type {OrderConfirmationApi} from './checkout/api/order-confirmation/order-confirmation';
+export type {Announcement} from './checkout/api/announcement/announcement';
 
 export type {CartLineItemApi} from './checkout/api/cart-line/cart-line-item';
 export type {PickupLocationListApi} from './checkout/api/pickup/pickup-location-list';

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -24,7 +24,7 @@ import type {
   AllowedComponents,
   AnyComponentExcept,
 } from './shared';
-import {Announcement} from './api/announcement/announcement';
+import type {Announcement} from './api/announcement/announcement';
 
 /**
  * A UI extension will register for one or more extension targets using `shopify.extend()`.


### PR DESCRIPTION
### Background

Mapped type in checkout-web for ui-extensions version 2025-07 couldn't correctly access Announcement type

### Solution

Export Announcement for use/reference outside package

### Note

Don't think it warrants a changeset as nothing really changing

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
