### PR TITLE
Update Customer account examples to use signals instead of hooks

### DIFF
--- a/.changeset/itchy-nails-wave.md
+++ b/.changeset/itchy-nails-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Update customer account examples to use signals

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-publish.example.tsx
@@ -1,9 +1,10 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useEffect} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
-}
+};
 
 function Extension() {
   useEffect(() => {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/analytics-visitor.example.tsx
@@ -1,9 +1,10 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useEffect} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
-}
+};
 
 function Extension() {
   useEffect(() => {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/attribute-values.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/attribute-values.example.tsx
@@ -1,34 +1,16 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
-import {useEffect, useState} from 'preact/hooks';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
-  const [
-    buyerSelectedFreeTShirt,
-    setBuyerSelectedFreeTShirt,
-  ] = useState(
-    shopify.attributes.current
-      ?.buyerSelectedFreeTShirt || false,
-  );
-  const [tshirtSize, setTshirtSize] = useState(
-    shopify.attributes.current?.tshirtSize || '',
-  );
-
-  useEffect(() => {
-    shopify.attributes.subscribe(
-      (updatedAttributes) => {
-        setBuyerSelectedFreeTShirt(
-          updatedAttributes.buyerSelectedFreeTShirt,
-        );
-        setTshirtSize(
-          updatedAttributes.tshirtSize,
-        );
-      },
-    );
-  }, []);
+function Extension() {
+  const buyerSelectedFreeTShirt =
+    shopify.attributes.value
+      ?.buyerSelectedFreeTShirt || false;
+  const tshirtSize =
+    shopify.attributes.value?.tshirtSize || '';
 
   if (Boolean(buyerSelectedFreeTShirt) === true) {
     return (

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account-company-and-location.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account-company-and-location.example.tsx
@@ -1,9 +1,10 @@
 /* See the locales/en.default.json tab for the translation keys and values for this example */
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
   render(<Extension />, document.body);
-}
+};
 
 function Extension() {
   const purchasingCompany =

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/authenticated-account.example.tsx
@@ -1,15 +1,16 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default async function () {
+export default async () => {
   render(<Extension />, document.body);
-}
+};
 
 function Extension() {
   const orderStatusCustomerId =
-    shopify.authenticatedAccount.customer.current
+    shopify.authenticatedAccount.customer.value
       .id;
   const authenticatedCustomerId =
-    shopify.authenticatedAccount.customer.current
+    shopify.authenticatedAccount.customer.value
       .id;
 
   if (

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/cart-line-item.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/cart-line-item.example.tsx
@@ -1,18 +1,13 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
-import {useEffect, useState} from 'preact/hooks';
-export default async () => {
-  render(<App />, document.body);
-}
 
-function App() {
-  const [title, setTitle] = useState(
-    shopify.target.current.merchandise?.title,
-  );
-  useEffect(() => {
-    shopify.target.subscribe((updatedTarget) => {
-      setTitle(updatedTarget.merchandise?.title);
-    });
-  }, []);
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  const title =
+    shopify.target.value.merchandise?.title;
 
   return (
     <s-text>Line item title: {title}</s-text>

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-account-api-fetch.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-account-api-fetch.example.tsx
@@ -1,11 +1,12 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   const [customerName, setCustomerName] =
     useState('');
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-privacy.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/customer-privacy.example.tsx
@@ -1,26 +1,14 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
-import {useEffect, useState} from 'preact/hooks';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
-  const [visitorConsent, setVisitorConsent] =
-    useState(
-      shopify.customerPrivacy.current
-        .visitorConsent || {},
-    );
-
-  useEffect(() => {
-    shopify.customerPrivacy.subscribe(
-      (updatedConsent) => {
-        setVisitorConsent(
-          updatedConsent.visitorConsent,
-        );
-      },
-    );
-  }, []);
+function Extension() {
+  const visitorConsent =
+    shopify.customerPrivacy.value
+      .visitorConsent || {};
 
   // Use consent values
   console.log(

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/localization-country.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/localization-country.example.tsx
@@ -1,9 +1,10 @@
 /* See the locales/en.default.json tab for the translation keys and values for this example */
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
   render(<Extension />, document.body);
-}
+};
 
 function Extension() {
   const countryCode =

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query-fetch.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query-fetch.example.tsx
@@ -1,11 +1,12 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   const [data, setData] = useState();
 
   useEffect(() => {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/query.example.tsx
@@ -1,11 +1,12 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   const [data, setData] = useState({});
 
   useEffect(() => {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/require-login.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/require-login.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   async function reportAnIssue() {
     await shopify.requireLogin();
     // send a request to backend

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/session-token.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/session-token.example.tsx
@@ -1,11 +1,12 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useEffect} from 'preact/hooks';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   useEffect(() => {
     async function queryApi() {
       // Request a new (or cached) session token from Shopify

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/settings-access.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/settings-access.example.tsx
@@ -1,24 +1,14 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
-  const [bannerTitle, setBannerTitle] = useState(
-    shopify.settings.current?.banner_title || '',
-  );
-
-  useEffect(() => {
-    shopify.settings.subscribe(
-      (updatedSettings) => {
-        setBannerTitle(
-          updatedSettings.banner_title,
-        );
-      },
-    );
-  }, []);
+function Extension() {
+  const bannerTitle =
+    shopify.settings.value?.banner_title || '';
 
   return <s-banner title={bannerTitle} />;
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate-pluralization.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate-pluralization.example.tsx
@@ -1,11 +1,12 @@
 /* See the locales/en.default.json tab for the translation keys and values for this example */
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   const points = 10000;
   const formattedPoints =
     shopify.i18n.formatNumber(points);

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/translate.example.tsx
@@ -1,11 +1,12 @@
 /* See the locales/en.default.json tab for the translation keys and values for this example */
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   return (
     <s-text>
       {shopify.i18n.translate('welcomeMessage')}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/default-preact.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/navigation/default-preact.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   return (
     <s-button
       onClick={() => {

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-apis-preact.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-apis-preact.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   return (
     <s-banner>
       {shopify.i18n.translate('welcomeMessage')}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-targets-preact.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/extension-targets-preact.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   return (
     <s-banner>
       {shopify.i18n.translate('welcomeMessage')}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/form-default-value.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/form-default-value.jsx
@@ -1,9 +1,10 @@
-import { render } from 'preact';
-import { useState } from 'preact/hooks';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+import {useState} from 'preact/hooks';
 
 export default async () => {
   render(<Extension />, document.body);
-}
+};
 
 const defaultValues = {
   text: 'default value',

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/form-implicit-default.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/form-implicit-default.jsx
@@ -1,9 +1,10 @@
-import { render } from 'preact';
-import { useState } from 'preact/hooks';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+import {useState} from 'preact/hooks';
 
 export default async () => {
   render(<Extension />, document.body);
-}
+};
 
 async function Extension() {
   const data = await fetch('/data.json');

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/ui-components-preact.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/ui-components-preact.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
-  render(<App />, document.body);
-}
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   return (
     <s-stack>
       <s-image src="/url/for/image" />

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/examples/basic-Avatar-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/examples/basic-Avatar-preact.example.tsx
@@ -1,9 +1,10 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
-  render(<App />, document.body);
-}
+export default async () => {
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   return <s-avatar initials="EW" alt="Evan White" size="base" />;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup/examples/basic-ButtonGroup-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup/examples/basic-ButtonGroup-preact.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
-  render(<App />, document.body);
-}
+export default async () => {
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   return (
     <s-button-group accessibilityLabel="Order actions">
       <s-button slot="primary-action" variant="primary">

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/examples/basic-CustomerAccountAction-preact.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
-  render(<App />, document.body);
+  render(<Extension />, document.body);
 };
 
-function App() {
+function Extension() {
   return (
     <s-customer-account-action heading="Edit order">
       Extension content

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/examples/basic-ImageGroup-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/examples/basic-ImageGroup-preact.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
-  render(<App />, document.body);
+  render(<Extension />, document.body);
 };
 
-function App() {
+function Extension() {
   return (
     <s-image-group>
       <s-image src="../assets/flower.jpg" />

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Menu/examples/basic-Menu-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Menu/examples/basic-Menu-preact.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
-  render(<App />, document.body);
-}
+export default async () => {
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   return (
     <>
       <s-button commandFor="order-actions-menu">Manage</s-button>

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/examples/basic-Page-preact.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default async () => {
-  render(<App />, document.body);
+  render(<Extension />, document.body);
 };
 
-function App() {
+function Extension() {
   return (
     <s-page heading="Order #1411" subheading="Confirmed Oct 5">
       <s-button

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Section/examples/basic-Section-preact.example.tsx
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Section/examples/basic-Section-preact.example.tsx
@@ -1,10 +1,11 @@
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-export default function extension() {
-  render(<App />, document.body);
-}
+export default async () => {
+  render(<Extension />, document.body);
+};
 
-function App() {
+function Extension() {
   return (
     <s-section heading="Rewards">
       <s-button slot="primary-action" variant="primary">


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-checkout/issues/7487
Related to https://github.com/Shopify/shopify-dev/pull/62266

We're moving away from hooks and using signals instead. The examples in the docs should reflect that.

### Solution

- Updates all examples to support and reflect the usage of signals
- Updates all examples to use the same base code

### 🎩

See https://github.com/Shopify/shopify-dev/pull/62266 for details

### Checklist

- [x] I have :tophat:'d these changes
- [x]  I have updated relevant documentation
