### PR TITLE
Update `s-form` example code

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Form/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/examples/default.html
@@ -1,4 +1,4 @@
 <s-form>
-  <s-text-field label="Email address" />
+  <s-text-field label="Email address" name="email" />
   <s-button variant="primary">Submit</s-button>
 </s-form>

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/examples/default.html
@@ -1,4 +1,4 @@
 <s-form>
   <s-text-field label="Email address" />
-  <s-button variant="primary" accessibilityRole="submit">Submit</s-button>
+  <s-button variant="primary">Submit</s-button>
 </s-form>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form/examples/basic-form.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form/examples/basic-form.example.html
@@ -1,4 +1,4 @@
 <s-form onSubmit="console.log('Form submitted'); return false;">
   <s-text-field label="Email address" />
-  <s-button accessibilityRole="submit">Submit</s-button>
+  <s-button>Submit</s-button>
 </s-form>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form/examples/basic-form.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form/examples/basic-form.example.html
@@ -1,4 +1,4 @@
 <s-form onSubmit="console.log('Form submitted'); return false;">
-  <s-text-field label="Email address" />
+  <s-text-field label="Email address" name="email" />
   <s-button>Submit</s-button>
 </s-form>


### PR DESCRIPTION
## TLDR

- Update form example to include `name` on `s-text-field`
- Remove deleted `accessibilityRole` prop from `s-button`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation

## References

- https://github.com/Shopify/extensibility-demo-app/pull/10
- Admin
   - Form: https://shopify.dev/docs/api/admin-extensions/2025-10-rc/polaris-web-components/forms/form
   - TextField: https://shopify.dev/docs/api/admin-extensions/2025-10-rc/polaris-web-components/forms/textfield
   - Button https://shopify.dev/docs/api/admin-extensions/2025-10-rc/polaris-web-components/actions/button
- Checkout
   - Form: https://shopify.dev/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/forms/form
   - TextField: https://shopify.dev/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/forms/textfield
   - Button: https://shopify.dev/docs/api/checkout-ui-extensions/2025-10-rc/polaris-web-components/actions/button