### PR TITLE
Add links for POS UI extensions developer preview

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -11,10 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
   - An extension can store up to 100 entries.
   - The maximum size for a key is ~1 KB, and for a value is ~1 MB.
   - If a target (such as \`pos.home.tile.render\`) is disabled or removed, the extension data remains.
-  - All stored extension data that has not been updated for a month is cleared automatically after that period.
-
-  > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  - All stored extension data that has not been updated for a month is cleared automatically after that period.`,
   isVisualComponent: false,
   type: 'APIs',
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSReceiptBlock.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSReceiptBlock.doc.ts
@@ -8,7 +8,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'POSReceiptBlock',
   description: `A component used to group other components together for display on POS receipts.
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.
   >
   > This component only accepts \`Text\` and \`QRCode\` components as children.`,
   isVisualComponent: true,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/QRCode.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/QRCode.doc.ts
@@ -8,7 +8,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'QRCode',
   description: `A component that renders a QR code in Shopify POS.
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   requires: 'use within a `POSReceiptBlock` component',
   isVisualComponent: true,
   type: 'component',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-update.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-update.event.observe.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCartUpdateObserve,
   description: `An event extension target that observes cart updates
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   category: 'Targets',
   subCategory: 'Cart details',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-complete.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-complete.event.observe.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCashTrackingSessionCompleteObserve,
   description: `An event extension target that observes when cash tracking session completes
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   category: 'Targets',
   subCategory: 'Cash tracking',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-start.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-start.event.observe.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCashTrackingSessionStartObserve,
   description: `An event extension target that observes when cash tracking session starts
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   category: 'Targets',
   subCategory: 'Cash tracking',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.menu-item.render.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosExchangePostActionMenuItemRender,
   description: `A static extension target that renders as a menu item on the post-exchange screen
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   defaultExample: {
     codeblock: generateCodeBlock(
       'Menu item',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.render.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosExchangePostActionRender,
   description: `A full-screen extension target that renders when a \`pos.exchange.post.action.menu-item.render\` target calls for it
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   defaultExample: {
     codeblock: generateCodeBlock(
       'Action',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.block.render.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosExchangePostBlockRender,
   description: `Renders a custom section within the native post exchange screen
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   defaultExample: {
     codeblock: generateCodeBlock(
       'Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-footer.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-footer.block.render.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReceiptFooterBlockRender,
   description: `Renders a custom section within the POS receipt footer
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   defaultExample: {
     codeblock: generateCodeBlock(
       'Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.menu-item.render.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReturnPostActionMenuItemRender,
   description: `A static extension target that renders as a menu item on the post-return screen
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   defaultExample: {
     codeblock: generateCodeBlock(
       'Menu item',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.render.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReturnPostActionRender,
   description: `A full-screen extension target that renders when a \`pos.return.post.action.menu-item.render\` target calls for it
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   defaultExample: {
     codeblock: generateCodeBlock(
       'Action',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.block.render.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReturnPostBlockRender,
   description: `Renders a custom section within the native post return screen
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   defaultExample: {
     codeblock: generateCodeBlock(
       'Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.transaction-complete.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.transaction-complete.event.observe.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosTransactionCompleteObserve,
   description: `An event extension target that observes completed transactions
   > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
   category: 'Targets',
   subCategory: 'Post-transaction',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
@@ -49,10 +49,10 @@ const data: LandingTemplateSchema = {
 - Added optional \`editable\` property to \`Cart\` interface.
 - Added \`useCartEditable\` hook to access the cart's editable state.
 - Added support for the ${TargetLink.PosCartLineItemDetailsActionMenuItemRender} and ${TargetLink.PosCartLineItemDetailsActionRender} targets on the cart line item details screen.
+- Introduced a [Storage API](/docs/api/pos-ui-extensions/apis/storage-api). The Storage API gives the UI Extension access to store data on the POS device that the extension is running on.
 
 ### Developer Preview
 
-  - Introduced a [Storage API](/docs/api/pos-ui-extensions/apis/storage-api). The Storage API gives the UI Extension access to store data on the POS device that the extension is running on.
   - Added support for the ${TargetLink.PosExchangePostActionMenuItemRender}, ${TargetLink.PosExchangePostActionRender}, ${TargetLink.PosExchangePostBlockRender} targets.
   - Added support for the ${TargetLink.PosReturnPostActionMenuItemRender}, ${TargetLink.PosReturnPostActionRender}, ${TargetLink.PosReturnPostBlockRender} targets.
   `,


### PR DESCRIPTION
### Background

Part of, https://github.com/shop/issues-retail/issues/15804

### Solution

- Remove "developer preview" from Storage API.
  - Updated version change log section for Storage API.
- Added link for all developer preview note in components/targets.
- Will also merge to `2025-04`.

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
