### PR TITLE
Add Cash Drawer Api

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cash-drawer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cash-drawer-api.doc.ts
@@ -1,0 +1,33 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Cash Drawer API',
+  description: `
+The Cash Drawer API is an API exposed to extensions for cash drawer functionality, specifically allowing UI extensions to control cash drawer operations.`,
+  isVisualComponent: false,
+  type: 'APIs',
+  definitions: [
+    {
+      title: 'CashDrawerApi',
+      description: 'Interface for handling cash drawer operations.',
+      type: 'CashDrawerApi',
+    },
+  ],
+  category: 'APIs',
+  related: [],
+  examples: {
+    description: 'Examples of using the Cash Drawer API',
+    examples: [
+      {
+        codeblock: generateCodeBlock(
+          'Cash Drawer API',
+          'cash-drawer-api',
+          'default.example',
+        ),
+      },
+    ],
+  },
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cash-drawer-api/default.example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cash-drawer-api/default.example.ts
@@ -1,0 +1,20 @@
+import {
+  Tile,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.home.tile.render',
+  (root, api) => {
+    const tile = root.createComponent(Tile, {
+      title: 'My app',
+      subtitle: 'Hello world!',
+      enabled: true,
+      onPress: () => {
+        api.cashDrawer.open();
+      },
+    });
+
+    root.append(tile);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -15,6 +15,8 @@ export type {
 export type {StandardApi} from './render/api/standard/standard-api';
 export type {ActionTargetApi} from './render/api/action-target-api/action-target-api';
 
+export type {CashDrawerApi} from './render/api/cash-drawer-api/cash-drawer-api';
+
 export type {
   ConnectivityStateSeverity,
   ConnectivityState,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cash-drawer-api/cash-drawer-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/api/cash-drawer-api/cash-drawer-api.ts
@@ -1,0 +1,12 @@
+/**
+ * The Cash Drawer API in POS UI extensions includes select cash drawer functionality.
+ */
+export interface CashDrawerApi {
+  /**
+   * Opens the connected cash drawer.
+   *
+   * @returns Void
+   *
+   */
+  open(): Promise<void>;
+}


### PR DESCRIPTION
### Background

https://github.com/shop/issues-retail/issues/16752

### Solution

This PR introduces the Cash Drawer API to the UI Extensions repository. As extension targets have yet to be finalized, this PR introduces the API only.

https://github.com/Shopify/ui-api-design/pull/1232

![Screenshot 2025-09-04 at 4.53.05 PM.png](https://app.graphite.dev/user-attachments/assets/acb2b504-79bf-48ba-9e1f-77127a110de8.png)

### 🎩

- Review documentation and that this API was implemented properly in this repo.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
