### PR TITLE
Add documentation for POS Page component

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -1,0 +1,39 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Page',
+  description:
+    'Use `s-page` as the main container for placing content in your app. Page comes with preset layouts and automatically adds spacing between elements.',
+  thumbnail: 'screen-thumbnail.png',
+  isVisualComponent: true,
+  type: '',
+  definitions: [
+    {
+      title: 'Properties',
+      description: '',
+      type: 'Page',
+    },
+    {
+      title: 'Slots',
+      description: '',
+      type: 'PageSlots',
+    },
+  ],
+  category: 'Polaris web components',
+  subCategory: 'Structure',
+  defaultExample: {
+    image: 'screen-default.png',
+    codeblock: {
+      title: 'Code',
+      tabs: [
+        {
+          code: './examples/default.html',
+          language: 'html',
+        },
+      ],
+    },
+  },
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/examples/default.html
@@ -1,0 +1,6 @@
+<s-page heading="Title">
+  <s-button slot="secondary-actions" onClick={onActionClick}>
+    Label
+  </s-button>
+  <s-heading>Title</s-heading>
+</s-page>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17911

### Background

Adding documentation for the `Page` component in the Point of Sale UI extensions.

### Solution

This PR adds documentation for the `s-page` component, which serves as the main container for content in Point of Sale apps. The documentation includes:

- Component description explaining that Page comes with preset layouts and automatic spacing
- Property and slot definitions
- A default example showing how to use the component with a heading and secondary actions

The documentation follows the standard format using the ReferenceEntityTemplateSchema and includes appropriate categorization under "Polaris web components" and "Structure" subcategory.

### 🎩

- Verify the documentation renders correctly in the docs site
- Check that the example code works as expected
- Ensure the component description accurately reflects the component's functionality

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation