### PR TITLE
fix typo

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
@@ -51,7 +51,7 @@ export interface StandardApi<ExtensionTarget extends AnyExtensionTarget> {
   i18n: I18n;
 
   /**
-   * Provides information to the receiver the of an intent.
+   * Provides information to the receiver of an intent.
    */
   intents: Intents;
 


### PR DESCRIPTION
### Background

Typo in intents type description:

Provides information to the receiver ~**the**~ of an intent.

### Solution

Fixes typo in type description

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have updated relevant documentation
