### PR TITLE
Migrate visible examples in Customer account docs to Preact

### DIFF
--- a/.changeset/wet-ants-wait.md
+++ b/.changeset/wet-ants-wait.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Migrate some customer account examples to Preact

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/configuration/multiple-targets-block.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/configuration/multiple-targets-block.example.tsx
@@ -1,10 +1,9 @@
 // ...
 
 // ./BlockExtension.jsx
-export default reactExtension(
-  'customer-account.order-status.block.render',
-  <BlockExtension />,
-);
+export default async () => {
+  render(<BlockExtension />, document.body);
+};
 
 function BlockExtension() {
   // ...

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/configuration/multiple-targets-fullpage.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/configuration/multiple-targets-fullpage.example.tsx
@@ -1,10 +1,9 @@
 // ...
 
 // ./FullPageExtension.jsx
-export default reactExtension(
-  'customer-account.page.render',
-  <FullPageExtension />,
-);
+export default async () => {
+  render(<FullPageExtension />, document.body);
+};
 
 function FullPageExtension() {
   // ...

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/configuration/single-target.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/configuration/single-target.example.tsx
@@ -1,10 +1,8 @@
 // ...
 
-export default reactExtension(
-  'customer-account.order-status.block.render',
-  <Extension />,
-);
-
+export default async () => {
+  render(<Extension />, document.body);
+};
 function Extension() {
   // ...
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/error-handling/sentry.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/error-handling/sentry.example.tsx
@@ -1,7 +1,5 @@
-import {
-  reactExtension,
-  Banner,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
@@ -25,11 +23,10 @@ self.addEventListener('error', (error) => {
 });
 
 // Your normal extension code.
-export default reactExtension(
-  'customer-account.order-status.block.render',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Banner>Your extension</Banner>;
+  return <s-banner>Your extension</s-banner>;
 }


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-checkout/issues/7668
Related to https://github.com/Shopify/shopify-dev/pull/62344

Some of the examples that are currently shown in the Customer account docs were still in React

### Solution

Convert them to Preact

### 🎩

See https://github.com/Shopify/shopify-dev/pull/62344 for details

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
