### PR TITLE
POS Pin Pad API

### DIFF
--- a/.changeset/light-ladybugs-brush.md
+++ b/.changeset/light-ladybugs-brush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+POS Pin Pad API

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -127,3 +127,12 @@ export type {CountryCode} from './types/country-code';
 
 export type {Session} from './types/session';
 export type {Storage, StorageError} from './types/storage';
+
+export type {
+  PinPadApiContent,
+  PinPadApi,
+  PinPadOptions,
+  PinPadApiActionType,
+} from './render/api/pin-pad-api/pin-pad-api';
+
+export type {PinPadResult, PinLength, PinPadActionType} from './types/pin-pad';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.ts
@@ -53,12 +53,8 @@ export type {NavigatorProps} from './render/components/Navigator/Navigator';
 export {NumberField} from './render/components/NumberField/NumberField';
 export type {NumberFieldProps} from './render/components/NumberField/NumberField';
 export {PinPad} from './render/components/PinPad/PinPad';
-export type {
-  PinPadProps,
-  PinLength,
-  PinPadActionType,
-  PinValidationResult,
-} from './render/components/PinPad/PinPad';
+export type {PinPadProps} from './render/components/PinPad/PinPad';
+export type {PinValidationResult} from './types/pin-pad';
 export {POSBlock} from './render/components/POSBlock/POSBlock';
 export type {POSBlockProps} from './render/components/POSBlock/POSBlock';
 export {POSBlockRow} from './render/components/POSBlock/POSBlockRow';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/action-target-api/action-target-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/action-target-api/action-target-api.ts
@@ -1,9 +1,11 @@
 import {ScannerApi} from '../scanner-api/scanner-api';
 import {NavigationApi} from '../navigation-api/navigation-api';
 import {StandardApi} from '../standard/standard-api';
+import {PinPadApi} from '../pin-pad-api/pin-pad-api';
 
 export type ActionTargetApi<T> = {[key: string]: any} & {
   extensionPoint: T;
 } & StandardApi<T> &
   ScannerApi &
