### PR TITLE
Update table referencing in documentation

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
@@ -67,6 +67,14 @@ const data: AdminReferenceEntityTemplateSchema = {
       ],
     },
   },
+  related: [
+    {
+      name: 'Index table',
+      subtitle: 'Composition',
+      url: 'docs/api/app-home/patterns/compositions/index-table',
+      type: 'component',
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/indexTable.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/indexTable.ab.doc.ts
@@ -37,6 +37,12 @@ const data: ReferenceEntityTemplateSchema = {
       url: '/docs/apps/launch/built-for-shopify/requirements',
       type: 'component',
     },
+    {
+      name: 'Table',
+      subtitle: 'Component',
+      url: '/docs/api/app-home/polaris-web-components/structure/table',
+      type: 'component',
+    },
   ],
 };
 


### PR DESCRIPTION
### Background

There is currently no way to discover Table from Index Table or vice-versa

### Solution

Added reference to Table in Index Ttable and Index table within Table in the 'Related' section.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
