### PR TITLE
Revert "Enhance Cart API for Selling Plan Support"

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.ts
@@ -5,11 +5,7 @@ export default extension(
   (root, api) => {
     const button = root.createComponent(Button, {
       onPress: () => {
-        api.cart.addLineItemSellingPlan({
-          lineItemUuid: api.cartLineItem.uuid,
-          sellingPlanId: 123,
-          sellingPlanName: 'My Selling Plan',
-        });
+        api.cart.addLineItemSellingPlan(api.cartLineItem.uuid);
       },
     });
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.tsx
@@ -13,7 +13,6 @@ const Modal = () => {
   const api = useApi<'pos.cart.line-item-details.action.render'>();
   // Your app determines the selling plan ID to add to the line item
   const sellingPlanId = 123456;
-  const sellingPlanName = 'My Selling Plan';
 
   return (
     <Navigator>
@@ -21,11 +20,10 @@ const Modal = () => {
         <ScrollView>
           <Button
             onPress={() =>
-              api.cart.addLineItemSellingPlan({
-                lineItemUuid: api.cartLineItem.uuid,
+              api.cart.addLineItemSellingPlan(
+                api.cartLineItem.uuid,
                 sellingPlanId,
-                sellingPlanName,
-              })
+              )
             }
           />
         </ScrollView>

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -7,7 +7,6 @@ import type {
   CustomSale,
   SetLineItemDiscountInput,
   SetLineItemPropertiesInput,
-  SetLineItemSellingPlanInput,
 } from '../../types/cart';
 
 /**
@@ -227,9 +226,10 @@ export interface CartApiContent {
   /**
    * Add a selling plan to a line item in the cart.
    *
-   * @param input required data to add a selling plan to the line item
+   * @param uuid the uuid of the line item that should receive the selling plan
+   * @param sellingPlanId the ID of the selling plan to add to the line item
    */
-  addLineItemSellingPlan(input: SetLineItemSellingPlanInput): Promise<void>;
+  addLineItemSellingPlan(uuid: string, sellingPlanId: number): Promise<void>;
 
   /**
    * Remove the selling plan from a line item in the cart.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -69,15 +69,14 @@ export interface SellingPlan {
   name: string;
   /**
    * The fingerprint of the applied selling plan within this cart session.
-   * Provided by POS. Not available during refund / exchanges.
    */
-  digest?: string;
+  digest: string;
   /**
-   * The delivery frequency, it can be either: day, week, month or year.
+   * The interval of the selling plan. i.e. "every 2 weeks"
    */
   deliveryInterval?: string;
   /**
-   * The number of intervals between deliveries.
+   * The interval count of the selling plan. i.e. "2"
    */
   deliveryIntervalCount?: number;
 }
@@ -153,19 +152,4 @@ export interface Address {
   name?: string;
   provinceCode?: string;
   countryCode?: CountryCode;
-}
-
-export interface SetLineItemSellingPlanInput {
-  /**
-   * The uuid of the line item to which the selling plan should be applied.
-   */
-  lineItemUuid: string;
-  /**
-   * The ID of the selling plan to apply to the line item.
-   */
-  sellingPlanId: number;
-  /**
-   * The name of the selling plan to apply to the line item.
-   */
-  sellingPlanName: string;
 }


### PR DESCRIPTION
> [!NOTE] 
> The previous PR was missing changelog so it was never released as a new version. It's safe to rollback this change.

Reverts Shopify/ui-extensions#3174

We're still discussing if name is truly required. We're able to make some improvements in POS to enhance the loading time. The change is still not immediate, but perhaps it's good enough for now. Rolling back while we're discussing further. We're still open to allowing apps to send `name` for immediate display if partners request it.
