### PR TITLE
18804: Add cartLineItem, pinpad, and storage apis

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
@@ -1,0 +1,52 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {ExtensionTargetType, TargetLink} from '../types/ExtensionTargetType';
+import {generateJsxCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateJsxCodeBlockForCartLineItemApi = (
+  title: string,
+  fileName: string,
+) => generateJsxCodeBlock(title, 'cart-line-item-api', fileName);
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Cart Line Item API',
+  description: `
+The Cart Line Item API provides an extension with data about the current Cart Line Item.
+
+#### Supporting targets
+- ${TargetLink.PosCartLineItemDetailsActionMenuItemRender}
+- ${TargetLink.PosCartLineItemDetailsActionRender}
+`,
+  isVisualComponent: false,
+  type: 'APIs',
+  definitions: [
+    {
+      title: 'CartLineItemApi',
+      description: '',
+      type: 'CartLineItemApi',
+    },
+  ],
+  examples: {
+    description: 'Examples of using the Cart Line Item API.',
+    examples: [
+      {
+        codeblock: generateJsxCodeBlockForCartLineItemApi(
+          'Retrieve the ID of the cart line item.',
+          'id',
+        ),
+      },
+    ],
+  },
+  category: 'APIs',
+  related: [
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsActionMenuItemRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-action-menu-item-render',
+    },
+    {
+      name: ExtensionTargetType.PosCartLineItemDetailsActionRender,
+      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-action-render',
+    },
+  ],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
@@ -1,0 +1,35 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateJsxCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateJsxCodeBlockForToastApi = (title: string, fileName: string) =>
+  generateJsxCodeBlock(title, 'pinpad-api', fileName);
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Pinpad API',
+  description:
+    'The Pinpad API allows the display of a Pinpad component for PIN validation.',
+  isVisualComponent: false,
+  type: 'APIs',
+  definitions: [
+    {
+      title: 'PinpadApi',
+      description: '',
+      type: 'PinPadApiContent',
+    },
+  ],
+  category: 'APIs',
+  related: [],
+  examples: {
+    description: 'Examples of using the Pinpad API',
+    examples: [
+      {
+        codeblock: generateJsxCodeBlockForToastApi(
+          'Display a Pinpad and validate the PIN',
+          'validation',
+        ),
+      },
+    ],
+  },
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -1,0 +1,66 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {CUSTOM_DATA} from '../helpers/helper.docs';
+import {generateJsxCodeBlock} from '../helpers/generateCodeBlock';
+
+const generateJsxCodeBlockForStorageApi = (title: string, fileName: string) =>
+  generateJsxCodeBlock(title, 'storage-api', fileName);
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Storage API',
+  description: `The Storage API allows fetching, setting, updating, and clearing an extension's data from the POS local storage.
+  - An extension can store up to 100 entries.
+  - The maximum size for a key is ~1 KB, and for a value is ~1 MB.
+  - If a target (such as \`pos.home.tile.render\`) is disabled or removed, the extension data remains.
+  - All stored extension data that has not been updated for a month is cleared automatically after that period.
+
+  > Note:
+  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  isVisualComponent: false,
+  type: 'APIs',
+  category: 'APIs',
+  related: [],
+  definitions: [
+    {
+      title: 'StorageApi',
+      description: '',
+      type: 'Storage',
+    },
+  ],
+  examples: {
+    description: 'Examples of using the Storage API',
+    examples: [
+      {
+        codeblock: generateJsxCodeBlockForStorageApi(
+          'Getting a single value from storage',
+          'get',
+        ),
+      },
+      {
+        codeblock: generateJsxCodeBlockForStorageApi(
+          'Setting a single value in storage',
+          'set',
+        ),
+      },
+      {
+        codeblock: generateJsxCodeBlockForStorageApi(
+          'Deleting a single value from storage',
+          'delete',
+        ),
+      },
+      {
+        codeblock: generateJsxCodeBlockForStorageApi(
+          'Clear all entries for an extension from storage',
+          'clear',
+        ),
+      },
+      {
+        codeblock: generateJsxCodeBlockForStorageApi(
+          'Retrieve all entries for an extension from storage',
+          'entries',
+        ),
+      },
+    ],
+  },
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-line-item-api/id.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-line-item-api/id.jsx
@@ -1,0 +1,15 @@
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+const Extension = () => {
+  return (
+    <s-page heading='Cart Line Item Details Action'>
+      <s-scroll-box>
+        <s-text>Cart Line Item ID: {shopify.cartLineItem.uuid}</s-text>
+      </s-scroll-box>
+    </s-page>
+  );
+};

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/pinpad-api/validation.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/pinpad-api/validation.jsx
@@ -1,0 +1,44 @@
+import { render } from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  const VALID_PIN = '123456';
+
+  const options = {
+    label: 'Enter PIN to disarm',
+    title: 'Auto-destruct sequence activated',
+    masked: true,
+    minPinLength: /** @type {6} */ (6),
+    maxPinLength: /** @type {8} */ (8),
+    pinPadAction: {
+      label: 'Emergency Override',
+      onClick: () => {
+        return [1, 2, 3, 4, 5, 6];
+      },
+    },
+    onPinEntry: (pin) => {
+      console.log(`PIN Entry: ${pin}`);
+    },
+  };
+
+  const onShowTapped = () => {
+    shopify.pinPad.showPinPad((pin) => {
+      if (pin.join('') === VALID_PIN) {
+        console.log('PIN is valid');
+        return {result: 'accept'};
+      } else {
+        console.log('PIN is invalid');
+        return {result: 'reject'};
+      }
+    }, options);
+  };
+
+  return (
+    <s-scroll-box>
+      <s-button onClick={onShowTapped}>Show Pin Pad</s-button>
+    </s-scroll-box>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/clear.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/clear.jsx
@@ -1,0 +1,35 @@
+import {render} from 'preact';
+import {useState, useEffect} from 'preact/hooks';
+
+export default async () => {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  const [itemCount, setItemCount] = useState(0);
+
+  useEffect(() => {
+    const initializeData = async () => {
+      const count = 10;
+      for (let i = 0; i < count; i++) {
+        await shopify.storage.set(`key-${i}`, `value-${i}`);
+      }
+      setItemCount(count);
+    };
+
+    initializeData();
+  }, []);
+
+  return (
+    <s-tile
+      heading="POS smart grid"
+      subheading="preact Extension"
+      itemCount={itemCount}
+      onClick={async () => {
+        await shopify.storage.clear();
+        shopify.toast.show('All data cleared');
+        setItemCount(0);
+      }}
+    />
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/delete.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/delete.jsx
@@ -1,0 +1,24 @@
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  return (
+    <s-tile
+      heading="POS smart grid"
+      subheading="preact Extension"
+      onClick={async () => {
+        await shopify.storage.set('key', 'A temporary value');
+        const storedData = await shopify.storage.get('key');
+        shopify.toast.show(`Current value: ${String(storedData)}`);
+        setTimeout(async () => {
+          await shopify.storage.delete('key');
+          const storedData = (await shopify.storage.get('key')) ?? '';
+          shopify.toast.show(`Current value after deletion: ${String(storedData)}`);
+        }, 2000);
+      }}
+    />
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/entries.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/entries.jsx
@@ -1,0 +1,26 @@
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  return (
+    <s-tile
+      heading="POS smart grid"
+      subheading="preact Extension"
+      onClick={async () => {
+        await shopify.storage.set('attempts', 2);
+        await shopify.storage.set('darkMode', true);
+        await shopify.storage.set('trackingId', 'd6ead53c-b5f5-0b16-dabb-17081ff238c3');
+
+        const allEntries = await shopify.storage.entries();
+        const message = allEntries.length
+          ? allEntries.map(([key, value]) => `${key}: ${value}`).join(', ')
+          : 'Nothing stored';
+
+        shopify.toast.show(message);
+      }}
+    />
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/get.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/get.jsx
@@ -1,0 +1,18 @@
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  return (
+    <s-tile
+      heading="POS smart grid"
+      subheading="preact Extension"
+      onClick={async () => {
+        const storedData = await shopify.storage.get('key');
+        shopify.toast.show(String(storedData ?? ''));
+      }}
+    />
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/set.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/storage-api/set.jsx
@@ -1,0 +1,26 @@
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  return (
+    <s-tile
+      heading="POS smart grid"
+      subheading="preact Extension"
+      onClick={async () => {
+        await Promise.all([
+          shopify.storage.set('trackingId', 'd6ead53c-b5f5-0b16-dabb-17081ff238c3'),
+          shopify.storage.set('someObject', {
+            boolean: true,
+            numeric: 2,
+            string: 'Hello world!',
+          }),
+          shopify.storage.set('attempts', 2),
+        ]);
+        shopify.toast.show('Data stored');
+      }}
+    />
+  );
+}


### PR DESCRIPTION
Closes [#18804](https://github.com/shop/issues-retail/issues/18804)
Paired with https://github.com/Shopify/shopify-dev/pull/63027

### Background
Add cartLineItem, pinpad, and storage api docs

<img width="2258" height="1602" alt="image" src="https://github.com/user-attachments/assets/0a2fb4fb-2e32-4354-b3c1-d4d2001bf11a" />

<img width="2180" height="1594" alt="image" src="https://github.com/user-attachments/assets/dcc63b99-b181-48a5-84da-13ab63f6b0b3" />

<img width="2234" height="1568" alt="image" src="https://github.com/user-attachments/assets/e6fd4d6f-7555-4a70-9618-734fd3388e03" />

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
