### PR TITLE
Export missing selling plan types

### DIFF
--- a/.changeset/funny-grapes-invent.md
+++ b/.changeset/funny-grapes-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Export selling plan related types

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -88,6 +88,8 @@ export type {
   CustomSale,
   Address,
   SellingPlan,
+  SellingPlanDeliveryInterval,
+  SetLineItemSellingPlanInput,
 } from './types/cart';
 
 export type {OrderLineItem, LineItemRefund} from './types/order';


### PR DESCRIPTION
### Background

Missing from previous PR: https://github.com/Shopify/ui-extensions/pull/3261

### Solution

Straightforward

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
