### PR TITLE
Update NumberField example to show required and error states

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
       tabs: [
         {
           code: './examples/default.html',
-          language: 'HTML',
+          language: 'html',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/examples/default.html
@@ -1,1 +1,2 @@
-<s-number-field label="Quantity" value="1" min="1"></s-number-field>
+<s-number-field label="Phone number" required value="+1 (416) 555-5555"></s-number-field>
+<s-number-field label="Phone number" required value="+1 (416) 555-5555555" error="Enter a valid phone number"></s-number-field>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17910

### Background

This PR updates the default example for the `NumberField` component in the Point of Sale UI extensions to better demonstrate required fields and error states.

### Solution

The default example has been changed from a simple quantity field to showcase two phone number input scenarios:
1. A required phone number field with a valid value
2. A required phone number field with an invalid value that displays an error message

This change provides developers with a more comprehensive example of how the `NumberField` component handles validation states, required fields, and error messaging.

### 🎩

- View the updated examples in the Point of Sale UI extensions documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation