### PR TITLE
Fix broken customer account links in RC version

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/categories/components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/categories/components.doc.ts
@@ -14,7 +14,7 @@ const data: CategoryTemplateSchema = {
           type: 'blocks',
           name: 'Checkout components',
           subtitle: 'More components',
-          url: '/docs/api/checkout-ui-extensions/polaris-web-components',
+          url: '/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components',
         },
       ],
     },

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
@@ -149,13 +149,13 @@ const data: LandingTemplateSchema = {
         {
           name: 'Checkout components',
           subtitle: 'API Reference',
-          url: '/api/checkout-ui-extensions/components',
+          url: '/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components',
           type: 'blocks',
         },
         {
           name: 'Customer account components',
           subtitle: 'API Reference',
-          url: '/api/customer-account-ui-extensions/components',
+          url: '/docs/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components',
           type: 'blocks',
         },
         {


### PR DESCRIPTION
### Background

Links to customer account and checkout components were broken in the RC, this PR updates the links

### 🎩

All these links were broken before: 

https://github.com/user-attachments/assets/f6d2941d-79b9-4852-b168-c17b05a4814b

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
