### PR TITLE
Fix broken image in Avatar docs

### DIFF
--- a/.changeset/mean-crabs-compete.md
+++ b/.changeset/mean-crabs-compete.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Fix broken image in customer account Avatar docs

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
@@ -59,7 +59,7 @@ const data: ReferenceEntityTemplateSchema = {
   **Don'ts**
   - Don't use different size avatars on the same page.
 
-  <img src='/assets/templated-apis-screenshots/customer-account-ui-extensions/unstable/avatar-best-practices.png' alt="An example showing dos and don'ts of the Avatar component" />
+  ![An example showing dos and don'ts of the Avatar component](/assets/templated-apis-screenshots/customer-account-ui-extensions/unstable/avatar-best-practices.png)
   `,
     },
   ],


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-checkout/issues/7484
Related to https://github.com/Shopify/shopify-dev/pull/62055

One of the images in the Customer account avatar docs is broken

### Solution

Replace the broken tag with markdown

### 🎩

See https://github.com/Shopify/shopify-dev/pull/62055 for details

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
