### PR TITLE
Remove force data refresh and UI typings

### DIFF
--- a/.changeset/sweet-cooks-exist.md
+++ b/.changeset/sweet-cooks-exist.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Remove ui typings from 2025-10

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -393,23 +393,6 @@ export interface CompanyLocation {
   id: string;
 }
 
-export interface Ui {
-  /**
-   * Refresh data so the surrounding information on the page is updated. The `content` string will appear in a toast message after refresh, to confirm the action was successful.
-   *
-   * To request access to this API:
-   *
-   * 1. Go to your partner dashboard and click **Apps**.
-   *
-   * 2. Select the app you need to request access for.
-   *
-   * 3. Click **API access**.
-   *
-   * 4. Under **Access force data refresh**, click **Request access**.
-   */
-  forceDataRefresh(content: string): Promise<void>;
-}
-
 export interface SessionToken {
   /**
    * Requests a session token that hasn't expired. You should call this method every

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -7,7 +7,6 @@ import {
   AuthenticatedAccount,
   GraphQLError,
   StorefrontApiVersion,
-  Ui,
   SessionToken,
   Analytics,
   CustomerPrivacy,

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -100,11 +100,6 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   settings: ReadonlySignalLike<ExtensionSettings>;
 
   /**
-   * Methods to interact with the extension's UI.
-   */
-  ui: Ui;
-
-  /**
    * The Toast API displays a non-disruptive message that displays at the bottom
    * of the interface to provide quick, at-a-glance feedback on the outcome
    * of an action.


### PR DESCRIPTION
### Background

Looks like only the docs were removed. Also removing the typings

### Solution

Remove typings

### 🎩

To try this out

```
"@shopify/ui-extensions": "https://registry.npmjs.org/@shopify/ui-extensions/-/ui-extensions-0.0.0-snapshot-20250910160331.tgz"
```

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
