### PR TITLE
Enhance Cart API for Selling Plan Support

### DIFF
--- a/.changeset/clean-keys-float.md
+++ b/.changeset/clean-keys-float.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Update POS Cart API selling plan method to support more fields

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.jsx
@@ -10,7 +10,13 @@ const Extension = () => {
       heading="My App"
       subheading="Call cart function"
       onClick={() => {
-        shopify.cart.addLineItemSellingPlan('aa-1234567', 123);
+        shopify.cart.addLineItemSellingPlan({
+          lineItemUuid: 'aa-1234567',
+          sellingPlanId: 123,
+          sellingPlanName: 'My Exclusive Subscription',
+          sellingPlanDeliveryInterval: 'MONTH', // optional
+          sellingPlanDeliveryIntervalCount: 2, // optional
+        });
       }}
     />
   );

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -7,6 +7,7 @@ import type {
   CustomSale,
   SetLineItemDiscountInput,
   SetLineItemPropertiesInput,
+  SetLineItemSellingPlanInput,
 } from '../../types/cart';
 
 /**
@@ -227,7 +228,7 @@ export interface CartApiContent {
    * @param uuid the uuid of the line item that should receive the selling plan
    * @param sellingPlanId the ID of the selling plan to add to the line item
    */
-  addLineItemSellingPlan(uuid: string, sellingPlanId: number): Promise<void>;
+  addLineItemSellingPlan(input: SetLineItemSellingPlanInput): Promise<void>;
 
   /**
    * Remove the selling plan from a line item in the cart.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -69,16 +69,24 @@ export interface SellingPlan {
   name: string;
   /**
    * The fingerprint of the applied selling plan within this cart session.
+   * Provided by POS. Not available during refund / exchanges.
    */
-  digest: string;
+  digest?: string;
   /**
-   * The interval of the selling plan. i.e. "every 2 weeks"
+   * The interval of the selling plan. (DAY, WEEK, MONTH, YEAR).
    */
-  deliveryInterval?: string;
+  deliveryInterval?: SellingPlanDeliveryInterval;
   /**
-   * The interval count of the selling plan. i.e. "2"
+   * The number of intervals between deliveries.
    */
   deliveryIntervalCount?: number;
+}
+
+export enum SellingPlanDeliveryInterval {
+  Day = 'DAY',
+  Week = 'WEEK',
+  Month = 'MONTH',
+  Year = 'YEAR',
 }
 
 export interface Discount {
@@ -152,4 +160,29 @@ export interface Address {
   name?: string;
   provinceCode?: string;
   countryCode?: CountryCode;
+}
+
+export interface SetLineItemSellingPlanInput {
+  /**
+   * The uuid of the line item to which the selling plan should be applied.
+   */
+  lineItemUuid: string;
+  /**
+   * The ID of the selling plan to apply to the line item.
+   */
+  sellingPlanId: number;
+  /**
+   * The name of the selling plan to apply to the line item.
+   */
+  sellingPlanName: string;
+  /**
+   * The interval of the selling plan. (DAY, WEEK, MONTH, YEAR).
+   * If not provided, POS will try to fetch it from the server after syncing the cart.
+   */
+  sellingPlanDeliveryInterval?: SellingPlanDeliveryInterval;
+  /**
+   * The number of intervals between deliveries.
+   * If not provided, POS will try to fetch it from the server after syncing the cart.
+   */
+  sellingPlanDeliveryIntervalCount?: number;
 }


### PR DESCRIPTION
### Background

The `addLineItemSellingPlan` only required `sellingPlanId`. While that's technically enough for the operation to complete, it results in less than ideal UX given that POS has to wait for the server to sync in order to display the selected selling plan name in the cart, which can take a few seconds.

This change was previously merged: https://github.com/Shopify/ui-extensions/pull/3174 and reverted: https://github.com/Shopify/ui-extensions/pull/3182 as part of our design phase. Ultimately, we decided it will enable better extensibility and better UX, so we're bringing it back.

### Solution

Require the 1P/3P app to send the selling plan `id` AND `name`. That way, POS can persist both values have them at hand without having to wait for server, providing immediate feedback to user. Fetching the `name` is straightforward so it should not be complicated for apps to add this.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
