### PR TITLE
Extended admin examples feature and templates to enable multiple exam…

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -132,6 +132,16 @@ const templates = {
   none: createTemplate({
     layoutStyles: 'padding: 0;',
   }),
+  padding: createTemplate({
+    layoutStyles: 'padding: 0;',
+    wrapperElement: 's-box',
+    wrapperAttributes: 'padding="base"',
+  }),
+  example: createTemplate({
+    layoutStyles: 'display: grid; place-items: center; gap: 0.5rem;',
+    wrapperElement: 's-box',
+    wrapperAttributes: 'padding="base"',
+  }),
 };
 
 const transformJson = async (filePath, isExtensions) => {
@@ -183,6 +193,29 @@ const transformJson = async (filePath, isExtensions) => {
       });
 
       entry.defaultExample.codeblock.tabs = newTabs;
+    }
+
+    if (entry.examples && entry.examples.exampleGroups) {
+      entry.examples.exampleGroups.forEach((exampleGroup) => {
+        exampleGroup.examples.forEach((example) => {
+          if (example.codeblock?.tabs) {
+            example.codeblock.tabs.forEach((tab) => {
+              const previewHTML =
+                tab.layout && tab.layout in templates
+                  ? templates[tab.layout](tab.code, tab.customStyles)
+                  : templates.example(tab.code, tab.customStyles);
+              const newTabs = [];
+
+              newTabs.push(
+                {code: tab.code, language: 'html'},
+                {code: previewHTML, language: 'preview'},
+              );
+
+              example.codeblock.tabs = newTabs;
+            });
+          }
+        });
+      });
     }
   });
 
@@ -293,7 +326,11 @@ try {
   await fs.rm(tempComponentDefs);
 } catch (error) {
   console.error(error);
-  console.log(error.stdout.toString());
-  console.log(error.stderr.toString());
+  if (error.stdout) {
+    console.log(error.stdout.toString());
+  }
+  if (error.stderr) {
+    console.log(error.stderr.toString());
+  }
   process.exit(1);
 }

--- a/packages/ui-extensions/src/surfaces/admin/docs-types.ts
+++ b/packages/ui-extensions/src/surfaces/admin/docs-types.ts
@@ -2,23 +2,44 @@ import type {CSSProperties} from 'react';
 import {
   ReferenceEntityTemplateSchema,
   CodeTabType,
+  ExampleType,
+  ExampleSectionSchema,
+  ExampleGroupType,
 } from '@shopify/generate-docs';
 
 // Don't allow all CSS properties to be used in the customStyles property
 type AllowedCSSProperties = Pick<CSSProperties, 'minHeight' | 'minBlockSize'>;
 
+type AdminCodeTabType = CodeTabType & {
+  layout?: string;
+  customStyles?: AllowedCSSProperties;
+};
+
+interface CodeLinkType {
+  name: string;
+  url: string;
+  icon: string;
+}
+
+interface AdminCodeblockType {
+  title: string;
+  tabs: AdminCodeTabType[];
+  links?: CodeLinkType[];
+}
+
+type AdminExampleType = Omit<ExampleType, 'codeblock'> & {
+  codeblock: AdminCodeblockType | AdminCodeblockType[];
+};
+
+type AdminExampleGroupType = Omit<ExampleGroupType, 'examples'> & {
+  examples: AdminExampleType[];
+};
+
 export interface AdminReferenceEntityTemplateSchema
-  extends Omit<ReferenceEntityTemplateSchema, 'defaultExample'> {
-  defaultExample?: Omit<
-    NonNullable<ReferenceEntityTemplateSchema['defaultExample']>,
-    'codeblock'
-  > & {
-    codeblock?: {
-      title: string;
-      tabs: (CodeTabType & {
-        layout?: string;
-        customStyles?: AllowedCSSProperties;
-      })[];
-    };
+  extends Omit<ReferenceEntityTemplateSchema, 'defaultExample' | 'examples'> {
+  defaultExample?: AdminExampleType;
+  examples?: Omit<ExampleSectionSchema, 'exampleGroups' | 'examples'> & {
+    exampleGroups?: AdminExampleGroupType[] | null;
+    examples?: AdminExampleType[] | null;
   };
 }


### PR DESCRIPTION
### Background

This PR extends the Admin UI Extensions documentation system to support multiple examples per component, enabling richer documentation with comprehensive example galleries.

### Solution

- **Enhanced Documentation Schema**: Extended `AdminReferenceEntityTemplateSchema` to include an `examples` field with support for grouped examples
- **Template System Integration**: Updated the documentation build process to render multiple examples with the same API as the default example

### Technical Changes

**Updated Files (2 files, 72 additions, 14 deletions):**

- **`docs-types.ts`** - Added `ExampleGroup` and `Example` interfaces, extended schema with optional `examples` field
- **`build-docs.mjs`** - Added template processing for multiple examples with proper HTML wrapping

### Key Features

- **Same API as defaultExample**: Examples use identical structure 
- **Organized by Groups**: Examples grouped by category (e.g., "Basic usage")
- **Backward Compatible**: Existing components continue to work unchanged

### 🎩 Testing Steps

1. Run: `yarn docs:admin`
2. Navigate to shopify-dev repo and test locally at `docs/api/app-home/polaris-web-components/`
3. Verify existing components still render correctly and new examples infrastructure is ready

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation