### PR TITLE
Export PinValidationResult type for PinPad API

### DIFF
--- a/.changeset/odd-dolphins-call.md
+++ b/.changeset/odd-dolphins-call.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Export PinValidationResult type for PinPad API

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -130,4 +130,5 @@ export type {
   PinPadResult,
   PinLength,
   PinPadActionType,
+  PinValidationResult,
 } from './types/pin-pad';


### PR DESCRIPTION
### Background

This PR addresses the need to export the `PinValidationResult` type from the PinPad API in the UI extensions package.

### Solution

Exported the `PinValidationResult` type from the point-of-sale pin-pad types to make it available for external use. This allows developers to properly type check validation results when working with the PinPad API.

### 🎩

- Import the `PinValidationResult` type in a project using the UI extensions package
- Verify the type is properly exported and can be used for type checking

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation