### PR TITLE
[ButtonGroup] Update docs

### DIFF
--- a/.changeset/dirty-suits-tie.md
+++ b/.changeset/dirty-suits-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Update ButtonGroup documentation and fix DateField Properties title

--- a/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup/ButtonGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup/ButtonGroup.doc.ts
@@ -12,6 +12,11 @@ const data: AdminReferenceEntityTemplateSchema = {
       description: '',
       type: 'ButtonGroup',
     },
+    {
+      title: 'Slots',
+      description: '',
+      type: 'ButtonGroupSlots',
+    },
   ],
   defaultExample: {
     image: 'button-default.png',

--- a/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup/examples/default.html
@@ -1,4 +1,4 @@
 <s-button-group>
-  <s-button>Cancel</s-button>
-  <s-button variant="primary">Save</s-button>
+  <s-button slot="primary-action">Save</s-button>
+  <s-button slot="secondary-actions">Cancel</s-button>
 </s-button-group>

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
@@ -8,7 +8,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   isVisualComponent: true,
   definitions: [
     {
-      title: 'DateField',
+      title: 'Properties',
       description: '',
       type: 'DateField',
     },

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/calloutCard.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/calloutCard.html
@@ -10,10 +10,10 @@
         <s-paragraph>
           Start by uploading an image to your gallery or choose from one of our templates.
         </s-paragraph>
-        <s-button-group>
-          <s-button slot="secondary-actions"> Upload image </s-button>
-          <s-button slot="secondary-actions"> Browse templates </s-button>
-        </s-button-group>
+        <s-stack direction="inline" gap="small-200">
+          <s-button> Upload image </s-button>
+          <s-button tone="neutral" variant="tertiary"> Browse templates </s-button>
+        </s-stack>
       </s-grid>
       <s-stack alignItems="center">
         <s-box maxInlineSize="200px" borderRadius="base" overflow="hidden">

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/calloutCard.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/calloutCard.html
@@ -11,8 +11,8 @@
           Start by uploading an image to your gallery or choose from one of our templates.
         </s-paragraph>
         <s-button-group>
-          <s-button> Upload image </s-button>
-          <s-button tone="neutral" variant="tertiary"> Browse templates </s-button>
+          <s-button slot="secondary-actions"> Upload image </s-button>
+          <s-button slot="secondary-actions"> Browse templates </s-button>
         </s-button-group>
       </s-grid>
       <s-stack alignItems="center">

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/emptyState.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/emptyState.html
@@ -19,8 +19,8 @@
       </s-paragraph>
     </s-stack>
     <s-button-group>
-      <s-button aria-label="Learn more about creating puzzles"> Learn more </s-button>
-      <s-button variant="primary" aria-label="Add a new puzzle"> Create puzzle </s-button>
+      <s-button slot="secondary-actions" aria-label="Learn more about creating puzzles"> Learn more </s-button>
+      <s-button slot="primary-action" aria-label="Add a new puzzle"> Create puzzle </s-button>
     </s-button-group>
     </s-grid>
   </s-grid>

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.html
@@ -309,7 +309,7 @@
                 Start by uploading an image to your gallery or choose from one of our templates.
               </s-paragraph>
               <s-button-group>
-                <s-button slot="primary-action"> Upload image </s-button>
+                <s-button slot="secondary-actions"> Upload image </s-button>
                 <s-button slot="secondary-actions"> Browse templates </s-button>
               </s-button-group>
             </s-grid>

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.html
@@ -309,8 +309,8 @@
                 Start by uploading an image to your gallery or choose from one of our templates.
               </s-paragraph>
               <s-button-group>
-                <s-button> Upload image </s-button>
-                <s-button tone="neutral" variant="tertiary"> Browse templates </s-button>
+                <s-button slot="primary-action"> Upload image </s-button>
+                <s-button slot="secondary-actions"> Browse templates </s-button>
               </s-button-group>
             </s-grid>
               <s-box maxInlineSize="200px" borderRadius="base" overflow="hidden">

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.html
@@ -308,10 +308,10 @@
               <s-paragraph>
                 Start by uploading an image to your gallery or choose from one of our templates.
               </s-paragraph>
-              <s-button-group>
-                <s-button slot="secondary-actions"> Upload image </s-button>
-                <s-button slot="secondary-actions"> Browse templates </s-button>
-              </s-button-group>
+              <s-stack direction="inline" gap="small-200">
+                <s-button> Upload image </s-button>
+                <s-button tone="neutral" variant="tertiary"> Browse templates </s-button>
+              </s-stack>
             </s-grid>
               <s-box maxInlineSize="200px" borderRadius="base" overflow="hidden">
                 <s-image

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.jsx
@@ -346,10 +346,10 @@ export default function HomePage() {
                   Start by uploading an image to your gallery or choose from one
                   of our templates.
                 </s-paragraph>
-                <s-button-group>
-                <s-button slot="secondary-actions"> Upload image </s-button>
-                <s-button slot="secondary-actions"> Browse templates </s-button>
-              </s-button-group>
+                <s-stack direction="inline" gap="small-200">
+                  <s-button> Upload image </s-button>
+                  <s-button tone="neutral" variant="tertiary"> Browse templates </s-button>
+                </s-stack>
               </s-grid>
               <s-stack alignItems="center">
                 <s-box

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.jsx
@@ -347,7 +347,7 @@ export default function HomePage() {
                   of our templates.
                 </s-paragraph>
                 <s-button-group>
-                <s-button slot="primary-action"> Upload image </s-button>
+                <s-button slot="secondary-actions"> Upload image </s-button>
                 <s-button slot="secondary-actions"> Browse templates </s-button>
               </s-button-group>
               </s-grid>

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.jsx
@@ -347,8 +347,8 @@ export default function HomePage() {
                   of our templates.
                 </s-paragraph>
                 <s-button-group>
-                <s-button> Upload image </s-button>
-                <s-button tone="neutral" variant="tertiary"> Browse templates </s-button>
+                <s-button slot="primary-action"> Upload image </s-button>
+                <s-button slot="secondary-actions"> Browse templates </s-button>
               </s-button-group>
               </s-grid>
               <s-stack alignItems="center">

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/index.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/index.html
@@ -37,8 +37,8 @@
               </s-paragraph>
             </s-stack>
             <s-button-group>
-              <s-button aria-label="Learn more about creating puzzles"> Learn more </s-button>
-              <s-button variant="primary" aria-label="Add a new puzzle"> Create puzzle </s-button>
+              <s-button slot="primary-action" aria-label="Learn more about creating puzzles"> Learn more </s-button>
+              <s-button slot="secondary-actions" aria-label="Add a new puzzle"> Create puzzle </s-button>
             </s-button-group>
           </s-grid>
         </s-grid>

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/index.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/index.html
@@ -37,8 +37,8 @@
               </s-paragraph>
             </s-stack>
             <s-button-group>
-              <s-button slot="primary-action" aria-label="Learn more about creating puzzles"> Learn more </s-button>
-              <s-button slot="secondary-actions" aria-label="Add a new puzzle"> Create puzzle </s-button>
+              <s-button slot="secondary-actions" aria-label="Learn more about creating puzzles"> Learn more </s-button>
+              <s-button slot="primary-action" aria-label="Add a new puzzle"> Create puzzle </s-button>
             </s-button-group>
           </s-grid>
         </s-grid>

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/index.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/index.jsx
@@ -33,8 +33,8 @@ export default function IndexPage() {
               </s-paragraph>
             </s-stack>
             <s-button-group>
-              <s-button aria-label="Learn more about creating puzzles"> Learn more </s-button>
-              <s-button variant="primary" aria-label="Add a new puzzle"> Create puzzle </s-button>
+              <s-button slot="secondary-actions" aria-label="Learn more about creating puzzles"> Learn more </s-button>
+              <s-button slot="primary-action" aria-label="Add a new puzzle"> Create puzzle </s-button>
             </s-button-group>
           </s-grid>
         </s-grid>


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-polaris/issues/1241

This PR updates the documentation for ButtonGroup and fixes a title in DateField documentation (DateField ---> Properties).

![Screenshot 2025-09-18 at 9.07.08 AM.png](https://app.graphite.dev/user-attachments/assets/c8aa3ed6-3f2e-434a-92e0-ddad0df72fe0.png)

| DateField before | DateField after |
|---|---|
| ![Screenshot 2025-09-18 at 9.12.17 AM.png](https://app.graphite.dev/user-attachments/assets/f008346c-4c72-4430-9ef9-896a91accf7c.png) | ![Screenshot 2025-09-18 at 9.09.47 AM.png](https://app.graphite.dev/user-attachments/assets/58ff9698-44fc-4aec-9b4c-b69ebb80dda6.png) |

### Solution

- Added a "Slots" section to the ButtonGroup documentation to better describe its usage
- Updated the default example for ButtonGroup to use the correct slot names (`primary-action` and `secondary-actions`)
- Fixed the title in DateField documentation from "DateField" to "Properties" for consistency

### 🎩

- Verified the documentation changes render correctly
- Confirmed the examples match the component implementation

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation