### PR TITLE
Example for navigating to POS native screen with uri

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -2,8 +2,23 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {generateCodeBlock} from '../helpers/generateCodeBlock';
 import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
 
-const generateCodeBlockForNavigationApi = (title: string, fileName: string) =>
-  generateCodeBlock(title, 'navigation-api', fileName);
+const generateCodeBlockForNavigationApiLegacy = (
+  title: string,
+  fileName: string,
+) => generateCodeBlock(title, 'navigation-api', fileName);
+
+const generateCodeBlockForNavigationApi = (title: string, fileName: string) => {
+  return {
+    title,
+    tabs: [
+      {
+        title: `${fileName}.jsx`,
+        code: `../examples/navigation-api/${fileName}.jsx`,
+        language: 'jsx',
+      },
+    ],
+  };
+};
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Navigation API',
@@ -33,9 +48,15 @@ The Navigation API enables POS UI extension to navigate between screens.
     description: 'Examples of using the Navigation API',
     examples: [
       {
-        codeblock: generateCodeBlockForNavigationApi(
+        codeblock: generateCodeBlockForNavigationApiLegacy(
           'Navigate between two screens',
           'two-screen',
+        ),
+      },
+      {
+        codeblock: generateCodeBlockForNavigationApi(
+          'Navigate to a POS native screen with uri',
+          'NavigatePosNativeScreen',
         ),
       },
     ],
@@ -46,7 +67,7 @@ The Navigation API enables POS UI extension to navigate between screens.
           {
             description:
               'Navigates to the specified screen. It is important to note that any screens you wish to navigate to must already exist in the Navigator.',
-            codeblock: generateCodeBlockForNavigationApi(
+            codeblock: generateCodeBlockForNavigationApiLegacy(
               'Navigate to a route in current navigation tree',
               'navigation-tree',
             ),

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/NavigatePosNativeScreen.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/NavigatePosNativeScreen.jsx
@@ -1,0 +1,35 @@
+import { render } from "preact";
+import { useEffect, useState } from "preact/hooks";
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  const productUri = `shopify:point-of-sale/products/7457058783314/variants/42045678780498`;
+  const [canNavigate, setCanNavigate] = useState(false);
+
+  useEffect(() => {
+    shopify.navigation.canNavigate(productUri).then((result) => {
+      setCanNavigate(result);
+    });
+  }, []);
+
+  const text = canNavigate ? "View featured product" : "No featured product";
+  return (
+    <s-navigator>
+      <s-screen name="Featured" title="Featured">
+        <s-scroll-box>
+          <s-button
+            isDisabled={!canNavigate}
+            onClick={() => {
+              shopify.navigation.navigate(productUri);
+            }}
+          >
+            {text}
+          </s-button>
+        </s-scroll-box>
+      </s-screen>
+    </s-navigator>
+  );
+}


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-retail/issues/2018

Adding navigate to POS native screens that also uses `canNavigate` with uri example. The dev docs result PR: https://github.com/Shopify/shopify-dev/pull/61833

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
