### PR TITLE
Add new components to BlockExtensionComponents and StandardComponents

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/BlockExtensionComponents.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/BlockExtensionComponents.ts
@@ -2,11 +2,17 @@ export type BlockExtensionComponents =
   | 'Badge'
   | 'Button'
   | 'DatePicker'
+  | 'DateSpinner'
   | 'Dialog'
+  | 'Heading'
   | 'Icon'
   | 'Image'
+  | 'Modal'
   | 'POSBlock'
+  | 'PosBlock' // Case is important in 2025-10
   | 'POSBlockRow'
+  | 'PrintPreview'
+  | 'Section'
   | 'Stack'
   | 'Text'
   | 'TimePicker';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/StandardComponents.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/StandardComponents.ts
@@ -18,6 +18,7 @@ export type StandardComponents =
   | 'NumberField'
   | 'Page'
   | 'POSBlock'
+  | 'PosBlock' // Case is important in 2025-10
   | 'QRCode'
   | 'Route'
   | 'Router'


### PR DESCRIPTION
### Background

This PR adds new component types to the Point of Sale extension system to support upcoming features.

### Solution

Added several new component types to the BlockExtensionComponents and StandardComponents interfaces:
- DateSpinner
- Heading
- Modal
- PrintPreview
- Section
- PosBlock (with a note about case sensitivity in 2025-10)

These additions will enable developers to use these components in their Point of Sale extensions, expanding the available UI toolkit.

### 🎩

- Verify that the new component types are properly recognized in the type system
- Check that existing code using these interfaces still compiles correctly

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation