### PR TITLE
[customer account] add authenticated account example to 2025-10 doc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/authenticated-account.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/authenticated-account.doc.ts
@@ -28,6 +28,23 @@ const data: ReferenceEntityTemplateSchema = {
     //   type: 'UseAuthenticatedAccountPurchasingCompanyGeneratedType',
     // },
   ],
+  defaultExample: {
+    codeblock: {
+      title: 'Show Loyalty Banner',
+      tabs: [
+        {
+          code: '../examples/apis/authenticated-account.example.tsx',
+          language: 'jsx',
+          title: 'Preact',
+        },
+        {
+          code: '../examples/apis/authenticated-account.locale.example.json',
+          language: 'json',
+          title: 'locales/en.default.json',
+        },
+      ],
+    },
+  },
   examples: {
     description: '',
     examples: [

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.example.tsx
@@ -1,0 +1,32 @@
+import {render} from 'preact';
+
+export default async function () {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  const orderStatusCustomerId =
+    shopify.authenticatedAccount.customer.current
+      .id;
+  const authenticatedCustomerId =
+    shopify.authenticatedAccount.customer.current
+      .id;
+
+  if (
+    authenticatedCustomerId &&
+    orderStatusCustomerId?.endsWith(
+      authenticatedCustomerId,
+    )
+  ) {
+    return (
+      <s-banner>
+        <s-link href="extension:manageLoyaltyPoints/">
+          {shopify.i18n.translate(
+            'manageLoyaltyPoints',
+          )}
+        </s-link>
+      </s-banner>
+    );
+  }
+  return null;
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.locale.example.json
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.locale.example.json
@@ -1,0 +1,3 @@
+{
+  "manageLoyaltyPoints": "Manage Loyalty Points"
+}


### PR DESCRIPTION
### Background

part of https://github.com/shop/issues-customer-accounts-and-login/issues/122 

add authenticated account example to 2025-10 doc

Same PR here for 2025-07 https://github.com/Shopify/ui-extensions/pull/3116 

### Solution

- no version bump needed
- the code is working 
<img width="1404" height="848" alt="Screenshot 2025-07-28 at 12 22 17 PM" src="https://github.com/user-attachments/assets/d9730dbe-19c6-45f0-87c9-1967391fa119" />

- shopify-dev side PR  https://github.com/Shopify/shopify-dev/pull/60780

<img width="1717" height="1040" alt="Screenshot 2025-07-28 at 1 29 55 PM" src="https://github.com/user-attachments/assets/df885f96-2e1f-4cd5-9b44-d74ace48a367" />



### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
