### PR TITLE
Add selling plan functionality to Cart API and line item types

### DIFF
--- a/.changeset/soft-forks-march.md
+++ b/.changeset/soft-forks-march.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add selling plan functionality to Cart API and line item types

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -183,6 +183,18 @@ The Cart API enables UI Extensions to manage and interact with POS cart contents
           'update-default-address',
         ),
       },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Add a selling plan to a line item in the cart',
+          'add-line-item-selling-plan',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForCartApi(
+          'Remove a selling plan from a line item in the cart',
+          'remove-line-item-selling-plan',
+        ),
+      },
     ],
   },
 };

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.ts
@@ -1,0 +1,14 @@
+import {Button, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.cart.line-item-details.action.render',
+  (root, api) => {
+    const button = root.createComponent(Button, {
+      onPress: () => {
+        api.cart.addLineItemSellingPlan(api.cartLineItem.uuid);
+      },
+    });
+
+    root.append(button);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import {
+  Button,
+  Screen,
+  ScrollView,
+  Navigator,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.cart.line-item-details.action.render'>();
+  // Your app determines the selling plan ID to add to the line item
+  const sellingPlanId = 123456;
+
+  return (
+    <Navigator>
+      <Screen name="Cart API" title="Add Line Item Selling Plan">
+        <ScrollView>
+          <Button
+            onPress={() =>
+              api.cart.addLineItemSellingPlan(
+                api.cartLineItem.uuid,
+                sellingPlanId,
+              )
+            }
+          />
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension(
+  'pos.cart.line-item-details.action.render',
+  () => <Modal />,
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-selling-plan.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-selling-plan.ts
@@ -1,0 +1,14 @@
+import {Button, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.cart.line-item-details.action.render',
+  (root, api) => {
+    const button = root.createComponent(Button, {
+      onPress: () => {
+        api.cart.removeLineItemSellingPlan(api.cartLineItem.uuid);
+      },
+    });
+
+    root.append(button);
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-selling-plan.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/remove-line-item-selling-plan.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import {
+  Button,
+  Screen,
+  ScrollView,
+  Navigator,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  const api = useApi<'pos.cart.line-item-details.action.render'>();
+  return (
+    <Navigator>
+      <Screen name="Cart API" title="Remove Line Item Selling Plan">
+        <ScrollView>
+          <Button
+            onPress={() =>
+              api.cart.removeLineItemSellingPlan(api.cartLineItem.uuid)
+            }
+          />
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension(
+  'pos.cart.line-item-details.action.render',
+  () => <Modal />,
+);

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -219,4 +219,19 @@ export interface CartApiContent {
    * @param addressId the address ID to set as the default address
    */
   updateDefaultAddress(addressId: number): Promise<void>;
+
+  /**
+   * Add a selling plan to a line item in the cart.
+   *
+   * @param uuid the uuid of the line item that should receive the selling plan
+   * @param sellingPlanId the ID of the selling plan to add to the line item
+   */
+  addLineItemSellingPlan(uuid: string, sellingPlanId: number): Promise<void>;
+
+  /**
+   * Remove the selling plan from a line item in the cart.
+   *
+   * @param uuid the uuid of the line item whose selling plan should be removed
+   */
+  removeLineItemSellingPlan(uuid: string): Promise<void>;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -47,6 +47,38 @@ export interface LineItem {
   properties: {[key: string]: string};
   isGiftCard: boolean;
   attributedUserId?: number;
+  requiresSellingPlan?: boolean;
+  hasSellingPlanGroups?: boolean;
+  /**
+   * The currently selected selling plan for this line item.
+   */
+  sellingPlan?: SellingPlan;
+}
+
+/**
+ * Represents a selling plan associated with a line item.
+ */
+export interface SellingPlan {
+  /**
+   * The unique identifier of the selling plan.
+   */
+  id: number;
+  /**
+   * The name of the selling plan.
+   */
+  name: string;
+  /**
+   * The fingerprint of the applied selling plan within this cart session.
+   */
+  digest: string;
+  /**
+   * The interval of the selling plan. i.e. "every 2 weeks"
+   */
+  deliveryInterval?: string;
+  /**
+   * The interval count of the selling plan. i.e. "2"
+   */
+  deliveryIntervalCount?: number;
 }
 
 export interface Discount {


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/16077

### Background

Add functionality to Cart API and line item types to support Selling Plans on POS.

### Solution

Straightforward changes, as described in our [tech design doc](https://docs.google.com/document/d/1kLy0E9kzY52h_ll5K5DTpoBWr7o88QuaTOh8XyJ3Mzw/edit?tab=t.0#bookmark=id.pfnuj1sm7nxi).

### 🎩

None for now, will be ready for tophatting later when integrated to POS.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
