### PR TITLE
Add documentation for POS Image component

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -1,0 +1,34 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Image',
+  description:
+    'Embeds an image within the interface and controls its presentation. Use to visually illustrate concepts, showcase products, or support user tasks and interactions.',
+  thumbnail: 'image-thumbnail.png',
+  isVisualComponent: true,
+  type: '',
+  definitions: [
+    {
+      title: 'Properties',
+      description: '',
+      type: 'Image',
+    },
+  ],
+  category: 'Polaris web components',
+  subCategory: 'Media',
+  defaultExample: {
+    image: 'image-default.png',
+    codeblock: {
+      title: 'Code',
+      tabs: [
+        {
+          code: './examples/default.html',
+          language: 'html',
+        },
+      ],
+    },
+  },
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/examples/default.html
@@ -1,0 +1,1 @@
+<s-image src="example.png" inlineSize="auto"></s-image>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17907

### Background

Adding documentation for the Image component in the Point of Sale UI extensions.

### Solution

This PR adds documentation for the `Image` component in the Point of Sale surface. The documentation includes:
- Component description explaining its purpose for embedding images and controlling their presentation
- A default example showing basic usage with `src` and `inlineSize` attributes
- Proper categorization as a "Polaris web component" in the "Media" subcategory
- Thumbnail reference for visual identification

### 🎩

- Verify the documentation renders correctly in the docs site
- Confirm the example code works as expected
- Check that the thumbnail image is properly displayed

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation