### PR TITLE
Migrate Customer account target examples to Preact

### DIFF
--- a/.changeset/flat-cows-count.md
+++ b/.changeset/flat-cows-count.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Migrate customer account target examples to Preact

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.footer.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.footer.render-after/default.example.tsx
@@ -1,24 +1,16 @@
-import {
-  BlockStack,
-  reactExtension,
-  Text,
-  useApi,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-// 1. Choose an extension target
-export default reactExtension(
-  'customer-account.footer.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  // 2. Use the extension API to gather context from extension
-  const {extension} = useApi();
-
-  // 3. Render a UI
   return (
-    <BlockStack>
-      <Text>target: {extension.target}</Text>
-    </BlockStack>
+    <s-stack direction="block">
+      <s-text>
+        target: {shopify.extension.target}
+      </s-text>
+    </s-stack>
   );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-index.block.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-index.block.render/default.example.tsx
@@ -1,13 +1,15 @@
-import {
-  reactExtension,
-  Text,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.order-index.block.render',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Text>I am a block extension that renders in the Orders section</Text>;
+  return (
+    <s-text>
+      I am a block extension that renders in the
+      Orders section
+    </s-text>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.block.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.block.render/default.example.tsx
@@ -1,23 +1,19 @@
-import {
-  reactExtension,
-  Banner,
-  useOrder,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.order-status.block.render',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  const order = useOrder();
+  const order = shopify.order.value;
 
   if (order) {
     return (
-      <Banner>
+      <s-banner>
         Please include your order ID ({order.id})
         in support requests
-      </Banner>
+      </s-banner>
     );
   }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.cart-line-item.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.cart-line-item.render-after/default.example.tsx
@@ -1,17 +1,16 @@
-import {
-  reactExtension,
-  Text,
-  useTarget,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.order-status.cart-line-item.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
   const {
     merchandise: {title},
-  } = useTarget();
-  return <Text>Line item title: {title}</Text>;
+  } = shopify.target.value;
+
+  return (
+    <s-text>Line item title: {title}</s-text>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.cart-line-list.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.cart-line-list.render-after/default.example.tsx
@@ -1,23 +1,19 @@
-import {
-  reactExtension,
-  Banner,
-  useOrder,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.order-status.cart-line-list.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  const order = useOrder();
+  const order = shopify.order.value;
 
   if (order) {
     return (
-      <Banner>
+      <s-banner>
         Please include your order ID ({order.id})
         in support requests
-      </Banner>
+      </s-banner>
     );
   }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.customer-information.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.customer-information.render-after/default.example.tsx
@@ -1,23 +1,19 @@
-import {
-  reactExtension,
-  Banner,
-  useOrder,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.order-status.customer-information.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  const order = useOrder();
+  const order = shopify.order.value;
 
   if (order) {
     return (
-      <Banner>
+      <s-banner>
         Please include your order ID ({order.id})
         in support requests
-      </Banner>
+      </s-banner>
     );
   }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.fulfillment-details.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.fulfillment-details.render-after/default.example.tsx
@@ -1,13 +1,15 @@
-import {
-  reactExtension,
-  Banner,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.order-status.fulfillment-details.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Banner>Note that tracking info update is subject to the courier who delivers your order</Banner>;
+  return (
+    <s-banner>
+      Note that tracking info update is subject to
+      the courier who delivers your order
+    </s-banner>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.payment-details.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.payment-details.render-after/default.example.tsx
@@ -1,13 +1,15 @@
-import {
-  reactExtension,
-  Banner,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.order-status.fulfillment-details.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Banner>Contact the merchant to complete your payment.</Banner>;
+  return (
+    <s-banner>
+      Contact the merchant to complete your
+      payment.
+    </s-banner>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.return-details.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.return-details.render-after/default.example.tsx
@@ -1,13 +1,15 @@
-import {
-  reactExtension,
-  Banner,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.order-status.return-details.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Banner>Your return request has been received and is processing</Banner>;
+  return (
+    <s-banner>
+      Your return request has been received and is
+      processing
+    </s-banner>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.unfulfilled-items.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.unfulfilled-items.render-after/default.example.tsx
@@ -1,13 +1,14 @@
-import {
-  reactExtension,
-  Banner,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.order-status.unfulfilled-items.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Banner>Fulfillment details not yet available.</Banner>;
+  return (
+    <s-banner>
+      Fulfillment details not yet available.
+    </s-banner>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order.action.menu-item.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order.action.menu-item.render/default.example.tsx
@@ -1,16 +1,17 @@
-import React from "react";
-import {
-  Button,
-  reactExtension,
-  useApi,
-} from "@shopify/ui-extensions-react/customer-account";
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  "customer-account.order.action.menu-item.render",
-  () => <MenuActionItemExtension />
-);
+export default async () => {
+  render(
+    <MenuActionItemExtension />,
+    document.body,
+  );
+};
 
 function MenuActionItemExtension() {
-  const {i18n} = useApi<"customer-account.order.action.menu-item.render">()
-  return <Button>{i18n.translate("menuItem.button")}</Button>;
+  return (
+    <s-button>
+      {shopify.i18n.translate('menuItem.button')}
+    </s-button>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order.action.menu-item.render/load-data-upfront.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order.action.menu-item.render/load-data-upfront.example.tsx
@@ -1,28 +1,26 @@
-import React from "react";
-import {
-  Button,
-  reactExtension,
-  useApi,
-} from "@shopify/ui-extensions-react/customer-account";
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  "customer-account.order.action.menu-item.render",
-  async () => {
-    const data = await fetchMenuItems();
-
-    return <MenuActionItemExtension data={data}/>
-  }
-);
+export default async () => {
+  const data = await fetchMenuItems();
+  render(
+    <MenuActionItemExtension data={data} />,
+    document.body,
+  );
+};
 
 interface Props {
   data: any;
 }
 
 function MenuActionItemExtension(props: Props) {
-  return <Button to={props.data.url}>{props.data.itemName}</Button>;
+  return (
+    <s-button href={props.data.url}>
+      {props.data.itemName}
+    </s-button>
+  );
 }
 
 function fetchMenuItems() {
-  throw new Error("Function not implemented.");
+  throw new Error('Function not implemented.');
 }
-

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order.action.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order.action.render/default.example.tsx
@@ -1,35 +1,26 @@
-import React from "react";
-import {
-  Button,
-  CustomerAccountAction,
-  TextBlock,
-  reactExtension,
-  useApi,
-} from "@shopify/ui-extensions-react/customer-account";
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  "customer-account.order.action.render",
-  ( ) => <MenuActionExtension />
-);
+export default async () => {
+  render(<MenuActionExtension />, document.body);
+};
 
-function MenuActionExtension( ) {
-  const api = useApi<"customer-account.order.action.render">()
-  const translate = api.i18n.translate;
+function MenuActionExtension() {
+  const translate = shopify.i18n.translate;
 
   return (
-    <CustomerAccountAction
-      title={translate("menuAction.title")}
-      primaryAction={
-        <Button
-          onPress={() => {
-            api.close();
-          }}
-        >
-          {translate("menuAction.primaryAction")}
-        </Button>
-      }
+    <s-customer-account-action
+      heading={translate('menuAction.title')}
     >
-      <TextBlock>{translate("menuAction.content")}</TextBlock>
-    </CustomerAccountAction>
+      <s-button
+        slot="primary-action"
+        onClick={() => shopify.close()}
+      >
+        {translate('menuAction.primaryAction')}
+      </s-button>
+      <s-paragraph>
+        {translate('menuAction.content')}
+      </s-paragraph>
+    </s-customer-account-action>
   );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.addresses.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.addresses.render-after/default.example.tsx
@@ -1,13 +1,12 @@
-import {
-  reactExtension,
-  Text,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.profile.addresses.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Text>I am an addresses extension</Text>;
+  return (
+    <s-text>I am an addresses extension</s-text>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.block.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.block.render/default.example.tsx
@@ -1,13 +1,12 @@
-import {
-  reactExtension,
-  Text,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.profile.block.render',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Text>I am a Profile extension</Text>;
+  return (
+    <s-text>I am a Profile extension</s-text>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.company-details.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.company-details.render-after/default.example.tsx
@@ -1,13 +1,14 @@
-import {
-  reactExtension,
-  Text,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.profile.addresses.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Text>I am a company details extension</Text>;
+  return (
+    <s-text>
+      I am a company details extension
+    </s-text>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.company-location-addresses.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.company-location-addresses.render-after/default.example.tsx
@@ -1,13 +1,14 @@
-import {
-  reactExtension,
-  Text,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.profile.company-location-addresses.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Text>I am a company location addresses extension</Text>;
+  return (
+    <s-text>
+      I am a company location addresses extension
+    </s-text>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.company-location-payment.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.company-location-payment.render-after/default.example.tsx
@@ -1,13 +1,14 @@
-import {
-  reactExtension,
-  Text,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.profile.company-location-payment.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Text>I am a company location payment extension</Text>;
+  return (
+    <s-text>
+      I am a company location payment extension
+    </s-text>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.company-location-staff.render-after/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.company-location-staff.render-after/default.example.tsx
@@ -1,13 +1,14 @@
-import {
-  reactExtension,
-  Text,
-} from '@shopify/ui-extensions-react/customer-account';
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
 
-export default reactExtension(
-  'customer-account.profile.payment.render-after',
-  () => <Extension />,
-);
+export default async () => {
+  render(<Extension />, document.body);
+};
 
 function Extension() {
-  return <Text>I am a company location staff extension</Text>;
+  return (
+    <s-text>
+      I am a company location staff extension
+    </s-text>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.footer.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.footer.render-after.doc.ts
@@ -14,19 +14,19 @@ the footer on all customer account pages (**Order index**, **Order status**, **P
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Footer',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account footer extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.footer.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account footer extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.footer.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   definitions: [CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   related: [],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-index.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-index.block.render.doc.ts
@@ -9,19 +9,19 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Order index',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account order index extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order-index.block.render/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order index extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-index.block.render/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [
     {
       name: 'Placement references',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.block.render.doc.ts
@@ -13,19 +13,19 @@ const data: ReferenceEntityTemplateSchema = {
   overviewPreviewDescription:
     'A [block extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the Order Status Page.',
   subCategory: 'Order status',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account order status extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order-status.block.render/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order status extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-status.block.render/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [
     {
       name: 'Placement references',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.cart-line-item.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.cart-line-item.render-after.doc.ts
@@ -13,19 +13,19 @@ const data: ReferenceEntityTemplateSchema = {
   ${ORDER_STATUS_SURFACE_NOTE}
   `,
   subCategory: 'Order status',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account order status card line item extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order-status.cart-line-item.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order status card line item extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-status.cart-line-item.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   ...ORDER_STATUS_CART_LINE_ITEM_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.cart-line-list.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.cart-line-list.render-after.doc.ts
@@ -10,19 +10,19 @@ const data: ReferenceEntityTemplateSchema = {
   ${ORDER_STATUS_SURFACE_NOTE}
   `,
   subCategory: 'Order status',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account order status cart line list extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order-status.cart-line-list.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order status cart line list extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-status.cart-line-list.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   ...ORDER_STATUS_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.customer-information.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.customer-information.render-after.doc.ts
@@ -10,20 +10,20 @@ const data: ReferenceEntityTemplateSchema = {
   ${ORDER_STATUS_SURFACE_NOTE}
   `,
   subCategory: 'Order status',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title:
-  //       'Customer account order status customer information extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title:
+        'Customer account order status customer information extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   ...ORDER_STATUS_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.fulfillment-details.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.fulfillment-details.render-after.doc.ts
@@ -8,20 +8,20 @@ const data: ReferenceEntityTemplateSchema = {
     A [static extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#static-extension-targets) that renders in the delivery status card on the Order Status page. A separate delivery status card is shown for each fulfillment.
   `,
   subCategory: 'Order status',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title:
-  //       'Customer account order status fulfillment details extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order-status.fulfillment-details.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title:
+        'Customer account order status fulfillment details extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-status.fulfillment-details.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   ...FULFILLMENT_DETAILS_APIS,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.payment-details.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.payment-details.render-after.doc.ts
@@ -8,19 +8,19 @@ const data: ReferenceEntityTemplateSchema = {
   A [static extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#static-extension-targets) that renders in the payment status section of the Order Status page.
   `,
   subCategory: 'Order status',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account order status payment status extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order-status.customer-information.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order status payment status extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-status.payment-details.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   ...ORDER_STATUS_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.return-details.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.return-details.render-after.doc.ts
@@ -8,19 +8,19 @@ const data: ReferenceEntityTemplateSchema = {
   A [static extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#static-extension-targets) that renders in the return status card on the Order Status page. This card only shows when a return has been requested.
   `,
   subCategory: 'Order status',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account order status return details extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order-status.return-details.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order status return details extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-status.return-details.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   ...ORDER_STATUS_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.unfulfilled-items.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.unfulfilled-items.render-after.doc.ts
@@ -8,20 +8,20 @@ const data: ReferenceEntityTemplateSchema = {
   A [static extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#static-extension-targets) that renders in the delivery status card for unfulfilled items on the Order Status page.
   `,
   subCategory: 'Order status',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title:
-  //       'Customer account order status unfulfilled details extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order-status.unfulfilled-items.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title:
+        'Customer account order status unfulfilled details extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-status.unfulfilled-items.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   ...ORDER_STATUS_API,
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.action.menu-item.render.doc.ts
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Order action menu',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account order menu item extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order.action.menu-item.render/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order menu item extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order.action.menu-item.render/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   examples: {
     description: 'Additional examples for menu item extensions.',
     examples: [
@@ -34,8 +34,8 @@ const data: ReferenceEntityTemplateSchema = {
           tabs: [
             {
               code: '../examples/targets/customer-account.order.action.menu-item.render/load-data-upfront.example.tsx',
-              language: 'jsx',
-              title: 'React',
+              language: 'tsx',
+              title: 'Preact',
             },
           ],
         },

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.action.render.doc.ts
@@ -18,19 +18,19 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Order action menu',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account order action extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.order.action.render/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order action extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order.action.render/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   definitions: [
     ORDER_ACTION_API,

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.addresses.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.addresses.render-after.doc.ts
@@ -8,19 +8,19 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (Default)',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account addresses extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.profile.addresses.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account addresses extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.profile.addresses.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   definitions: [CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.block.render.doc.ts
@@ -10,19 +10,19 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (Default)',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account profile extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.profile.block.render/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account profile extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.profile.block.render/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [
     {
       name: 'Placement references',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-details.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-details.render-after.doc.ts
@@ -8,19 +8,19 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (B2B)',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account company details extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.profile.company-details.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account company details extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.profile.company-details.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   definitions: [CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-addresses.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-addresses.render-after.doc.ts
@@ -11,19 +11,19 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (B2B)',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account company location addresses extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.profile.company-location-addresses.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account company location addresses extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.profile.company-location-addresses.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   definitions: [COMPANY_LOCATION_API, CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-payment.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-payment.render-after.doc.ts
@@ -11,19 +11,19 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (B2B)',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account company location payment extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.profile.company-location-payment.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account company location payment extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.profile.company-location-payment.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   definitions: [COMPANY_LOCATION_API, CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-staff.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.company-location-staff.render-after.doc.ts
@@ -11,19 +11,19 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   isVisualComponent: false,
   subCategory: 'Profile (B2B)',
-  // defaultExample: {
-  //   description: '',
-  //   codeblock: {
-  //     title: 'Customer account company location staff extension example',
-  //     tabs: [
-  //       {
-  //         code: '../examples/targets/customer-account.profile.company-location-staff.render-after/default.example.tsx',
-  //         language: 'jsx',
-  //         title: 'React',
-  //       },
-  //     ],
-  //   },
-  // },
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account company location staff extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.profile.company-location-staff.render-after/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
   related: [],
   definitions: [COMPANY_LOCATION_API, CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
   type: 'Target',


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-checkout/issues/7668
https://github.com/Shopify/shopify-dev/pull/62347

The target examples hadn't been migrated to Preact and were commented out in the docs

### Solution

Migrate them to Preact and uncomment

### 🎩

See https://github.com/Shopify/shopify-dev/pull/62347 for details

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
