### PR TITLE
Add a link to the useNavigate docs about 'shopify:navigate'

### DIFF
--- a/packages/ui-extensions/src/docs/shared/components/Link.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Link.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Link',
   description:
-    'Makes text interactive, allowing users to navigate to other pages or perform specific actions. Supports standard URLs, custom protocols, and navigation within Shopify or app pages.',
+    "Makes text interactive, allowing users to navigate to other pages or perform specific actions. Supports standard URLs, custom protocols, and navigation within Shopify or app pages.\n\nWhen using the Link component inside embedded apps, you'll need to handle the `'shopify:navigate'` event to intercept navigation requests. Refer to [handling navigation events](/docs/api/app-home?accordionItem=getting-started-existing-remix-application) for implementation details and framework-specific examples.",
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],


### PR DESCRIPTION
Fixes https://github.com/shop/issues-polaris/issues/1183

<img width="3768" height="1408" alt="image" src="https://github.com/user-attachments/assets/319f7e85-0ab2-42f3-a0c0-afb6b1a9c44f" />

### Background

The Polaris `s-link` component will prevent links from working while inside of an embedded app due to [this code](https://github.com/shop/world/blob/main/libraries/javascript/polaris/admin-ui-components/lib/componentBundleGenerationPlugin.js#L66). It looks like we are firing off a `shopify:navigate` event instead.

### Solution

This is not very clear/discoverable in the place devs would likely look when their links aren't navigating anywhere. This simply provides a small note and a link to where we discuss it further in our [current docs](https://shopify.dev/docs/api/app-home?accordionItem=getting-started-existing-remix-application).

[Video](https://screenshot.click/12-49-1rg0c-13l10.mp4)

### 🎩

- Ensure that the link works

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
