### PR TITLE
[customer account] add announcement targets for 2025-10-rc

### DIFF
--- a/.changeset/tidy-spiders-report.md
+++ b/.changeset/tidy-spiders-report.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+[customer account] add announcement targets

--- a/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview This file is used to generate the documentation for the customer-account surface. For component types, see the components folder.
+ */
 import {
   AvatarProps,
   AvatarElementProps,

--- a/packages/ui-extensions/src/surfaces/customer-account/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/extension-targets.ts
@@ -38,6 +38,11 @@ export interface OrderStatusExtensionTargets {
       StandardApi<'customer-account.order-status.block.render'>,
     StandardComponents
   >;
+  'customer-account.order-status.announcement.render': RenderExtension<
+    OrderStatusApi<'customer-account.order-status.announcement.render'> &
+      StandardApi<'customer-account.order-status.announcement.render'>,
+    StandardComponents
+  >;
   /**
    * A static extension target that renders on every line item, inside the details
    * under the line item properties element on the **Order status** page.
@@ -107,8 +112,16 @@ export interface CustomerAccountExtensionTargets {
     StandardApi<'customer-account.order-index.block.render'>,
     StandardComponents
   >;
+  'customer-account.order-index.announcement.render': RenderExtension<
+    StandardApi<'customer-account.order-index.announcement.render'>,
+    StandardComponents
+  >;
   'customer-account.profile.block.render': RenderExtension<
     StandardApi<'customer-account.profile.block.render'>,
+    StandardComponents
+  >;
+  'customer-account.profile.announcement.render': RenderExtension<
+    StandardApi<'customer-account.profile.announcement.render'>,
     StandardComponents
   >;
   'customer-account.profile.addresses.render-after': RenderExtension<


### PR DESCRIPTION
### Background

[The Announcement component](https://github.com/Shopify/ui-api-design/pull/1196) has been approved by TAG team, we are starting to implement it for 2025-10 remote-dom version. 
 
- I only added targets here
- we share the same type with checkout, so for the component's type, we will try to use use checkout's

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
