### PR TITLE
Add announcement targets documentation

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/announcement.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/announcement.doc.ts
@@ -1,0 +1,22 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {getLinksByTag} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Announcement',
+  description: 'The API for interacting with the announcement bar.',
+  isVisualComponent: false,
+  category: 'APIs',
+  type: 'API',
+  definitions: [
+    {
+      title: 'AnnouncementApi',
+      description:
+        'The API object provided to the `purchase.thank-you.announcement.render` extension target.',
+      type: 'AnnouncementApi',
+    },
+  ],
+  related: getLinksByTag('apis'),
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
@@ -152,6 +152,7 @@ export function getExamples(
     ...createExample('purchase.thank-you.footer.render-after/default'),
     ...createExample('purchase.checkout.chat.render/default'),
     ...createExample('purchase.thank-you.chat.render/default'),
+    ...createExample('purchase.thank-you.announcement.render/default'),
     'analytics-publish': {
       description:
         'You can publish analytics events to the Shopify analytics frameworks and they will be propagated to all web pixels on the page.',
@@ -768,6 +769,13 @@ const SHIPPING_OPTION_LIST_API_DEFINITION = {
   type: 'ShippingOptionListApi',
 };
 
+const ANNOUNCEMENT_API_DEFINITION = {
+  title: 'AnnouncementApi',
+  description:
+    'The API object provided to the `purchase.thank-you.announcement.render` extension target.',
+  type: 'AnnouncementApi',
+};
+
 const COMMON_API = {
   category: 'Targets',
   isVisualComponent: false,
@@ -821,6 +829,15 @@ export const CHECKOUT_CART_LINE_ITEM_API = {
 
 export const THANK_YOU_API = {
   definitions: [ORDER_CONFIRMATION_API_DEFINITION, STANDARD_API_DEFINITION],
+  ...COMMON_API,
+};
+
+export const THANK_YOU_ANNOUNCEMENT_API = {
+  definitions: [
+    ANNOUNCEMENT_API_DEFINITION,
+    ORDER_CONFIRMATION_API_DEFINITION,
+    STANDARD_API_DEFINITION,
+  ],
   ...COMMON_API,
 };
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.announcement.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/targets/purchase.thank-you.announcement.render.doc.ts
@@ -1,0 +1,22 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {
+  getExample,
+  getLinksByTag,
+  THANK_YOU_ANNOUNCEMENT_API,
+} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'purchase.thank-you.announcement.render',
+  description:
+    'A static extension target that is rendered on top of the **Thank you page** as a dismissable announcement.',
+  defaultExample: getExample('purchase.thank-you.announcement.render/default', [
+    'jsx',
+    'js',
+  ]),
+  subCategory: 'Announcement',
+  related: getLinksByTag('targets'),
+  ...THANK_YOU_ANNOUNCEMENT_API,
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-index.announcement.render/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-index.announcement.render/default.example.ts
@@ -1,0 +1,71 @@
+import {
+  BlockStack,
+  Button,
+  InlineStack,
+  Link,
+  Modal,
+  TextField,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/customer-account';
+
+export default extension(
+  'customer-account.order-index.announcement.render',
+  (root) => {
+    const modalFragment = root.createFragment();
+    modalFragment.appendChild(
+      root.createComponent(
+        Modal,
+        {
+          title:
+            'Tell us about your shopping experience',
+          padding: true,
+        },
+        [
+          root.createComponent(
+            BlockStack,
+            undefined,
+            [
+              root.createComponent(
+                Text,
+                undefined,
+                "We'd love to hear about your shopping experience",
+              ),
+              root.createComponent(TextField, {
+                multiline: 4,
+                label:
+                  'How can we make your shopping experience better?',
+              }),
+              root.createComponent(
+                Button,
+                undefined,
+                'Submit',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    root.appendChild(
+      root.createComponent(
+        InlineStack,
+        undefined,
+        [
+          root.createComponent(
+            Text,
+            undefined,
+            'Check our latest offers',
+          ),
+          root.createComponent(
+            Link,
+            {
+              overlay: modalFragment,
+            },
+            'Fill out the survey',
+          ),
+        ],
+      ),
+    );
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-index.announcement.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-index.announcement.render/default.example.tsx
@@ -1,0 +1,47 @@
+import {
+  BlockStack,
+  Button,
+  InlineStack,
+  Link,
+  Modal,
+  reactExtension,
+  TextField,
+  Text,
+} from '@shopify/ui-extensions-react/customer-account';
+
+// 1. Choose an extension target
+export default reactExtension(
+  'customer-account.order-index.announcement.render',
+  () => <Extension />,
+);
+
+function Extension() {
+  // 2. Render a UI
+  return (
+    <InlineStack>
+      <Text>Check our latest offers</Text>
+      <Link
+        overlay={
+          <Modal
+            title="Tell us about your shopping experience"
+            padding
+          >
+            <BlockStack>
+              <Text>
+                We'd love to hear about your
+                shopping experience
+              </Text>
+              <TextField
+                multiline={4}
+                label="How can we make your shopping experience better?"
+              ></TextField>
+              <Button>Submit</Button>
+            </BlockStack>
+          </Modal>
+        }
+      >
+        Fill out the survey
+      </Link>
+    </InlineStack>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.announcement.render/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.announcement.render/default.example.ts
@@ -1,0 +1,71 @@
+import {
+  BlockStack,
+  Button,
+  InlineStack,
+  Link,
+  Modal,
+  TextField,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/customer-account';
+
+export default extension(
+  'customer-account.order-status.announcement.render',
+  (root, {shop}) => {
+    const modalFragment = root.createFragment();
+    modalFragment.appendChild(
+      root.createComponent(
+        Modal,
+        {
+          title:
+            'Tell us about your shopping experience',
+          padding: true,
+        },
+        [
+          root.createComponent(
+            BlockStack,
+            undefined,
+            [
+              root.createComponent(
+                Text,
+                undefined,
+                `We'd love to hear about your shopping experience at ${shop.name}`,
+              ),
+              root.createComponent(TextField, {
+                multiline: 4,
+                label:
+                  'How can we make your shopping experience better?',
+              }),
+              root.createComponent(
+                Button,
+                undefined,
+                'Submit',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    root.appendChild(
+      root.createComponent(
+        InlineStack,
+        undefined,
+        [
+          root.createComponent(
+            Text,
+            undefined,
+            'Check our latest offers',
+          ),
+          root.createComponent(
+            Link,
+            {
+              overlay: modalFragment,
+            },
+            'Fill out the survey',
+          ),
+        ],
+      ),
+    );
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.announcement.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.announcement.render/default.example.tsx
@@ -1,0 +1,51 @@
+import {
+  BlockStack,
+  Button,
+  InlineStack,
+  Link,
+  Modal,
+  reactExtension,
+  TextField,
+  Text,
+  useApi,
+} from '@shopify/ui-extensions-react/customer-account';
+
+// 1. Choose an extension target
+export default reactExtension(
+  'customer-account.order-status.announcement.render',
+  () => <Extension />,
+);
+
+function Extension() {
+  // 2. Use the extension API to gather context from the shop
+  const {shop} = useApi();
+
+  // 3. Render a UI
+  return (
+    <InlineStack>
+      <Text>Check our latest offers</Text>
+      <Link
+        overlay={
+          <Modal
+            title="Tell us about your shopping experience"
+            padding
+          >
+            <BlockStack>
+              <Text>
+                We'd love to hear about your
+                shopping experience at {shop.name}
+              </Text>
+              <TextField
+                multiline={4}
+                label="How can we make your shopping experience better?"
+              ></TextField>
+              <Button>Submit</Button>
+            </BlockStack>
+          </Modal>
+        }
+      >
+        Fill out the survey
+      </Link>
+    </InlineStack>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.announcement.render/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.announcement.render/default.example.ts
@@ -1,0 +1,71 @@
+import {
+  BlockStack,
+  Button,
+  InlineStack,
+  Link,
+  Modal,
+  TextField,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/customer-account';
+
+export default extension(
+  'customer-account.profile.announcement.render',
+  (root) => {
+    const modalFragment = root.createFragment();
+    modalFragment.appendChild(
+      root.createComponent(
+        Modal,
+        {
+          title:
+            'Tell us about your shopping experience',
+          padding: true,
+        },
+        [
+          root.createComponent(
+            BlockStack,
+            undefined,
+            [
+              root.createComponent(
+                Text,
+                undefined,
+                "We'd love to hear about your shopping experience",
+              ),
+              root.createComponent(TextField, {
+                multiline: 4,
+                label:
+                  'How can we make your shopping experience better?',
+              }),
+              root.createComponent(
+                Button,
+                undefined,
+                'Submit',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    root.appendChild(
+      root.createComponent(
+        InlineStack,
+        undefined,
+        [
+          root.createComponent(
+            Text,
+            undefined,
+            'Check our latest offers',
+          ),
+          root.createComponent(
+            Link,
+            {
+              overlay: modalFragment,
+            },
+            'Fill out the survey',
+          ),
+        ],
+      ),
+    );
+  },
+);

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.announcement.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.announcement.render/default.example.tsx
@@ -1,0 +1,47 @@
+import {
+  BlockStack,
+  Button,
+  InlineStack,
+  Link,
+  Modal,
+  reactExtension,
+  TextField,
+  Text,
+} from '@shopify/ui-extensions-react/customer-account';
+
+// 1. Choose an extension target
+export default reactExtension(
+  'customer-account.profile.announcement.render',
+  () => <Extension />,
+);
+
+function Extension() {
+  // 2. Render a UI
+  return (
+    <InlineStack>
+      <Text>Check our latest offers</Text>
+      <Link
+        overlay={
+          <Modal
+            title="Tell us about your shopping experience"
+            padding
+          >
+            <BlockStack>
+              <Text>
+                We'd love to hear about your
+                shopping experience
+              </Text>
+              <TextField
+                multiline={4}
+                label="How can we make your shopping experience better?"
+              ></TextField>
+              <Button>Submit</Button>
+            </BlockStack>
+          </Modal>
+        }
+      >
+        Fill out the survey
+      </Link>
+    </InlineStack>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/helper.docs.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/helper.docs.ts
@@ -59,6 +59,13 @@ const FULFILLMENT_API_DEFINITION = {
   type: 'FulfillmentApi',
 };
 
+const ANNOUNCEMENT_API_DEFINITION = {
+  title: 'AnnouncementApi',
+  description:
+    'The API object provided to this and other `announcement` extension targets.',
+  type: 'AnnouncementApi',
+};
+
 export const REQUIRES_PROTECTED_CUSTOMER_DATA =
   'access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) for some properties.';
 
@@ -95,6 +102,29 @@ export const ORDER_STATUS_API = {
     CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION,
   ],
   ...COMMON_API,
+};
+
+export const ORDER_STATUS_ANNOUNCEMENT_API = {
+  definitions: [
+    ANNOUNCEMENT_API_DEFINITION,
+    ORDER_STATUS_API_DEFINITION,
+    CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION,
+  ],
+  ...COMMON_API,
+};
+
+export const ORDER_INDEX_ANNOUNCEMENT_API = {
+  definitions: [
+    ANNOUNCEMENT_API_DEFINITION,
+    CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION,
+  ],
+};
+
+export const PROFILE_ANNOUNCEMENT_API = {
+  definitions: [
+    ANNOUNCEMENT_API_DEFINITION,
+    CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION,
+  ],
 };
 
 export const FULFILLMENT_DETAILS_APIS = {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-index.announcement.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-index.announcement.render.doc.ts
@@ -1,0 +1,37 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {ORDER_STATUS_ANNOUNCEMENT_API} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'customer-account.order-index.announcement.render',
+  description: `A static extension target that is rendered on top of the **Order Index page** as a dismissable announcement.`,
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order index announcement extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-index.announcement.render/default.example.tsx',
+          language: 'jsx',
+          title: 'React',
+        },
+        {
+          code: '../examples/targets/customer-account.order-index.announcement.render/default.example.ts',
+          language: 'js',
+          title: 'Javascript',
+        },
+      ],
+    },
+  },
+  subCategory: 'Order index',
+  related: [
+    {
+      name: 'Placement references',
+      subtitle: 'Navigate to',
+      url: '/docs/apps/customer-accounts/best-practices/testing-ui-extensions#order-index',
+    },
+  ],
+  ...ORDER_STATUS_ANNOUNCEMENT_API,
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.announcement.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.announcement.render.doc.ts
@@ -1,0 +1,37 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {ORDER_STATUS_ANNOUNCEMENT_API} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'customer-account.order-status.announcement.render',
+  description: `A static extension target that is rendered on top of the **Order Status page** as a dismissable announcement.`,
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order status announcement extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-status.announcement.render/default.example.tsx',
+          language: 'jsx',
+          title: 'React',
+        },
+        {
+          code: '../examples/targets/customer-account.order-status.announcement.render/default.example.ts',
+          language: 'js',
+          title: 'Javascript',
+        },
+      ],
+    },
+  },
+  subCategory: 'Order status',
+  related: [
+    {
+      name: 'Placement references',
+      subtitle: 'Navigate to',
+      url: '/docs/apps/customer-accounts/best-practices/testing-ui-extensions#order-status',
+    },
+  ],
+  ...ORDER_STATUS_ANNOUNCEMENT_API,
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.announcement.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.announcement.render.doc.ts
@@ -1,0 +1,39 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {PROFILE_ANNOUNCEMENT_API} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'customer-account.profile.announcement.render',
+  description: `A static extension target that is rendered on top of the **Profile page** as a dismissable announcement.`,
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account profile announcement extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.profile.announcement.render/default.example.tsx',
+          language: 'jsx',
+          title: 'React',
+        },
+        {
+          code: '../examples/targets/customer-account.profile.announcement.render/default.example.ts',
+          language: 'js',
+          title: 'Javascript',
+        },
+      ],
+    },
+  },
+  subCategory: 'Profile (Default)',
+  related: [
+    {
+      name: 'Placement references',
+      subtitle: 'Navigate to',
+      url: '/docs/apps/customer-accounts/best-practices/testing-ui-extensions#profile',
+    },
+  ],
+  ...PROFILE_ANNOUNCEMENT_API,
+  category: 'Targets',
+  isVisualComponent: false,
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout.ts
@@ -143,7 +143,7 @@ export type {
   OrderStatusApi,
 } from './checkout/api/order-status/order-status';
 export type {OrderConfirmationApi} from './checkout/api/order-confirmation/order-confirmation';
-export type {Announcement} from './checkout/api/announcement/announcement';
+export type {AnnouncementApi} from './checkout/api/announcement/announcement';
 
 export type {CartLineItemApi} from './checkout/api/cart-line/cart-line-item';
 export type {PickupLocationListApi} from './checkout/api/pickup/pickup-location-list';

--- a/packages/ui-extensions/src/surfaces/checkout/api/announcement/announcement.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/announcement/announcement.ts
@@ -1,7 +1,21 @@
-export interface Announcement {
-  announcement: {
-    close(): void;
-    addEventListener(type: 'close', cb: () => void): void;
-    removeEventListener(type: 'close', cb: () => void): void;
-  };
+/**
+ * The API for interacting with the announcement bar.
+ */
+export interface AnnouncementApi {
+  announcement: Announcement;
+}
+
+interface Announcement {
+  /**
+   * Close the Announcement bar.
+   */
+  close(): void;
+  /**
+   * Listen for events from the announcement bar.
+   */
+  addEventListener(type: 'close', cb: () => void): void;
+  /**
+   * Remove a listener for events from the announcement bar.
+   */
+  removeEventListener(type: 'close', cb: () => void): void;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -18,13 +18,13 @@ import type {RedeemableApi} from './api/redeemable/redeemable';
 import type {StandardApi} from './api/standard/standard';
 import type {ShippingOptionItemApi} from './api/shipping/shipping-option-item';
 import type {ShippingOptionListApi} from './api/shipping/shipping-option-list';
+import {AnnouncementApi} from './api/announcement/announcement';
 import type {RenderExtension, RunnableExtension} from './extension';
 import type {
   AnyComponent,
   AllowedComponents,
   AnyComponentExcept,
 } from './shared';
-import type {Announcement} from './api/announcement/announcement';
 
 /**
  * A UI extension will register for one or more extension targets using `shopify.extend()`.
@@ -654,7 +654,7 @@ export interface RenderExtensionTargets {
   'purchase.thank-you.announcement.render': RenderExtension<
     OrderConfirmationApi &
       StandardApi<'purchase.thank-you.announcement.render'> &
-      Announcement,
+      AnnouncementApi,
     AnyComponent
   >;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api.ts
@@ -97,3 +97,5 @@ export type {
   OrderApi,
   ExtensionSettings,
 } from './api/standard-api/standard-api';
+
+export type {AnnouncementApi} from './api/announcement/announcement';

--- a/packages/ui-extensions/src/surfaces/customer-account/api/announcement/announcement.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/announcement/announcement.ts
@@ -1,7 +1,21 @@
-export interface Announcement {
-  announcement: {
-    close(): void;
-    addEventListener(type: 'close', cb: () => void): void;
-    removeEventListener(type: 'close', cb: () => void): void;
-  };
+/**
+ * The API for interacting with the announcement bar.
+ */
+export interface AnnouncementApi {
+  announcement: Announcement;
+}
+
+interface Announcement {
+  /**
+   * Close the Announcement bar.
+   */
+  close(): void;
+  /**
+   * Listen for events from the announcement bar.
+   */
+  addEventListener(type: 'close', cb: () => void): void;
+  /**
+   * Remove a listener for events from the announcement bar.
+   */
+  removeEventListener(type: 'close', cb: () => void): void;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/targets.ts
@@ -11,7 +11,7 @@ import {
   FulfillmentApi,
   ReturnApi,
 } from './api/standard-api/standard-api';
-import {Announcement} from './api/announcement/announcement';
+import {AnnouncementApi} from './api/announcement/announcement';
 
 type Components = typeof import('./components');
 
@@ -97,7 +97,7 @@ export interface OrderStatusExtensionTargets {
   'customer-account.order-status.announcement.render': RenderExtension<
     OrderStatusApi<'customer-account.order-status.announcement.render'> &
       StandardApi<'customer-account.order-status.announcement.render'> &
-      Announcement,
+      AnnouncementApi,
     AnyComponent
   >;
   'customer-account.order.page.render': RenderExtension<
@@ -129,7 +129,7 @@ export interface CustomerAccountExtensionTargets {
   >;
   'customer-account.order-index.announcement.render': RenderExtension<
     StandardApi<'customer-account.order-index.announcement.render'> &
-      Announcement,
+      AnnouncementApi,
     AllComponents
   >;
   'customer-account.profile.block.render': RenderExtension<
@@ -137,7 +137,8 @@ export interface CustomerAccountExtensionTargets {
     AllComponents
   >;
   'customer-account.profile.announcement.render': RenderExtension<
-    StandardApi<'customer-account.profile.announcement.render'> & Announcement,
+    StandardApi<'customer-account.profile.announcement.render'> &
+      AnnouncementApi,
     AllComponents
   >;
   'customer-account.profile.addresses.render-after': RenderExtension<


### PR DESCRIPTION
Part of https://github.com/shop/issues-checkout/issues/7222

### Background

This PR adds a new extension target for the Thank You (Checkout), Order Status, Order Index and Profile (Customer Account) pages, allowing developers to render dismissible announcements at the top of the page.

### Solution

Added new extension targets:

- `purchase.thank-you.announcement.render`
- `customer-account.order-status.announcement.render`
- `customer-account.order-index.announcement.render`
- `customer-account.profile.announcement.render`

These targets render a dismissable announcement on the the Thank You (Checkout), Order Status, Order Index and Profile (Customer Account) pages. This provides developers with another way to communicate important information to customers after they complete their purchase.

The implementation includes:
- Adding the target definition to the `RenderExtensionTargets` interface
- Creating documentation for the new target
- Adding example implementations in both JS and React (TSX) formats
- Updating the helper docs to include the new examples

### 🎩

- Create a new extension using the new targets
- Complete a checkout flow to verify the announcement appears correctly on the Thank You page
- Check the announcement appears on post-purchase pages (Order Status, Order Index, and Profile)
- Verify the announcement is dismissible

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation