### PR TITLE
17206: Add auth and direct api docs 2025-10

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/authenticated-fetch/authenticated-fetch.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/authenticated-fetch/authenticated-fetch.jsx
@@ -1,0 +1,27 @@
+import {render} from 'preact';
+import {useState, useEffect} from 'preact/hooks';
+
+export default async () => {
+  render(<CustomerDetailsBlock />, document.body);
+};
+
+export function CustomerDetailsBlock() {
+  const [loyaltyInfo, setLoyaltyInfo] = useState('');
+  useEffect(() => {
+    getLoyaltyInfo();
+  }, [shopify.customer.id]);
+
+  async function getLoyaltyInfo() {
+    console.log('fetching', `${URL}/api/loyalty/${shopify.customer.id}`)
+    const res = await fetch(`${URL}/api/loyalty/${shopify.customer.id}`);
+    const json = await res.json();
+    setLoyaltyInfo(json.loyaltySummary);
+  }
+  return (
+    <s-pos-block>
+      <s-box padding="large">
+        <s-text>{loyaltyInfo}</s-text>
+      </s-box>
+    </s-pos-block>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/direct-api-access/direct-api-access.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/direct-api-access/direct-api-access.jsx
@@ -1,0 +1,96 @@
+import {render} from 'preact';
+import {useState, useEffect} from 'preact/hooks';
+
+
+// This mutation requires the `write_products` access scope.
+// https://shopify.dev/docs/api/admin-graphql/latest/mutations/metafieldsset
+async function mutateMetafield(productId) {
+  const requestBody = {
+    query: `#graphql
+        mutation MetafieldsSet($metafields: [MetafieldsSetInput!]!) {
+          metafieldsSet(metafields: $metafields) {
+            metafields {
+              key
+              namespace
+              value
+              createdAt
+              updatedAt
+            }
+          }
+        }
+      `,
+    variables: {
+      metafields: [
+        {
+          key: 'direct_api',
+          namespace: 'custom',
+          ownerId: `gid://shopify/Product/${productId}`,
+          value: 'Example Value',
+          type: 'single_line_text_field',
+        },
+      ],
+    },
+  };
+
+  await fetch('shopify:admin/api/graphql.json', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+}
+
+// This query requires the `read_products` access scope.
+// https://shopify.dev/docs/api/admin-graphql/latest/queries/product
+async function queryProductMetafields(productId) {
+  const requestBody = {
+    query: `#graphql
+      query GetProduct($id: ID!) {
+        product(id: $id) {
+          id
+          metafields(first: 10) {
+            edges {
+              node {
+                id
+                namespace
+                key
+                value
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables: {id: `gid://shopify/Product/${productId}`},
+  };
+  const res = await fetch('shopify:admin/api/graphql.json', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+  return res.json();
+}
+
+export default async () => {
+  render(<ProductDetailsBlock />, document.body);
+};
+
+export function ProductDetailsBlock() {
+  const [productInfo, setProductInfo] = useState('');
+  useEffect(() => {
+    async function getProductInfo() {
+      const result = await queryProductMetafields(shopify.product.id);
+      setProductInfo(JSON.stringify(result, null, 2));
+    }
+    getProductInfo();
+  }, [shopify.product.id]);
+
+  return (
+    <s-pos-block>
+      <s-box padding="large">
+        <s-text>Metafields: {productInfo}</s-text>
+      </s-box>
+      <s-box padding="large">
+        <s-text>Set Metafields: {productInfo}</s-text>
+        <s-button onClick={() => mutateMetafield(shopify.product.id)}>Set Metafields</s-button>
+      </s-box>
+    </s-pos-block>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pos-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pos-overview.doc.ts
@@ -60,6 +60,56 @@ const data: LandingTemplateSchema = {
         },
       ],
     },
+    {
+      type: 'Generic',
+      title: 'App Authentication',
+      sectionContent:
+        "POS UI extensions can also make authenticated calls to your app's backend. When you use `fetch()` to make a request to your app's configured auth domain or any of its subdomains, an `Authorization` header is automatically added with a Shopify [OpenID Connect ID Token (formerly known as a Session Token)](/docs/api/app-bridge-library/reference/id-token). There's no need to manually manage ID tokens.\n\nRelative URLs passed to `fetch()` are resolved against your app's `app_url`. This means if your app's backend is on the same domain as your `app_url`, you can make requests to it using `fetch('/path')`.\n\nIf you need to make requests to a different domain, you can use the [`session.getSessionToken()` method](apis/session-api#sessionapi-propertydetail-getsessiontoken) to retrieve the ID token and manually add it to your request headers.\n\n**Important**: ID tokens are only returned for authenticated users who are permitted to use your app. When the authenticated user (the user that logged into Shopify POS with their email address) doesn't have the correct app permission enabled for your app, the token will be null. This is irrelevant of which POS Staff member is pinned in, as those are not authenticated users. For more information on configuring app permissions, see the [Shopify app permissions documentation](https://help.shopify.com/en/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).",
+      anchorLink: 'app-authentication',
+      codeblock: {
+        title: "Make requests to your app's backend",
+        tabs: [
+          {
+            code: './examples/authenticated-fetch/authenticated-fetch.jsx',
+            language: 'jsx',
+            title: 'JSX',
+          },
+        ],
+      },
+    },
+    {
+      type: 'Generic',
+      title: 'Direct API access',
+      sectionNotice: [
+        {
+          title: 'Access scopes',
+          type: 'note',
+          sectionContent: `Be sure to declare all required access scopes in your app's TOML file. For local development, access scopes are only registered or updated when the app is deployed and installed on your test store.`,
+        },
+      ],
+      sectionContent:
+        "You can make Shopify Admin API requests directly from your extension using the standard [web fetch API](https://developer.mozilla.org/en-US/docs/Web/API/fetch)!\n\nAny `fetch()` calls from your extension to Shopify's Admin GraphQL API are automatically authenticated by default. These calls are fast too, because Shopify handles requests directly.\n\nDirect API requests use [online access](https://shopify.dev/docs/apps/build/authentication-authorization/access-token-types/online-access-tokens) mode by default.",
+      anchorLink: 'direct-api-access',
+
+      codeblock: {
+        title: 'Query Shopify data directly',
+        tabs: [
+          {
+            code: './examples/direct-api-access/direct-api-access.jsx',
+            language: 'jsx',
+            title: 'JSX',
+          },
+        ],
+      },
+      sectionCard: [
+        {
+          name: 'Learn more about access scopes',
+          subtitle: 'Developer guide',
+          url: '/docs/api/usage/access-scopes',
+          type: 'information',
+        },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
Closes [#17206](https://github.com/shop/issues-retail/issues/17206)


### Background
Add auth and direct api docs 2025-10

<img width="1176" height="696" alt="image" src="https://github.com/user-attachments/assets/bb126a4d-0408-4c51-a419-2c3209f43b4a" />
<img width="1132" height="734" alt="image" src="https://github.com/user-attachments/assets/22332a8e-9201-4491-a8e5-b6464974c25e" />


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
