### PR TITLE
18601: fix components docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/examples/default.html
@@ -1,7 +1,5 @@
-  <s-badge text="New" />
-  <s-badge text="Success" variant="success" />
-  <s-badge text="Warning" variant="warning" />
-  <s-badge text="Critical" variant="critical" />
-  <s-badge text="Active" status="active" />
-  <s-badge text="Complete" status="complete" />
-  <s-badge text="In Progress" variant="info" status="active" />
+<s-badge tone="neutral">Neutral</s-badge>
+<s-badge tone="success">Success</s-badge>
+<s-badge tone="info">Highlight</s-badge>
+<s-badge tone="warning">Warning</s-badge>
+<s-badge tone="critical">Critical</s-badge>

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/examples/default.html
@@ -1,13 +1,11 @@
 <s-date-field 
   label="Date"
-  required 
   value="2024-10-26"
   details="Select a date">
 </s-date-field>
 
 <s-date-field 
   label="Date" 
-  required 
   value="1890-10-26" 
   error="Date out of range"
   details="Select a date">

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -13,6 +13,11 @@ const data: ReferenceEntityTemplateSchema = {
       description: '',
       type: 'Section',
     },
+    {
+      title: 'Slots',
+      description: '',
+      type: 'SectionSlots',
+    },
   ],
   category: 'Polaris web components',
   subCategory: 'Structure',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/examples/default.html
@@ -1,4 +1,4 @@
-<s-tile heading="Title" subheading="Subtitle" itemCount="2" tone="accent"></s-tile>
+<s-tile heading="Title" subheading="Subtitle" itemCount={2} tone="accent"></s-tile>
 
 <s-tile heading="Title" subheading="Subtitle" tone="accent"></s-tile>
 


### PR DESCRIPTION
Closes [#18601](https://github.com/shop/issues-retail/issues/18601)

### Background
Fix out of date props and add slots for Section

### Solution

<img width="1041" height="469" alt="Screenshot 2025-09-19 at 9 46 21 AM" src="https://github.com/user-attachments/assets/fff89b6e-b613-4d31-85f5-e3de5f56d7c3" />
<img width="1018" height="520" alt="Screenshot 2025-09-19 at 10 40 03 AM" src="https://github.com/user-attachments/assets/11c89413-7268-428b-aae7-1aa4dfcd9916" />
<img width="1239" height="308" alt="Screenshot 2025-09-19 at 10 26 23 AM" src="https://github.com/user-attachments/assets/9b412af2-0081-49bd-a0b8-5f4d1683ad92" />

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
