### PR TITLE
18625: add navigate state example

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -46,6 +46,12 @@ The Navigation API enables POS UI extension to navigate between screens.
           'native-screen',
         ),
       },
+      {
+        codeblock: generateJsxCodeBlockForNavigationApi(
+          'Navigate to a screen with state parameters',
+          'state-params',
+        ),
+      },
     ],
   },
 };

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/state-params.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/state-params.jsx
@@ -1,0 +1,34 @@
+import { render } from "preact";
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+const Extension = () => {
+  const url = navigation.currentEntry.url;
+  
+  /** @type {{ firstParam?: string; secondParam?: string }} */
+  const state = navigation.currentEntry.getState();
+
+  if (url?.includes("screentwo")) {
+    return (
+      <s-page heading="Screen Two Title">
+        <s-scroll-box>
+          <s-text>First Param: {state.firstParam}</s-text>
+          <s-text>Second Param: {state.secondParam}</s-text>
+        </s-scroll-box>
+      </s-page>
+    );
+  }
+
+  return (
+    <s-page heading="Screen One Title">
+      <s-scroll-box>
+        <s-button onClick={() => navigation.navigate("ScreenTwo", { state: { firstParam: "test", secondParam: "test2" } })}>
+          Navigate to Screen Two
+        </s-button>
+        <s-button onClick={() => navigation.back()}>Go back</s-button>
+      </s-scroll-box>
+    </s-page>
+  );
+};

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -35,7 +35,7 @@ export interface Navigation {
   /**
    * The navigate() method navigates to a specific URL, updating any provided state in the history entries list.
    */
-  navigate: NavigateFunction;
+  navigate: (url: string, options?: NavigationNavigateOptions) => void;
   /**
    * The currentEntry read-only property of the Navigation interface returns a NavigationHistoryEntry object representing the location the user is currently navigated to right now.
    */
@@ -52,12 +52,4 @@ export interface Navigation {
     type: 'currententrychange',
     cb: (event: NavigationCurrentEntryChangeEvent) => void,
   ): void;
-}
-
-export interface NavigateFunction {
-  /**
-   * Navigates to a specific URL, updating any provided state in the history entries list.
-   * @param url The destination URL to navigate to.
-   */
-  (url: string, options?: NavigationNavigateOptions): void;
 }


### PR DESCRIPTION
Closes [#18625](https://github.com/shop/issues-retail/issues/18625)

Paired with https://github.com/Shopify/shopify-dev/pull/63019

### Background
Add navigate state example and fix navigate typing not showing in docs

<img width="1182" height="1290" alt="image" src="https://github.com/user-attachments/assets/f180de12-fe74-439b-907e-19243752185a" />

<img width="2234" height="1478" alt="image" src="https://github.com/user-attachments/assets/a91ead61-103c-4a68-83d7-9da2f592b7d7" />

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
