### PR TITLE
Fix customer account docs build command

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
@@ -58,7 +58,7 @@ const generateExtensionsDocs = async () => {
 
   const scripts = [
     `yarn tsc --project ${docsRelativePath}/${tsconfig} --moduleResolution node  --target esNext  --module CommonJS`,
-    `yarn generate-docs --input ./${docsRelativePath}/reference ./${docsRelativePath} ./${docsRelativePath}/../../../src/surfaces/customer-account/components --typesInput ./${srcRelativePath} --output ./${outputDir}`,
+    `yarn generate-docs --overridePath ./${docsRelativePath}/typeOverride.json --input ./${docsRelativePath}/reference ./${srcRelativePath} --typesInput ./${srcRelativePath} --output ./${outputDir}`,
     `yarn tsc ${docsRelativePath}/staticPages/*.doc.ts --moduleResolution node  --target esNext  --module CommonJS`,
     `yarn generate-docs --isLandingPage --input ./${docsRelativePath}/staticPages --output ./${outputDir}`,
     `yarn tsc ${docsRelativePath}/categories/*.doc.ts --moduleResolution node  --target esNext  --module CommonJS`,


### PR DESCRIPTION
## Summary

Fixed the `yarn docs:customer-account` command which was failing with a "Cannot find module" error since the recent update to `@shopify/generate-docs`

The customer-account documentation build script had some differences from the checkout version that were causing the errors. I made two changes to the arguments we pass to `generate-docs`:

1. Updated the `--input` from `--input ./${docsRelativePath}/reference ./${docsRelativePath} ./${docsRelativePath}/../../../src/surfaces/customer-account/components` to `--input ./${docsRelativePath}/reference ./${srcRelativePath}`
2. Added `--overridePath ./${docsRelativePath}/typeOverride.json`

## Testing

- Make some test changes to component docs and api docs in customer accounts
- `yarn docs:customer-account 2025-10-rc` should run successfully and you should see your changes