### PR TITLE
Pin Pad API updates

### DIFF
--- a/.changeset/eighty-boats-deny.md
+++ b/.changeset/eighty-boats-deny.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Pin Pad API updates

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
@@ -8,7 +8,9 @@ export interface PinPadApiContent {
    * @param options the options for the pin pad
    */
   showPinPad(
-    onSubmit: (pin: number[]) => Promise<PinValidationResult>,
+    onSubmit: (
+      pin: number[],
+    ) => Promise<PinValidationResult> | PinValidationResult,
     options?: PinPadOptions,
   ): void;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
@@ -24,6 +24,10 @@ export interface PinPadActionType {
 
 export interface PinPadOptions {
   /**
+   * The function to be called when a pin is entered
+   */
+  onPinEntry?: (pin: number[]) => void;
+  /**
    * The function to be called when the pin pad modal is dismissed
    */
   onDismissed?: (result: PinPadResult) => void;


### PR DESCRIPTION
### Background

This PR updates the Pin Pad API in the Point of Sale surface to improve flexibility and bring it in line with the 2025-07 PinPad component

### Solution

- Updated the `showPinPad` method's `onSubmit` callback to accept either a Promise or a direct `PinValidationResult`, allowing for both synchronous and asynchronous validation
- Added a new `onPinEntry` callback option to the `PinPadOptions` interface, enabling developers to track pin entries in real-time before submission

These changes provide more flexibility for extension developers when implementing pin pad functionality, allowing for both immediate validation responses and the ability to monitor pin entry as it happens.

### 🎩

- Test the `showPinPad` method with both Promise-based and direct validation returns
- Verify the new `onPinEntry` callback is triggered correctly when pins are entered

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation