### PR TITLE
fix bullet lists for checkout UI component docs

### DIFF
--- a/.changeset/proud-ties-reply.md
+++ b/.changeset/proud-ties-reply.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+fix checkout UI component docs list formatting

--- a/packages/ui-extensions/src/surfaces/checkout/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Box/Box.doc.ts
@@ -33,12 +33,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best Practices',
       sectionContent: `
-        - Use \`s-box\` when you need a container that preserves the natural size of its contents.
-        - \`s-box\` is particularly useful in layout components like \`s-stack\` where you want to prevent children from stretching to fit.
-        - \`s-box\` has a \`display: block\` layout by default.
-        - Use \`s-box\` for simple container needs where you don't need the additional features of more specialized components like \`s-stack\`.
-        - Consider using \`s-box\` when you need to apply specific styling or layout properties to a group of elements without affecting their natural dimensions.
-      `,
+- Use \`s-box\` when you need a container that preserves the natural size of its contents.
+- \`s-box\` is particularly useful in layout components like \`s-stack\` where you want to prevent children from stretching to fit.
+- \`s-box\` has a \`display: block\` layout by default.
+- Use \`s-box\` for simple container needs where you don't need the additional features of more specialized components like \`s-stack\`.
+- Consider using \`s-box\` when you need to apply specific styling or layout properties to a group of elements without affecting their natural dimensions.`,
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/checkout/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/OrderedList/OrderedList.doc.ts
@@ -39,12 +39,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best Practices',
       sectionContent: `
-        - Use \`s-ordered-list\` when you need to present items in a specific sequence or order.
-        - Each item in the list should be wrapped in a \`s-list-item\` component.
-        - Keep list items concise and consistent in length when possible.
-        - Use \`s-ordered-list\` for step-by-step instructions, numbered procedures, or ranked items.
-        - Consider using \`s-ordered-list\` when the order of items is important for understanding.
-      `,
+- Use \`s-ordered-list\` when you need to present items in a specific sequence or order.
+- Each item in the list should be wrapped in a \`s-list-item\` component.
+- Keep list items concise and consistent in length when possible.
+- Use \`s-ordered-list\` for step-by-step instructions, numbered procedures, or ranked items.
+- Consider using \`s-ordered-list\` when the order of items is important for understanding.`,
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.doc.ts
@@ -42,8 +42,8 @@ const data: ReferenceEntityTemplateSchema = {
 - Include a square logo if that’s what your customers are familiar with.
 - Increase usability by adding a text description of what the QR code does.
 - Always provide an alternate method for customers to access the content of the QR code.
-  - If the content is a URL, provide a [\`s-link\`](/docs/api/checkout-ui-extensions/components/link) nearby.
-  - If the content is data, provide a [\`s-button\`](/docs/api/checkout-ui-extensions/components/button) to copy the data to the clipboard, or show the data in a readonly [\`s-text-field\`](/docs/api/checkout-ui-extensions/components/textfield).`,
+- If the content is a URL, provide a [\`s-link\`](/docs/api/checkout-ui-extensions/components/link) nearby.
+- If the content is data, provide a [\`s-button\`](/docs/api/checkout-ui-extensions/components/button) to copy the data to the clipboard, or show the data in a readonly [\`s-text-field\`](/docs/api/checkout-ui-extensions/components/textfield).`,
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList/UnorderedList.doc.ts
@@ -39,12 +39,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best Practices',
       sectionContent: `
-        - Use \`s-unordered-list\` when you need to present a list of related items or options.
-        - Each item in the list should be wrapped in a \`s-list-item\` component.
-        - Keep list items concise and consistent in length when possible.
-        - Use \`s-unordered-list\` for navigation menus, feature lists, or any collection of related items.
-        - Consider using \`s-unordered-list\` when you want to present information in a clear, scannable format.
-      `,
+- Use \`s-unordered-list\` when you need to present a list of related items or options.
+- Each item in the list should be wrapped in a \`s-list-item\` component.
+- Keep list items concise and consistent in length when possible.
+- Use \`s-unordered-list\` for navigation menus, feature lists, or any collection of related items.
+- Consider using \`s-unordered-list\` when you want to present information in a clear, scannable format.`,
     },
   ],
 };


### PR DESCRIPTION
corresponding world [PR](https://github.com/shop/world/pull/172646)

Part of remote-dom bugbash, fixing bullet lists for following component docs:

- ordered list
- unordered list
- qrcode
- box

Can be found in the best practice sections at the bottom of each page

example before:

<img width="1104" height="722" alt="image" src="https://github.com/user-attachments/assets/0ffcc38b-36a1-4af3-b6b0-17b5fed1fa62" />

after:

<img width="2208" height="1444" alt="image" src="https://github.com/user-attachments/assets/42e2640e-e760-4d36-b521-9977caff5c47" />

