### PR TITLE
POS Pin Pad API

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -121,3 +121,11 @@ export type {CountryCode} from './types/country-code';
 export type {Session} from './types/session';
 export type {Storage} from './types/storage';
 export {StorageError} from './types/storage';
+
+export type {PinPadApiContent, PinPadApi} from './api/pin-pad-api';
+export type {
+  PinPadOptions,
+  PinPadResult,
+  PinLength,
+  PinPadActionType,
+} from './types/pin-pad';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
@@ -1,0 +1,21 @@
+import {PinPadOptions, PinValidationResult} from '../types/pin-pad';
+
+export interface PinPadApiContent {
+  /** Shows a pin pad to the user in a modal dialog.
+   *
+   * @param onSubmit the function to be called when the PIN is submitted.
+   * The callback should be used to validate the PIN and return `accept` or `reject`.
+   * @param options the options for the pin pad
+   */
+  showPinPad(
+    onSubmit: (pin: number[]) => Promise<PinValidationResult>,
+    options?: PinPadOptions,
+  ): void;
+}
+
+/**
+ * Access the Pin Pad API for pin pad functionality in a modal.
+ */
+export interface PinPadApi {
+  pinPad: PinPadApiContent;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/standard/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/standard/standard-api.ts
@@ -6,6 +6,7 @@ import {ToastApi} from '../toast-api/toast-api';
 import {ProductSearchApi} from '../product-search-api/product-search-api';
 import {PrintApi} from '../print-api/print-api';
 import {StorageApi} from '../storage-api/storage-api';
+import {PinPadApi} from '../pin-pad-api';
 
 export type StandardApi<T> = {[key: string]: any} & {
   extensionPoint: T;
@@ -16,4 +17,5 @@ export type StandardApi<T> = {[key: string]: any} & {
   ProductSearchApi &
   DeviceApi &
   ConnectivityApi &
-  StorageApi;
+  StorageApi &
+  PinPadApi;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
@@ -1,0 +1,54 @@
+export interface PinPadResult {
+  /**
+   * Whether the PIN entry was completed (not cancelled)
+   */
+  completed: boolean;
+  /**
+   * The entered PIN (only present if completed is true)
+   */
+  pin?: number[];
+}
+
+/**
+ * Represents the result of the pin pad onSubmit function.
+ * @typedef {('accept'|'reject')} PinValidationResult
+ */
+export type PinValidationResult = 'accept' | 'reject';
+
+export type PinLength = 4 | 5 | 6 | 7 | 8 | 9 | 10;
+
+export interface PinPadActionType {
+  label: string;
+  onClick: () => Promise<number[]>;
+}
+
+export interface PinPadOptions {
+  /**
+   * The function to be called when the pin pad modal is dismissed
+   */
+  onDismissed?: (result: PinPadResult) => void;
+  /**
+   * The content for the prompt on the pin pad
+   */
+  label?: string;
+  /**
+   * Whether the entered PIN should be masked
+   */
+  masked?: boolean;
+  /**
+   * The minimum length of the PIN
+   */
+  minPinLength?: PinLength;
+  /**
+   * The maximum length of the PIN
+   */
+  maxPinLength?: PinLength;
+  /**
+   * The call to action between the entry view and the keypad
+   */
+  pinPadAction?: PinPadActionType;
+  /**
+   * Title shown in the modal header
+   */
+  title?: string;
+}


### PR DESCRIPTION
### Background

https://github.com/shop/issues-retail/issues/17432
Historically, POS has allowed extension developers to show a Pin Pad to their users by use of the `<PinPad />` component. For 2025-10 we are unifying POS extensions with Polaris Web Components. Because PinPad is a niche component used only for POS, getting alignment with the TAG team to add it to the PWC spec has proved very difficult. 

Instead, in 2025-10 we will be offering PinPad via a non-component API, exposing a `showPinPad` method that shows a modal with a PinPad when called.

### Solution

Here we add a new `PinPad` API to the POS surface which exposes a single method, `showPinPad`. The method, when called, shows a modal dialog to host the PinPad. It has two parameters:

1) A required callback for the extension to validate the PIN when it is submitted on the `PinPad`, allowing extensions to accept or reject entered PINs
2) An optional `options` parameter which allows developers to specify options for the PinPad. These options provide feature parity with the [original PinPad component](https://shopify.dev/docs/api/pos-ui-extensions/latest/components/pinpad). 

Where the old PinPad component and the new non-component API share common types, they have been moved to the `types` folder rather than being duplicated. Some common types are modified to reflect the fact we are using a modal and to more closely follow PWC standards (e.g. replacing `onPress` with `onClick`).


### 🎩

There is a [draft PR for POS](https://app.graphite.dev/github/pr/Shopify/pos-next-react-native/67134/Prototype-Extensions-Pin-Pad-API#file-areas/clients/pos-mobile/src/extensibility/api/base/usePinPadApi.ts) that implements these changes for tophatting.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
