### PR TITLE
Update DateField example in POS UI extensions

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
       tabs: [
         {
           code: './examples/default.html',
-          language: 'HTML',
+          language: 'html',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/examples/default.html
@@ -1,1 +1,14 @@
-<s-date-field label="Select date" value="2024-01-15"></s-date-field>
+<s-date-field 
+  label="Date"
+  required 
+  value="2024-10-26"
+  details="Select a date">
+</s-date-field>
+
+<s-date-field 
+  label="Date" 
+  required 
+  value="1890-10-26" 
+  error="Date out of range"
+  details="Select a date">
+</s-date-field>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17903

### Background

Enhancing the DateField component documentation with more comprehensive examples.

### Solution

Updated the DateField documentation to showcase more realistic usage scenarios. The changes include:
- Fixed the language identifier from "HTML" to "html" for proper syntax highlighting
- Expanded the example to demonstrate both a standard DateField and one with an error state
- Added attributes like `required`, `details`, and `error` to show different component states
- Used more descriptive date values to better illustrate the component's functionality

These improvements will help developers better understand how to implement and style DateField components in different scenarios.

### 🎩

- Verified the documentation renders correctly
- Confirmed the examples work as expected in the UI

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation