### PR TITLE
Add Section component documentation for POS

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -1,0 +1,34 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Section',
+  description:
+    'Groups related content into clearly-defined thematic areas. Sections have contextual heading levels to maintain a meaningful and accessible page structure.',
+  thumbnail: 'section-thumbnail.png',
+  isVisualComponent: true,
+  type: '',
+  definitions: [
+    {
+      title: 'Properties',
+      description: '',
+      type: 'Section',
+    },
+  ],
+  category: 'Polaris web components',
+  subCategory: 'Structure',
+  defaultExample: {
+    image: 'section-default.png',
+    codeblock: {
+      title: 'Code',
+      tabs: [
+        {
+          code: './examples/default.html',
+          language: 'html',
+        },
+      ],
+    },
+  },
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/examples/default.html
@@ -1,0 +1,10 @@
+<s-section heading="Section header">
+  <s-button slot="secondary-actions" onClick={onActionClick}>
+    Action
+  </s-button>
+  <s-choice-list>
+    {data.map((item) => (
+      <s-choice value={item.value}>{item.label}</s-choice>
+    ))}
+  </s-choice-list>
+</s-section>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17915

### Background

Adding documentation and examples for the Section component in the Point of Sale UI extensions.

### Solution

This PR adds documentation for the Section component, which groups related content into clearly-defined thematic areas with contextual heading levels for accessibility. The documentation includes:

- Component description highlighting its purpose for organizing content
- A default example showing how to use the component with secondary actions and choice lists
- Proper categorization as a structure component within Polaris web components

### 🎩

- Verify the documentation renders correctly
- Check that the example code works as expected
- Ensure the thumbnail images are displaying properly

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation