### PR TITLE
add new preact signal like type

### DIFF
--- a/.changeset/afraid-feet-jog.md
+++ b/.changeset/afraid-feet-jog.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+add signal-like value property to checkout api

--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -937,3 +937,17 @@ export interface GraphQLError {
     code: string;
   };
 }
+
+/**
+ * Represents a read-only value managed on the main thread that an extension can subscribe to.
+ *
+ * Example: Checkout uses this to manage the state of an object and
+ * communicate state changes to extensions running in a sandboxed web worker.
+ *
+ * This interface is compatible with Preact's ReadonlySignal:
+ * https://github.com/preactjs/signals/blob/a023a132a81bd4ba4a0bebb8cbbeffbd8c8bbafc/packages/core/src/index.ts#L700-L709
+ */
+export interface ReadonlySignalLike<T> {
+  readonly value: T;
+  subscribe(fn: (value: T) => void): () => void;
+}

--- a/packages/ui-extensions/src/surfaces/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout.ts
@@ -84,6 +84,7 @@ export type {
   ValidationError,
   MailingAddress,
   ShippingAddress,
+  StatefulRemoteSubscribable,
 } from './checkout/api/shared';
 
 export type {

--- a/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
@@ -1,5 +1,4 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-
+import type {StatefulRemoteSubscribable} from '../shared';
 import type {CartLine} from '../standard/standard';
 
 export interface CartLineItemApi {

--- a/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import type {StatefulRemoteSubscribable} from '../shared';
 
 export interface OrderConfirmation {
   order: {

--- a/packages/ui-extensions/src/surfaces/checkout/api/payment/payment-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/payment/payment-option-item.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import type {StatefulRemoteSubscribable} from '../shared';
 
 export type PaymentMethodAttributesResult =
   | PaymentMethodAttributesResultSuccess

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
@@ -1,5 +1,4 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-
+import type {StatefulRemoteSubscribable} from '../shared';
 import type {PickupLocationOption} from '../standard/standard';
 
 export interface PickupLocationItemApi {

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-list.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import type {StatefulRemoteSubscribable} from '../shared';
 
 export interface PickupLocationListApi {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import type {StatefulRemoteSubscribable} from '../shared';
 
 export interface PickupPointListApi {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
@@ -1,4 +1,4 @@
-import type {CountryCode} from '../../../shared';
+import type {CountryCode, ReadonlySignalLike} from '../../../shared';
 
 export interface ValidationError {
   /**
@@ -147,4 +147,15 @@ export interface ShippingAddress extends MailingAddress {
    * Specifies whether the address should be saved to the buyer's account.
    */
   oneTimeUse?: boolean;
+}
+
+/**
+ * A remote-subscribable object exposed to a sandboxed web worker.
+ *
+ * Example: extensions use this to get updates about an object
+ * managed by Checkout on the main thread.
+ */
+export interface StatefulRemoteSubscribable<T> extends ReadonlySignalLike<T> {
+  readonly current: T;
+  destroy(): Promise<void>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
@@ -1,5 +1,4 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-
+import type {StatefulRemoteSubscribable} from '../shared';
 import type {ShippingOption} from '../standard/standard';
 
 export interface ShippingOptionItemApi {

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
@@ -1,5 +1,4 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-
+import type {StatefulRemoteSubscribable} from '../shared';
 import type {
   DeliveryGroup,
   DeliveryGroupType,

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1,11 +1,10 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-
 import type {
   ValidationError,
   SellingPlan,
   Attribute,
   MailingAddress,
   ShippingAddress,
+  StatefulRemoteSubscribable,
 } from '../shared';
 import type {ExtensionTarget} from '../../extension-targets';
 import type {
@@ -983,6 +982,7 @@ export interface CartLine {
    */
   parentRelationship: CartLineParentRelationship | null;
 }
+
 export interface CartLineParentRelationship {
   /**
    * The parent cart line that a cart line is associated with.

--- a/packages/ui-extensions/src/surfaces/checkout/preact/subscription.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/preact/subscription.ts
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'preact/hooks';
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+
+import type {StatefulRemoteSubscribable} from '../api/shared';
 
 type Subscriber<T> = Parameters<StatefulRemoteSubscribable<T>['subscribe']>[0];
 


### PR DESCRIPTION
Adds `RemoteSignalLike` interface for use in all surfaces.

Checkout extends this interface to maintain backwards compatibility with `StatefulRemoteSubscribable`

### 🎩

Tophatted locally with a symlink to local package. `.value` type shows up for expected checkout APIs

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
