### PR TITLE
Update Icon example and fix language case in documentation

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -23,7 +23,7 @@ const data: ReferenceEntityTemplateSchema = {
       tabs: [
         {
           code: './examples/default.html',
-          language: 'HTML',
+          language: 'html',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/examples/default.html
@@ -1,1 +1,1 @@
-<s-icon source="cart"></s-icon>
+<s-icon type="alert-circle"></s-icon>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17906

### Background

This PR updates the Icon component documentation in the point-of-sale surface.

### Solution

Made two small but important changes to the Icon component documentation:
1. Fixed the language identifier in the code tab from uppercase "HTML" to lowercase "html" for proper syntax highlighting
2. Changed the example icon from "cart" to "alert-circle" to better showcase the component

These changes improve the documentation accuracy and provide a clearer example for developers.

### 🎩

- Verify the documentation renders correctly with proper syntax highlighting
- Confirm the "alert-circle" icon displays properly in the example

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation