### PR TITLE
Update avatar size prop

### DIFF
--- a/.changeset/real-boxes-fail.md
+++ b/.changeset/real-boxes-fail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Update Customer Account Avatar size prop to SizeKeyword

--- a/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
@@ -1,4 +1,4 @@
-import {Size, IdProps} from './components/shared';
+import {SizeKeyword, IdProps} from './components/shared';
 
 export interface CustomerAccountActionProps extends IdProps {
   /**
@@ -109,21 +109,24 @@ export interface AvatarProps extends IdProps {
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload
    */
-  onLoad?(): void;
+  onLoad?(event: Event): void;
 
   /**
    * Invoked on load error of provided image.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
    */
-  onError?(): void;
+  onError?(event: Event): void;
 
   /**
    * Size of the avatar.
    *
    * @default 'base'
    */
-  size?: Extract<Size, 'base' | 'large' | 'extraLarge' | 'fill'>;
+  size?: Extract<
+    SizeKeyword,
+    'small-200' | 'small' | 'base' | 'large' | 'large-200'
+  >;
 
   /**
    * An alternative text description that describe the image for the reader

--- a/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
@@ -1,4 +1,10 @@
 import {SizeKeyword, IdProps} from './components/shared';
+import {
+  AvatarProps,
+  AvatarElementProps,
+  AvatarElement,
+  AvatarEvents,
+} from './components/Avatar';
 
 export interface CustomerAccountActionProps extends IdProps {
   /**
@@ -91,55 +97,14 @@ declare module 'preact' {
   }
 }
 
-export interface AvatarProps extends IdProps {
-  /**
-   * Initials to display in the avatar.
-   */
-  initials?: string;
-
-  /**
-   * The URL or path to the image.
-   *
-   * Initials will be rendered as a fallback if `src` is not provided, fails to load or does not load quickly.
-   */
-  src?: string;
-
-  /**
-   * Invoked when load of provided image completes successfully.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload
-   */
-  onLoad?(event: Event): void;
-
-  /**
-   * Invoked on load error of provided image.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
-   */
-  onError?(event: Event): void;
-
-  /**
-   * Size of the avatar.
-   *
-   * @default 'base'
-   */
-  size?: Extract<
-    SizeKeyword,
-    'small-200' | 'small' | 'base' | 'large' | 'large-200'
-  >;
-
-  /**
-   * An alternative text description that describe the image for the reader
-   * to understand what it is about or identify the user the avatar belongs to.
-   */
-  alt?: string;
-}
-
-export interface AvatarElement extends AvatarProps, Omit<HTMLElement, 'id'> {}
+export type AvatarElementPropsDocs = AvatarElementProps;
+export type AvatarPropsDocs = AvatarProps;
+export type AvatarElementDocs = AvatarElement;
+export type AvatarEventsDocs = AvatarEvents;
 
 declare global {
   interface HTMLElementTagNameMap {
-    ['s-avatar']: AvatarElement;
+    ['s-avatar']: AvatarElementDocs;
   }
 }
 
@@ -147,7 +112,8 @@ declare module 'preact' {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace createElement.JSX {
     interface IntrinsicElements {
-      ['s-avatar']: BaseElementPropsWithChildren<AvatarElement> & AvatarProps;
+      ['s-avatar']: BaseElementPropsWithChildren<AvatarElementDocs> &
+        AvatarPropsDocs;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar.d.ts
@@ -1,6 +1,15 @@
 import {BaseElementPropsWithChildren, IdProps, SizeKeyword} from './shared';
 
-export interface AvatarProps extends IdProps {
+export type CallbackEventListener<
+  TTagName extends keyof HTMLElementTagNameMap,
+  TEvent extends Event = Event,
+> =
+  | (EventListener & {
+      (event: CallbackEvent<TTagName, TEvent>): void;
+    })
+  | null;
+
+export interface AvatarElementProps extends IdProps {
   /**
    * Initials to display in the avatar.
    */
@@ -12,20 +21,6 @@ export interface AvatarProps extends IdProps {
    * Initials will be rendered as a fallback if `src` is not provided, fails to load or does not load quickly.
    */
   src?: string;
-
-  /**
-   * Invoked when load of provided image completes successfully.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload
-   */
-  onLoad?(event: Event): void;
-
-  /**
-   * Invoked on load error of provided image.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
-   */
-  onError?(event: Event): void;
 
   /**
    * Size of the avatar.
@@ -44,7 +39,42 @@ export interface AvatarProps extends IdProps {
   alt?: string;
 }
 
-export interface AvatarElement extends AvatarProps, Omit<HTMLElement, 'id'> {}
+export interface AvatarElementEvents {
+  /**
+   * Invoked when load of provided image completes successfully.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload
+   */
+  onLoad?(event: Event): void;
+
+  /**
+   * Invoked on load error of provided image.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
+   */
+  onError?(event: Event): void;
+}
+
+export interface AvatarElement
+  extends AvatarElementProps,
+    Omit<HTMLElement, 'id'> {
+  onload: AvatarElementEvents['onLoad'];
+  onerror: AvatarElementEvents['onError'];
+}
+
+export interface AvatarEvents {
+  /**
+   * Callback when the image loads successfully.
+   */
+  load?: ((event: CallbackEventListener<typeof tagName>) => void) | null;
+
+  /**
+   * Callback when the image fails to load.
+   */
+  error?: ((event: CallbackEventListener<typeof tagName>) => void) | null;
+}
+
+export type AvatarProps = AvatarElementProps & AvatarElementEvents;
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar.d.ts
@@ -1,4 +1,4 @@
-import {BaseElementPropsWithChildren, Size, IdProps} from './shared';
+import {BaseElementPropsWithChildren, IdProps, SizeKeyword} from './shared';
 
 export interface AvatarProps extends IdProps {
   /**
@@ -18,21 +18,24 @@ export interface AvatarProps extends IdProps {
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload
    */
-  onLoad?(): void;
+  onLoad?(event: Event): void;
 
   /**
    * Invoked on load error of provided image.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
    */
-  onError?(): void;
+  onError?(event: Event): void;
 
   /**
    * Size of the avatar.
    *
    * @default 'base'
    */
-  size?: Extract<Size, 'base' | 'large' | 'extraLarge' | 'fill'>;
+  size?: Extract<
+    SizeKeyword,
+    'small-200' | 'small' | 'base' | 'large' | 'large-200'
+  >;
 
   /**
    * An alternative text description that describe the image for the reader

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
@@ -38,11 +38,12 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best Practices',
       sectionContent: `
   - By default, if a user does not provide their first or last name, the avatar component will display a placeholder icon. However, if at least one of the names is provided, the avatar will be replaced with one or two initials representing the user.
-  - There are 4 sizes for the avatar component:
-    * Base (32x32 px): Use by default.
-    * Large (39×39 px): Use when the avatar is a focal point, such as a customer details card.
-    * Extra-large (47x47 px): Use when placing more emphasis on the avatar
-    * Fill to fit: Use when there is a particular size that does not match any of the three sizes provided. If using images please ensure the resolution meets the size requirements.
+  - There are 5 sizes for the avatar component:
+    * small-200 (21x21 px): Use when showing avatars in tables / lists where space is limited.
+    * small (26x26 px): Use when you want to conserve space but want a larger size than small-200.
+    * base (32x32 px): Use by default.
+    * large (39×39 px): Use when the avatar is a focal point, such as a customer details card.
+    * large-200 (47x47 px): Use when placing more emphasis on the avatar.
 
   - Provide alt text for avatars to assist customers using assistive technologies.
 

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
@@ -12,7 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'AvatarProps',
       description: '',
-      type: 'AvatarProps',
+      type: 'AvatarElementPropsDocs',
+    },
+    {
+      title: 'Events',
+      description:
+        'Learn more about [registering events](/docs/api/app-home/using-polaris-components#event-handling).',
+      type: 'AvatarEventsDocs',
     },
   ],
   category: 'Polaris web components',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/shared.ts
@@ -5,13 +5,20 @@ export interface IdProps {
   id?: string;
 }
 
-export type Size =
-  | 'extraSmall'
+export type SizeKeyword =
+  | 'small-500'
+  | 'small-400'
+  | 'small-300'
+  | 'small-200'
+  | 'small-100'
   | 'small'
   | 'base'
   | 'large'
-  | 'extraLarge'
-  | 'fill';
+  | 'large-100'
+  | 'large-200'
+  | 'large-300'
+  | 'large-400'
+  | 'large-500';
 
 export interface BaseElementProps<TClass = HTMLElement> {
   // Assigns a unique key to this element.


### PR DESCRIPTION
### Background

Updates avatar size prop to SizeKeyword. We do not have to specify small-100 and large-100 as these are aliases of small and large. We are following the same approach as admin here.

Also see https://github.com/Shopify/shopify-dev/pull/61707

### Solution

Updated typings and used SizeKeyword

### 🎩

<img width="2555" height="1257" alt="Screenshot 2025-08-18 at 3 13 54 PM" src="https://github.com/user-attachments/assets/d2c2e27c-fecd-4750-bc5e-7f62f6c060d1" />



### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
