### PR TITLE
2025-10 Release Candidate 27

### DIFF
--- a/.changeset/real-stingrays-wave.md
+++ b/.changeset/real-stingrays-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+2025-10 RC 27


### PR DESCRIPTION
### Background

This PR adds a changeset for the `@shopify/ui-extensions` package for the 2025-10 RC 27 release.

### Solution

Added a new changeset file `.changeset/real-stingrays-wave.md` that marks `@shopify/ui-extensions` for a patch version update with the description "2025-10 RC 27".

### 🎩

- Verify the changeset file is correctly formatted
- Ensure the package name and version bump type are accurate

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation