### PR TITLE
Adds return and refund ids to ReturnTransactionData and ExchangeTransationData

### DIFF
--- a/.changeset/tough-panthers-impress.md
+++ b/.changeset/tough-panthers-impress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Modified transaction data interface fields to include returnId and refundId to Return and Exchange TransactionData.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
@@ -3,6 +3,7 @@ import {LineItem} from '../../types/cart';
 
 export interface ExchangeTransactionData extends BaseTransactionComplete {
   transactionType: 'Exchange';
+  returnId?: number;
   exchangeId?: number;
   lineItemsAdded: LineItem[];
   lineItemsRemoved: LineItem[];

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
@@ -3,6 +3,7 @@ import {LineItem} from '../../types/cart';
 
 export interface ReturnTransactionData extends BaseTransactionComplete {
   transactionType: 'Return';
+  refundId?: number;
   returnId?: number;
   exchangeId?: number;
   lineItems: LineItem[];


### PR DESCRIPTION
### Background

We need to ensure that `Return` resource ids from Shopify Admin API are included in the transaction data passed to specific extension targets used for compliance workflows. This will allow partners to properly track orders that have returns. Currently `ExchangeTransactionData` has no return id and `ReturnTransactionData` is passing a `Refund` resource ID to the `returnId` field.

Closes https://github.com/shop/issues-retail/issues/17098. Re-creating https://github.com/Shopify/ui-extensions/pull/3161 because the author left Shopify.

### Solution

Update `ExchangeTransactionData` with optional `returnId` and `ReturnTransactionData` with optional `refundId`. This change has already been merged in unstable branch in https://github.com/Shopify/ui-extensions/pull/3148. Documentation will be updated after merge.