### PR TITLE
Update Modal component documentation and examples for POS

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Modal',
   description:
-    "Use `s-modal` to display content in a full-screen overlay. Modals are used to display important information that requires the merchant's attention.",
-  thumbnail: 'modal-thumbnail.png',
+    "Use `s-modal` to display content in an overlay. Modals are used to display important information that requires the merchant's attention.",
+  thumbnail: 'dialog-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
@@ -27,13 +27,13 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Polaris web components',
   subCategory: 'Structure',
   defaultExample: {
-    image: 'modal-default.png',
+    image: 'dialog-default.png',
     codeblock: {
       title: 'Code',
       tabs: [
         {
           code: './examples/default.html',
-          language: 'HTML',
+          language: 'html',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/examples/default.html
@@ -1,1 +1,9 @@
-  <s-modal></s-modal>
+<s-button command="--show" commandFor="modal">Open modal</s-button>
+<s-modal id="modal" heading="Header">
+  <s-stack alignItems="center" justifyContent="center" gap="base">
+    <s-text color="subdued">Subheader</s-text>
+  </s-stack>
+  <s-button slot="primary-action" onClick={handlePrimaryAction}>
+    Label
+  </s-button>
+</s-modal>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17908

### Background

This PR updates the Modal component documentation for the point-of-sale UI extensions to better reflect its appearance and usage.

### Solution

- Updated the component description to describe the modal as displaying content in an "overlay" rather than a "full-screen overlay"
- Changed the thumbnail reference from `modal-thumbnail.png` to `dialog-thumbnail.png`
- Updated the default example image from `modal-default.png` to `dialog-default.png`
- Fixed the language specification for the code example from `HTML` to lowercase `html`
- Enhanced the default example code to show a complete implementation with:
  - A button to trigger the modal
  - Modal content with heading
  - Stack component with text
  - A primary action button

These changes provide developers with a more accurate and comprehensive example of how to implement the Modal component.

### 🎩

- Verify the updated documentation renders correctly
- Confirm the example code works as expected
- Check that the new thumbnail and example images are properly displayed

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation