### PR TITLE
Changed the return value of the canNavigate function to a Promise

### DIFF
--- a/.changeset/odd-walls-brake.md
+++ b/.changeset/odd-walls-brake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+The function canNavigate of Navigation API will return a Promise instead of a boolean since it throws an error if the user is on a version of POS extensions that is lower than 2025-10.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -31,9 +31,9 @@ export interface NavigationApiContent {
 
   /** Checks if the user has permission to navigate to the specified screen.
    * @param uri the uri to check if the user has permission to navigate to.
-   * @returns false if the uri is a valid uri to navigate to a POS screen and the user does not have permission to navigate to the specified screen, true otherwise.
+   * @returns false if the uri is a valid uri to navigate to a POS screen and the user does not have permission to navigate to the specified screen, true otherwise. The promise rejects if the user is not on the correct API version of POS extensions.
    */
-  canNavigate(uri: string | URL): boolean;
+  canNavigate(uri: string | URL): Promise<boolean>;
 }
 
 /**


### PR DESCRIPTION
### Background

This PR is an update on [this PR](https://github.com/Shopify/ui-extensions/pull/3134).

### Solution

We need to change the update the value of the canNavigate function since we will be throwing an error if the API version is lower than 2025-10 in the function.

### 🎩

- Same thing as [this PR](https://github.com/Shopify/ui-extensions/pull/3134).

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
