### PR TITLE
Docs: Updated discounts API docs to reflect case-insensitive discount codes (2025-04)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -253,7 +253,7 @@ export interface DiscountCodeAddChange {
   type: 'addDiscountCode';
 
   /**
-   * The code for the discount (case-sensitive)
+   * The code for the discount (case-insensitive)
    */
   code: string;
 }
@@ -265,7 +265,7 @@ export interface DiscountCodeRemoveChange {
   type: 'removeDiscountCode';
 
   /**
-   * The code for the discount (case-sensitive)
+   * The code for the discount (case-insensitive)
    */
   code: string;
 }


### PR DESCRIPTION
### Background
**Closes:** https://github.com/shop/issues-checkout/issues/597
**Issue:** The documentation for the checkout UI extensions discounts API states that the discount code types for add/remove are case-sensitive for the **2025-04 version** as shown in the image below, when they are actually case-insensitive as associated with https://github.com/shop/issues-checkout/issues/597

<img width="630" height="624" alt="17-41-m4p2z-vriwx" src="https://github.com/user-attachments/assets/78d0d1e2-aa98-43d1-9148-d53148d9e72c" />


### Solution
Updated documentation to state discount code types for add/remove are case-insensitive for the 2025-04 version as shown below:

<img width="576" height="757" alt="17-36-0kq5r-ynesi" src="https://github.com/user-attachments/assets/d9682ecb-afdb-4317-a020-c88926809289" />

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
