### PR TITLE
POS navigate returns promise

### DIFF
--- a/.changeset/rude-clocks-pretend.md
+++ b/.changeset/rude-clocks-pretend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+POS navigate API updated to return Promise<void> as implemented

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -35,7 +35,7 @@ export interface Navigation {
   /**
    * The navigate() method navigates to a specific URL, updating any provided state in the history entries list.
    */
-  navigate: (url: string, options?: NavigationNavigateOptions) => void;
+  navigate: (url: string, options?: NavigationNavigateOptions) => Promise<void>;
   /**
    * The currentEntry read-only property of the Navigation interface returns a NavigationHistoryEntry object representing the location the user is currently navigated to right now.
    */


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-retail/issues/18859

For 2025-10, the ui-extension interface should return Promise<void> as that is what the POS app implementation currently returns in `useNavigationApi` in 10.12 / 2025-10. We throw errors when there is an invalid uri, or things like not having the correct permissions to view the data. The promise allows partners to catch errors that are thrown using try/catch, and then react as they see fit.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
