### PR TITLE
Move force data refresh to global api

### DIFF
--- a/.changeset/silly-seas-stare.md
+++ b/.changeset/silly-seas-stare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Move forceDataRefresh from ui to standard-api

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -121,6 +121,21 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    */
   toast: ToastApi;
 
+  /**
+   * Refresh data so the surrounding information on the page is updated. The `content` string will appear in a toast message after refresh, to confirm the action was successful.
+   *
+   * To request access to this API:
+   *
+   * 1. Go to your partner dashboard and click **Apps**.
+   *
+   * 2. Select the app you need to request access for.
+   *
+   * 3. Click **API access**.
+   *
+   * 4. Under **Access force data refresh**, click **Request access**.
+   */
+  forceDataRefresh(content: string): Promise<void>;
+
   navigation: StandardExtensionNavigation;
 
   /**


### PR DESCRIPTION
### Background

Partially fixes https://github.com/shop/issues-checkout/issues/6460

### Solution

Just copies the api under standard api

### 🎩

Nothing to tophat really just copying a type to standard api

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
