### PR TITLE
Add .gitignore exception for build-doc*.mjs files, add point-of-sale …

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'packages/*/*.esnext',
     'packages/ui-extensions/src/surfaces/checkout/**/*.d.ts',
     'packages/ui-extensions/src/surfaces/checkout/preact/tests/',
+    'packages/ui-extensions/src/surfaces/point-of-sale/**/*.d.ts',
   ],
   rules: {
     // Codebase was originally written without some strict Shopify conventions

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 packages/**/*.esnext
 packages/**/*.node
 packages/**/*.mjs
+!packages/**/build-doc*.mjs
 !components/*.d.ts
 !components.d.ts
 packages/**/*.js

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -231,7 +231,7 @@ try {
     path.join(docsPath, 'screenshots'),
     path.join(
       shopifyDevPath,
-      'app/assets/images/templated-apis-screenshots/admin',
+      'react-app/public/images/templated-apis-screenshots/admin',
     ),
     {recursive: true},
   );

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
@@ -85,7 +85,7 @@ const generateExtensionsDocs = async () => {
     path.join(docsPath, 'screenshots'),
     path.join(
       shopifyDevPath,
-      'app/assets/images/templated-apis-screenshots/customer-account-ui-extensions',
+      'react-app/public/images/templated-apis-screenshots/customer-account-ui-extensions',
       EXTENSIONS_API_VERSION,
     ),
     {recursive: true},

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
@@ -1,0 +1,178 @@
+/* eslint-disable no-undef, no-console */
+import fs from 'fs/promises';
+import {existsSync} from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+import {
+  generateFiles,
+  copyGeneratedToShopifyDev,
+  replaceFileContent,
+} from '../build-doc-shared.mjs';
+
+const EXTENSIONS_API_VERSION = process.argv[2];
+
+if (!EXTENSIONS_API_VERSION) {
+  console.error('Error: API_VERSION is required.');
+  console.error('Usage: node build-docs.mjs <API_VERSION>');
+  console.error('Example: node build-docs.mjs 2024-01');
+  process.exit(1);
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const rootPath = path.join(__dirname, '../../..');
+const docsRelativePath = 'docs/surfaces/point-of-sale';
+const docsGeneratedRelativePath = 'docs/surfaces/point-of-sale/generated';
+const srcRelativePath = 'src/surfaces/point-of-sale';
+const docsPath = path.join(rootPath, docsRelativePath);
+const srcPath = path.join(rootPath, srcRelativePath);
+const generatedDocsPath = path.join(docsPath, 'generated');
+const shopifyDevPath = path.join(rootPath, '../../../shopify-dev');
+const shopifyDevDBPath = path.join(
+  shopifyDevPath,
+  'db/data/docs/templated_apis',
+);
+
+const generatedDocsDataFile = 'generated_docs_data.json';
+const generatedStaticPagesFile = 'generated_static_pages.json';
+
+const componentDefs = path.join(srcPath, 'components.d.ts');
+const tempComponentDefs = path.join(srcPath, 'components.ts');
+
+const tsconfig = 'tsconfig.docs.json';
+
+const transformJson = async (filePath) => {
+  let jsonData = JSON.parse((await fs.readFile(filePath, 'utf8')).toString());
+
+  jsonData = jsonData.filter(Boolean);
+  await fs.writeFile(filePath, JSON.stringify(jsonData, null, 2));
+};
+
+const cleanup = async () => {
+  try {
+    // Clean up temporary component definitions file
+    if (existsSync(tempComponentDefs)) {
+      await fs.rm(tempComponentDefs);
+    }
+
+    // Clean up any remaining .js files from compilation
+    const srcFiles = await fs.readdir(rootPath, {recursive: true});
+    const builtFiles = srcFiles.filter((file) => file.endsWith('.doc.js'));
+    await Promise.all(
+      builtFiles.map((file) => {
+        const jsFilePath = path.join(rootPath, file);
+        return existsSync(jsFilePath) ? fs.rm(jsFilePath) : Promise.resolve();
+      }),
+    );
+  } catch (cleanupError) {
+    console.warn(
+      'Warning: Failed to clean up temporary files:',
+      cleanupError.message,
+    );
+  }
+};
+
+// Set up cleanup handlers for various exit scenarios
+process.on('exit', () => {
+  // Note: Only synchronous operations work in 'exit' handler
+  try {
+    if (existsSync(tempComponentDefs)) {
+      require('fs').unlinkSync(tempComponentDefs);
+    }
+  } catch (e) {
+    // Ignore cleanup errors on exit
+  }
+});
+
+process.on('SIGINT', async () => {
+  console.log('\nReceived SIGINT, cleaning up...');
+  await cleanup();
+  process.exit(130);
+});
+
+process.on('SIGTERM', async () => {
+  console.log('\nReceived SIGTERM, cleaning up...');
+  await cleanup();
+  process.exit(143);
+});
+
+process.on('uncaughtException', async (error) => {
+  console.error('Uncaught Exception:', error);
+  await cleanup();
+  process.exit(1);
+});
+
+process.on('unhandledRejection', async (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  await cleanup();
+  process.exit(1);
+});
+
+const generateExtensionsDocs = async () => {
+  console.log(
+    `Building Point of Sale UI Extensions docs for ${EXTENSIONS_API_VERSION} version`,
+  );
+
+  const outputDir = `${docsGeneratedRelativePath}/pos_ui_extensions/${EXTENSIONS_API_VERSION}`;
+
+  const scripts = [
+    `yarn tsc --project ${docsRelativePath}/${tsconfig} --moduleResolution node  --target esNext  --module CommonJS`,
+    `yarn generate-docs --input ./${docsRelativePath}/reference ./${docsRelativePath} ./${docsRelativePath}/../../../src/surfaces/point-of-sale/components --typesInput ./${srcRelativePath} --output ./${outputDir}`,
+    `yarn tsc ${docsRelativePath}/staticPages/*.doc.ts --moduleResolution node  --target esNext  --module CommonJS`,
+    `yarn generate-docs --isLandingPage --input ./${docsRelativePath}/staticPages --output ./${outputDir}`,
+  ];
+
+  await generateFiles({
+    scripts,
+    outputDir,
+    rootPath,
+    generatedDocsDataFile,
+    generatedStaticPagesFile,
+    transformJson,
+  });
+
+  // Update API version in relative doc links
+  await replaceFileContent({
+    filePaths: path.join(outputDir, generatedDocsDataFile),
+    searchValue: '/docs/api/pos-ui-extensions/[^/]*/',
+    replaceValue: `/docs/api/pos-ui-extensions/${EXTENSIONS_API_VERSION}/`,
+  });
+
+  await fs.cp(
+    path.join(docsPath, 'screenshots'),
+    path.join(
+      shopifyDevPath,
+      'react-app/public/images/templated-apis-screenshots/pos-ui-extensions',
+      EXTENSIONS_API_VERSION,
+    ),
+    {recursive: true},
+  );
+};
+
+try {
+  if (existsSync(generatedDocsPath)) {
+    await fs.rm(generatedDocsPath, {recursive: true});
+  }
+  await fs.copyFile(componentDefs, tempComponentDefs);
+  await replaceFileContent({
+    filePaths: tempComponentDefs,
+    searchValue: /typeof globalThis\.HTMLElement/g,
+    replaceValue: 'any',
+  });
+  await generateExtensionsDocs();
+  await copyGeneratedToShopifyDev({
+    generatedDocsPath,
+    shopifyDevPath,
+    shopifyDevDBPath,
+  });
+
+  await cleanup();
+} catch (error) {
+  console.error(error);
+  console.log(error.stdout?.toString() || '');
+  console.log(error.stderr?.toString() || '');
+  await cleanup();
+  process.exit(1);
+}


### PR DESCRIPTION
…docs generator

### Background

https://github.com/Shopify/shopify-dev/pull/59810 In shopify-dev, the /app/ folder should no longer hold our images. Also, there was a .gitignore rule that was ignoring changes to our generator scripts, so that must have been in error.

This also adds the previously-ignored point-of-sale generator script.

### Solution

Update the generator scripts for pos, admin, and checkout to point at the correct directory for images going forward.

### 🎩

- Generate your docs, and verify that any image changes work as expected.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
