### PR TITLE
[UI Components]: Fix missing type error

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/shared.ts
@@ -39,6 +39,7 @@ export type AnyComponent =
   | 'Stack'
   | 'Text'
   | 'TextArea'
+  | 'TextField'
   | 'Time'
   | 'UnorderedList';
 


### PR DESCRIPTION
### Background

- @simontaisne noticed that the TextField component missing in the types when using it on extensions, I noticed we forgot to add them in the AllowedComponents list.

### Solution

- Adding missing TextField component in the list of component types for extensions.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
