### PR TITLE
[Doc] add authenticated account code example

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/authenticated-account.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/authenticated-account.doc.ts
@@ -9,6 +9,28 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   category: 'APIs',
   type: 'API',
+  defaultExample: {
+    codeblock: {
+      title: 'Show Loyalty Banner',
+      tabs: [
+        {
+          code: '../examples/apis/authenticated-account.example.tsx',
+          language: 'jsx',
+          title: 'React',
+        },
+        {
+          code: '../examples/apis/authenticated-account.example.ts',
+          language: 'js',
+          title: 'JavaScript',
+        },
+        {
+          code: '../examples/apis/authenticated-account.locale.example.json',
+          language: 'json',
+          title: 'locales/en.default.json',
+        },
+      ],
+    },
+  },
   definitions: [
     {
       title: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.title,

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.example.ts
@@ -1,0 +1,41 @@
+/* See the locales/en.default.json tab for the translation keys and values for this example */
+import {
+  Banner,
+  Link,
+  extension,
+} from '@shopify/ui-extensions/customer-account';
+
+export default extension(
+  'customer-account.order-status.block.render',
+  (
+    root,
+    {i18n, authenticatedAccount, buyerIdentity},
+  ) => {
+    const orderStatusCustomerId =
+      buyerIdentity?.customer?.current?.id;
+
+    const authenticatedCustomerId =
+      authenticatedAccount?.customer?.current?.id;
+
+    if (
+      authenticatedCustomerId &&
+      orderStatusCustomerId?.endsWith(
+        authenticatedCustomerId,
+      )
+    ) {
+      const link = root.createComponent(
+        Link,
+        {
+          to: 'extension:manageLoyaltyPoints/',
+        },
+        i18n.translate('manageLoyaltyPoints'),
+      );
+      const app = root.createComponent(
+        Banner,
+        {},
+        link,
+      );
+      root.appendChild(app);
+    }
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.example.tsx
@@ -1,0 +1,41 @@
+/* See the locales/en.default.json tab for the translation keys and values for this example */
+import {
+  useAuthenticatedAccountCustomer,
+  useCustomer,
+  useI18n,
+  reactExtension,
+} from '@shopify/ui-extensions-react/customer-account';
+import {
+  Banner,
+  Link,
+} from '@shopify/ui-extensions/customer-account';
+
+export default reactExtension(
+  'customer-account.order-status.block.render',
+  () => <Extension />,
+);
+
+function Extension() {
+  const i18n = useI18n();
+  const authenticatedCustomer =
+    useAuthenticatedAccountCustomer();
+  const orderStatusCustomer = useCustomer();
+
+  if (
+    authenticatedCustomer?.id &&
+    orderStatusCustomer?.id?.endsWith(
+      authenticatedCustomer?.id,
+    )
+  ) {
+    return (
+      <Banner>
+        <Link
+          to={'extension:manageLoyaltyPoints/'}
+        >
+          {i18n.translate('manageLoyaltyPoints')}
+        </Link>
+      </Banner>
+    );
+  }
+  return null;
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.locale.example.json
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.locale.example.json
@@ -1,0 +1,3 @@
+{
+  "manageLoyaltyPoints": "Manage Loyalty Points"
+}


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-customer-accounts-and-login/issues/122 
Add authenticated account code example.
No need to bump version. 

- the code is working
<img width="1496" height="922" alt="Screenshot 2025-07-28 at 11 15 12 AM" src="https://github.com/user-attachments/assets/8f3ce1cf-6811-4cd8-9cf5-09f346f96ee5" />

- shopify-dev doc PR https://github.com/Shopify/shopify-dev/pull/60780 
<img width="1803" height="1126" alt="Screenshot 2025-07-28 at 11 20 15 AM" src="https://github.com/user-attachments/assets/fdff6d29-4666-435c-af67-decc8aad12a6" />


- 2025-10 version will also be added soon

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
