### PR TITLE
Update Button component description and examples in POS UI extensions

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
-    'Use `s-button` to trigger actions or navigate between screens. Buttons communicate what action will occur when the user touches them.',
+    'Triggers actions or events, such as opening dialogs or navigating to other pages. Use Button to let users perform specific tasks or initiate interactions throughout the interface.',
   thumbnail: 'button-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -28,7 +28,7 @@ const data: ReferenceEntityTemplateSchema = {
       tabs: [
         {
           code: './examples/default.html',
-          language: 'HTML',
+          language: 'html',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/examples/default.html
@@ -1,1 +1,4 @@
-<s-button>Save changes</s-button>
+<s-button variant="primary">Label</s-button>
+<s-button variant="secondary">Label</s-button>
+<s-button tone="critical">Label</s-button>
+<s-button disabled>Label</s-button>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17898

### Background

This PR updates the Button component documentation to provide a clearer description and more comprehensive examples.

### Solution

- Updated the Button component description to better explain its purpose and use cases
- Changed the language identifier from "HTML" to "html" for proper syntax highlighting
- Enhanced the default example to showcase multiple button variants:
  - Primary button
  - Secondary button
  - Critical tone button
  - Disabled button

These changes make the documentation more helpful for developers by showing the range of button options available and providing clearer guidance on when to use the Button component.

### 🎩

- Verified the updated documentation renders correctly
- Confirmed all button variants display properly in the examples

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation