### PR TITLE
Update component migration table with newly available Polaris web components

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/upgrading-to-2025-10.doc.ts
@@ -304,14 +304,14 @@ Use the comparison table below to see which Polaris web components are available
 |   \`Button\`                 |   [\`Button\`](polaris-web-components/actions/button)   |   Available   |
 |   \`CameraScanner\`          |   \`CameraScanner\`   |   Coming soon   |
 |   \`DateField\`              |   [\`DateField\`](polaris-web-components/forms/datefield)   |   Available   |
-|   \`DatePicker\`             |   \`DatePicker\`   |   Coming soon   |
-|   \`DateSpinner\`            |   \`DateSpinner\`   |   Coming soon   |
+|   \`DatePicker\`             |   [\`DatePicker\`](polaris-web-components/forms/datepicker)   |   Available   |
+|   \`DatePicker\`            |   [\`DateSpinner\`](polaris-web-components/forms/datespinner)   |   Available, Replaces \`DatePicker.inputMode="spinner"\`   |
 |   \`Dialog\`                 |   [\`Modal\`](polaris-web-components/structure/modal)   |   Available   |
-|   \`EmailField\`             |   [\`EmailField\`](/polaris-web-components/forms/emailfield)   |   Available   |
-|   \`Heading\`                |   \`Heading\`   |   Coming soon   |
+|   \`EmailField\`             |   [\`EmailField\`](polaris-web-components/forms/emailfield)   |   Available   |
+|   \`Heading\`                |   [\`Heading\`](polaris-web-components/titles-and-text/heading)   |   Available   |
 |   \`Icon\`                   |   [\`Icon\`](polaris-web-components/media/icon)   |  Available, more icons coming soon.  |
-|   \`Image\`                  |   \`Image\`   |   Coming soon   |
-|   \`List\`                   |      |  Removed. Use \`Array.map()\`   |
+|   \`Image\`                  |   [\`Image\`](polaris-web-components/media/image)   |   Available   |
+|   \`List\`                   |   VirtualizedList   |  Coming soon   |
 |   \`Navigator\`              |      |   Removed.   |
 |   \`NumberField\`            |   [\`NumberField\`](polaris-web-components/forms/numberfield)   |   Available   |
 |   \`PinPad\`                 |     |   Coming soon   |
@@ -321,10 +321,10 @@ Use the comparison table below to see which Polaris web components are available
 |   \`PrintPreview\`           |   \`DocumentPreview\`   |   Coming soon   |
 |   \`QRCode\`                 |   \`QRCode\`   |   Coming soon   |
 |   \`RadioButtonList\`        |   [\`ChoiceList\`](polaris-web-components/forms/choicelist)   |   Available   |
-|   \`Screen\`                 |   \`Page\`   |   Coming soon   |
+|   \`Screen\`                 |   [\`Page\`](polaris-web-components/structure/page)   |   Available   |
 |   \`ScrollView\`             |   [\`ScrollBox\`](polaris-web-components/structure/scrollbox)   |   Available  |
 |   \`SearchBar\`              |   [\`SearchField\`](polaris-web-components/forms/searchfield)   |   Available   |
-|   \`Section\`                |   \`Section\`   |   Coming soon   |
+|   \`Section\`                |   [\`Section\`](polaris-web-components/structure/section)   |   Available   |
 |   \`SectionHeader\`          |     |   Use \`Section.heading\`   |
 |   \`SegmentedControl\`       |   \`Tabs\`/\`Tab\`   |   Coming soon   |
 |   \`Selectable\`             |   [\`Clickable\`](polaris-web-components/actions/clickable)   |   Available   |
@@ -335,7 +335,7 @@ Use the comparison table below to see which Polaris web components are available
 |   \`TextField\`              |   [\`TextField\`](polaris-web-components/forms/textfield)   |   Available   |
 |   \`Tile\`                   | [\`Tile\`](polaris-web-components/actions/tile)  |  Available   |
 |   \`TimeField\`              |   \`TimeField\`   |   Coming soon   |
-|   \`TimePicker\`             |   \`TimePicker\`   |   Coming soon   |
+|   \`TimePicker\`             |   [\`TimePicker\`](polaris-web-components/forms/timepicker)   |   Available   |
 `,
     },
   ],


### PR DESCRIPTION
### Background

Updates the component availability status in the Point of Sale upgrade documentation for the 2025-10 release.

### Solution

This PR updates the component comparison table in the Point of Sale upgrade documentation to reflect the current availability status of several Polaris web components:

- Fixed the link for `EmailField` by removing the leading slash
- Updated `Heading` from "Coming soon" to "Available" with a link to documentation
- Updated `Image` from "Coming soon" to "Available" with a link to documentation
- Changed `List` from "Removed" to "Coming soon" with the new component name `VirtualizedList`
- Updated `Screen` (now `Page`) from "Coming soon" to "Available" with a link to documentation
- Updated `Section` from "Coming soon" to "Available" with a link to documentation
- Updated `TimePicker` from "Coming soon" to "Available" with a link to documentation

These updates ensure merchants and developers have accurate information about which components are available for use in the new version.

### 🎩

- Verified all links are correct and working
- Confirmed component availability status is accurate

Test documentation [here](https://app.graphite.dev/github/pr/Shopify/shopify-dev/62302/Update-pos-dev-docs).

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation