### PR TITLE
Add 'Considerations' section to s-admin-block docs about height limit

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'AdminBlock',
   description:
-    '`s-admin-block` is similar to the AdminAction, providing a deeper integration with the container your UI is rendered into. This component should only be used in Block Extensions, which render inline on a resource page.',
+    '`s-admin-block` provides a deeper integration with the container your UI is rendered into. This component should only be used in Block Extensions, which render inline on a resource page.',
   requires: '',
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/adminblock.png',

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'AdminBlock',
   description:
-    '`s-admin-block` is similar to the AdminBlock, providing a deeper integration with the container your UI is rendered into. However, this only applies to Block Extensions which render inline on a resource page.',
+    '`s-admin-block` is similar to the AdminAction, providing a deeper integration with the container your UI is rendered into. However, this only applies to Block Extensions which render inline on a resource page.',
   requires: '',
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/adminblock.png',
@@ -18,6 +18,17 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Other',
+  subSections: [
+    {
+      title: 'Considerations',
+      type: 'Generic' as const,
+      anchorLink: 'considerations',
+      sectionContent: `- Initial height is limited to 300px.
+- When content exceeds the height limit, a "Show more" button appears.
+- In development, the following warning also displays: "Warning! This Block is too tall."
+- After expanding, content outside the container is cut off with a link to navigate to the extension's app.`,
+    },
+  ],
   defaultExample: {
     image:
       '/assets/templated-apis-screenshots/admin/components/adminblock-example.png',

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'AdminBlock',
   description:
-    '`s-admin-block` is similar to the AdminAction, providing a deeper integration with the container your UI is rendered into. However, this only applies to Block Extensions which render inline on a resource page.',
+    '`s-admin-block` is similar to the AdminAction, providing a deeper integration with the container your UI is rendered into. This component should only be used in Block Extensions, which render inline on a resource page.',
   requires: '',
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/adminblock.png',

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
@@ -26,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `- Initial height is limited to 300px.
 - When content exceeds the height limit, a "Show more" button appears.
 - In development, the following warning also displays: "Warning! This Block is too tall."
-- After expanding, content outside the container is cut off with a link to navigate to the extension's app.`,
+- After expanding to the max height, content that exceeds the limit is cut off, and the merchant must navigate to the extension's app via the provided link.`,
     },
   ],
   defaultExample: {


### PR DESCRIPTION
### Background

This PR corrects the documentation for the `AdminBlock` component and adds important considerations for developers using this component.

### Solution

- Fixed an incorrect reference in the description, changing "AdminBlock" to "AdminAction" for clarity
- Added a new "Considerations" section that outlines important height limitations and behavior:
  - Initial 300px height limit
  - "Show more" button behavior when content exceeds the limit
  - Development warning for oversized blocks
  - Content overflow handling with navigation link

These changes provide developers with clearer documentation about how the AdminBlock component behaves, particularly regarding height constraints and overflow handling.

### 🎩

https://shopify-dev.myshopify.io/docs/api/admin-extensions/2025-10-rc/components/other/adminblock

- Verified the documentation renders correctly
- Confirmed the description correction is accurate
- Ensured the new considerations section provides valuable information for developers

### Checklist

- [x] I have 🎩'd these changes
- [ ] I have updated relevant documentation

## References

- Prior Art: **Considerations** section in `Heading` docs
   - https://shopify.dev/docs/api/admin-extensions/2025-10-rc/polaris-web-components/titles-and-text/heading