### PR TITLE
Add ButtonGroup to Customer account component mapping

### DIFF
--- a/.changeset/neat-kids-hug.md
+++ b/.changeset/neat-kids-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add ButtonGroup to customer account component mapping

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10-rc.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10-rc.doc.ts
@@ -32,13 +32,14 @@ We advise against migrating your production customer account UI extension to Pol
       sectionContent: `
 |   **Legacy Component**   |   **Polaris Web Component**   |   **Migration Notes**   |
 | :----------------------: | :-------------------------------: | :---------------------: |
-|   \`Avatar\`                |   [Avatar](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/avatar)   |   Available today.   |
-|   \`Card\`                  |  [Section](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/section)   |   Available today.   |
-|   \`CustomerAccountAction\`  |  [CustomerAccountAction](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/customeraccountaction)   |   Available today.       |
-|   \`ImageGroup\`            |  [ImageGroup](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/imagegroup)                         |   Available today.       |
-|   \`Menu\`                  |  [Menu](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/menu)    |   Available today.   |
-|   \`Page\`                  |  [Page](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/page)    |   Available today. |
-|   \`ResourceItem\`          |                                |   Use [Section](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/section).   |
+|   \`Avatar\`                |   [Avatar](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/avatar)   |   Available today   |
+|                             |  [ButtonGroup](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/buttongroup)   |   Available today   |
+|   \`Card\`                  |  [Section](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/section)   |   Available today   |
+|   \`CustomerAccountAction\`  |  [CustomerAccountAction](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/customeraccountaction)   |   Available today       |
+|   \`ImageGroup\`            |  [ImageGroup](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/imagegroup)                         |   Available today       |
+|   \`Menu\`                  |  [Menu](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/menu)    |   Available today   |
+|   \`Page\`                  |  [Page](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/page)    |   Available today |
+|   \`ResourceItem\`          |                                |   Use [Section](/api/customer-account-ui-extensions/2025-10-rc/polaris-web-components/section)   |
 `,
     },
     {


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-checkout/issues/7484
Related to https://github.com/Shopify/shopify-dev/pull/62071

Checkout includes components in their [mapping](https://shopify.dev/docs/api/checkout-ui-extensions/2025-10-rc/upgrading-to-2025-10#mapping-legacy-components-to-polaris-web-components) that didn't exist before. We should do the same.

### Solution

Add ButtonGroup to the component mapping

### 🎩

See https://github.com/Shopify/shopify-dev/pull/62071 for details

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
