### PR TITLE
Add autoSubmit to POS PinPad API and improve PinPadActionType

### DIFF
--- a/.changeset/wild-hornets-hope.md
+++ b/.changeset/wild-hornets-hope.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add autoSubmit to POS PinPad API and improve PinPadActionType

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
@@ -19,7 +19,7 @@ export type PinLength = 4 | 5 | 6 | 7 | 8 | 9 | 10;
 
 export interface PinPadActionType {
   label: string;
-  onClick: () => Promise<number[]>;
+  onClick: () => Promise<number[]> | number[];
 }
 
 export interface PinPadOptions {
@@ -55,4 +55,8 @@ export interface PinPadOptions {
    * Title shown in the modal header
    */
   title?: string;
+  /**
+   * Whether the pin should be automatically submitted when the user has entered the maximum PIN length
+   */
+  autoSubmit?: boolean;
 }


### PR DESCRIPTION
### Background

This PR updates the `PinPadActionType` interface to allow for synchronous return values and adds an `autoSubmit` option to the `PinPadOptions` interface.

### Solution

- Modified the `onClick` property in `PinPadActionType` to accept either a Promise or a direct array of numbers, making it more flexible for both asynchronous and synchronous implementations
- Added a new `autoSubmit` boolean option to the `PinPadOptions` interface with documentation that explains it allows automatic submission when the user enters the maximum PIN length

These changes improve the developer experience by providing more flexibility in how PIN pad actions can be implemented and adding a convenient auto-submit feature.

### 🎩

- Test the PIN pad with both synchronous and asynchronous onClick handlers
- Verify the autoSubmit functionality works correctly when enabled

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation