### PR TITLE
Segmentation templates data extension target update

### DIFF
--- a/.changeset/wicked-lions-matter.md
+++ b/.changeset/wicked-lions-matter.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions': minor
+'@shopify/ui-extensions': patch
 ---
 
 segmentation-templates moving to data-extension target

--- a/.changeset/wicked-lions-matter.md
+++ b/.changeset/wicked-lions-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+segmentation-templates moving to data-extension target

--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -1,7 +1,10 @@
 export type {I18n, I18nTranslate} from '../../api';
 export type {StandardApi, Intents} from './api/standard/standard';
 export type {Navigation} from './api/block/block';
-export type {CustomerSegmentTemplateApi} from './api/customer-segment-template/customer-segment-template';
+export type {
+  CustomerSegmentTemplateApi,
+  CustomerSegmentTemplate,
+} from './api/customer-segment-template/customer-segment-template';
 export type {ActionExtensionApi} from './api/action/action';
 export type {BlockExtensionApi} from './api/block/block';
 export type {PrintActionExtensionApi} from './api/print-action/print-action';

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.ts
@@ -12,7 +12,7 @@ export interface CustomerSegmentTemplateApi<
 }
 
 export type CustomerStandardMetafieldDependency = 'facts.birth_date';
-export interface CustomerSegmentTemplateProps {
+export interface CustomerSegmentTemplate {
   /**
    * The localized title of the template.
    */

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.ts
@@ -10,3 +10,34 @@ export interface CustomerSegmentTemplateApi<
   /** @private */
   __enabledFeatures: string[];
 }
+
+export type CustomerStandardMetafieldDependency = 'facts.birth_date';
+export interface CustomerSegmentTemplateProps {
+  /**
+   * The localized title of the template.
+   */
+  title: string;
+  /**
+   * The localized description of the template. An array can be used for multiple paragraphs.
+   */
+  description: string | string[];
+  /**
+   * The code snippet to render in the template with syntax highlighting. The `query` is not validated in the template.
+   */
+  query: string;
+  /**
+   * The code snippet to insert in the segment editor. If missing, `query` will be used. The `queryToInsert` is not validated in the template.
+   */
+  queryToInsert: string;
+  /**
+   * The list of customer standard metafields or custom metafields used in the template's query.
+   */
+  dependencies?: {
+    standardMetafields?: CustomerStandardMetafieldDependency[];
+    customMetafields?: string[];
+  };
+  /**
+   * ISO 8601-encoded date and time string. A "New" badge will be rendered for templates introduced in the last month.
+   */
+  createdOn: string;
+}

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -11,6 +11,7 @@ import type {
   PurchaseOptionsCardConfigurationApi,
   DiscountFunctionSettingsApi,
   CustomerSegmentTemplateApi,
+  CustomerSegmentTemplate,
 } from './api';
 import {
   ShouldRenderApi,
@@ -20,7 +21,6 @@ import type {StandardComponents} from './components/StandardComponents';
 import type {BlockExtensionComponents} from './components/BlockExtensionComponents';
 import type {ActionExtensionComponents} from './components/ActionExtensionComponents';
 import type {PrintActionExtensionComponents} from './components/PrintActionExtensionComponents';
-import {CustomerSegmentTemplate} from './components';
 
 export interface ExtensionTargets {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -10,6 +10,7 @@ import type {
   ValidationSettingsApi,
   PurchaseOptionsCardConfigurationApi,
   DiscountFunctionSettingsApi,
+  CustomerSegmentTemplateApi,
 } from './api';
 import {
   ShouldRenderApi,
@@ -23,10 +24,10 @@ import {CustomerSegmentTemplate} from './components';
 
 export interface ExtensionTargets {
   /**
-   * Renders a data structe for a [`CustomerSegmentTemplate`](/docs/api/admin-extensions/components/customersegmenttemplate) in the [customer segment editor](https://help.shopify.com/en/manual/customers/customer-segmentation/customer-segments).
+   * Renders a  [`CustomerSegmentTemplate`](/docs/api/admin-extensions/components/customersegmenttemplate) in the [customer segment editor](https://help.shopify.com/en/manual/customers/customer-segmentation/customer-segments).
    */
   'admin.customers.segmentation-templates.data': RunnableExtension<
-    ShouldRenderApi<'admin.customers.segmentation-templates.data'>,
+    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,
     {templates: CustomerSegmentTemplate[]}
   >;
 

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -1,7 +1,6 @@
 import type {RunnableExtension, RenderExtension} from '../../extension';
 
 import type {
-  CustomerSegmentTemplateApi,
   ActionExtensionApi,
   BlockExtensionApi,
   PrintActionExtensionApi,
@@ -20,14 +19,15 @@ import type {StandardComponents} from './components/StandardComponents';
 import type {BlockExtensionComponents} from './components/BlockExtensionComponents';
 import type {ActionExtensionComponents} from './components/ActionExtensionComponents';
 import type {PrintActionExtensionComponents} from './components/PrintActionExtensionComponents';
+import {CustomerSegmentTemplate} from './components';
 
 export interface ExtensionTargets {
   /**
-   * Renders a [`CustomerSegmentTemplate`](/docs/api/admin-extensions/components/customersegmenttemplate) in the [customer segment editor](https://help.shopify.com/en/manual/customers/customer-segmentation/customer-segments).
+   * Renders a data structe for a [`CustomerSegmentTemplate`](/docs/api/admin-extensions/components/customersegmenttemplate) in the [customer segment editor](https://help.shopify.com/en/manual/customers/customer-segmentation/customer-segments).
    */
-  'admin.customers.segmentation-templates.render': RenderExtension<
-    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.render'>,
-    StandardComponents
+  'admin.customers.segmentation-templates.data': RunnableExtension<
+    ShouldRenderApi<'admin.customers.segmentation-templates.data'>,
+    {templates: CustomerSegmentTemplate[]}
   >;
 
   // Blocks


### PR DESCRIPTION
### Background

After making the transition to a data-extension for 2025-10-rc https://github.com/Shopify/segmentation-templates-app/pull/250, we need to update the target extension

⚠️  Only ship before moving the segmentation-templates-app for release

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
