### PR TITLE
Update Banner component examples and fix language case in documentation

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -28,7 +28,7 @@ const data: ReferenceEntityTemplateSchema = {
       tabs: [
         {
           code: './examples/default.html',
-          language: 'HTML',
+          language: 'html',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/examples/default.html
@@ -1,3 +1,15 @@
-<s-banner heading="Order shipped" tone="success">
-  Your order #1001 has been shipped and is on its way to you.
+<s-banner heading="Label" tone="success">
+  <s-button slot="primary-action">Action</s-button>
+</s-banner>
+
+<s-banner heading="Label" tone="info">
+  <s-button slot="primary-action">Action</s-button>
+</s-banner>
+
+<s-banner heading="Label" tone="warning">
+  <s-button slot="primary-action">Action</s-button>
+</s-banner>
+
+<s-banner heading="Label" tone="critical">
+  <s-button slot="primary-action">Action</s-button>
 </s-banner>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17987

### Background

This PR updates the Banner component examples in the point-of-sale UI extensions to better showcase all available tone variants.

### Solution

- Fixed the language case in Banner documentation from "HTML" to "html" for consistency
- Enhanced the default example to display all four tone variants (success, info, warning, critical)
- Added primary action buttons to each banner example to demonstrate slot usage
- Simplified the banner headings to use "Label" for consistency across examples

These changes provide a more comprehensive demonstration of the Banner component's capabilities and styling options.

### 🎩

- View the updated Banner component examples in the documentation
- Verify all four tone variants display correctly
- Confirm the primary action buttons appear properly in each banner

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation