### PR TITLE
[Doc] add analytics api to customer account ui extension 2025-10-rc doc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/analytics.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/analytics.doc.ts
@@ -1,0 +1,52 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Analytics',
+  description: 'The API for interacting with web pixels.',
+  isVisualComponent: false,
+  category: 'APIs',
+  type: 'API',
+  definitions: [
+    {
+      title: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.title,
+      description: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.description,
+      type: 'Docs_Standard_AnalyticsApi',
+    },
+  ],
+  defaultExample: {
+    codeblock: {
+      title: 'Publish',
+      tabs: [
+        {
+          code: '../examples/apis/analytics-publish.example.tsx',
+          language: 'jsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'You can submit visitor information to Shopify, these will be sent to the shop backend and not be propagated to web pixels on the page.',
+        codeblock: {
+          title: 'Visitor',
+          tabs: [
+            {
+              code: '../examples/apis/analytics-visitor.example.tsx',
+              language: 'jsx',
+              title: 'Preact',
+            },
+          ],
+        },
+      },
+    ],
+  },
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.tsx
@@ -1,0 +1,35 @@
+import {render} from 'preact';
+import {useEffect} from 'preact/hooks';
+
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  useEffect(() => {
+    shopify.analytics
+      .publish(
+        'customer-account-extension-loaded',
+        {
+          extensionName: 'My Extension',
+        },
+      )
+      .then((result) => {
+        if (result) {
+          console.log(
+            'succesfully published event, web pixels can now recieve this event',
+          );
+        } else {
+          console.log('failed to publish event');
+        }
+      })
+      .catch((error) => {
+        console.log('failed to publish event');
+        console.log('error', error);
+      });
+  }, []);
+
+  return (
+    <s-banner>See console for result</s-banner>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.tsx
@@ -1,0 +1,27 @@
+import {render} from 'preact';
+import {useEffect} from 'preact/hooks';
+
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  useEffect(() => {
+    shopify.analytics
+      .visitor({
+        email: 'someEmail@example.com',
+        phone: '+1 555 555 5555',
+      })
+      .then((result) => {
+        if (result.type === 'success') {
+          console.log('Success', result);
+        } else {
+          console.error('Error', result);
+        }
+      });
+  }, []);
+
+  return (
+    <s-banner>See console for result</s-banner>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -139,6 +139,9 @@ export interface Docs_Standard_LocalizationApi
 export interface Docs_Standard_SessionTokenApi
   extends Pick<StandardApi<any>, 'sessionToken'> {}
 
+export interface Docs_Standard_AnalyticsApi
+  extends Pick<StandardApi<any>, 'analytics'> {}
+
 export interface Docs_Standard_SettingsApi
   extends Pick<StandardApi, 'settings'> {}
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -83,6 +83,8 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * Methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
+   *
+   * > Note: Requires to [connect a third-party domain](https://help.shopify.com/en/manual/domains/add-a-domain/connecting-domains/connect-domain-customer-account) to Shopify for your customer account pages.
    */
   analytics: Analytics;
 


### PR DESCRIPTION
### Background

More context could be seen here: https://github.com/Shopify/shopify-dev/pull/60534

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
