### PR TITLE
Clarify DirectAPI and AuthAPI versions, add note for LineItemDetails …

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/pos-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/pos-overview.doc.ts
@@ -79,7 +79,7 @@ const data: LandingTemplateSchema = {
         {
           title: 'Note',
           type: 'info',
-          sectionContent: `App Authentication is available as of POS version 10.6.0 for extensions targeting \`2025-07\` or later. This feature will be available for all extensions targeting stable API versions in the future.`,
+          sectionContent: `App Authentication is available as of POS version 10.6.0 for extensions targeting \`2025-07\` or later.`,
         },
       ],
       sectionContent:
@@ -108,7 +108,7 @@ const data: LandingTemplateSchema = {
         {
           title: 'Note',
           type: 'info',
-          sectionContent: `Direct API access is available as of POS version 10.6.0 for extensions targeting \`2025-07\` or later. This feature will be available for all extensions targeting stable API versions in the future.`,
+          sectionContent: `Direct API access is available as of POS version 10.6.0 for extensions targeting \`2025-07\` or later.`,
         },
         {
           title: 'Access scopes',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -47,6 +47,7 @@ const data: LandingTemplateSchema = {
 - Added optional \`tone\` property to [Icon](/docs/api/pos-ui-extensions/components/icon) component and expanded \`name\` and \`size\` options.
 - Added optional \`editable\` property to \`Cart\` interface.
 - Added \`useCartEditable\` hook to access the cart's editable state.
+- Added support for the ${TargetLink.PosCartLineItemDetailsActionMenuItemRender} and ${TargetLink.PosCartLineItemDetailsActionRender} targets on the cart line item details screen.
 
 ### Developer Preview
 


### PR DESCRIPTION
…action extensions on the version page

### Background

https://shopify.slack.com/archives/C07TB5BRP0Q/p1751899318607069 A couple of details were missing or unclear in our 2025-07 documentation.

### Solution

Clarify by removing the "Will be available" wording for Direct and Auth API's, and add an entry to the changelog about the line item details action targets.

### 🎩

See companion PR: https://github.com/Shopify/shopify-dev/pull/60423

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