-  NavigationApi;
+  NavigationApi &
+  PinPadApi;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/pin-pad-api/pin-pad-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/pin-pad-api/pin-pad-api.ts
@@ -1,0 +1,40 @@
+import {
+  BasePinPadOptions,
+  PinPadResult,
+  PinValidationResult,
+} from '../../../types/pin-pad';
+
+export interface PinPadApiActionType {
+  label: string;
+  onClick: () => Promise<number[]>;
+}
+export type PinPadOptions = Omit<BasePinPadOptions, 'pinPadAction'> & {
+  /**
+   * The function to be called when the pin pad modal is dismissed
+   */
+  onDismissed?: (result: PinPadResult) => void;
+  /**
+   * The call to action between the entry view and the keypad
+   */
+  pinPadAction?: PinPadApiActionType;
+};
+
+export interface PinPadApiContent {
+  /** Shows a pin pad to the user in a modal dialog.
+   *
+   * @param onSubmit the function to be called when the PIN is submitted.
+   * The callback should be used to validate the PIN and return `accept` or `reject`.
+   * @param options the options for the pin pad
+   */
+  showPinPad(
+    onSubmit: (pin: number[]) => Promise<PinValidationResult>,
+    options?: PinPadOptions,
+  ): void;
+}
+
+/**
+ * Access the Pin Pad API for pin pad functionality in a modal.
+ */
+export interface PinPadApi {
+  pinPad: PinPadApiContent;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/PinPad/PinPad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/PinPad/PinPad.ts
@@ -1,33 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
-
-/**
- * Represents the result of the pin pad onSubmit function.
- * @typedef {('accept'|'reject')} PinValidationResult
- */
-export type PinValidationResult = 'accept' | 'reject';
-
-/**
- * Represents the allowed lengths of a PIN.
- * @typedef {(4|5|6|7|8|9|10)} PinLength
- */
-export type PinLength = 4 | 5 | 6 | 7 | 8 | 9 | 10;
-
-/**
- * Represents an action type for the PinPad component.
- * @typedef {Object} PinPadActionType
- * @property {string} label - The label for the action button.
- * @property {function(): number[]} onPress - The function to be called when the action button is pressed.
- */
-export interface PinPadActionType {
-  /**
-   * The label for the action button.
-   */
-  label: string;
-  /**
-   * The function to be called when the action button is pressed.
-   */
-  onPress: () => Promise<number[]>;
-}
+import {BasePinPadOptions, PinValidationResult} from '../../../types/pin-pad';
 
 /**
  * Represents the properties for the PinPad component.
@@ -40,35 +12,11 @@ export interface PinPadActionType {
  * @property {function(pin: number[]): Promise<PinValidationResult>} onSubmit - The function to be called when the PIN is submitted.
  * @property {function(pin: number[]): void} [onPinEntry] - The function to be called when a PIN is entered.
  */
-export interface PinPadProps {
-  /**
-   * Whether the entered PIN should be masked.
-   */
-  masked?: boolean;
-  /**
-   * The minimum length of the PIN.
-   */
-  minPinLength?: PinLength;
-  /**
-   * The maximum length of the PIN.
-   */
-  maxPinLength?: PinLength;
-  /**
-   * The content for the prompt on the pin pad.
-   */
-  label?: string;
-  /**
-   * The call to action between the entry view and the keypad, consisting of a label and function that returns the pin.
-   */
-  pinPadAction?: PinPadActionType;
+export interface PinPadProps extends BasePinPadOptions {
   /**
    * The function to be called when the PIN is submitted.
    */
   onSubmit: (pin: number[]) => Promise<PinValidationResult>;
-  /**
-   * The function to be called when a PIN is entered.
-   */
-  onPinEntry?: (pin: number[]) => void;
 }
 
 export const PinPad = createRemoteComponent<'PinPad', PinPadProps>('PinPad');

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
@@ -1,0 +1,51 @@
+export interface PinPadResult {
+  /**
+   * Whether the PIN entry was completed (not cancelled)
+   */
+  completed: boolean;
+  /**
+   * The entered PIN (only present if completed is true)
+   */
+  pin?: number[];
+}
+
+/**
+ * Represents the result of the pin pad onSubmit function.
+ * @typedef {('accept'|'reject')} PinValidationResult
+ */
+export type PinValidationResult = 'accept' | 'reject';
+
+export type PinLength = 4 | 5 | 6 | 7 | 8 | 9 | 10;
+
+export interface PinPadActionType {
+  label: string;
+  onPress: () => Promise<number[]>;
+  loadingAfterOnPress?: boolean;
+}
+
+export interface BasePinPadOptions {
+  /**
+   * The content for the prompt on the pin pad
+   */
+  label?: string;
+  /**
+   * Whether the entered PIN should be masked
+   */
+  masked?: boolean;
+  /**
+   * The minimum length of the PIN
+   */
+  minPinLength?: PinLength;
+  /**
+   * The maximum length of the PIN
+   */
+  maxPinLength?: PinLength;
+  /**
+   * The call to action between the entry view and the keypad
+   */
+  pinPadAction?: PinPadActionType;
+  /**
+   * Title shown in the modal header
+   */
+  title?: string;
+}


### PR DESCRIPTION
### Background

https://github.com/shop/issues-retail/issues/17432
Historically, POS has allowed extension developers to show a Pin Pad to their users by use of the `<PinPad />` component. For 2025-10 we are unifying POS extensions with Polaris Web Components. Because PinPad is a niche component used only for POS, getting alignment with the TAG team to add it to the PWC spec has proved very difficult. 

Instead, in 2025-10 we will be offering PinPad via a non-component API, exposing a `showPinPad` method that shows a modal with a PinPad when called.

### Solution

Here we add a new `PinPad` API to the POS surface which exposes a single method, `showPinPad`. The method, when called, shows a modal dialog to host the PinPad. It has two parameters:

1) A required callback for the extension to validate the PIN when it is submitted on the `PinPad`, allowing extensions to accept or reject entered PINs
2) An optional `options` parameter which allows developers to specify options for the PinPad. These options provide feature parity with the [original PinPad component](https://shopify.dev/docs/api/pos-ui-extensions/latest/components/pinpad). 

Where the old PinPad component and the new non-component API share common types, they have been moved to the `types` folder rather than being duplicated. Some common types are modified to reflect the fact we are using a modal and to more closely follow PWC standards (e.g. replacing `onPress` with `onClick`).


### 🎩

There is a [draft PR for POS](https://app.graphite.dev/github/pr/Shopify/pos-next-react-native/67134/Prototype-Extensions-Pin-Pad-API#file-areas/clients/pos-mobile/src/extensibility/api/base/usePinPadApi.ts) that implements these changes for tophatting.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
