### PR TITLE
Add Preact signal-like type to Customer account

### DIFF
--- a/.changeset/sweet-boxes-check.md
+++ b/.changeset/sweet-boxes-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add signal-like value property to customer account api

--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -951,3 +951,14 @@ export interface ReadonlySignalLike<T> {
   readonly value: T;
   subscribe(fn: (value: T) => void): () => void;
 }
+
+/**
+ * A remote-subscribable object exposed to a sandboxed web worker.
+ *
+ * Example: extensions use this to get updates about an object
+ * managed by Checkout on the main thread.
+ */
+export interface StatefulRemoteSubscribable<T> extends ReadonlySignalLike<T> {
+  readonly current: T;
+  destroy(): Promise<void>;
+}

--- a/packages/ui-extensions/src/surfaces/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout.ts
@@ -84,7 +84,6 @@ export type {
   ValidationError,
   MailingAddress,
   ShippingAddress,
-  StatefulRemoteSubscribable,
 } from './checkout/api/shared';
 
 export type {

--- a/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '../shared';
+import type {StatefulRemoteSubscribable} from '../../../../shared';
 import type {CartLine} from '../standard/standard';
 
 export interface CartLineItemApi {

--- a/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '../shared';
+import type {StatefulRemoteSubscribable} from '../../../../shared';
 
 export interface OrderConfirmation {
   order: {

--- a/packages/ui-extensions/src/surfaces/checkout/api/payment/payment-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/payment/payment-option-item.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '../shared';
+import type {StatefulRemoteSubscribable} from '../../../../shared';
 
 export type PaymentMethodAttributesResult =
   | PaymentMethodAttributesResultSuccess

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '../shared';
+import type {StatefulRemoteSubscribable} from '../../../../shared';
 import type {PickupLocationOption} from '../standard/standard';
 
 export interface PickupLocationItemApi {

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-list.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '../shared';
+import type {StatefulRemoteSubscribable} from '../../../../shared';
 
 export interface PickupLocationListApi {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '../shared';
+import type {StatefulRemoteSubscribable} from '../../../../shared';
 
 export interface PickupPointListApi {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
@@ -1,4 +1,4 @@
-import type {CountryCode, ReadonlySignalLike} from '../../../shared';
+import type {CountryCode} from '../../../shared';
 
 export interface ValidationError {
   /**
@@ -147,15 +147,4 @@ export interface ShippingAddress extends MailingAddress {
    * Specifies whether the address should be saved to the buyer's account.
    */
   oneTimeUse?: boolean;
-}
-
-/**
- * A remote-subscribable object exposed to a sandboxed web worker.
- *
- * Example: extensions use this to get updates about an object
- * managed by Checkout on the main thread.
- */
-export interface StatefulRemoteSubscribable<T> extends ReadonlySignalLike<T> {
-  readonly current: T;
-  destroy(): Promise<void>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '../shared';
+import type {StatefulRemoteSubscribable} from '../../../../shared';
 import type {ShippingOption} from '../standard/standard';
 
 export interface ShippingOptionItemApi {

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
@@ -1,4 +1,4 @@
-import type {StatefulRemoteSubscribable} from '../shared';
+import type {StatefulRemoteSubscribable} from '../../../../shared';
 import type {
   DeliveryGroup,
   DeliveryGroupType,

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -4,7 +4,6 @@ import type {
   Attribute,
   MailingAddress,
   ShippingAddress,
-  StatefulRemoteSubscribable,
 } from '../shared';
 import type {ExtensionTarget} from '../../extension-targets';
 import type {
@@ -17,6 +16,7 @@ import type {
   GraphQLError,
   StorefrontApiVersion,
   LocalizedFieldKey,
+  StatefulRemoteSubscribable,
 } from '../../../../shared';
 
 export type {ApiVersion, Capability} from '../../../../shared';

--- a/packages/ui-extensions/src/surfaces/checkout/preact/subscription.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/preact/subscription.ts
@@ -1,6 +1,6 @@
 import {useEffect, useState} from 'preact/hooks';
 
-import type {StatefulRemoteSubscribable} from '../api/shared';
+import type {StatefulRemoteSubscribable} from '../../../shared';
 
 type Subscriber<T> = Parameters<StatefulRemoteSubscribable<T>['subscribe']>[0];
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api.ts
@@ -78,6 +78,7 @@ export type {
   VisitorResult,
   VisitorSuccess,
   VisitorError,
+  StatefulRemoteSubscribable,
 } from './api/shared';
 
 export type {CartLineItemApi} from './api/cart-line/cart-line-item';

--- a/packages/ui-extensions/src/surfaces/customer-account/api/cart-line/cart-line-item.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/cart-line/cart-line-item.ts
@@ -1,6 +1,5 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-
 import {CartLine} from '../order-status/order-status';
+import {StatefulRemoteSubscribable} from '../shared';
 
 export interface CartLineItemApi {
   /**

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -1,5 +1,3 @@
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-
 import type {
   CurrencyCode,
   Country,
@@ -8,6 +6,7 @@ import type {
   Attribute,
   MailingAddress,
   Language,
+  StatefulRemoteSubscribable,
 } from '../shared';
 import type {ExtensionTarget} from '../../extension-targets';
 import {Extension} from '../shared';

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -1,5 +1,4 @@
 import type {ExtensionTarget} from '../extension-targets';
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 import type {
   ApiVersion,
@@ -10,6 +9,7 @@ import type {
   CountryCode,
   GraphQLError,
   StorefrontApiVersion,
+  StatefulRemoteSubscribable,
 } from '../../../shared';
 
 export {
@@ -21,6 +21,7 @@ export {
   CountryCode,
   GraphQLError,
   StorefrontApiVersion,
+  StatefulRemoteSubscribable,
 };
 
 /**

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -13,10 +13,10 @@ import {
   CustomerPrivacy,
   ApplyTrackingConsentChangeType,
   ToastApi,
+  StatefulRemoteSubscribable,
 } from '../shared';
 
 import type {ExtensionTarget} from '../../extension-targets';
-import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 /**
  * The merchant-defined setting values for the extension.

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/subscription.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/subscription.ts
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'preact/hooks';
-import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+
+import {StatefulRemoteSubscribable} from '../api/shared';
 
 type Subscriber<T> = Parameters<StatefulRemoteSubscribable<T>['subscribe']>[0];
 


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-checkout/issues/7540
Related Checkout issue https://github.com/shop/issues-checkout/issues/5129
Related to https://github.com/Shopify/shopify-dev/pull/62111

### Solution

Export `StatefulRemoteSubscribable` from Customer account

| Before | After |
|-------|-------|
| <img width="1080" height="256" alt="Screenshot 2025-08-29 at 12 43 05 PM" src="https://github.com/user-attachments/assets/633cd926-f5d9-430c-b5e0-c2bb84653e59" /> | <img width="680" height="259" alt="Screenshot 2025-08-29 at 12 43 31 PM" src="https://github.com/user-attachments/assets/e7dd0520-aeab-4201-b681-f14a02415b16" /> |
| <img width="787" height="262" alt="Screenshot 2025-09-03 at 11 07 23 AM" src="https://github.com/user-attachments/assets/8e9e0ff4-ab1c-4068-9c56-d241eac5cb56" /> | <img width="696" height="236" alt="Screenshot 2025-09-03 at 10 55 10 AM" src="https://github.com/user-attachments/assets/2e1fd9a9-3450-4fd1-bed6-f3a4db9cfdc1" /> |

### 🎩

1. See https://github.com/Shopify/shopify-dev/pull/62111 for details
2. Try using the latest snapshot

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
