### PR TITLE
Add metafields to discount allocations

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/discounts.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/tests/discounts.test.tsx
@@ -36,6 +36,14 @@ describe('Discounts API hooks', () => {
             currencyCode: 'USD',
           },
           type: 'code',
+          metafields: [
+            {
+              key: 'some-key',
+              namespace: 'some-namespace',
+              value: 'some-value',
+              valueType: 'string',
+            },
+          ],
         },
         {
           title: '10% off',
@@ -44,6 +52,7 @@ describe('Discounts API hooks', () => {
             currencyCode: 'USD',
           },
           type: 'automatic',
+          metafields: [],
         },
         {
           title: '15% off',

--- a/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/discounts.test.tsx
+++ b/packages/ui-extensions-react/src/surfaces/customer-account/hooks/tests/discounts.test.tsx
@@ -39,6 +39,14 @@ describe('Discounts API hooks', () => {
             currencyCode: 'USD',
           },
           type: 'code',
+          metafields: [
+            {
+              key: 'some-key',
+              namespace: 'some-namespace',
+              value: 'some-value',
+              valueType: 'string',
+            },
+          ],
         },
         {
           title: '10% off',
@@ -47,6 +55,7 @@ describe('Discounts API hooks', () => {
             currencyCode: 'USD',
           },
           type: 'automatic',
+          metafields: [],
         },
         {
           title: '15% off',

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1197,6 +1197,11 @@ export interface CartDiscountAllocationBase {
    * The money amount that has been discounted from the order
    */
   discountedAmount: Money;
+
+  /**
+   * The metafields associated with this discount allocation
+   */
+  metafields: Metafield[];
 }
 
 export interface CartCodeDiscountAllocation extends CartDiscountAllocationBase {

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -778,6 +778,11 @@ export interface CartDiscountAllocationBase {
    * The money amount that has been discounted from the order
    */
   discountedAmount: Money;
+
+  /**
+   * The metafields associated with this discount allocation
+   */
+  metafields: Metafield[];
 }
 
 export interface CartCodeDiscountAllocation extends CartDiscountAllocationBase {


### PR DESCRIPTION
### Background

The discount team will work on adding [custom metafields](https://docs.google.com/document/d/1knk49FxnPZJBggkwVkzMDeY_ORMyp1viSVjg6KdjLF4/edit?tab=t.0#bookmark=kix.epkhanfqbppz) to various discount objects. This first PR adds metafields to discount allocations.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation