### PR TITLE
Update TextArea example and fix language case in documentation

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
       tabs: [
         {
           code: './examples/default.html',
-          language: 'HTML',
+          language: 'html',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/examples/default.html
@@ -1,1 +1,1 @@
-<s-text-area label="Description" placeholder="Enter product description"></s-text-area>
+<s-text-area label="Add note" placeholder="Enter a custom note" value="Custom note" ></s-text-area>


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/17918

### Background

This PR updates the TextArea component documentation and example in the Point of Sale UI extensions.

### Solution

- Changed the language attribute in the TextArea documentation from uppercase "HTML" to lowercase "html" for consistency
- Updated the default example to show a more realistic use case with:
  - Changed label from "Description" to "Add note"
  - Changed placeholder from "Enter product description" to "Enter a custom note"
  - Added a default value of "Custom note" to demonstrate the component with pre-filled content

These changes provide a more representative example of how the TextArea component would be used in a Point of Sale context.

### 🎩

- View the TextArea component documentation to verify the example renders correctly
- Check that the language syntax highlighting works properly with the lowercase "html" value

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation