### PR TITLE
[POS]: export SellingPlan type and add extra fields

### DIFF
--- a/.changeset/wicked-moons-lay.md
+++ b/.changeset/wicked-moons-lay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Expose additional selling plan-related fields in POS UI extensions models

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -87,6 +87,7 @@ export type {
   LineItemDiscount,
   CustomSale,
   Address,
+  SellingPlan,
 } from './types/cart';
 
 export type {OrderLineItem, LineItemRefund} from './types/order';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/product.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/product.ts
@@ -22,6 +22,8 @@ export interface Product {
   hasOnlyDefaultVariant: boolean;
   hasInStockVariants?: boolean;
   onlineStoreUrl?: string;
+  requiresSellingPlan?: boolean;
+  hasSellingPlanGroups?: boolean;
 }
 
 export interface ProductVariant {


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/16794

### Background

Follow up PR for: https://github.com/Shopify/ui-extensions/pull/3112, which was missing some fields / export

### Solution

Straightforward. Matches existing POS modals.

### 🎩

No extra tophat on this repo needed. Tested locally against POS, and it already connects nicely with ProductSearch API mappers.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
