### PR TITLE
18830: undo navigation lower case

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -1,5 +1,4 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
-import {CUSTOM_DATA} from '../helpers/helper.docs';
 import {generateJsxCodeBlock} from '../helpers/generateCodeBlock';
 
 const generateJsxCodeBlockForStorageApi = (title: string, fileName: string) =>
@@ -11,10 +10,7 @@ const data: ReferenceEntityTemplateSchema = {
   - An extension can store up to 100 entries.
   - The maximum size for a key is ~1 KB, and for a value is ~1 MB.
   - If a target (such as \`pos.home.tile.render\`) is disabled or removed, the extension data remains.
-  - All stored extension data that has not been updated for a month is cleared automatically after that period.
-
-  > Note:
-  > This is part of a POS UI Extensions developer preview. More information to come.`,
+  - All stored extension data that has not been updated for a month is cleared automatically after that period.`,
   isVisualComponent: false,
   type: 'APIs',
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/state-params.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/state-params.jsx
@@ -10,7 +10,7 @@ const Extension = () => {
   /** @type {{ firstParam?: string; secondParam?: string }} */
   const state = navigation.currentEntry.getState();
 
-  if (url?.includes("screentwo")) {
+  if (url?.includes("ScreenTwo")) {
     return (
       <s-page heading="Screen Two Title">
         <s-scroll-box>

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/two-screen.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/two-screen.jsx
@@ -7,8 +7,7 @@ export default async () => {
 const Extension = () => {
   const url = navigation.currentEntry.url;
 
-  // note: url is lowercased, so we compare with lowercase strings
-  if (url?.includes("screentwo")) {
+  if (url?.includes("ScreenTwo")) {
     return (
       <s-page heading="Screen Two Title">
         <s-scroll-box>

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -12,7 +12,7 @@ export interface NavigationHistoryEntry {
   /** Returns the key of the history entry. This is a unique, UA-generated value that represents the history entry's slot in the entries list rather than the entry itself. */
   key: string;
   /**
-   * Returns the lowercased URL of this history entry.
+   * Returns the URL of this history entry.
    */
   url: string | null;
   /**


### PR DESCRIPTION
Closes [#18830](https://github.com/shop/issues-retail/issues/18830)
Paired with https://github.com/Shopify/shopify-dev/pull/63053

### Background
Undo lower cased currentEntry.url in docs and remove dev preview banner for storage api 

<img width="2246" height="1408" alt="image" src="https://github.com/user-attachments/assets/4f4b4968-c0cb-4245-8bc5-07669301cdde" />

<img width="1182" height="874" alt="image" src="https://github.com/user-attachments/assets/6b4ce8eb-feeb-404c-a1e8-10aae97304d7" />

<img width="1284" height="1052" alt="image" src="https://github.com/user-attachments/assets/908b7a12-a020-46ee-9d47-dd87d34cc8cb" />

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
