### PR TITLE
[chore]: Bump generate docs library to 0.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@shopify/babel-preset": "^24.1.0",
     "@shopify/browserslist-config": "^3.0.0",
     "@shopify/eslint-plugin": "^42.0.0",
-    "@shopify/generate-docs": "0.17.1",
     "@shopify/loom": "^1.0.0",
     "@shopify/loom-cli": "^1.0.0",
     "@shopify/loom-plugin-build-library": "^1.0.0",

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -127,7 +127,7 @@
   ],
   "devDependencies": {
     "@remote-ui/async-subscription": "^2.1.16",
-    "@shopify/generate-docs": "0.17.1",
+    "@shopify/generate-docs": "0.19.3",
     "typescript": "^4.9.0",
     "@faker-js/faker": "^8.4.1"
   },

--- a/packages/ui-extensions/yarn.lock
+++ b/packages/ui-extensions/yarn.lock
@@ -52,10 +52,10 @@
   resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.4.5.tgz#20328970c314374d96fdaae1cf93aca4b47fefee"
   integrity sha512-Cr+06niG/vmE4A9YsmaKngRuuVSWKMY42NMwtZfy+gctRWGu6Wj9BWuMJg5CEp+JTkRBPToqT5rqnrg1G/Wvow==
 
-"@shopify/generate-docs@0.17.1":
-  version "0.17.1"
-  resolved "https://npm.shopify.io/node/@shopify/generate-docs/-/generate-docs-0.17.1.tgz#b9ff1b3e4a2c9285c91acc9bdc20a370f14b9b5d"
-  integrity sha512-xtObqw2vqSbYB4QlB1Cd911aNZYjpKAEwfWnlcOUqkYVGgf+obEuMVNMSFsM3P63vAReH2nS3I7tvG0YWFv7Iw==
+"@shopify/generate-docs@0.19.3":
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/@shopify/generate-docs/-/generate-docs-0.19.3.tgz#cace7efe6277dbae9b2fdc1ac40236983f74625d"
+  integrity sha512-jAEJeiXtkk6yU/CMe1c+9ydgQRMTLLmx1gdaMoW/QL+1bnIsHDINOsvyIHzSVKfNX0WSbe0zquG9W+W/iNzKaQ==
   dependencies:
     "@types/react" "^18.0.21"
     globby "^11.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,10 +1913,10 @@
     pkg-dir "^5.0.0"
     pluralize "^8.0.0"
 
-"@shopify/generate-docs@0.17.1":
-  version "0.17.1"
-  resolved "https://registry.npmjs.org/@shopify/generate-docs/-/generate-docs-0.17.1.tgz"
-  integrity sha512-xtObqw2vqSbYB4QlB1Cd911aNZYjpKAEwfWnlcOUqkYVGgf+obEuMVNMSFsM3P63vAReH2nS3I7tvG0YWFv7Iw==
+"@shopify/generate-docs@0.19.3":
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/@shopify/generate-docs/-/generate-docs-0.19.3.tgz#cace7efe6277dbae9b2fdc1ac40236983f74625d"
+  integrity sha512-jAEJeiXtkk6yU/CMe1c+9ydgQRMTLLmx1gdaMoW/QL+1bnIsHDINOsvyIHzSVKfNX0WSbe0zquG9W+W/iNzKaQ==
   dependencies:
     "@types/react" "^18.0.21"
     globby "^11.1.0"


### PR DESCRIPTION
### Background

- Bumping generate-docs library to fix several issues when generating docs.

### Solution

- bumped the library
- removed duplicate of the library from the root package
  - this was causing a weird "race condition" when generating docs locally causing the APIs/Components to not be parsed correctly.

### 🎩

- `yarn docs:checkout 2025-10-rc` or your surface :D

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation

