### PR TITLE
Navigate API example docs: update s-button to use disabled instead of isDisabled

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/NavigatePosNativeScreen.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/NavigatePosNativeScreen.jsx
@@ -21,7 +21,7 @@ function Extension() {
       <s-screen name="Featured" title="Featured">
         <s-scroll-box>
           <s-button
-            isDisabled={!canNavigate}
+            disabled={!canNavigate}
             onClick={() => {
               shopify.navigation.navigate(productUri);
             }}


### PR DESCRIPTION
### Background

Small update to the example cause `<s-button>`'s `isDisabled` prop was renamed to `disabled` recently.


shopify-dev PR: https://github.com/Shopify/shopify-dev/pull/61953

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
