### PR TITLE
POS native screen navigation uris again

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/native-screen.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/navigation-api/native-screen.jsx
@@ -5,17 +5,28 @@ export default async () => {
 };
 
 function Extension() {
-  const productUri = `shopify:point-of-sale/products/${shopify.product.id}/variants/${shopify.product.variantId}`;
-
+  /**
+   * Available POS native screen uris:
+   * - `shopify:point-of-sale/products/123` to present product details.
+   * - `shopify:point-of-sale/products/123/variants/456` to present product variant details.
+   * - `shopify:point-of-sale/customers/123` to present customer details.
+   * - `shopify:point-of-sale/orders/123` to present order details.
+   * - `shopify:point-of-sale/draft_orders/123` to present draft order details.
+   * - `shopify:point-of-sale/staff/123` to present staff details.
+   */
+  const uri = `shopify:point-of-sale/products/${shopify.product.id}`;
   return (
-    <s-page heading="Featured">
+    <s-page heading="POS native screen navigation">
       <s-scroll-box>
         <s-button
           onClick={() => {
-            navigation.navigate(productUri);
+            navigation.navigate(uri).catch(() => {
+              // Due to staff permissions or POS subscription plan permission or invalid url, etc.
+              shopify.toast.show('Unable to view product details.');
+            });
           }}
         >
-          View featured product
+          View product details
         </s-button>
       </s-scroll-box>
     </s-page>


### PR DESCRIPTION
### Background

Adds available native screen uris to example.

shopify-dev: https://github.com/Shopify/shopify-dev/pull/63113

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
