### PR TITLE
Add subcategories to Customer account components

### DIFF
--- a/.changeset/blue-worms-impress.md
+++ b/.changeset/blue-worms-impress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add customer account components to subcategories

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
@@ -22,6 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
+  subCategory: 'Media',
   defaultExample: {
     image: 'avatar-preview.png',
     altText:

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup/ButtonGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup/ButtonGroup.doc.ts
@@ -21,6 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
+  subCategory: 'Actions',
   defaultExample: {
     image: 'buttongroup-preview.png',
     altText:

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
@@ -27,6 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
+  subCategory: 'Actions',
   defaultExample: {
     image: 'customeraccountaction-preview.png',
     altText:

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.doc.ts
@@ -16,6 +16,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
+  subCategory: 'Media',
   defaultExample: {
     image: 'imagegroup-preview.png',
     altText:

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Menu/Menu.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Menu/Menu.doc.ts
@@ -22,6 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
+  subCategory: 'Actions',
   defaultExample: {
     image: 'menu-preview.png',
     altText: 'An example of a Menu with three actions.',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.doc.ts
@@ -39,6 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
+  subCategory: 'Structure',
   defaultExample: {
     image: 'page-preview.png',
     altText:

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Section/Section.doc.ts
@@ -4,7 +4,6 @@ import sharedContent from '../../../../docs/shared/components/Section';
 
 const data: ReferenceEntityTemplateSchema = {
   ...sharedContent,
-  subCategory: undefined,
   thumbnail: 'section-thumbnail.png',
   isVisualComponent: true,
   subSections: [


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-checkout/issues/7484
Related to https://github.com/Shopify/shopify-dev/pull/62069

We have enough components now to put them into subcategories to match Checkout and Admin and so that they're easier to find.

### Solution

Include `subcategory` in Customer account component doc definitions.

### 🎩

See https://github.com/Shopify/shopify-dev/pull/62069 for details

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
