### PR TITLE
Includes product bundle component data on line items

### DIFF
--- a/.changeset/bundle-components-transaction.md
+++ b/.changeset/bundle-components-transaction.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added optional `components` field to `LineItem` interface with new `LineItemComponent` type to provide properties of product bundle components.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -1,5 +1,6 @@
 import {CountryCode} from './country-code';
 import {TaxLine} from './tax-line';
+import {Money} from './money';
 
 export interface Cart {
   /**
@@ -53,6 +54,24 @@ export interface LineItem {
    * The currently selected selling plan for this line item.
    */
   sellingPlan?: SellingPlan;
+  /**
+   * The components associated if LineItem represents a product bundle.
+   */
+  components?: LineItemComponent[];
+}
+
+/**
+ * Product data for a single component in a line item bundle. Not including
+ * uuid because we do not want any chance of these components being mutated.
+ */
+export interface LineItemComponent {
+  title: string;
+  quantity: number;
+  price: Money;
+  taxable: boolean;
+  taxLines: TaxLine[];
+  variantId?: string;
+  productId?: string;
 }
 
 /**


### PR DESCRIPTION
### Background

We are not passing the correct transaction data to pos.receipt-footer.block.render and other targets for product bundles. This is a critical requirement for FC Barcelona, a large merchant that needs to start becoming fiscally compliant with our partner's app. Our partner's app needs product bundle information passed to their extension target code to correctly calculate taxes for FC Barcelona and other merchants.

### Solution

Adds product bundle components to the cart line item interface, which is what `TransactionCompleteData` currently uses. We are not including a `uuid` field so that the components could not be possible mutated even if queried pre checkout completion.

One consideration is whether we should have a separate line item interface for transaction complete data, if we don't want to add to all cart APIs right now.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
