### PR TITLE
Simplify selling plans APIs for POS

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/add-line-item-selling-plan.jsx
@@ -14,8 +14,6 @@ const Extension = () => {
           lineItemUuid: 'aa-1234567',
           sellingPlanId: 123,
           sellingPlanName: 'My Exclusive Subscription',
-          sellingPlanDeliveryInterval: 'MONTH', // optional
-          sellingPlanDeliveryIntervalCount: 2, // optional
         });
       }}
     />

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -88,7 +88,6 @@ export type {
   CustomSale,
   Address,
   SellingPlan,
-  SellingPlanDeliveryInterval,
   SetLineItemSellingPlanInput,
 } from './types/cart';
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -77,18 +77,11 @@ export interface SellingPlan {
   /**
    * The interval of the selling plan. (DAY, WEEK, MONTH, YEAR).
    */
-  deliveryInterval?: SellingPlanDeliveryInterval;
+  deliveryInterval?: string;
   /**
    * The number of intervals between deliveries.
    */
   deliveryIntervalCount?: number;
-}
-
-export enum SellingPlanDeliveryInterval {
-  Day = 'DAY',
-  Week = 'WEEK',
-  Month = 'MONTH',
-  Year = 'YEAR',
 }
 
 export interface Discount {
@@ -175,16 +168,7 @@ export interface SetLineItemSellingPlanInput {
   sellingPlanId: number;
   /**
    * The name of the selling plan to apply to the line item.
-   */
-  sellingPlanName: string;
-  /**
-   * The interval of the selling plan. (DAY, WEEK, MONTH, YEAR).
    * If not provided, POS will try to fetch it from the server after syncing the cart.
    */
-  sellingPlanDeliveryInterval?: SellingPlanDeliveryInterval;
-  /**
-   * The number of intervals between deliveries.
-   * If not provided, POS will try to fetch it from the server after syncing the cart.
-   */
-  sellingPlanDeliveryIntervalCount?: number;
+  sellingPlanName?: string;
 }


### PR DESCRIPTION
### Background

### Solution

The final API for selling plans for POS will look like this:
- `lineItemUuid`: **required**, to know to which line item to apply the change
- `sellingPlanId`: **required**, to know which plan to apply
- `sellingPlanName`: **optional**, to display the name in POS right away. If not provided, POS will try to get it from the server

As part of this PR, we're removing `sellingPlanDeliveryInterval` and `sellingPlanDeliveryIntervalCount` from the input, to simplify the API. POS will fetch those from the server instead.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have updated relevant documentation
