### PR TITLE
Adjusted comments for clearer dev documentation

### DIFF
--- a/.changeset/nasty-terms-move.md
+++ b/.changeset/nasty-terms-move.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Updated comments for documentation and adjusted the return value of the previous navigate function

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -1,12 +1,14 @@
 export interface NavigationApiContent {
-  /** Navigate to a route in current navigation tree.
+  /**
+   * Using `(screenName: string, params?: any)` navigates to a route in current navigation tree.
    * Pushes the specified screen if it isn't present in the navigation tree, goes back to a created screen otherwise.
    * @param screenName the name of the screen you want to navigate to.
    * @param params the parameters you want to pass to that screen.
    */
-  navigate(screenName: string, params?: any): void;
+  navigate(screenName: string, params?: any): Promise<void>;
 
-  /** Opens a POS Native screen modally.
+  /**
+   * Using `(uri: string | URL)` opens a POS Native screen modally.
    * If the uri starts with `shopify:point-of-sale/` it will be treated as a POS Native screen. Otherwise it will try to navigate to an extension screen.
    * Available POS Native screens:
    * - `shopify:point-of-sale/products/{product_id}` to present product details.


### PR DESCRIPTION
### Background

Adjusted the comments in Navigation for clearer dev documentation (due to function overloading). https://github.com/Shopify/shopify-dev/pull/61642 is the dev documentation PR. (This is the same as https://github.com/Shopify/ui-extensions/pull/3154) but with an added changeset to trigger the release.

### 🎩

- A code review is sufficient for this change.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
