### PR TITLE
Fix popover example

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Popover/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Popover/examples/default.html
@@ -1,7 +1,7 @@
 <s-button commandFor="product-options-popover">Product options</s-button>
 
-<s-popover id="product-options-popover" accessibilityLabel="Product options">
-  <s-stack direction="column" gap="small-500" padding="small-200 small-300">
+<s-popover id="product-options-popover">
+  <s-stack direction="block">
     <s-button variant="tertiary">Import</s-button>
     <s-button variant="tertiary">Export</s-button>
   </s-stack>


### PR DESCRIPTION
### Background

`accessibilityLabel` isn't available on Popover, direction is `block` and no gap or padding should be set.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
