### PR TITLE
Updated ReturnTransactionData and ExchangeTransactionData interfaces

### DIFF
--- a/.changeset/clever-walls-chew.md
+++ b/.changeset/clever-walls-chew.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Modified transaction data interface fields to include returnId and refundId to Return and Exchange TransactionData.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
@@ -3,6 +3,7 @@ import {LineItem} from '../../types/cart';
 
 export interface ExchangeTransactionData extends BaseTransactionComplete {
   transactionType: 'Exchange';
+  returnId?: number;
   exchangeId?: number;
   lineItemsAdded: LineItem[];
   lineItemsRemoved: LineItem[];

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
@@ -3,6 +3,7 @@ import {LineItem} from '../../types/cart';
 
 export interface ReturnTransactionData extends BaseTransactionComplete {
   transactionType: 'Return';
+  refundId?: number;
   returnId?: number;
   exchangeId?: number;
   lineItems: LineItem[];


### PR DESCRIPTION
### Background

Closes https://github.com/shop/issues-retail/issues/16805?issue=shop%7Cissues-retail%7C17025 

### Solution

Updated the interface fields to add returnId and refundId

### 🎩

- This PR is difficult to tophat standalone.
- This PR serves as a proposed approach to eventually close this [ticket](https://github.com/shop/issues-retail/issues/16805). Once the approach is finalized, we can update the POS with the changes and tophat locally.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
