### PR TITLE
Update SearchField documentation and examples

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'SearchField',
   description:
-    'Use `s-search-field` to provide search functionality within your application. Includes built-in search styling and behavior optimized for filtering content.',
-  thumbnail: 'search-field-thumbnail.png',
+    'Let users enter search terms or find specific items using a single-line input field.',
+  thumbnail: 'search-bar-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
@@ -22,13 +22,13 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Polaris web components',
   subCategory: 'Forms',
   defaultExample: {
-    image: 'search-field-default.png',
+    image: 'search-bar-default.png',
     codeblock: {
       title: 'Code',
       tabs: [
         {
           code: './examples/default.html',
-          language: 'HTML',
+          language: 'html',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/examples/default.html
@@ -1,1 +1,1 @@
-<s-search-field placeholder="Search products"></s-search-field>
+<s-search-field placeholder="Search"></s-search-field>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17914

### Background

This PR updates the documentation for the `SearchField` component in the Point of Sale UI extensions.

### Solution

- Updated the component description to be more user-focused: "Let users enter search terms or find specific items using a single-line input field"
- Changed the thumbnail reference from `search-field-thumbnail.png` to `search-bar-thumbnail.png`
- Updated the default example image reference from `search-field-default.png` to `search-bar-default.png`
- Simplified the placeholder text in the example from "Search products" to "Search"
- Fixed the language specification in the codeblock from uppercase "HTML" to lowercase "html"

These changes improve the clarity of the documentation and ensure consistent naming conventions.

### 🎩

- Verified the updated documentation renders correctly
- Confirmed the new thumbnail and example images are available

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation