### PR TITLE
Fix target generation script for single-component targets

### DIFF
--- a/packages/ui-extensions/buildTargetDts.ts
+++ b/packages/ui-extensions/buildTargetDts.ts
@@ -134,12 +134,22 @@ function extractTargetComponents(
   return extensionTargetArray
     .map((extensionTargets) => {
       return extensionTargets.getProperties().map((property) => {
-        const components = property
+        const componentsType = property
           .getType()
           .getProperty('components')
-          ?.getTypeAtLocation(extensionTargets)
-          .getUnionTypes()
-          .map((t) => t.getText().replaceAll('"', ''));
+          ?.getTypeAtLocation(extensionTargets);
+
+        let components: string[] | undefined;
+        if (componentsType) {
+          if (componentsType.isUnion()) {
+            components = componentsType
+              .getUnionTypes()
+              .map((t) => t.getText().replaceAll('"', ''));
+            // Single component targets like SmartGridComponents = 'Tile' return an empty array for getUnionTypes, so we need to handle that case
+          } else if (componentsType.isLiteral()) {
+            components = [componentsType.getText().replaceAll('"', '')];
+          }
+        }
 
         return {
           name: property.getName(),


### PR DESCRIPTION
### Background

`pos.home.tile.render`, which only accepts a Tile component, was generating an empty target type definition

### Solution

Update the build script to consider the case where the type is a single string literal

### 🎩

- yarn build and verify that packages/ui-extensions/build/ts/surfaces/point-of-sale/targets/pos.home.tile.render.d.ts includes the import for "Tile.d.ts"

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
