### PR TITLE
Update ChoiceList component thumbnail and example image paths

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'ChoiceList',
   description:
     'Use `s-choice-list` to group related choices together, allowing single or multiple selections. Provides a structured way to present options to users.',
-  thumbnail: 'choice-list-thumbnail.png',
+  thumbnail: 'radio-button-list-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
@@ -28,13 +28,13 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Polaris web components',
   subCategory: 'Forms',
   defaultExample: {
-    image: 'choice-list-default.png',
+    image: 'radio-button-list-default.png',
     codeblock: {
       title: 'Code',
       tabs: [
         {
           code: './examples/default.html',
-          language: 'HTML',
+          language: 'html',
         },
       ],
     },


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17989

### Background

This PR updates the image references and language specification in the ChoiceList documentation.

### Solution

- Changed the thumbnail reference from `choice-list-thumbnail.png` to `radio-button-list-thumbnail.png`
- Updated the default example image from `choice-list-default.png` to `radio-button-list-default.png`
- Fixed the language specification for the code example from uppercase `HTML` to lowercase `html`

These changes ensure consistency in the documentation and properly reference the correct image assets.

### 🎩

- Verified that the new image references point to existing assets
- Confirmed that the HTML language specification follows the correct format

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation