### PR TITLE
Enhance Cart API for Selling Plan Support

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.ts
@@ -5,7 +5,11 @@ export default extension(
   (root, api) => {
     const button = root.createComponent(Button, {
       onPress: () => {
-        api.cart.addLineItemSellingPlan(api.cartLineItem.uuid);
+        api.cart.addLineItemSellingPlan({
+          lineItemUuid: api.cartLineItem.uuid,
+          sellingPlanId: 123,
+          sellingPlanName: 'My Selling Plan',
+        });
       },
     });
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.tsx
@@ -13,6 +13,7 @@ const Modal = () => {
   const api = useApi<'pos.cart.line-item-details.action.render'>();
   // Your app determines the selling plan ID to add to the line item
   const sellingPlanId = 123456;
+  const sellingPlanName = 'My Selling Plan';
 
   return (
     <Navigator>
@@ -20,10 +21,11 @@ const Modal = () => {
         <ScrollView>
           <Button
             onPress={() =>
-              api.cart.addLineItemSellingPlan(
-                api.cartLineItem.uuid,
+              api.cart.addLineItemSellingPlan({
+                lineItemUuid: api.cartLineItem.uuid,
                 sellingPlanId,
-              )
+                sellingPlanName,
+              })
             }
           />
         </ScrollView>

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -7,6 +7,7 @@ import type {
   CustomSale,
   SetLineItemDiscountInput,
   SetLineItemPropertiesInput,
+  SetLineItemSellingPlanInput,
 } from '../../types/cart';
 
 /**
@@ -226,10 +227,9 @@ export interface CartApiContent {
   /**
    * Add a selling plan to a line item in the cart.
    *
-   * @param uuid the uuid of the line item that should receive the selling plan
-   * @param sellingPlanId the ID of the selling plan to add to the line item
+   * @param input required data to add a selling plan to the line item
    */
-  addLineItemSellingPlan(uuid: string, sellingPlanId: number): Promise<void>;
+  addLineItemSellingPlan(input: SetLineItemSellingPlanInput): Promise<void>;
 
   /**
    * Remove the selling plan from a line item in the cart.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -69,14 +69,15 @@ export interface SellingPlan {
   name: string;
   /**
    * The fingerprint of the applied selling plan within this cart session.
+   * Provided by POS. Not available during refund / exchanges.
    */
-  digest: string;
+  digest?: string;
   /**
-   * The interval of the selling plan. i.e. "every 2 weeks"
+   * The delivery frequency, it can be either: day, week, month or year.
    */
   deliveryInterval?: string;
   /**
-   * The interval count of the selling plan. i.e. "2"
+   * The number of intervals between deliveries.
    */
   deliveryIntervalCount?: number;
 }
@@ -152,4 +153,19 @@ export interface Address {
   name?: string;
   provinceCode?: string;
   countryCode?: CountryCode;
+}
+
+export interface SetLineItemSellingPlanInput {
+  /**
+   * The uuid of the line item to which the selling plan should be applied.
+   */
+  lineItemUuid: string;
+  /**
+   * The ID of the selling plan to apply to the line item.
+   */
+  sellingPlanId: number;
+  /**
+   * The name of the selling plan to apply to the line item.
+   */
+  sellingPlanName: string;
 }


### PR DESCRIPTION
### Background

The `addLineItemSellingPlan` only required `sellingPlanId`. While that's technically enough for the operation to complete, it results in less than ideal UX given that POS has to wait for the server to sync in order to display the selected selling plan name in the cart, which can take a few seconds.

### Solution

Require the 1P/3P app to send the selling plan `id` AND `name`. That way, POS can persist both values have them at hand without having to wait for server, providing immediate feedback to user. Fetching the `name` is straightforward so it should not be complicated for apps to add this.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
