### PR TITLE
update 2025-10 migration docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/new-tsconfig.example.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/new-tsconfig.example.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  }
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/old-tsconfig.example.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/old-tsconfig.example.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["./src"]
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/support-new-shopify-global.example.bash
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/support-new-shopify-global.example.bash
@@ -1,0 +1,5 @@
+# Upgrade to latest version of the CLI
+npm install -g @shopify/cli
+
+# Run the app to generate the type definition file
+shopify app dev

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
@@ -91,6 +91,52 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
     },
     {
       type: 'GenericAccordion',
+      anchorLink: 'make-typescript-adjustments',
+      title: 'Make TypeScript adjustments',
+      sectionContent: `
+These steps make TypeScript aware of the new global \`shopify\` object. Skip these steps if your app was not built using TypeScript.
+`,
+      accordionContent: [
+        {
+          title: "Update your extension's tsconfig.json",
+          description:
+            "Update your extension config at a path like `extensions/{extension-name}/tsconfig.json`. You do **not** need to change your app's root `tsconfig.json` file.",
+          codeblock: {
+            title: "Update your extension's tsconfig.json",
+            tabs: [
+              {
+                title: 'New tsconfig.json',
+                code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
+                language: 'json',
+              },
+              {
+                title: 'Old tsconfig.json',
+                code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+        {
+          title:
+            'Generate type definition file to support new global shopify object',
+          description:
+            'These commands generate a `shopify.d.ts` file in your extension directory.',
+          codeblock: {
+            title: 'Support new global shopify object',
+            tabs: [
+              {
+                title: 'CLI',
+                code: './examples/upgrading-to-2025-10/support-new-shopify-global.example.bash',
+                language: 'bash',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      type: 'GenericAccordion',
       anchorLink: 'migrate-api-calls',
       title: 'Migrate API calls',
       sectionContent:


### PR DESCRIPTION
resolves: https://github.com/shop/issues-checkout/issues/5712
Additional docs to bring TypeScript up to speed for 2025-10 related changes

corresponding [world PR](https://github.com/shop/world/pull/108880)

tsconfig.json updates
<img width="1713" height="932" alt="image" src="https://github.com/user-attachments/assets/0ecc1c1b-a56f-4bb7-abc8-e7d98ae6634d" />

CLI commands to generate shopify.d.ts
<img width="1713" height="932" alt="image" src="https://github.com/user-attachments/assets/58c47e25-8afc-4a75-a891-f9b7b3b9f7ee" />

Second code tab showing old tsconfig.json
<img width="1461" height="586" alt="image" src="https://github.com/user-attachments/assets/af8baf18-1202-4b20-a99c-7e2873a23999" />
