### PR TITLE
18243: fix toast options docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/toast-api/show.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/toast-api/show.jsx
@@ -8,7 +8,7 @@ const Extension = () => {
   return (
     <s-tile
       heading="My App"
-      onClick={() => shopify.toast.show('Toast content', 5000)}
+      onClick={() => shopify.toast.show('Toast content', {duration: 5000})}
     />
   );
 };


### PR DESCRIPTION
Closes [#18243](https://github.com/shop/issues-retail/issues/18243)

### Background
Fix toast API docs to pass duration as options object

<img width="1287" height="528" alt="image" src="https://github.com/user-attachments/assets/cb587721-3a4b-4dba-8f94-c96d5cdfd199" />

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
