### PR TITLE
Import each component type instead of inlining

### DIFF
--- a/.changeset/eighty-bears-hang.md
+++ b/.changeset/eighty-bears-hang.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Import component types instead of inlining them to reduce file size

--- a/packages/ui-extensions/buildTargetDts.ts
+++ b/packages/ui-extensions/buildTargetDts.ts
@@ -6,11 +6,7 @@ import {
   copyFileSync,
 } from 'fs';
 import {join, resolve} from 'path';
-import type {
-  InterfaceDeclaration,
-  ModuleDeclaration,
-  SourceFile,
-} from 'ts-morph';
+import type {SourceFile} from 'ts-morph';
 import {Project} from 'ts-morph';
 
 function copyComponentDefinitions({
@@ -88,9 +84,7 @@ export type Output = Target['output'];
 
 function processComponentDefinitions({
   srcPaths,
-  project,
   componentName,
-  names,
   targetFile,
 }: {
   srcPaths: string[];
@@ -111,59 +105,9 @@ function processComponentDefinitions({
     return;
   }
 
-  const componentSource = project.addSourceFileAtPath(componentSourcePath);
-  const variablesAliasMap = new Map<string, string>();
-
-  // Process variable statements
-  componentSource.getVariableStatements().forEach((variable) => {
-    const structure = variable.getStructure();
-    structure.declarations.forEach((declaration) => {
-      let name = declaration.name;
-      if (names.has(name)) {
-        name = `${componentName}${name}`;
-        variable.replaceWithText(
-          variable.getText().replace(declaration.name, name),
-        );
-        variablesAliasMap.set(declaration.name, name);
-      }
-      names.add(name);
-    });
-
-    targetFile.insertVariableStatement(0, variable.getStructure());
+  targetFile.addImportDeclaration({
+    moduleSpecifier: `../components/${componentName}.d.ts`,
   });
-
-  // Process interfaces
-  componentSource.getInterfaces().forEach((componentInterface) => {
-    let name = componentInterface.getName();
-    if (names.has(name)) {
-      name = `${componentName}${name}`;
-      componentInterface.rename(name, {
-        usePrefixAndSuffixText: true,
-        renameInStrings: true,
-      });
-    }
-    names.add(name);
-
-    updateReferences(componentInterface, variablesAliasMap);
-    targetFile.insertInterface(0, componentInterface.getStructure());
-  });
-
-  // Process modules
-  componentSource.getModules().forEach((module) => {
-    updateReferences(module, variablesAliasMap);
-    targetFile.insertModule(0, module.getStructure());
-  });
-}
-
-function updateReferences(
-  node: ModuleDeclaration | InterfaceDeclaration,
-  aliasMap: Map<string, string>,
-) {
-  let text = node.getText();
-  aliasMap.forEach((alias, original) => {
-    text = text.replace(original, alias);
-  });
-  node.replaceWithText(text);
 }
 
 function getTargets(sourceFile: SourceFile) {


### PR DESCRIPTION
### Background

Fix https://github.com/shop/issues-admin-extensibility/issues/963

### Solution

Import each component instead of inlining duplicated content.

### 🎩
1. Use the CLI to create a new remote dom extension `POLARIS_UNIFIED=true shopify app generate extension` - you can pick any of them
2. Update the package.json to pull in the tarball for this snapshot
    ```json
    "@shopify/ui-extensions": "https://registry.npmjs.org/@shopify/ui-extensions/-/ui-extensions-0.0.0-snapshot-20250826175324.tgz"
    ```
3. Run `pnpm install`
4. Run `shopify app build`
5. Reload the TS server
6. Verify that you get type-safety for the components just like before

### Checklist

- [X] I have :tophat:'d these changes
