### PR TITLE
fix: remove unused image reference from index pattern documentation

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/index.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/index.ab.doc.ts
@@ -49,8 +49,6 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Patterns',
   thumbnail: '/assets/templated-apis-screenshots/admin/patterns/index.png',
   defaultExample: {
-    image:
-      '/assets/templated-apis-screenshots/admin/patterns/index-example.png',
     codeblock: {
       title: 'Index',
       tabs: [


### PR DESCRIPTION
### Background

Reference image was not properly removed from the index pattern.

### Solution

Removed the line that added the reference image on index pattern.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
