### PR TITLE
[Intents] add `intents.invoke` documentation and types to standard API

### DIFF
--- a/.changeset/smart-seahorses-impress.md
+++ b/.changeset/smart-seahorses-impress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+expose intents.invoke API to UI Extensions

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-article.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-article.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Article');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Article created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-catalog.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-catalog.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Catalog');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Catalog created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-collection.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-collection.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Collection');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Collection created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-customer.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-customer.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Customer');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Customer created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-discount.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-discount.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Discount', {
+  data: {type: 'amount-off-product'},
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Discount created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-market.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-market.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Market');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Market created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-menu.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-menu.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Menu');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Menu created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-metafield-definition.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-metafield-definition.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/MetafieldDefinition', {
+  data: {ownerType: 'product'},
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Metafield definition created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-metaobject-definition.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-metaobject-definition.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/MetaobjectDefinition');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Metaobject definition created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-metaobject.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-metaobject.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Metaobject', {
+  data: {type: 'shopify--color-pattern'},
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Metaobject created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-page.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-page.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Page');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Page created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-product.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-product.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Product');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Product created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-variant.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-variant.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/ProductVariant', {
+  data: {productId: 'gid://shopify/Product/123456789'},
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Product variant created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-article.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-article.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Article', {
+  value: 'gid://shopify/Article/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Article updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-catalog.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-catalog.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Catalog', {
+  value: 'gid://shopify/Catalog/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Catalog updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-collection.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-collection.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Collection', {
+  value: 'gid://shopify/Collection/987654321',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Collection updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-customer.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-customer.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Customer', {
+  value: 'gid://shopify/Customer/456789123',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Customer updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-discount.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-discount.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Discount', {
+  value: 'gid://shopify/Discount/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Discount updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-market.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-market.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Market', {
+  value: 'gid://shopify/Market/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Market updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-menu.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-menu.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Menu', {
+  value: 'gid://shopify/Menu/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Menu updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-metafield-definition.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-metafield-definition.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/MetafieldDefinition', {
+  value: 'gid://shopify/MetafieldDefinition/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Metafield definition updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-metaobject-definition.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-metaobject-definition.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/MetaobjectDefinition', {
+  value: 'gid://shopify/MetaobjectDefinition/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Metaobject definition updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-metaobject.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-metaobject.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Metaobject', {
+  value: 'gid://shopify/Metaobject/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Metaobject updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-page.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-page.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Page', {
+  value: 'gid://shopify/Page/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Page updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-product.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-product.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Product', {
+  value: 'gid://shopify/Product/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Product updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-variant.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-variant.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/ProductVariant', {
+  value: 'gid://shopify/ProductVariant/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Product variant updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
@@ -1,0 +1,544 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Intents',
+  overviewPreviewDescription:
+    'Orchestrate workflows and operations across Shopify resources',
+  description: `The Intents API provides a way to invoke existing admin workflows for creating, editing, and managing Shopify resources.`,
+  isVisualComponent: true,
+  category: 'API',
+  thumbnail: 'intents.png',
+  requires:
+    'an Admin [block](/docs/api/admin-extensions/unstable/extension-targets#block-locations) or [action](/docs/api/admin-extensions/unstable/extension-targets#action-locations) extension.',
+  defaultExample: {
+    image: 'intents.png',
+    codeblock: {
+      title: 'Creating a collection',
+      tabs: [
+        {
+          code: './examples/create-collection.js',
+          language: 'js',
+        },
+      ],
+    },
+  },
+  definitions: [
+    {
+      title: 'invoke',
+      description: `The \`invoke\` API is a function that accepts either a string query or an options object describing the intent to invoke and returns a Promise that resolves to an activity handle for the workflow.
+
+## Intent Format
+
+Intents are invoked using a string query format: \`\${action}:\${type},\${value}\`
+
+Where:
+- \`action\` - The operation to perform (\`create\` or \`edit\`)
+- \`type\` - The resource type (e.g., \`shopify/Product\`)
+- \`value\` - The resource identifier (only for edit actions)
+
+## Supported Resources
+
+### Article
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Article\` | — | — |
+| \`edit\` | \`shopify/Article\` | \`gid://shopify/Article/{id}\` | — |
+
+### Catalog
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Catalog\` | — | — |
+| \`edit\` | \`shopify/Catalog\` | \`gid://shopify/Catalog/{id}\` | — |
+
+### Collection
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Collection\` | — | — |
+| \`edit\` | \`shopify/Collection\` | \`gid://shopify/Collection/{id}\` | — |
+
+### Customer
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Customer\` | — | — |
+| \`edit\` | \`shopify/Customer\` | \`gid://shopify/Customer/{id}\` | — |
+
+### Discount
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Discount\` | — | \`{ type: 'amount-off-product' \\| 'amount-off-order' \\| 'buy-x-get-y' \\| 'free-shipping' }\` |
+| \`edit\` | \`shopify/Discount\` | \`gid://shopify/Discount/{id}\` | — |
+
+### Market
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Market\` | — | — |
+| \`edit\` | \`shopify/Market\` | \`gid://shopify/Market/{id}\` | — |
+
+### Menu
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Menu\` | — | — |
+| \`edit\` | \`shopify/Menu\` | \`gid://shopify/Menu/{id}\` | — |
+
+### Metafield Definition
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/MetafieldDefinition\` | — | — |
+| \`edit\` | \`shopify/MetafieldDefinition\` | \`gid://shopify/MetafieldDefinition/{id}\` | — |
+
+### Metaobject
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Metaobject\` | — | \`{ type: 'shopify--color-pattern' }\` |
+| \`edit\` | \`shopify/Metaobject\` | \`gid://shopify/Metaobject/{id}\` | — |
+
+### Metaobject Definition
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/MetaobjectDefinition\` | — | — |
+| \`edit\` | \`shopify/MetaobjectDefinition\` | \`gid://shopify/MetaobjectDefinition/{id}\` | — |
+
+### Page
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Page\` | — | — |
+| \`edit\` | \`shopify/Page\` | \`gid://shopify/Page/{id}\` | — |
+
+### Product
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Product\` | — | — |
+| \`edit\` | \`shopify/Product\` | \`gid://shopify/Product/{id}\` | — |
+
+### Product Variant
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/ProductVariant\` | — | \`{ productId: 'gid://shopify/Product/{id}' }\` |
+| \`edit\` | \`shopify/ProductVariant\` | \`gid://shopify/ProductVariant/{id}\` | — |`,
+      type: 'IntentInvokeApi',
+    },
+    {
+      title: 'IntentAction',
+      description: `Supported actions that can be performed on resources.
+- \`create\`: Opens a creation workflow for a new resource
+- \`edit\`: Opens an editing workflow for an existing resource (requires \`value\` parameter)`,
+      type: 'IntentAction',
+    },
+    {
+      title: 'IntentType',
+      description: `Supported resource types that can be targeted by intents.`,
+      type: 'IntentType',
+    },
+    {
+      title: 'IntentQueryOptions',
+      description: `Options for invoking intents when using the query string format.`,
+      type: 'IntentQueryOptions',
+    },
+    {
+      title: 'IntentResponse',
+      description: `Response object returned when the intent workflow completes.`,
+      type: 'IntentResponse',
+    },
+  ],
+  examples: {
+    description: 'Intents for each Shopify resource type',
+    exampleGroups: [
+      {
+        title: 'Article',
+        examples: [
+          {
+            description:
+              'Create a new article. Opens the article creation workflow.',
+            codeblock: {
+              title: 'Create article',
+              tabs: [
+                {
+                  code: './examples/create-article.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description: 'Edit an existing article. Requires an article GID.',
+            codeblock: {
+              title: 'Edit article',
+              tabs: [
+                {
+                  code: './examples/edit-article.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Catalog',
+        examples: [
+          {
+            description:
+              'Create a new catalog. Opens the catalog creation workflow.',
+            codeblock: {
+              title: 'Create catalog',
+              tabs: [
+                {
+                  code: './examples/create-catalog.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description: 'Edit an existing catalog. Requires a catalog GID.',
+            codeblock: {
+              title: 'Edit catalog',
+              tabs: [
+                {
+                  code: './examples/edit-catalog.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Collection',
+        examples: [
+          {
+            description:
+              'Create a new collection. Opens the collection creation workflow.',
+            codeblock: {
+              title: 'Create collection',
+              tabs: [
+                {
+                  code: './examples/create-collection.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              'Edit an existing collection. Requires a collection GID.',
+            codeblock: {
+              title: 'Edit collection',
+              tabs: [
+                {
+                  code: './examples/edit-collection.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Customer',
+        examples: [
+          {
+            description:
+              'Create a new customer. Opens the customer creation workflow.',
+            codeblock: {
+              title: 'Create customer',
+              tabs: [
+                {
+                  code: './examples/create-customer.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description: 'Edit an existing customer. Requires a customer GID.',
+            codeblock: {
+              title: 'Edit customer',
+              tabs: [
+                {
+                  code: './examples/edit-customer.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Discount',
+        examples: [
+          {
+            description:
+              'Create a new discount. Opens the discount creation workflow. Requires a discount type.',
+            codeblock: {
+              title: 'Create discount',
+              tabs: [
+                {
+                  code: './examples/create-discount.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description: 'Edit an existing discount. Requires a discount GID.',
+            codeblock: {
+              title: 'Edit discount',
+              tabs: [
+                {
+                  code: './examples/edit-discount.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Market',
+        examples: [
+          {
+            description:
+              'Create a new market. Opens the market creation workflow.',
+            codeblock: {
+              title: 'Create market',
+              tabs: [
+                {
+                  code: './examples/create-market.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description: 'Edit an existing market. Requires a market GID.',
+            codeblock: {
+              title: 'Edit market',
+              tabs: [
+                {
+                  code: './examples/edit-market.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Menu',
+        examples: [
+          {
+            description: 'Create a new menu. Opens the menu creation workflow.',
+            codeblock: {
+              title: 'Create menu',
+              tabs: [
+                {
+                  code: './examples/create-menu.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description: 'Edit an existing menu. Requires a menu GID.',
+            codeblock: {
+              title: 'Edit menu',
+              tabs: [
+                {
+                  code: './examples/edit-menu.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Metafield Definition',
+        examples: [
+          {
+            description:
+              'Create a new metafield definition. Opens the metafield definition creation workflow.',
+            codeblock: {
+              title: 'Create metafield definition',
+              tabs: [
+                {
+                  code: './examples/create-metafield-definition.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              'Edit an existing metafield definition. Requires a metafield definition GID.',
+            codeblock: {
+              title: 'Edit metafield definition',
+              tabs: [
+                {
+                  code: './examples/edit-metafield-definition.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Metaobject',
+        examples: [
+          {
+            description:
+              'Create a new metaobject. Opens the metaobject creation workflow. Requires a type.',
+            codeblock: {
+              title: 'Create metaobject',
+              tabs: [
+                {
+                  code: './examples/create-metaobject.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              'Edit an existing metaobject. Requires a metaobject GID.',
+            codeblock: {
+              title: 'Edit metaobject',
+              tabs: [
+                {
+                  code: './examples/edit-metaobject.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Metaobject Definition',
+        examples: [
+          {
+            description:
+              'Create a new metaobject definition. Opens the metaobject definition creation workflow.',
+            codeblock: {
+              title: 'Create metaobject definition',
+              tabs: [
+                {
+                  code: './examples/create-metaobject-definition.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              'Edit an existing metaobject definition. Requires a metaobject definition GID.',
+            codeblock: {
+              title: 'Edit metaobject definition',
+              tabs: [
+                {
+                  code: './examples/edit-metaobject-definition.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Page',
+        examples: [
+          {
+            description: 'Create a new page. Opens the page creation workflow.',
+            codeblock: {
+              title: 'Create page',
+              tabs: [
+                {
+                  code: './examples/create-page.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description: 'Edit an existing page. Requires a page GID.',
+            codeblock: {
+              title: 'Edit page',
+              tabs: [
+                {
+                  code: './examples/edit-page.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Product',
+        examples: [
+          {
+            description:
+              'Create a new product. Opens the product creation workflow.',
+            codeblock: {
+              title: 'Create product',
+              tabs: [
+                {
+                  code: './examples/create-product.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description: 'Edit an existing product. Requires a product GID.',
+            codeblock: {
+              title: 'Edit product',
+              tabs: [
+                {
+                  code: './examples/edit-product.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: 'Product Variant',
+        examples: [
+          {
+            description:
+              'Create a new product variant. Opens the variant creation workflow. Requires a product ID.',
+            codeblock: {
+              title: 'Create variant',
+              tabs: [
+                {
+                  code: './examples/create-variant.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              'Edit an existing product variant. Requires a variant GID.',
+            codeblock: {
+              title: 'Edit variant',
+              tabs: [
+                {
+                  code: './examples/edit-variant.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/intents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/intents.ts
@@ -1,0 +1,153 @@
+/**
+ * User dismissed or closed the workflow without completing it.
+ */
+export interface ClosedIntentResponse {
+  code?: 'closed';
+}
+
+/**
+ * Successful intent completion.
+ */
+export interface SuccessIntentResponse {
+  code?: 'ok';
+  data?: {[key: string]: unknown};
+}
+
+/**
+ * Failed intent completion.
+ */
+export interface ErrorIntentResponse {
+  code?: 'error';
+  message?: string;
+  issues?: {
+    /**
+     * The path to the field with the issue.
+     */
+    path?: string[];
+    /**
+     * The error message for the issue.
+     */
+    message?: string;
+    /**
+     * A code identifier for the issue.
+     */
+    code?: string;
+  }[];
+}
+
+/**
+ * Result of an intent activity.
+ * Discriminated union representing all possible completion outcomes.
+ */
+export type IntentResponse =
+  | SuccessIntentResponse
+  | ErrorIntentResponse
+  | ClosedIntentResponse;
+
+/**
+ * Activity handle for tracking intent workflow progress.
+ */
+export interface IntentActivity {
+  /**
+   * A Promise that resolves when the intent workflow completes, returning the response.
+   */
+  complete?: Promise<IntentResponse>;
+}
+
+/**
+ * The action to perform on a resource.
+ */
+export type IntentAction = 'create' | 'edit';
+
+/**
+ * Supported resource types that can be targeted by intents.
+ */
+export type IntentType =
+  | 'shopify/Article'
+  | 'shopify/Catalog'
+  | 'shopify/Collection'
+  | 'shopify/Customer'
+  | 'shopify/Discount'
+  | 'shopify/Market'
+  | 'shopify/Menu'
+  | 'shopify/MetafieldDefinition'
+  | 'shopify/Metaobject'
+  | 'shopify/MetaobjectDefinition'
+  | 'shopify/Page'
+  | 'shopify/Product'
+  | 'shopify/ProductVariant';
+
+/**
+ * Options for invoking intents when using the query string format.
+ */
+export interface IntentQueryOptions {
+  /**
+   * The resource identifier for edit actions (e.g., 'gid://shopify/Product/123').
+   */
+  value?: string;
+  /**
+   * Additional data required for certain intent types.
+   * For example:
+   * - Discount creation requires { type: 'amount-off-product' | 'amount-off-order' | 'buy-x-get-y' | 'free-shipping' }
+   * - ProductVariant creation requires { productId: 'gid://shopify/Product/123' }
+   * - Metaobject creation requires { type: 'shopify--color-pattern' }
+   */
+  data?: {[key: string]: unknown};
+}
+
+/**
+ * Structured description of an intent to invoke.
+ */
+export interface IntentQuery extends IntentQueryOptions {
+  /**
+   * The operation to perform on the target resource.
+   */
+  action: IntentAction;
+  /**
+   * The resource type (e.g., 'shopify/Product').
+   */
+  type: IntentType;
+}
+
+/**
+ * The invoke API for triggering intent workflows.
+ *
+ * @param intent - Either a string query or structured object describing the intent
+ * @param options - Optional parameters when using string query format
+ * @returns A Promise resolving to an activity handle for tracking the workflow
+ *
+ * @example
+ * ```javascript
+ * // Create a new product
+ * const activity = await intents.invoke('create:shopify/Product');
+ * const response = await activity.complete;
+ *
+ * // Edit an existing product
+ * const activity = await intents.invoke('edit:shopify/Product,gid://shopify/Product/123');
+ * const response = await activity.complete;
+ *
+ * // Create a discount with required type
+ * const activity = await intents.invoke('create:shopify/Discount', {
+ *   data: { type: 'amount-off-product' }
+ * });
+ * const response = await activity.complete;
+ * ```
+ */
+export interface IntentInvokeApi {
+  (query: IntentQuery): Promise<IntentActivity>;
+  (intentURL: string, options?: IntentQueryOptions): Promise<IntentActivity>;
+}
+
+/**
+ * Intent information provided to the receiver of an intent.
+ */
+export interface Intents {
+  /**
+   * The URL that was used to launch the intent.
+   */
+  launchUrl?: string | URL;
+  /**
+   * Invoke an intent workflow to create or edit Shopify resources.
+   */
+  invoke?: IntentInvokeApi;
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.ts
@@ -2,13 +2,9 @@ import type {I18n} from '../../../../api';
 import {ApiVersion} from '../../../../shared';
 import type {Storage} from './storage';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+import type {Intents} from '../intents/intents';
 
-export interface Intents {
-  /**
-   * The URL that was used to launch the intent.
-   */
-  launchUrl?: string | URL;
-}
+export type {Intents} from '../intents/intents';
 
 /**
  * GraphQL error returned by the Shopify Admin API.


### PR DESCRIPTION
Related https://app.graphite.dev/github/pr/Shopify/extensibility/781
Related https://github.com/Shopify/shopify-dev/pull/63115

Partially resolves https://github.com/shop/issues-admin-extensibility/issues/77

### Background

Exposes the `intents.invoke()` API types to Admin UI Extensions as part of the https://vault.shopify.io/gsd/projects/46517-App-Extensions-Admin-Intents-API-for-Embedded-Apps-and-UI-Extensions project

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
