### PR TITLE
chore: update shopify-dev local url

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
@@ -72,7 +72,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/admin-extensions"
   else
-    echo "Docs: https://shopify-dev.myshopify.io/docs/api/admin-extensions"
+    echo "Docs: https://shopify-dev.shop.dev/docs/api/admin-extensions"
   fi
 else
   echo "Not copying docs to shopify-dev because it was not found at $SHOPIFY_DEV_PATH."

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -90,7 +90,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/checkout-ui-extensions"
   else
-    echo "Docs: https://shopify-dev.myshopify.io/docs/api/checkout-ui-extensions"
+    echo "Docs: https://shopify-dev.shop.dev/docs/api/checkout-ui-extensions"
   fi
 else
     echo "Not copying docs to shopify-dev because it was not found at $SHOPIFY_DEV_PATH."

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.sh
@@ -88,7 +88,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/customer-account-ui-extensions"
   else
-    echo "Docs: https://shopify-dev.myshopify.io/docs/api/customer-account-ui-extensions"
+    echo "Docs: https://shopify-dev.shop.dev/docs/api/customer-account-ui-extensions"
   fi
 else
   echo "Not copying docs to shopify-dev because it was not found at $SHOPIFY_DEV_PATH."

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.sh
@@ -69,7 +69,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/pos-ui-extensions"
   else
-    echo "Docs: https://shopify-dev.myshopify.io/docs/api/pos-ui-extensions"
+    echo "Docs: https://shopify-dev.shop.dev/docs/api/pos-ui-extensions"
   fi
 else
   echo "Not copying docs to shopify-dev because it was not found at $SHOPIFY_DEV_PATH."


### PR DESCRIPTION
### Background

As per this [slack thread](https://shopify.slack.com/archives/C0Q0DSZR8/p1757956146871719) the local development url for shopify-dev is moving from `https://shopify-dev.myshopify.io/` to `https://shopify-dev.shop.dev/`

An example of error if not changed is [this thread](https://shopify.slack.com/archives/C01JS0YA85D/p1758556593647079)

### Solution

Replace `https://shopify-dev.myshopify.io/` to `https://shopify-dev.shop.dev/`

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
