### PR TITLE
Update Customer Account announcement target examples

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-index.announcement.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-index.announcement.render/default.example.tsx
@@ -1,0 +1,38 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  return (
+    <s-announcement>
+      <s-stack direction="inline" gap="base">
+        <s-text>Check our latest offers</s-text>
+        <s-link
+          commandFor="modal"
+          command="--show"
+        >
+          Fill out the survey
+        </s-link>
+      </s-stack>
+      <s-modal
+        id="modal"
+        heading="Tell us about your shopping experience"
+      >
+        <s-stack gap="base">
+          <s-text>
+            We'd love to hear about your shopping
+            experience
+          </s-text>
+          <s-text-area
+            rows="4"
+            label="How can we make your shopping experience better?"
+          ></s-text-area>
+          <s-button>Submit</s-button>
+        </s-stack>
+      </s-modal>
+    </s-announcement>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.announcement.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order-status.announcement.render/default.example.tsx
@@ -1,0 +1,38 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  return (
+    <s-announcement>
+      <s-stack direction="inline" gap="base">
+        <s-text>Check our latest offers</s-text>
+        <s-link
+          commandFor="modal"
+          command="--show"
+        >
+          Fill out the survey
+        </s-link>
+      </s-stack>
+      <s-modal
+        id="modal"
+        heading="Tell us about your shopping experience"
+      >
+        <s-stack gap="base">
+          <s-text>
+            We'd love to hear about your shopping
+            experience
+          </s-text>
+          <s-text-area
+            rows="4"
+            label="How can we make your shopping experience better?"
+          ></s-text-area>
+          <s-button>Submit</s-button>
+        </s-stack>
+      </s-modal>
+    </s-announcement>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.announcement.render/default.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.profile.announcement.render/default.example.tsx
@@ -1,0 +1,38 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  return (
+    <s-announcement>
+      <s-stack direction="inline" gap="base">
+        <s-text>Check our latest offers</s-text>
+        <s-link
+          commandFor="modal"
+          command="--show"
+        >
+          Fill out the survey
+        </s-link>
+      </s-stack>
+      <s-modal
+        id="modal"
+        heading="Tell us about your shopping experience"
+      >
+        <s-stack gap="base">
+          <s-text>
+            We'd love to hear about your shopping
+            experience
+          </s-text>
+          <s-text-area
+            rows="4"
+            label="How can we make your shopping experience better?"
+          ></s-text-area>
+          <s-button>Submit</s-button>
+        </s-stack>
+      </s-modal>
+    </s-announcement>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-index.announcement.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-index.announcement.render.doc.ts
@@ -1,0 +1,32 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {ORDER_STATUS_API} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'customer-account.order-index.announcement.render',
+  description: `A static extension target that is rendered on top of the **Order Index page** as a dismissable announcement.`,
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order index announcement extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-index.announcement.render/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
+  subCategory: 'Order index',
+  related: [
+    {
+      name: 'Placement references',
+      subtitle: 'Navigate to',
+      url: '/docs/apps/customer-accounts/best-practices/testing-ui-extensions#order-index',
+    },
+  ],
+  ...ORDER_STATUS_API,
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.announcement.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order-status.announcement.render.doc.ts
@@ -1,0 +1,32 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {ORDER_STATUS_API} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'customer-account.order-status.announcement.render',
+  description: `A static extension target that is rendered on top of the **Order Status page** as a dismissable announcement.`,
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account order status announcement extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.order-status.announcement.render/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
+  subCategory: 'Order status',
+  related: [
+    {
+      name: 'Placement references',
+      subtitle: 'Navigate to',
+      url: '/docs/apps/customer-accounts/best-practices/testing-ui-extensions#order-status',
+    },
+  ],
+  ...ORDER_STATUS_API,
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.announcement.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.profile.announcement.render.doc.ts
@@ -1,0 +1,34 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'customer-account.profile.announcement.render',
+  description: `A static extension target that is rendered on top of the **Profile page** as a dismissable announcement.`,
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Customer account profile announcement extension example',
+      tabs: [
+        {
+          code: '../examples/targets/customer-account.profile.announcement.render/default.example.tsx',
+          language: 'tsx',
+          title: 'Preact',
+        },
+      ],
+    },
+  },
+  subCategory: 'Profile (Default)',
+  related: [
+    {
+      name: 'Placement references',
+      subtitle: 'Navigate to',
+      url: '/docs/apps/customer-accounts/best-practices/testing-ui-extensions#profile',
+    },
+  ],
+  definitions: [CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION],
+  category: 'Targets',
+  isVisualComponent: false,
+};
+
+export default data;


### PR DESCRIPTION
### Background

This PR adds examples for announcement target for Order Status, Order Index and Profile (Customer Account) pages

### Solution

Add examples for:

- `customer-account.order-status.announcement.render`
- `customer-account.order-index.announcement.render`
- `customer-account.profile.announcement.render`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation