### PR TITLE
Update POS component migration table with available Polaris web components

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/apis-new.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/apis-new.tsx
@@ -6,26 +6,10 @@ export default function extension() {
 }
 
 function Extension() {
-  return (
-    <s-checkbox
-      onChange={onCheckboxChange}
-      label="Include a complimentary gift"
-    />
-  );
+  return <s-button onClick={onButtonClick}>Print</s-button>;
 }
 
-async function onCheckboxChange(event) {
-  const isChecked = event.target.checked;
-
-  const result =
-    await shopify.applyAttributeChange({
-      type: 'updateAttribute',
-      key: 'includeGift',
-      value: isChecked ? 'yes' : 'no',
-    });
-
-  console.log(
-    'applyAttributeChange result',
-    result,
-  );
+async function onButtonClick() {
+  await shopify.print.print('documents/test-print');
+  console.log('print completed');
 }

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/apis-old-js.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/apis-old-js.ts
@@ -1,23 +1,15 @@
-import {extension, Checkbox} from '@shopify/ui-extensions/point-of-sale';
+import {extension, Button} from '@shopify/ui-extensions/point-of-sale';
 
 export default extension('pos.home.modal.render', (root, api) => {
-  async function onCheckboxChange(isChecked) {
-    const result = await api.applyAttributeChange({
-      type: 'updateAttribute',
-      key: 'includeGift',
-      value: isChecked ? 'yes' : 'no',
-    });
-
-    console.log('applyAttributeChange result', result);
+  async function onButtonClick() {
+    await api.print.print('documents/test-print');
+    console.log('print completed');
   }
 
   root.replaceChildren(
-    root.createComponent(
-      Checkbox,
-      {
-        onChange: onCheckboxChange,
-      },
-      'Include a complimentary gift',
-    ),
+    root.createComponent(Button, {
+      onPress: onButtonClick,
+      title: 'Print',
+    }),
   );
 });

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/apis-old-react.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/apis-old-react.tsx
@@ -1,6 +1,6 @@
 import {
   reactExtension,
-  Checkbox,
+  Button,
   useApi,
 } from '@shopify/ui-extensions-react/point-of-sale';
 
@@ -9,19 +9,10 @@ export default reactExtension('pos.home.modal.render', () => <Extension />);
 function Extension() {
   const api = useApi();
 
-  async function onCheckboxChange(isChecked) {
-    const result = await api.applyAttributeChange({
-      type: 'updateAttribute',
-      key: 'includeGift',
-      value: isChecked ? 'yes' : 'no',
-    });
-
-    console.log('applyAttributeChange result', result);
+  async function onButtonClick(isChecked) {
+    await api.print.print('documents/test-print');
+    console.log('print completed');
   }
 
-  return (
-    <Checkbox onChange={onCheckboxChange}>
-      Include a complimentary gift
-    </Checkbox>
-  );
+  return <Button onPress={onButtonClick} title="Print" />;
 }

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/components-old-js.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/components-old-js.ts
@@ -1,17 +1,17 @@
 import {
   extension,
-  InlineStack,
+  Stack,
   TextField,
   Button,
 } from '@shopify/ui-extensions/point-of-sale';
 
 export default extension('pos.home.modal.render', (root, _api) => {
   root.replaceChildren(
-    root.createComponent(InlineStack, {}, [
+    root.createComponent(Stack, {direction: 'inline', gap: '200'}, [
       root.createComponent(TextField, {
         label: 'Gift message',
       }),
-      root.createComponent(Button, {}, 'Save'),
+      root.createComponent(Button, {title: 'Save', variant: 'primary'}),
     ]),
   );
 });

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/components-old-react.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/components-old-react.tsx
@@ -1,6 +1,6 @@
 import {
   reactExtension,
-  InlineStack,
+  Stack,
   TextField,
   Button,
 } from '@shopify/ui-extensions-react/point-of-sale';
@@ -9,9 +9,9 @@ export default reactExtension('pos.home.modal.render', () => <Extension />);
 
 function Extension() {
   return (
-    <InlineStack>
+    <Stack direction="inline" gap="200">
       <TextField label="Gift message" />
-      <Button>Save</Button>
-    </InlineStack>
+      <Button title="Save" variant="primary" />
+    </Stack>
   );
 }

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/hooks-new.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/hooks-new.tsx
@@ -1,30 +1,18 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
-import {useAttributeValues} from '@shopify/ui-extensions/point-of-sale/preact';
+import {useConnectivitySubscription} from '@shopify/ui-extensions/point-of-sale/preact';
 
 export default function extension() {
-  render(<Extension />, document.body);
+  render(<ConnectivityStatus />, document.body);
 }
 
-function Extension() {
-  const [includeGift] = useAttributeValues(['includeGift']);
+function ConnectivityStatus() {
+  const connectivity = useConnectivitySubscription();
+  const isConnected = connectivity.internetConnected === 'Connected';
+
   return (
-    <s-checkbox
-      checked={includeGift === 'yes'}
-      onChange={onCheckboxChange}
-      label="Include a complimentary gift"
-    />
+    <s-text tone={isConnected ? 'success' : 'warning'}>
+      Status: {isConnected ? 'Online' : 'Offline'}
+    </s-text>
   );
-}
-
-async function onCheckboxChange(event) {
-  const isChecked = event.target.checked;
-
-  const result = await shopify.applyAttributeChange({
-    type: 'updateAttribute',
-    key: 'includeGift',
-    value: isChecked ? 'yes' : 'no',
-  });
-
-  console.log('applyAttributeChange result', result);
 }

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/hooks-old.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/upgrading-to-2025-10/hooks-old.tsx
@@ -1,29 +1,21 @@
+import React from 'react';
 import {
+  Text,
+  useConnectivitySubscription,
   reactExtension,
-  Checkbox,
-  useAttributeValues,
-  useApplyAttributeChange,
 } from '@shopify/ui-extensions-react/point-of-sale';
 
-export default reactExtension('pos.home.modal.render', () => <Extension />);
-
-function Extension() {
-  const [includeGift] = useAttributeValues(['includeGift']);
-  const applyAttributeChange = useApplyAttributeChange();
-
-  async function onCheckboxChange(isChecked) {
-    const result = await applyAttributeChange({
-      type: 'updateAttribute',
-      key: 'includeGift',
-      value: isChecked ? 'yes' : 'no',
-    });
-
-    console.log('applyAttributeChange result', result);
-  }
+const ConnectivityStatus = () => {
+  const connectivity = useConnectivitySubscription();
+  const isConnected = connectivity.internetConnected === 'Connected';
 
   return (
-    <Checkbox checked={includeGift === 'yes'} onChange={onCheckboxChange}>
-      Include a complimentary gift
-    </Checkbox>
+    <Text color={isConnected ? 'TextSuccess' : 'TextWarning'}>
+      Status: {isConnected ? 'Online' : 'Offline'}
+    </Text>
   );
-}
+};
+
+export default reactExtension('pos.home.modal.render', () => (
+  <ConnectivityStatus />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/upgrading-to-2025-10.doc.ts
@@ -298,43 +298,44 @@ Use the comparison table below to see which Polaris web components are available
       sectionContent: `
 |   **Legacy&nbsp;Component**   |   **Polaris&nbsp;Web&nbsp;Component**   |   **Migration&nbsp;Notes**   |
 | :----------------------: | :-------------------------------: | :---------------------: |
-|   \`Badge\`                  |                                                           |   Coming soon                          |
-|   \`Banner\`                 |                                                           |   Coming soon                          |
-|   \`Box\`                    |                                                           |   Coming soon                          |
-|   \`Button\`                 |                                                           |   Coming soon                          |
-|   \`CameraScanner\`          |                                                           |   Coming soon                          |
-|   \`DateField\`              |                                                           |   Coming soon                          |
-|   \`DatePicker\`             |                                                           |   Coming soon                          |
-|   \`Dialog\`                 |                                                           |   Coming soon                          |
-|   \`EmailField\`             |                                                           |   Coming soon                          |
-|   \`Icon\`                   |                                                           |   Coming soon                          |
-|   \`Image\`                  |                                                           |   Coming soon                          |
-|   \`List\`                   |                                                           |   Coming soon                          |
-|   \`Navigator\`              |                                                           |   Coming soon                          |
-|   \`NumberField\`            |                                                           |   Coming soon                          |
-|   \`PinPad\`                 |                                                           |   Coming soon                          |
-|   \`POSBlock\`               |                                                           |   Coming soon                          |
-|   \`POSBlockRow\`            |                                                           |   Coming soon                          |
-|   \`POSReceiptBlock\`        |                                                           |   Coming soon                          |
-|   \`PrintPreview\`           |                                                           |   Coming soon                          |
-|   \`QRCode\`                 |                                                           |   Coming soon                          |
-|   \`RadioButtonList\`        |                                                           |   Coming soon                          |
-|   \`Screen\`                 |                                                           |   Coming soon                          |
-|   \`ScrollView\`             |                                                           |   Coming soon                          |
-|   \`SearchBar\`              |                                                           |   Coming soon                          |
-|   \`Section\`                |                                                           |   Coming soon                          |
-|   \`SectionHeader\`          |                                                           |   Coming soon                          |
-|   \`SegmentedControl\`       |                                                           |   Coming soon                          |
-|   \`Selectable\`             |                                                           |   Coming soon                          |
-|   \`Spacing\`                |                                                           |   Coming soon                          |
-|   \`Stack\`                  |                                                           |   Coming soon                          |
-|   \`Stepper\`                |                                                           |   Coming soon                          |
-|   \`Text\`                   |                                                           |   Coming soon                          |
-|   \`TextArea\`               |                                                           |   Coming soon                          |
-|   \`TextField\`              |                                                           |   Coming soon                          |
-|   \`Tile\`                   |                                                           |   Coming soon                          |
-|   \`TimeField\`              |                                                           |   Coming soon                          |
-|   \`TimePicker\`             |                                                           |   Coming soon                          |
+|   \`Badge\`                  |   [\`Badge\`](polaris-web-components/titles-and-text/badge)   |   Available   |
+|   \`Banner\`                 |   [\`Banner\`](polaris-web-components/feedback/banner)   |   Available   |
+|   \`Box\`                    |   [\`Box\`](polaris-web-components/structure/box)   |   Available   |
+|   \`Button\`                 |   [\`Button\`](polaris-web-components/actions/button)   |   Available   |
+|   \`CameraScanner\`          |   \`CameraScanner\`   |   Coming soon   |
+|   \`DateField\`              |   [\`DateField\`](polaris-web-components/forms/datefield)   |   Available   |
+|   \`DatePicker\`             |   \`DatePicker\`   |   Coming soon   |
+|   \`DateSpinner\`            |   \`DateSpinner\`   |   Coming soon   |
+|   \`Dialog\`                 |   [\`Modal\`](polaris-web-components/structure/modal)   |   Available   |
+|   \`EmailField\`             |   [\`EmailField\`](/polaris-web-components/forms/emailfield)   |   Available   |
+|   \`Heading\`                |   \`Heading\`   |   Coming soon   |
+|   \`Icon\`                   |   [\`Icon\`](polaris-web-components/media/icon)   |  Available, more icons coming soon.  |
+|   \`Image\`                  |   \`Image\`   |   Coming soon   |
+|   \`List\`                   |      |  Removed. Use \`Array.map()\`   |
+|   \`Navigator\`              |      |   Removed.   |
+|   \`NumberField\`            |   [\`NumberField\`](polaris-web-components/forms/numberfield)   |   Available   |
+|   \`PinPad\`                 |     |   Coming soon   |
+|   \`POSBlock\`               |   \`POSBlock\`   |   Coming soon   |
+|   \`POSBlockRow\`            |    |   Replaced by \`POSBlock\`  |
+|   \`POSReceiptBlock\`        |     |   Replaced by \`POSBlock\`   |
+|   \`PrintPreview\`           |   \`DocumentPreview\`   |   Coming soon   |
+|   \`QRCode\`                 |   \`QRCode\`   |   Coming soon   |
+|   \`RadioButtonList\`        |   [\`ChoiceList\`](polaris-web-components/forms/choicelist)   |   Available   |
+|   \`Screen\`                 |   \`Page\`   |   Coming soon   |
+|   \`ScrollView\`             |   [\`ScrollBox\`](polaris-web-components/structure/scrollbox)   |   Available  |
+|   \`SearchBar\`              |   [\`SearchField\`](polaris-web-components/forms/searchfield)   |   Available   |
+|   \`Section\`                |   \`Section\`   |   Coming soon   |
+|   \`SectionHeader\`          |     |   Use \`Section.heading\`   |
+|   \`SegmentedControl\`       |   \`Tabs\`/\`Tab\`   |   Coming soon   |
+|   \`Selectable\`             |   [\`Clickable\`](polaris-web-components/actions/clickable)   |   Available   |
+|   \`Stack\`                  |   [\`Stack\`](polaris-web-components/structure/stack)   |   Available   |
+|   \`Stepper\`                |   [\`NumberField\`](polaris-web-components/forms/numberfield)   |   Use \`NumberField\` with stepper controls   |
+|   \`Text\`                   |   [\`Text\`](polaris-web-components/titles-and-text/text)   |   Available   |
+|   \`TextArea\`               |   [\`TextArea\`](polaris-web-components/forms/textarea)   |   Available   |
+|   \`TextField\`              |   [\`TextField\`](polaris-web-components/forms/textfield)   |   Available   |
+|   \`Tile\`                   | [\`Tile\`](polaris-web-components/actions/tile)  |  Available   |
+|   \`TimeField\`              |   \`TimeField\`   |   Coming soon   |
+|   \`TimePicker\`             |   \`TimePicker\`   |   Coming soon   |
 `,
     },
   ],


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17204

### Background

Updated component migration table in the "Upgrading to 2025-10" documentation for Point of Sale UI Extensions. It provides detailed information about which legacy components are available as Polaris Web Components, including links to documentation and migration notes.

Updated examples with POS specific code.

### Solution

The PR replaces the "Coming soon" placeholders with actual component availability information, documentation links, and migration notes. It adds details for all legacy components, indicating which ones are:
- Available now with links to documentation
- Coming soon
- Removed or replaced by other components

This helps developers understand the migration path for each component when upgrading to the 2025-10 version. The PR also updates the example code to demonstrate the use of the new print API and connectivity subscription hooks.

### 🎩

- Verified all documentation links are correct
- Confirmed component availability status is accurate
- Verified sample code looks valid

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation