### PR TITLE
Adds DiscountApplication and DiscountAllocation to correct interfaces

### DIFF
--- a/.changeset/discount-applications-allocations.md
+++ b/.changeset/discount-applications-allocations.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added discount application and allocation support to POS transaction data interfaces. Added optional `discountApplications` field to `SaleTransactionData` and optional `discountAllocations` field to `LineItem` to provide detailed discount attribution data for receipt extensions.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/SaleTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/SaleTransactionData.ts
@@ -1,8 +1,10 @@
 import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {LineItem} from '../../types/cart';
+import {DiscountApplication} from '../../types/discount-application';
 
 export interface SaleTransactionData extends BaseTransactionComplete {
   transactionType: 'Sale';
   draftCheckoutUuid?: string;
   lineItems: LineItem[];
+  discountApplications?: DiscountApplication[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -1,5 +1,6 @@
 import {CountryCode} from './country-code';
 import {TaxLine} from './tax-line';
+import {DiscountAllocation} from './discount-allocation';
 
 export interface Cart {
   /**
@@ -40,6 +41,7 @@ export interface LineItem {
   variantId?: number;
   productId?: number;
   discounts: Discount[];
+  discountAllocations?: DiscountAllocation[];
   taxable: boolean;
   taxLines: TaxLine[];
   sku?: string;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-allocation.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-allocation.ts
@@ -1,0 +1,12 @@
+import type {MoneyV2} from './money-v2';
+import type {DiscountApplication} from './discount-application';
+
+export interface DiscountAllocation {
+  allocatedAmountSet: MoneyBag;
+  discountApplication: DiscountApplication;
+}
+
+export interface MoneyBag {
+  shopMoney: MoneyV2;
+  presentmentMoney: MoneyV2;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-application.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-application.ts
@@ -1,0 +1,59 @@
+import type {MoneyV2} from './money-v2';
+
+export enum DiscountApplicationAllocationMethod {
+  ACROSS = 'ACROSS',
+  EACH = 'EACH',
+  ONE = 'ONE',
+}
+
+export enum DiscountApplicationTargetSelection {
+  ALL = 'ALL',
+  ENTITLED = 'ENTITLED',
+  EXPLICIT = 'EXPLICIT',
+}
+
+export enum DiscountApplicationTargetType {
+  LINE_ITEM = 'LINE_ITEM',
+  SHIPPING_LINE = 'SHIPPING_LINE',
+}
+
+export type DiscountApplication =
+  | AutomaticDiscountApplication
+  | DiscountCodeApplication
+  | ManualDiscountApplication
+  | ScriptDiscountApplication;
+
+export interface DiscountApplicationBase {
+  allocationMethod: DiscountApplicationAllocationMethod;
+  index: number;
+  targetSelection: DiscountApplicationTargetSelection;
+  targetType: DiscountApplicationTargetType;
+  value: PricingValue;
+}
+
+export interface AutomaticDiscountApplication extends DiscountApplicationBase {
+  type: 'automatic';
+  title: string;
+}
+
+export interface DiscountCodeApplication extends DiscountApplicationBase {
+  type: 'code';
+  code: string;
+}
+
+export interface ManualDiscountApplication extends DiscountApplicationBase {
+  type: 'manual';
+  title: string;
+  description?: string;
+}
+
+export interface ScriptDiscountApplication extends DiscountApplicationBase {
+  type: 'script';
+  title: string;
+}
+
+export type PricingValue = MoneyV2 | PricingPercentageValue;
+
+export interface PricingPercentageValue {
+  percentage: number;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/money-v2.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/money-v2.ts
@@ -1,0 +1,4 @@
+export interface MoneyV2 {
+  amount: string;
+  currencyCode: string;
+}


### PR DESCRIPTION
### Background

Partners need access to discount application data at the order level and discount allocation data at the line item level within the pos.receipt-footer.block.render extension target. This will allow them to correctly calculate taxes for all line items.

This PR makes the correct updates to the relevant interfaces. That includes the line item interface shared with the cart API.

Closes https://github.com/shop/issues-retail/issues/18108
Closes https://github.com/shop/issues-retail/issues/18109

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
