### PR TITLE
Align POS Navigation in Global

### DIFF
--- a/.changeset/gentle-rice-remember.md
+++ b/.changeset/gentle-rice-remember.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Aligned POS navigation api

--- a/packages/ui-extensions/buildTargetDts.ts
+++ b/packages/ui-extensions/buildTargetDts.ts
@@ -69,7 +69,11 @@ function createInitialTargetDefinition({
   const targetPath = join(directory, fileName);
 
   const template = `import type {ExtensionTargets} from '../extension-targets';
-  ${surface === 'customer-account' ? `import '../globals';\n` : ''}
+  ${
+    surface === 'customer-account' || surface === 'point-of-sale'
+      ? `import '../globals';\n`
+      : ''
+  }
 type Target = ExtensionTargets[${name}];
 export type Api = Target['api'];
 export type Output = Target['output'];

--- a/packages/ui-extensions/src/surfaces/customer-account/globals.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/globals.ts
@@ -10,5 +10,7 @@ export interface ShopifyGlobal {
 }
 
 declare global {
+  // @ts-expect-error - Intentionally overriding navigation type for POS context
+  // This is safe as point-of-sale and customer-account are never used together
   const navigation: Navigation;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -28,11 +28,6 @@ export type {DeviceApi, DeviceApiContent} from './api/device-api/device-api';
 
 export type {LocaleApi, LocaleApiContent} from './api/locale-api/locale-api';
 
-export type {
-  NavigationApiContent,
-  NavigationApi,
-} from './api/navigation-api/navigation-api';
-
 export type {OrderApiContent, OrderApi} from './api/order-api/order-api';
 
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/action-target-api/action-target-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/action-target-api/action-target-api.ts
@@ -1,9 +1,7 @@
 import {ScannerApi} from '../scanner-api/scanner-api';
-import {NavigationApi} from '../navigation-api/navigation-api';
 import {StandardApi} from '../standard/standard-api';
 
 export type ActionTargetApi<T> = {[key: string]: any} & {
   extensionPoint: T;
 } & StandardApi<T> &
-  ScannerApi &
-  NavigationApi;
+  ScannerApi;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -1,45 +1,63 @@
-export interface NavigationApiContent {
+export interface NavigationNavigateOptions {
   /**
-   * Using `(screenName: string, params?: any)` navigates to a route in current navigation tree.
-   * Pushes the specified screen if it isn't present in the navigation tree, goes back to a created screen otherwise.
-   * @param screenName the name of the screen you want to navigate to.
-   * @param params the parameters you want to pass to that screen.
+   * Developer-defined information to be stored in the associated NavigationHistoryEntry once the navigation is complete, retrievable via getState().
    */
-  navigate(screenName: string, params?: any): Promise<void>;
-
-  /**
-   * Using `(uri: string | URL)` opens a POS Native screen modally.
-   * If the uri starts with `shopify:point-of-sale/` it will be treated as a POS Native screen. Otherwise it will try to navigate to an extension screen.
-   * Available POS Native screens:
-   * - `shopify:point-of-sale/products/{product_id}` to present product details.
-   * - `shopify:point-of-sale/products/{product_id}/variants/{variant_id}` to present product variant details.
-   * - `shopify:point-of-sale/customers/{customer_id}` to present customer details.
-   * - `shopify:point-of-sale/orders/{order_id}` to present order details.
-   * - `shopify:point-of-sale/draft_orders/{draft_order_id}` to present draft order details.
-   * - `shopify:point-of-sale/staff/{staff_id}` to present staff details.
-   * @param uri the uri of the POS Native screen to present modally.
-   * @returns A promise that resolves when the POS screen is presented, rejects when an error occurs.
-   * @example Open product variant details screen for product id 123 and variant id 456
-   * navigate('shopify:point-of-sale/products/123/variants/456');
-   */
-  navigate(uri: string | URL): Promise<void>;
-
-  /** Pops the currently shown screen */
-  pop(): void;
-
-  /** Dismisses the extension. */
-  dismiss(): void;
-
-  /** Checks if the user has permission to navigate to the specified screen.
-   * @param uri the uri to check if the user has permission to navigate to.
-   * @returns false if the uri is a valid uri to navigate to a POS screen and the user does not have permission to navigate to the specified screen, true otherwise. The promise rejects if the user is not on the correct API version of POS extensions.
-   */
-  canNavigate(uri: string | URL): Promise<boolean>;
+  state?: unknown;
 }
 
 /**
- * Access the navigation API for navigation functionality from a full screen modal.
+ * The NavigationHistoryEntry interface of the Navigation API represents a single navigation history entry.
  */
-export interface NavigationApi {
-  navigation: NavigationApiContent;
+export interface NavigationHistoryEntry {
+  /** Returns the key of the history entry. This is a unique, UA-generated value that represents the history entry's slot in the entries list rather than the entry itself. */
+  key: string;
+  /**
+   * Returns the URL of this history entry.
+   */
+  url: string | null;
+  /**
+   * Returns a clone of the available state associated with this history entry.
+   */
+  getState(): unknown;
+}
+
+/**
+ * The NavigationCurrentEntryChangeEvent interface of the Navigation API is the event object for the currententrychange event, which fires when the Navigation.currentEntry has changed.
+ */
+export interface NavigationCurrentEntryChangeEvent {
+  /**
+   * Returns the NavigationHistoryEntry that was navigated from.
+   */
+  from: NavigationHistoryEntry;
+}
+
+export interface Navigation {
+  /**
+   * The navigate() method navigates to a specific URL, updating any provided state in the history entries list.
+   */
+  navigate: NavigateFunction;
+  /**
+   * The currentEntry read-only property of the Navigation interface returns a NavigationHistoryEntry object representing the location the user is currently navigated to right now.
+   */
+  currentEntry: NavigationHistoryEntry;
+  /**
+   * The back() method of the Navigation interface navigates to the previous entry in the history list.
+   */
+  back(): void;
+  addEventListener(
+    type: 'currententrychange',
+    cb: (event: NavigationCurrentEntryChangeEvent) => void,
+  ): void;
+  removeEventListener(
+    type: 'currententrychange',
+    cb: (event: NavigationCurrentEntryChangeEvent) => void,
+  ): void;
+}
+
+export interface NavigateFunction {
+  /**
+   * Navigates to a specific URL, updating any provided state in the history entries list.
+   * @param url The destination URL to navigate to.
+   */
+  (url: string, options?: NavigationNavigateOptions): void;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
@@ -1,0 +1,6 @@
+import {Navigation} from './api/navigation-api/navigation-api';
+
+declare global {
+  // @ts-expect-error - Intentionally overriding navigation type for POS context
+  const navigation: Navigation;
+}


### PR DESCRIPTION
### Background
- This PR aligns POS' navigation system to be on the global, using the aligned interfaces.

Note that we are still missing `updateCurrentEntry` as it's not a requirement currently for us, and we needed to cut some scope. However, we do have the `goBack()` function as a requirement for our surface, which does not currently exist in customer-account's implementation.

### Solution
While most of the Navigation type is aligned, there are some small differences. As such, we have our own globals.ts file. Because we also provide the navigation type, I had to add a comment indicating an expected TS error. Let me know if this is problematic, as I'm not a type script expert when it comes to bundling.

### 🎩


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
