### PR TITLE
Added navigation to POS pages and canNavigate function to Navigation API

### DIFF
--- a/.changeset/forty-files-relax.md
+++ b/.changeset/forty-files-relax.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Updated the navigation function in Navigation API to allow for navigation to POS native screen and added a canNavigate function to allow partners to check if they can navigate to the specified POS native screen

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -6,11 +6,34 @@ export interface NavigationApiContent {
    */
   navigate(screenName: string, params?: any): void;
 
+  /** Opens a POS Native screen modally.
+   * If the uri starts with `shopify://point-of-sale/` it will be treated as a POS Native screen. Otherwise it will try to navigate to an extension screen.
+   * Available POS Native screens:
+   * - `shopify://point-of-sale/products/{product_id}` to present product details.
+   * - `shopify://point-of-sale/products/{product_id}/variants/{variant_id}` to present product variant details.
+   * - `shopify://point-of-sale/customers/{customer_id}` to present customer details.
+   * - `shopify://point-of-sale/orders/{order_id}` to present order details.
+   * - `shopify://point-of-sale/draft_orders/{draft_order_id}` to present draft order details.
+   * - `shopify://point-of-sale/staff/{staff_id}` to present staff details.
+   * @param uri the uri of the POS Native screen to present modally.
+   * @returns A promise that resolves when the POS screen is presented, rejects when an error occurs.
+   * @example
+   * // Open product variant details screen for product id 123 and variant id 456
+   * navigate('shopify://point-of-sale/products/123/variants/456');
+   */
+  navigate(uri: string | URL): Promise<void>;
+
   /** Pops the currently shown screen */
   pop(): void;
 
   /** Dismisses the extension. */
   dismiss(): void;
+
+  /** Checks if the user has permission to navigate to the specified screen.
+   * @param uri the uri to check if the user has permission to navigate to.
+   * @returns false if the uri is a valid uri to navigate to a POS screen and the user does not have permission to navigate to the specified screen, true otherwise.
+   */
+  canNavigate(uri: string | URL): boolean;
 }
 
 /**


### PR DESCRIPTION
### Background

Resolves https://github.com/shop/issues-retail/issues/1810 and https://github.com/shop/issues-retail/issues/8397. This PR is made together with [this PR](https://github.com/Shopify/pos-next-react-native/pull/64876).

### Solution

We have decided to overload the `navigate` function with our new `navigate` function. This works with the implementation seen in the `pos-next-react-native` repo in the PR linked above. (Two declarations but one implementation). We have also added a `canNavigate` function to allow partners to check if the user has permissions to access the resource and adjust their flows accordingly.

Note: Documentation and e2e tests will be updated in later PRs, referencing [this issue](https://github.com/shop/issues-retail/issues/2018) and [this issue](https://github.com/shop/issues-retail/issues/2015).

### 🎩

- Please check [this PR](https://github.com/Shopify/pos-next-react-native/pull/64876) for tophatting instructions.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
