### PR TITLE
Add analytics api on 2025-07 customer account ui extension doc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/analytics.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/analytics.doc.ts
@@ -16,7 +16,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     codeblock: {
-      title: 'Using a session token with fetch()',
+      title: 'Publish',
       tabs: [
         {
           code: '../examples/apis/analytics-publish.example.tsx',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/analytics.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/analytics.doc.ts
@@ -1,3 +1,4 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
@@ -18,17 +19,41 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Using a session token with fetch()',
       tabs: [
         {
-          code: '../examples/apis/session-token.example.tsx',
+          code: '../examples/apis/analytics-publish.example.tsx',
           language: 'jsx',
           title: 'React',
         },
         {
-          code: '../examples/apis/session-token.example.ts',
+          code: '../examples/apis/analytics-publish.example.ts',
           language: 'js',
           title: 'JavaScript',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'You can submit visitor information to Shopify, these will be sent to the shop backend and not be propagated to web pixels on the page.',
+        codeblock: {
+          title: 'Visitor',
+          tabs: [
+            {
+              code: '../examples/apis/analytics-visitor.example.tsx',
+              language: 'jsx',
+              title: 'React',
+            },
+            {
+              code: '../examples/apis/analytics-visitor.example.ts',
+              language: 'js',
+              title: 'JavaScript',
+            },
+          ],
+        },
+      },
+    ],
   },
   related: [],
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/analytics.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/analytics.doc.ts
@@ -1,0 +1,36 @@
+import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Analytics',
+  description: 'The API for interacting with web pixels.',
+  isVisualComponent: false,
+  category: 'APIs',
+  type: 'API',
+  definitions: [
+    {
+      title: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.title,
+      description: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.description,
+      type: 'Docs_Standard_AnalyticsApi',
+    },
+  ],
+  defaultExample: {
+    codeblock: {
+      title: 'Using a session token with fetch()',
+      tabs: [
+        {
+          code: '../examples/apis/session-token.example.tsx',
+          language: 'jsx',
+          title: 'React',
+        },
+        {
+          code: '../examples/apis/session-token.example.ts',
+          language: 'js',
+          title: 'JavaScript',
+        },
+      ],
+    },
+  },
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.ts
@@ -1,0 +1,31 @@
+import {extension} from '@shopify/ui-extensions-react/customer-account';
+import {useEffect} from 'react';
+
+export default extension(
+  'purchase.checkout.block.render',
+  (root, {analytics}) => {
+    useEffect(() => {
+      analytics
+        .publish('checkout-extension-loaded', {
+          extensionName: 'My Extension',
+        })
+        .then((result) => {
+          if (result) {
+            console.log(
+              'succesfully published event, web pixels can now recieve this event',
+            );
+          } else {
+            console.log(
+              'failed to publish event',
+            );
+          }
+        })
+        .catch((error) => {
+          console.error(
+            'failed to publish event',
+          );
+          console.error('error', error);
+        });
+    });
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.ts
@@ -1,31 +1,27 @@
-import {extension} from '@shopify/ui-extensions-react/customer-account';
-import {useEffect} from 'react';
+import {extension} from '@shopify/ui-extensions/customer-account';
 
 export default extension(
-  'purchase.checkout.block.render',
+  'customer-account.order-status.block.render',
   (root, {analytics}) => {
-    useEffect(() => {
-      analytics
-        .publish('checkout-extension-loaded', {
+    analytics
+      .publish(
+        'customer-account-extension-loaded',
+        {
           extensionName: 'My Extension',
-        })
-        .then((result) => {
-          if (result) {
-            console.log(
-              'succesfully published event, web pixels can now recieve this event',
-            );
-          } else {
-            console.log(
-              'failed to publish event',
-            );
-          }
-        })
-        .catch((error) => {
-          console.error(
-            'failed to publish event',
+        },
+      )
+      .then((result) => {
+        if (result) {
+          console.log(
+            'succesfully published event, web pixels can now recieve this event',
           );
-          console.error('error', error);
-        });
-    });
+        } else {
+          console.log('failed to publish event');
+        }
+      })
+      .catch((error) => {
+        console.error('failed to publish event');
+        console.error('error', error);
+      });
   },
 );

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.tsx
@@ -1,13 +1,12 @@
-import {useState, useEffect} from 'react';
 import {
   Banner,
   reactExtension,
   useApi,
 } from '@shopify/ui-extensions-react/customer-account';
 
-export const purchaseCheckoutBlockRender =
+export const orderStatusBlockRender =
   reactExtension(
-    'purchase.checkout.block.render',
+    'customer-account.order-status.block.render',
     () => <Extension />,
   );
 
@@ -15,9 +14,12 @@ function Extension() {
   const {analytics} = useApi();
 
   analytics
-    .publish('checkout-extension-loaded', {
-      extensionName: 'My Extension',
-    })
+    .publish(
+      'customer-account-extension-loaded',
+      {
+        extensionName: 'My Extension',
+      },
+    )
     .then((result) => {
       if (result) {
         console.log(

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.tsx
@@ -1,0 +1,36 @@
+import {useState, useEffect} from 'react';
+import {
+  Banner,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/customer-account';
+
+export const purchaseCheckoutBlockRender =
+  reactExtension(
+    'purchase.checkout.block.render',
+    () => <Extension />,
+  );
+
+function Extension() {
+  const {analytics} = useApi();
+
+  analytics
+    .publish('checkout-extension-loaded', {
+      extensionName: 'My Extension',
+    })
+    .then((result) => {
+      if (result) {
+        console.log(
+          'succesfully published event, web pixels can now recieve this event',
+        );
+      } else {
+        console.log('failed to publish event');
+      }
+    })
+    .catch((error) => {
+      console.log('failed to publish event');
+      console.log('error', error);
+    });
+
+  return <Banner>See console for result</Banner>;
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.ts
@@ -1,0 +1,25 @@
+import {extension} from '@shopify/ui-extensions-react/customer-account';
+
+export default extension(
+  'purchase.checkout.block.render',
+  (root, {analytics}) => {
+    analytics
+      .visitor({
+        email: 'someEmail@example.com',
+        phone: '+1 555 555 5555',
+      })
+      .then((result) => {
+        if (result.type === 'success') {
+          console.log(
+            `Success`,
+            JSON.stringify(result),
+          );
+        } else {
+          console.log(
+            `Error`,
+            JSON.stringify(result),
+          );
+        }
+      });
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.ts
@@ -1,7 +1,7 @@
-import {extension} from '@shopify/ui-extensions-react/customer-account';
+import {extension} from '@shopify/ui-extensions/customer-account';
 
 export default extension(
-  'purchase.checkout.block.render',
+  'customer-account.order-status.block.render',
   (root, {analytics}) => {
     analytics
       .visitor({

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.tsx
@@ -1,13 +1,12 @@
-import {useState, useEffect} from 'react';
 import {
   Banner,
   reactExtension,
   useApi,
 } from '@shopify/ui-extensions-react/customer-account';
 
-export const purchaseCheckoutBlockRender =
+export const orderStatusBlockRender =
   reactExtension(
-    'purchase.checkout.block.render',
+    'customer-account.order-status.block.render',
     () => <Extension />,
   );
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.tsx
@@ -1,0 +1,31 @@
+import {useState, useEffect} from 'react';
+import {
+  Banner,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/customer-account';
+
+export const purchaseCheckoutBlockRender =
+  reactExtension(
+    'purchase.checkout.block.render',
+    () => <Extension />,
+  );
+
+function Extension() {
+  const {analytics} = useApi();
+
+  analytics
+    .visitor({
+      email: 'someEmail@example.com',
+      phone: '+1 555 555 5555',
+    })
+    .then((result) => {
+      if (result.type === 'success') {
+        console.log('Success', result);
+      } else {
+        console.error('Error', result);
+      }
+    });
+
+  return <Banner>See console for result</Banner>;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -67,6 +67,9 @@ export interface Docs_Standard_LocalizationApi
 export interface Docs_Standard_SessionTokenApi
   extends Pick<StandardApi<any>, 'sessionToken'> {}
 
+export interface Docs_Standard_AnalyticsApi
+  extends Pick<StandardApi<any>, 'analytics'> {}
+
 export interface Docs_Standard_SettingsApi
   extends Pick<StandardApi, 'settings'> {}
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -82,6 +82,8 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * Methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
+   *
+   * > Note: Requires to [connect a third-party domain](https://help.shopify.com/en/manual/domains/add-a-domain/connecting-domains/connect-domain-customer-account) to Shopify for your customer account pages.
    */
   analytics: Analytics;
 


### PR DESCRIPTION
### Background

We have move analytics api from order status api to standard api in this PR. https://github.com/shop/world/pull/104457

This PR is to update public document. You can refer to this PR: https://github.com/Shopify/shopify-dev/pull/60394

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
