### PR TITLE
Adds tagged code for cash management tutorial

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/BannerAlert.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/BannerAlert.tsx
@@ -12,6 +12,7 @@ import {useBusinessRules} from './useBusinessRules';
 // 2. Implement the `BannerAlert` component
 const BannerAlert = () => {
   // [END banner-alert.component]
+
   // [START banner-alert.api]
   // 3. Setup the api
   const api = useApi<'pos.cash-session-details.banner.render'>();
@@ -34,12 +35,10 @@ const BannerAlert = () => {
   // [END banner-alert.loading-state]
 
   // [START banner-alert.render-implementation]
-  // 6. Display an alert banner if a business rule is violated
+  // 6. Display an alert banner when a business rule is violated
   if (isViolated) {
     return <Banner title={alertMessage} variant="alert" visible />;
   }
-
-  return null;
   // [END banner-alert.render-implementation]
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/BannerAlert.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/BannerAlert.tsx
@@ -1,0 +1,51 @@
+import React, {useState, useEffect} from 'react';
+
+import {
+  reactExtension,
+  Banner,
+  useApi,
+  Text,
+} from '@shopify/ui-extensions-react/point-of-sale';
+import {useBusinessRules} from './useBusinessRules';
+
+// [START banner-alert.component]
+// 2. Implement the `BannerAlert` component
+const BannerAlert = () => {
+  // [END banner-alert.component]
+  // [START banner-alert.api]
+  // 3. Setup the api
+  const api = useApi<'pos.cash-session-details.banner.render'>();
+  // [END banner-alert.api]
+
+  // [START banner-alert.use-business-rules]
+  // 4. Check if any business rules are violated using the useBusinessRules hook
+  const [deviceId, setDeviceId] = useState<string>('');
+  useEffect(() => {
+    api.device.getDeviceId().then(setDeviceId);
+  }, []);
+  const {isViolated, alertMessage, loading} = useBusinessRules(deviceId);
+  // [END banner-alert.use-business-rules]
+
+  // [START banner-alert.loading-state]
+  // 5. Handle error and loading states
+  if (loading) {
+    return <Text>Loading...</Text>;
+  }
+  // [END banner-alert.loading-state]
+
+  // [START banner-alert.render-implementation]
+  // 6. Display an alert banner if a business rule is violated
+  if (isViolated) {
+    return <Banner title={alertMessage} variant="alert" visible />;
+  }
+
+  return null;
+  // [END banner-alert.render-implementation]
+};
+
+// [START banner-alert.render-extension]
+// 1. Render the BannerAlert component at the `pos.cash-session-details.banner.render` target
+export default reactExtension('pos.cash-session-details.banner.render', () => (
+  <BannerAlert />
+));
+// [END banner-alert.render-extension]

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/InStoreCashInfo.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/InStoreCashInfo.tsx
@@ -1,0 +1,102 @@
+import React, {useState, useEffect} from 'react';
+
+import {
+  Text,
+  useApi,
+  reactExtension,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+// [START in-store-cash-info.component]
+// 2. Implement the `InStoreCashInfo` component
+const InStoreCashInfo = () => {
+  // [END in-store-cash-info.component]
+
+  // [START in-store-cash-info.api]
+  // 3. Setup the api
+  const api = useApi<'pos.cash-session-details.block.render'>();
+  const {locationId} = api.session.currentSession;
+  // [END in-store-cash-info.api]
+
+  // [START in-store-cash-info.fetch-drawer-amount]
+  // 4. Fetch the total amount of cash on hand at the location
+  const [totalDrawerAmount, setTotalDrawerAmount] = useState<number | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const fetchTotalDrawerAmount = async (locationId: number) => {
+    const result = await fetch('shopify:admin/api/graphql.json', {
+      method: 'POST',
+      body: JSON.stringify({
+        query: `
+          TBD
+        `,
+        variables: {
+          locationId: `gid://shopify/Location/${locationId}`,
+        },
+      }),
+    });
+
+    const json = await result.json();
+
+    if (json.errors) {
+      console.error('GraphQL Errors:', json.errors);
+      json.errors.forEach((error: any) => {
+        console.error('GraphQL Error Details:', error);
+      });
+      return null;
+    }
+
+    if (!result.ok) {
+      console.error('Network Error:', result.statusText);
+      return null;
+    }
+
+    return json.data;
+  };
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const amount = await fetchTotalDrawerAmount(locationId);
+        setTotalDrawerAmount(amount);
+      } catch (err) {
+        console.error('Error fetching drawer amount:', err);
+        setError('Unable to fetch cash drawer information');
+      }
+      setLoading(false);
+    };
+
+    loadData();
+  }, []);
+  // [END in-store-cash-info.fetch-drawer-amount]
+
+  // [START in-store-cash-info.loading-error]
+  // 5. Handle loading and error states
+  if (loading) {
+    return <Text>Loading...</Text>;
+  }
+
+  if (error) {
+    return <Text color="TextWarning">{error}</Text>;
+  }
+  // [END in-store-cash-info.loading-error]
+
+  // [START in-store-cash-info.render-implementation]
+  // 6. Display the total amount of cash on hand at the location
+  return (
+    <Text>
+      {totalDrawerAmount !== null
+        ? `$${totalDrawerAmount.toFixed(2)}`
+        : 'No data available'}
+    </Text>
+  );
+  // [END in-store-cash-info.render-implementation]
+};
+
+// [START in-store-cash-info.render-extension]
+// 1. Render the InStoreCashInfo component at the `pos.cash-session-details.block.render` target
+export default reactExtension('pos.cash-session-details.block.render', () => (
+  <InStoreCashInfo />
+));
+// [END in-store-cash-info.render-extension]

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/SafeModal.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/SafeModal.tsx
@@ -18,7 +18,7 @@ import {
 import type {Storage} from '@shopify/ui-extensions/point-of-sale';
 
 // [START safe-modal.data-interfaces]
-// 2. Define the data structures for safe activity data and safe details.
+// 2. Define safe management data
 interface SafeActivity {
   id: number;
   type: string;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/SafeModal.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/SafeModal.tsx
@@ -8,21 +8,23 @@ import {
   useApi,
   Button,
   Stack,
-  Section,
   TextField,
   List,
   ListRowSubtitle,
+  Navigator,
+  SectionHeader,
 } from '@shopify/ui-extensions-react/point-of-sale';
 
 import type {Storage} from '@shopify/ui-extensions/point-of-sale';
 
 // [START safe-modal.data-interfaces]
-// 2. Define the interfaces for storing safe management data
+// 2. Define the data structures for safe activity data and safe details.
 interface SafeActivity {
   id: number;
   type: string;
   amount: number;
   timestamp: Date;
+  staffName?: string;
 }
 
 interface SafeDetails {
@@ -36,20 +38,19 @@ interface SafeDetails {
 const SafeModal = () => {
   const [activityType, setActivityType] = useState('deposit');
   const [amount, setAmount] = useState('');
-  // [END safe-modal.component]
-
-  // [START safe-modal.storage-setup]
-  // 4. Setup the api and storage
-  const api = useApi<'pos.product-details.action.render'>();
-  const storage: Storage<SafeDetails> = api.storage;
-
-  // 5. Setup the states for the safe management data
   const [balance, setBalance] = useState<number>(0);
   const [activities, setActivities] = useState<SafeActivity[]>([]);
-  // [END safe-modal.storage-setup]
+  // [END safe-modal.component]
+
+  // [START safe-modal.api-storage]
+  // 4. Setup the api and storage
+  const api = useApi<'pos.cash-session-details.action.render'>();
+  const storage: Storage<SafeDetails> = api.storage;
+  const {staffMemberId} = api.session.currentSession;
+  // [END safe-modal.api-storage]
 
   // [START safe-modal.load-data]
-  // 6. Load the data from the storage
+  // 5. Intalize or load the data from the storage
   useEffect(() => {
     const loadData = async () => {
       try {
@@ -68,31 +69,30 @@ const SafeModal = () => {
   // [END safe-modal.load-data]
 
   // [START safe-modal.handle-activity]
-  // 7. Implement deposit and withdrawal logic
+  // 6. Implement deposit and withdraw logic
   const handleActivity = async () => {
     const activityAmount = parseFloat(amount);
 
     try {
-      let newBalance = balance;
       if (activityType === 'deposit') {
-        newBalance = balance + activityAmount;
-      } else if (activityType === 'withdrawal') {
-        newBalance = balance - activityAmount;
+        setBalance(balance + activityAmount);
+      } else if (activityType === 'withdraw') {
+        setBalance(balance - activityAmount);
       }
-      setBalance(newBalance);
-      await storage.set('balance', newBalance);
+      await storage.set('balance', balance);
 
       const newActivity: SafeActivity = {
         id: activities.length + 1,
         type: activityType,
         amount: activityAmount,
         timestamp: new Date(),
+        staffName: staffMemberId?.toString(),
       };
-      const updatedActivities = [...activities, newActivity];
-      setActivities(updatedActivities);
-      await storage.set('activities', updatedActivities);
+      setActivities([...activities, newActivity]);
+      await storage.set('activities', activities);
 
       setAmount('');
+      api.navigation.pop();
     } catch (error) {
       console.error('Error saving activity:', error);
     }
@@ -100,76 +100,135 @@ const SafeModal = () => {
   // [END safe-modal.handle-activity]
 
   // [START safe-modal.validation]
-  // 8. Check if the activity amount is valid
+  // 7. Check if the activity amount is valid
   const canSubmit = () => {
     const activityAmount = parseFloat(amount);
     if (isNaN(activityAmount) || activityAmount <= 0) return false;
-    if (activityType === 'withdrawal' && activityAmount > balance) return false;
+    if (activityType === 'withdraw' && activityAmount > balance) return false;
     return true;
   };
   // [END safe-modal.validation]
 
   // [START safe-modal.format-activities]
-  // 9. Format the activities in to a list
+  // 8. Format the activities into a list
   const activityListData = (activities || []).map((activity: SafeActivity) => ({
     id: activity.id.toString(),
     leftSide: {
-      label: `$${(activity.amount || 0).toFixed(2)}`,
+      label: new Date(activity.timestamp).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      }),
       subtitle: [
         {
-          content: activity.type === 'deposit' ? 'Deposit' : 'Withdrawal',
+          content: activity.staffName,
         },
       ] as [ListRowSubtitle],
     },
     rightSide: {
-      label: new Date(activity.timestamp).toLocaleString(),
+      label: `${activity.type === 'deposit' ? '+' : '-'} $${(
+        activity.amount || 0
+      ).toFixed(2)}`,
     },
   }));
   // [END safe-modal.format-activities]
 
-  // 10. Render the SafeModal component to use the safe management solution
+  // [START safe-modal.format-overview]
+  // 9. Format the safe overview into a list
+  const overviewListData = [
+    {
+      id: 'current-balance',
+      leftSide: {
+        label: 'Current balance:',
+      },
+      rightSide: {
+        label: `$${(balance || 0).toFixed(2)}`,
+      },
+    },
+    {
+      id: 'last-activity',
+      leftSide: {
+        label: 'Last activity:',
+      },
+      rightSide: {
+        label:
+          activities.length > 0
+            ? new Date(
+                activities[activities.length - 1].timestamp,
+              ).toLocaleString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+              })
+            : 'No activities yet',
+      },
+    },
+  ];
+  // [END safe-modal.format-overview]
+
+  // [START safe-modal.render-ui]
+  // 10. Render the SafeModal component to display the safe management solution
   return (
-    <Screen name="SafeManagement" title="Safe Management">
-      <ScrollView>
-        {/* [START safe-modal.overview-section] */}
-        <Section title="Overview">
-          <Stack padding="200">
-            <Text>Current Balance</Text>
-            <Text>${(balance || 0).toFixed(2)}</Text>
-          </Stack>
-          <Stack padding="200">
-            <Text>Activities Count</Text>
-            <Text>{activities.length}</Text>
-          </Stack>
-        </Section>
-        {/* [END safe-modal.overview-section] */}
+    <Navigator>
+      <Screen name="SafeManagement" title="Manage Safe">
+        <ScrollView>
+          <Stack
+            direction="inline"
+            gap="300"
+            inlineSize="100%"
+            alignItems="stretch"
+          >
+            <Stack direction="block" flex={3} inlineSize="100%">
+              <Text variant="display">Manage Safe</Text>
 
-        {/* [START safe-modal.activity-form] */}
-        <Section title="New Activity">
-          <Stack direction="inline" gap="200" inlineSize="100%">
-            <Stack flex={1} flexChildren>
-              <Button
-                title="Deposit"
-                onPress={() => setActivityType('deposit')}
-                type={activityType === 'deposit' ? 'primary' : undefined}
-              />
+              <SectionHeader title="Overview" />
+              <Stack inlineSize="100%">
+                <List data={overviewListData} />
+              </Stack>
+
+              <SectionHeader title="Recent activity" />
+              <Stack inlineSize="100%">
+                <List data={activityListData.reverse()} />
+              </Stack>
             </Stack>
-            <Stack flex={1} flexChildren>
-              <Button
-                title="Withdrawal"
-                onPress={() => setActivityType('withdrawal')}
-                type={activityType === 'withdrawal' ? 'primary' : undefined}
-              />
+
+            <Stack direction="block" gap="200" flex={1} paddingBlockStart="400">
+              <Stack inlineSize="100%" flexChildren>
+                <Button
+                  title="+ Deposit"
+                  onPress={() => {
+                    setActivityType('deposit');
+                    api.navigation.navigate('ActivityModal');
+                  }}
+                  type="basic"
+                />
+              </Stack>
+              <Stack inlineSize="100%" flexChildren>
+                <Button
+                  title="- Withdraw"
+                  onPress={() => {
+                    setActivityType('withdraw');
+                    api.navigation.navigate('ActivityModal');
+                  }}
+                  type="basic"
+                />
+              </Stack>
             </Stack>
           </Stack>
+        </ScrollView>
+      </Screen>
 
+      <Screen name="ActivityModal" title="Activity Modal">
+        <ScrollView>
           <TextField
             label="Amount ($)"
             value={amount}
             onChange={setAmount}
             placeholder="0.00"
             error={
-              activityType === 'withdrawal' && parseFloat(amount) > balance
+              activityType === 'withdraw' && parseFloat(amount) > balance
                 ? `Cannot exceed balance of $${(balance || 0).toFixed(2)}`
                 : undefined
             }
@@ -177,38 +236,22 @@ const SafeModal = () => {
 
           <Button
             title={`Confirm ${
-              activityType === 'deposit' ? 'Deposit' : 'Withdrawal'
+              activityType === 'deposit' ? 'Deposit' : 'Withdraw'
             }`}
             onPress={handleActivity}
             type="primary"
             isDisabled={!canSubmit()}
           />
-        </Section>
-        {/* [END safe-modal.activity-form] */}
-
-        {/* [START safe-modal.activities-list] */}
-        <Section title="Recent Activities">
-          <List data={activityListData} />
-          {/* [START safe-modal.clear-activities] */}
-          <Button
-            title="Clear Activities"
-            type="destructive"
-            onPress={() => {
-              storage.set('activities', []);
-              setActivities([]);
-            }}
-          />
-          {/* [END safe-modal.clear-activities] */}
-        </Section>
-        {/* [END safe-modal.activities-list] */}
-      </ScrollView>
-    </Screen>
+        </ScrollView>
+      </Screen>
+    </Navigator>
   );
 };
+// [END safe-modal.render-ui]
 
 // [START safe-modal.render-extension]
-// 1. Render the SafeModal component at the `pos.product-details.action.render` target
-export default reactExtension('pos.product-details.action.render', () => (
+// 1. Render the SafeModal component at the `pos.cash-session-details.action.render` target
+export default reactExtension('pos.cash-session-details.action.render', () => (
   <SafeModal />
 ));
 // [END safe-modal.render-extension]

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/SafeModal.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/SafeModal.tsx
@@ -1,0 +1,214 @@
+import React, {useState, useEffect} from 'react';
+
+import {
+  Text,
+  Screen,
+  ScrollView,
+  reactExtension,
+  useApi,
+  Button,
+  Stack,
+  Section,
+  TextField,
+  List,
+  ListRowSubtitle,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+import type {Storage} from '@shopify/ui-extensions/point-of-sale';
+
+// [START safe-modal.data-interfaces]
+// 2. Define the interfaces for storing safe management data
+interface SafeActivity {
+  id: number;
+  type: string;
+  amount: number;
+  timestamp: Date;
+}
+
+interface SafeDetails {
+  balance: number;
+  activities: SafeActivity[];
+}
+// [END safe-modal.data-interfaces]
+
+// [START safe-modal.component]
+// 3. Implement the `SafeModal` component
+const SafeModal = () => {
+  const [activityType, setActivityType] = useState('deposit');
+  const [amount, setAmount] = useState('');
+  // [END safe-modal.component]
+
+  // [START safe-modal.storage-setup]
+  // 4. Setup the api and storage
+  const api = useApi<'pos.product-details.action.render'>();
+  const storage: Storage<SafeDetails> = api.storage;
+
+  // 5. Setup the states for the safe management data
+  const [balance, setBalance] = useState<number>(0);
+  const [activities, setActivities] = useState<SafeActivity[]>([]);
+  // [END safe-modal.storage-setup]
+
+  // [START safe-modal.load-data]
+  // 6. Load the data from the storage
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const storedBalance = (await storage.get('balance')) || 0;
+        const storedActivities = (await storage.get('activities')) || [];
+
+        setBalance(storedBalance);
+        setActivities(storedActivities);
+      } catch (error) {
+        console.error('Error loading data from storage:', error);
+      }
+    };
+
+    loadData();
+  }, [storage]);
+  // [END safe-modal.load-data]
+
+  // [START safe-modal.handle-activity]
+  // 7. Implement deposit and withdrawal logic
+  const handleActivity = async () => {
+    const activityAmount = parseFloat(amount);
+
+    try {
+      let newBalance = balance;
+      if (activityType === 'deposit') {
+        newBalance = balance + activityAmount;
+      } else if (activityType === 'withdrawal') {
+        newBalance = balance - activityAmount;
+      }
+      setBalance(newBalance);
+      await storage.set('balance', newBalance);
+
+      const newActivity: SafeActivity = {
+        id: activities.length + 1,
+        type: activityType,
+        amount: activityAmount,
+        timestamp: new Date(),
+      };
+      const updatedActivities = [...activities, newActivity];
+      setActivities(updatedActivities);
+      await storage.set('activities', updatedActivities);
+
+      setAmount('');
+    } catch (error) {
+      console.error('Error saving activity:', error);
+    }
+  };
+  // [END safe-modal.handle-activity]
+
+  // [START safe-modal.validation]
+  // 8. Check if the activity amount is valid
+  const canSubmit = () => {
+    const activityAmount = parseFloat(amount);
+    if (isNaN(activityAmount) || activityAmount <= 0) return false;
+    if (activityType === 'withdrawal' && activityAmount > balance) return false;
+    return true;
+  };
+  // [END safe-modal.validation]
+
+  // [START safe-modal.format-activities]
+  // 9. Format the activities in to a list
+  const activityListData = (activities || []).map((activity: SafeActivity) => ({
+    id: activity.id.toString(),
+    leftSide: {
+      label: `$${(activity.amount || 0).toFixed(2)}`,
+      subtitle: [
+        {
+          content: activity.type === 'deposit' ? 'Deposit' : 'Withdrawal',
+        },
+      ] as [ListRowSubtitle],
+    },
+    rightSide: {
+      label: new Date(activity.timestamp).toLocaleString(),
+    },
+  }));
+  // [END safe-modal.format-activities]
+
+  // 10. Render the SafeModal component to use the safe management solution
+  return (
+    <Screen name="SafeManagement" title="Safe Management">
+      <ScrollView>
+        {/* [START safe-modal.overview-section] */}
+        <Section title="Overview">
+          <Stack padding="200">
+            <Text>Current Balance</Text>
+            <Text>${(balance || 0).toFixed(2)}</Text>
+          </Stack>
+          <Stack padding="200">
+            <Text>Activities Count</Text>
+            <Text>{activities.length}</Text>
+          </Stack>
+        </Section>
+        {/* [END safe-modal.overview-section] */}
+
+        {/* [START safe-modal.activity-form] */}
+        <Section title="New Activity">
+          <Stack direction="inline" gap="200" inlineSize="100%">
+            <Stack flex={1} flexChildren>
+              <Button
+                title="Deposit"
+                onPress={() => setActivityType('deposit')}
+                type={activityType === 'deposit' ? 'primary' : undefined}
+              />
+            </Stack>
+            <Stack flex={1} flexChildren>
+              <Button
+                title="Withdrawal"
+                onPress={() => setActivityType('withdrawal')}
+                type={activityType === 'withdrawal' ? 'primary' : undefined}
+              />
+            </Stack>
+          </Stack>
+
+          <TextField
+            label="Amount ($)"
+            value={amount}
+            onChange={setAmount}
+            placeholder="0.00"
+            error={
+              activityType === 'withdrawal' && parseFloat(amount) > balance
+                ? `Cannot exceed balance of $${(balance || 0).toFixed(2)}`
+                : undefined
+            }
+          />
+
+          <Button
+            title={`Confirm ${
+              activityType === 'deposit' ? 'Deposit' : 'Withdrawal'
+            }`}
+            onPress={handleActivity}
+            type="primary"
+            isDisabled={!canSubmit()}
+          />
+        </Section>
+        {/* [END safe-modal.activity-form] */}
+
+        {/* [START safe-modal.activities-list] */}
+        <Section title="Recent Activities">
+          <List data={activityListData} />
+          {/* [START safe-modal.clear-activities] */}
+          <Button
+            title="Clear Activities"
+            type="destructive"
+            onPress={() => {
+              storage.set('activities', []);
+              setActivities([]);
+            }}
+          />
+          {/* [END safe-modal.clear-activities] */}
+        </Section>
+        {/* [END safe-modal.activities-list] */}
+      </ScrollView>
+    </Screen>
+  );
+};
+
+// [START safe-modal.render-extension]
+// 1. Render the SafeModal component at the `pos.product-details.action.render` target
+export default reactExtension('pos.product-details.action.render', () => (
+  <SafeModal />
+));
+// [END safe-modal.render-extension]

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/shopify.extension.toml
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/shopify.extension.toml
@@ -1,0 +1,28 @@
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "unstable"
+
+[[extensions]]
+type = "ui_extension"
+name = "cash-management-extension"
+
+handle = "cash-management-extension"
+description = "Safe Management"
+
+# Controls where in POS your extension will be injected,
+# and the file that contains your extension’s source code.
+[[extensions.targeting]]
+module = "./src/SafeModal.tsx"
+target = "pos.cash-session-details.action.render"
+
+[[extensions.targeting]]
+module = "./src/BannerAlert.tsx"
+target = "pos.cash-session-details.banner.render"
+
+[[extensions.targeting]]
+module = "./src/MenuItem.tsx"
+target = "pos.cash-session-details.action.menu-item.render"
+
+[[extensions.targeting]]
+module = "./src/InStoreCashInfo.tsx"
+target = "pos.cash-session-summary.block.render"

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/useBusinessRules.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/useBusinessRules.ts
@@ -1,0 +1,110 @@
+import {useEffect, useState} from 'react';
+
+// [START use-business-rules.define-thresholds]
+// 1. Define business rules, let's use a min/max cash threshold as an example
+type BusinessRuleViolation = {
+  isViolated: boolean;
+  message?: string;
+  ruleType?: string;
+};
+
+const MIN_CASH_THRESHOLD = 100;
+const MAX_CASH_THRESHOLD = 1000;
+// [END use-business-rules.define-thresholds]
+
+// [START use-business-rules.direct-api]
+// 2. Fetch the amount of cash in the drawer currently associated with the POS device
+export const fetchDrawerAmount = async (pointOfSaleDeviceId: string) => {
+  const result = await fetch('shopify:admin/api/graphql.json', {
+    method: 'POST',
+    body: JSON.stringify({
+      query: `
+          TBD
+        `,
+      variables: {
+        pointOfSaleDeviceId: `gid://shopify/PointOfSaleDevice/${pointOfSaleDeviceId}`,
+      },
+    }),
+  });
+
+  const json = await result.json();
+
+  if (json.errors) {
+    console.error('GraphQL Errors:', json.errors);
+    json.errors.forEach((error: any) => {
+      console.error('GraphQL Error Details:', error);
+    });
+    return null;
+  }
+
+  if (!result.ok) {
+    console.error('Network Error:', result.statusText);
+    return null;
+  }
+
+  return json.data;
+};
+// [END use-business-rules.direct-api]
+
+// [START use-business-rules.hook]
+// 3. Implement the useBusinessRules hook
+export const useBusinessRules = (pointOfSaleDeviceId: string) => {
+  const [isViolated, setIsViolated] = useState(false);
+  const [alertMessage, setAlertMessage] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function checkRules() {
+      try {
+        const result = await checkDrawerAmount(pointOfSaleDeviceId);
+        setIsViolated(result.isViolated);
+
+        if (result.isViolated) {
+          setAlertMessage(result.message || '');
+        }
+        setLoading(false);
+      } catch (error) {
+        console.error(error);
+        setLoading(false);
+      }
+    }
+    checkRules();
+  }, [pointOfSaleDeviceId]);
+
+  return {
+    isViolated,
+    alertMessage,
+    loading,
+  };
+};
+// [END use-business-rules.hook]
+
+// [START use-business-rules.check-drawer-amount]
+// 4. Check if the drawer amount is within the min/max threshold
+export const checkDrawerAmount = async (
+  pointOfSaleDeviceId: string,
+): Promise<BusinessRuleViolation> => {
+  const drawerAmount = await fetchDrawerAmount(pointOfSaleDeviceId);
+  if (drawerAmount < MIN_CASH_THRESHOLD) {
+    return {
+      isViolated: true,
+      ruleType: 'drawer_amount',
+      message: `Drawer amount is $${
+        MIN_CASH_THRESHOLD - drawerAmount
+      } below the minimum threshold`,
+    };
+  }
+  if (drawerAmount > MAX_CASH_THRESHOLD) {
+    return {
+      isViolated: true,
+      ruleType: 'drawer_amount',
+      message: `Drawer amount is $${
+        drawerAmount - MAX_CASH_THRESHOLD
+      } above the maximum threshold`,
+    };
+  }
+  return {
+    isViolated: false,
+  };
+};
+// [END use-business-rules.check-drawer-amount]

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/useBusinessRules.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/cash-management-example/useBusinessRules.ts
@@ -46,8 +46,38 @@ export const fetchDrawerAmount = async (pointOfSaleDeviceId: string) => {
 };
 // [END use-business-rules.direct-api]
 
+// [START use-business-rules.check-drawer-amount]
+// 3. Check if the drawer amount is within the min/max threshold
+export const checkDrawerAmount = async (
+  pointOfSaleDeviceId: string,
+): Promise<BusinessRuleViolation> => {
+  const drawerAmount = await fetchDrawerAmount(pointOfSaleDeviceId);
+  if (drawerAmount < MIN_CASH_THRESHOLD) {
+    return {
+      isViolated: true,
+      ruleType: 'drawer_amount',
+      message: `Drawer amount is $${
+        MIN_CASH_THRESHOLD - drawerAmount
+      } below the minimum threshold`,
+    };
+  }
+  if (drawerAmount > MAX_CASH_THRESHOLD) {
+    return {
+      isViolated: true,
+      ruleType: 'drawer_amount',
+      message: `Drawer amount is $${
+        drawerAmount - MAX_CASH_THRESHOLD
+      } above the maximum threshold`,
+    };
+  }
+  return {
+    isViolated: false,
+  };
+};
+// [END use-business-rules.check-drawer-amount]
+
 // [START use-business-rules.hook]
-// 3. Implement the useBusinessRules hook
+// 4. Implement the useBusinessRules hook
 export const useBusinessRules = (pointOfSaleDeviceId: string) => {
   const [isViolated, setIsViolated] = useState(false);
   const [alertMessage, setAlertMessage] = useState('');
@@ -78,33 +108,3 @@ export const useBusinessRules = (pointOfSaleDeviceId: string) => {
   };
 };
 // [END use-business-rules.hook]
-
-// [START use-business-rules.check-drawer-amount]
-// 4. Check if the drawer amount is within the min/max threshold
-export const checkDrawerAmount = async (
-  pointOfSaleDeviceId: string,
-): Promise<BusinessRuleViolation> => {
-  const drawerAmount = await fetchDrawerAmount(pointOfSaleDeviceId);
-  if (drawerAmount < MIN_CASH_THRESHOLD) {
-    return {
-      isViolated: true,
-      ruleType: 'drawer_amount',
-      message: `Drawer amount is $${
-        MIN_CASH_THRESHOLD - drawerAmount
-      } below the minimum threshold`,
-    };
-  }
-  if (drawerAmount > MAX_CASH_THRESHOLD) {
-    return {
-      isViolated: true,
-      ruleType: 'drawer_amount',
-      message: `Drawer amount is $${
-        drawerAmount - MAX_CASH_THRESHOLD
-      } above the maximum threshold`,
-    };
-  }
-  return {
-    isViolated: false,
-  };
-};
-// [END use-business-rules.check-drawer-amount]


### PR DESCRIPTION
https://github.com/shop/issues-retail/issues/16100

### Background

Added example components for a cash management extension in the Point of Sale UI Extensions documentation.

Linked to the tutorial in this [PR](https://app.graphite.dev/github/pr/Shopify/shopify-dev/60387/).

### Solution

Created a comprehensive cash management example for the Point of Sale UI Extensions documentation with the following components:

1. `BannerAlert.tsx` - A component that displays alert banners when business rules are violated (e.g., cash drawer amount outside of thresholds)
2. `SafeModal.tsx` - A modal interface for managing safe deposits and withdrawals with transaction history
3. `useBusinessRules.ts` - A custom hook that checks if cash drawer amounts violate business rules
4. `InStoreCashInfo.tsx` - A component that displays the total cash on hand in store
5. `shopify.extension.toml` - Configuration file that defines the extension targets

The example demonstrates how to implement cash management extensions that:
- Track safe balance, deposits and withdrawals
- Implement business rules to monitor cash drawer thresholds
- Use an alert system that displays banner warnings when business rules are violated
- Display total cash on hand at the location

### 🎩

- Run the example in a development environment to verify the cash management UI works correctly
- Test deposit and withdrawal operations to ensure balance updates properly
- Verify business rule alerts display correctly when thresholds are violated

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation