### PR TITLE
16680: add version doc reminder workflow

### DIFF
--- a/.github/workflows/pos-version-doc-reminder.yml
+++ b/.github/workflows/pos-version-doc-reminder.yml
@@ -1,0 +1,60 @@
+name: POS Version Doc Reminder
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 2023-04
+      - 2023-07
+      - 2023-10
+      - 2024-01
+      - 2024-04
+      - 2024-07
+      - 2024-10
+      - unstable
+      - 20[0-9][0-9]-[01][1470]
+    paths:
+      - 'packages/ui-extensions/src/surfaces/point-of-sale/**'
+      - 'packages/ui-extensions-react/src/surfaces/point-of-sale/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-version-doc:
+    name: Check POS Version Documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'changeset-release/') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify if POS version doc was updated
+        id: changed-files-version-doc
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        with:
+          files: |
+            packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts
+
+      - name: Check if version doc needs updating
+        if: steps.changed-files-version-doc.outputs.any_changed == 'false'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const comment = `## 📝 POS Version Documentation Reminder
+
+            We detected changes in \`packages/*/src/surfaces/point-of-sale\`, but there are no updates to the POS versions documentation.
+
+            If these changes are user-facing and should be documented in the version changelog, please update:
+            \`packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/versions.doc.ts\`
+
+            If you are making internal changes that don't affect the public API, you can ignore this reminder.`;
+
+            // Post a comment on the PR
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: comment
+            });


### PR DESCRIPTION
Related to https://github.com/shop/issues-retail/issues/16680

### Background
As a run team project, we looked into how we can improve the processes we have in place to keep our versions changelog up to date. This is a problem we noticed in this [thread](https://shopify.slack.com/archives/C07TB5BRP0Q/p1751899318607069). The release of Direct API in 2025-07 wasn't mentioned in the changelog as it hadn't been updated in this [PR](https://github.com/Shopify/ui-extensions/pull/2800).

This PR is to add a github workflow which checks for updates in packages/ui-extensions/src/surfaces/point-of-sale and packages/ui-extensions-react/src/surfaces/point-of-sale to verify if there is an associated update in version.doc.ts. If there isn't, github actions will leave a comment on the PR as reminder (similar to how we have it for [changeset](https://github.com/Shopify/ui-extensions/blob/unstable/.github/workflows/changesets-reminder.yml) updates)

### Solution
The implementation of this workflow is very similar to the [changeset](https://github.com/Shopify/ui-extensions/blob/unstable/.github/workflows/changesets-reminder.yml) reminder

### 🎩
Here's an [example](https://github.com/Shopify/ui-extensions/pull/3124#issuecomment-3155360911) of a comment from the workflow 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
