### PR TITLE
Adds DiscountAllocation to CartLineItem API

### DIFF
--- a/.changeset/discount-allocations.md
+++ b/.changeset/discount-allocations.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added optional `discountAllocations` field to Cart Line Item API so that POS extensions can see the precise proportion of a discount applied to a particular line item. Only the `allocatedAmount` field is included for this purpose, matching the Storefront API structure. See https://shopify.dev/docs/api/storefront/latest/objects/DiscountAllocation.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -1,5 +1,6 @@
 import {CountryCode} from './country-code';
 import {TaxLine} from './tax-line';
+import {DiscountAllocation} from './discount-allocation';
 
 export interface Cart {
   /**
@@ -40,6 +41,7 @@ export interface LineItem {
   variantId?: number;
   productId?: number;
   discounts: Discount[];
+  discountAllocations?: DiscountAllocation[];
   taxable: boolean;
   taxLines: TaxLine[];
   sku?: string;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-allocation.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-allocation.ts
@@ -1,0 +1,5 @@
+import type {MoneyV2} from './money';
+
+export interface DiscountAllocation {
+  allocatedAmount: MoneyV2;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/money.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/money.ts
@@ -2,3 +2,8 @@ export interface Money {
   amount: number;
   currency: string;
 }
+
+export interface MoneyV2 {
+  amount: string;
+  currencyCode: string;
+}


### PR DESCRIPTION
### Background

Added optional `discountAllocations` field to Cart Line Item API so that POS extensions can see the precise proportion of a discount applied to a particular line item to accurately calculate a line item's total amount. Only the `allocatedAmount` field is included for this purpose. See https://shopify.dev/docs/api/storefront/latest/objects/DiscountAllocation.