### PR TITLE
Update EmailField example with required field and error state

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
       tabs: [
         {
           code: './examples/default.html',
-          language: 'HTML',
+          language: 'html',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/examples/default.html
@@ -1,1 +1,12 @@
-<s-email-field label="Email address" placeholder="Enter your email"></s-email-field>
+<s-email-field 
+  label="Email" 
+  placeholder="Enter your email"
+  required
+  value="example@shopify.com"></s-email-field>
+
+<s-email-field 
+  label="Email" 
+  placeholder="Enter your email"
+  required
+  error="Enter a valid email address"
+  value="example.com"></s-email-field>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17904

### Background

This PR enhances the EmailField component documentation with more comprehensive examples.

### Solution

Updated the EmailField documentation to:
- Fix the language attribute from "HTML" to "html" for proper syntax highlighting
- Expand the default example to showcase two use cases:
  1. A valid email field with a pre-filled value
  2. An error state example showing validation feedback

These improvements provide developers with a better understanding of how to implement the EmailField component in different states.

### 🎩

- View the updated documentation to verify the examples render correctly
- Test that both the valid and error states display as expected

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation