### PR TITLE
Updated ReturnTransactionData and ExchangeTransactionData interfaces

### DIFF
--- a/.changeset/tough-panthers-impress.md
+++ b/.changeset/tough-panthers-impress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Modified transaction data interface fields to include returnId and refundId to Return and Exchange TransactionData.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
@@ -3,6 +3,7 @@ import {LineItem} from '../../types/cart';
 
 export interface ExchangeTransactionData extends BaseTransactionComplete {
   transactionType: 'Exchange';
+  returnId?: number;
   exchangeId?: number;
   lineItemsAdded: LineItem[];
   lineItemsRemoved: LineItem[];

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
@@ -3,6 +3,7 @@ import {LineItem} from '../../types/cart';
 
 export interface ReturnTransactionData extends BaseTransactionComplete {
   transactionType: 'Return';
+  refundId?: number;
   returnId?: number;
   exchangeId?: number;
   lineItems: LineItem[];


### PR DESCRIPTION
### Background

Closes https://github.com/issues/assigned?issue=shop%7Cissues-retail%7C17098

### Solution

Updated the interface fields to add optional `returnId` and `refundId`. The change has already been merged in `unstable` branch with this [PR](https://github.com/Shopify/ui-extensions/pull/3148).

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
