### PR TITLE
Update 2025-10 migration guide for customer accounts

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/apis-new.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/apis-new.jsx
@@ -1,0 +1,12 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  return (
+    <s-text>Line item title: {shopify.target.value.merchandise.title}</s-text>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/apis-old-react.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/apis-old-react.jsx
@@ -1,0 +1,18 @@
+import {
+  reactExtension,
+  Text,
+  useCartLineTarget,
+} from '@shopify/ui-extensions-react/customer-account';
+
+export default reactExtension(
+  'customer-account.order-status.cart-line-item.render-after',
+  () => <Extension />,
+);
+
+function Extension() {
+  const {
+    merchandise: {title},
+  } = useCartLineTarget();
+
+  return <Text>Line item title: {title}</Text>;
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/components-new.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/components-new.jsx
@@ -1,0 +1,15 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  return (
+    <s-stack direction="inline" gap="base">
+      <s-text-field label="Gift message"></s-text-field>
+      <s-button variant="primary">Save</s-button>
+    </s-stack>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/components-old-react.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/components-old-react.jsx
@@ -1,0 +1,20 @@
+import {
+  reactExtension,
+  InlineStack,
+  TextField,
+  Button,
+} from '@shopify/ui-extensions-react/customer-account';
+
+export default reactExtension(
+  'customer-account.order-status.block.render',
+  () => <Extension />,
+);
+
+function Extension() {
+  return (
+    <InlineStack>
+      <TextField label="Gift message" />
+      <Button>Save</Button>
+    </InlineStack>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/new-tsconfig.example.json
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/new-tsconfig.example.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  }
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/old-tsconfig.example.json
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/old-tsconfig.example.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["./src"]
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/package-json-new.json
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/package-json-new.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@preact/signals": "^2.3.x",
+    "@shopify/ui-extensions": "~2025.10.0-rc"
+  }
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/package-json-old-js.json
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/package-json-old-js.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@shopify/ui-extensions": "2025.4.x"
+  }
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/package-json-old-react.json
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/package-json-old-react.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "react": "^18.0.0",
+    "@shopify/ui-extensions": "2025.4.x",
+    "@shopify/ui-extensions-react": "2025.4.x",
+    "react-reconciler": "0.29.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0"
+  }
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/shopify.extension-new.toml
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/shopify.extension-new.toml
@@ -1,0 +1,8 @@
+api_version = "2025-10"
+
+[[extensions]]
+name = "your-extension"
+handle = "your-extension"
+type = "ui_extension"
+
+# Contents of your existing file...

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/support-new-shopify-global.example.bash
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/upgrading-to-2025-10-rc/support-new-shopify-global.example.bash
@@ -1,0 +1,5 @@
+# Upgrade to latest version of the CLI
+npm install -g @shopify/cli
+
+# Run the app to generate the type definition file
+shopify app dev

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10-rc.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10-rc.doc.ts
@@ -5,23 +5,224 @@ import type {LandingTemplateSchema} from '@shopify/generate-docs';
 
 const data: LandingTemplateSchema = {
   title: 'Upgrading to 2025-10',
-  description: `This guide describes how to upgrade your customer account UI extension to API version \`2025-10\`.`,
+  description: `This guide describes how to upgrade your customer account UI extension to API version \`2025-10\` and adopt [Polaris](/beta/next-gen-dev-platform/polaris) web components.`,
   // The id for the page that is used for routing. If this documentation is for a primary landing page, confirm the id matches the reference name.
   id: 'upgrading-to-2025-10-rc',
   sections: [
     {
       type: 'Generic',
-      anchorLink: 'migrating-to-polaris-web-components',
-      title: 'Migrating to Polaris web components',
+      anchorLink: 'update-api-version',
+      title: 'Update API version',
       sectionContent:
-        'Set the API version to `2025-10` in `shopify.extension.toml` to use the new Polaris UI framework (still in early preview). Use the comparison table below to see what Polaris web components are available today and how they map to legacy components.',
-      sectionNotice: [
+        'Set the API version to `2025-10` in `shopify.extension.toml` to use Polaris web components.',
+      codeblock: {
+        title: 'shopify.extension.toml',
+        tabs: [
+          {
+            title: 'shopify.extension.toml',
+            code: './examples/upgrading-to-2025-10-rc/shopify.extension-new.toml',
+            language: 'toml',
+          },
+        ],
+      },
+    },
+    {
+      type: 'GenericAccordion',
+      anchorLink: 'adjust-dependencies',
+      title: 'Adjust package dependencies',
+      sectionContent: `
+As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the dependencies in your \`package.json\` file and re-install.
+`,
+      accordionContent: [
         {
-          title: 'Early access preview',
-          sectionContent: `This is an early access preview of the [Polaris](https://shopify.dev/beta/next-gen-dev-platform/polaris) UI framework. We will be adding more components over time, so please refer to the comparison table below to see which components are currently available, which ones are coming soon, and how they correspond to their legacy versions.
-
-We advise against migrating your production customer account UI extension to Polaris until the release is stable. However, this is a great opportunity to explore the new version and start planning your migration.`,
-          type: 'info',
+          title: 'New dependencies with Preact',
+          description: '',
+          codeblock: {
+            title: 'New dependencies with Preact',
+            tabs: [
+              {
+                title: 'package.json',
+                code: './examples/upgrading-to-2025-10-rc/package-json-new.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous dependencies with React',
+          description: '',
+          codeblock: {
+            title: 'Previous dependencies with React',
+            tabs: [
+              {
+                title: 'package.json',
+                code: './examples/upgrading-to-2025-10-rc/package-json-old-react.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous dependencies with JavaScript',
+          description: '',
+          codeblock: {
+            title: 'Previous dependencies with JavaScript',
+            tabs: [
+              {
+                title: 'package.json',
+                code: './examples/upgrading-to-2025-10-rc/package-json-old-js.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      type: 'GenericAccordion',
+      anchorLink: 'make-typescript-adjustments',
+      title: 'Make TypeScript adjustments',
+      sectionContent: `
+These steps make TypeScript aware of the new global \`shopify\` object. Skip these steps if your app was not built using TypeScript.
+`,
+      accordionContent: [
+        {
+          title: "Update your extension's tsconfig.json",
+          description:
+            "Update your extension config at a path like `extensions/{extension-name}/tsconfig.json`. You do **not** need to change your app's root `tsconfig.json` file.",
+          codeblock: {
+            title: "Update your extension's tsconfig.json",
+            tabs: [
+              {
+                title: 'New tsconfig.json',
+                code: './examples/upgrading-to-2025-10-rc/new-tsconfig.example.json',
+                language: 'json',
+              },
+              {
+                title: 'Old tsconfig.json',
+                code: './examples/upgrading-to-2025-10-rc/old-tsconfig.example.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+        {
+          title:
+            'Generate type definition file to support new global shopify object',
+          description:
+            'These commands generate a `shopify.d.ts` file in your extension directory.',
+          codeblock: {
+            title: 'Support new global shopify object',
+            tabs: [
+              {
+                title: 'CLI',
+                code: './examples/upgrading-to-2025-10-rc/support-new-shopify-global.example.bash',
+                language: 'bash',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      type: 'GenericAccordion',
+      anchorLink: 'migrate-api-calls',
+      title: 'Migrate API calls',
+      sectionContent:
+        "Instead of accessing APIs from a callback parameter or React hook, access them from the global `shopify` object. Here's an example of migrating the Cart Line Target API call.",
+      accordionContent: [
+        {
+          title: 'New API calls in Preact',
+          description: '',
+          codeblock: {
+            title: 'New API calls in Preact',
+            tabs: [
+              {
+                title: 'Preact',
+                code: './examples/upgrading-to-2025-10-rc/apis-new.jsx',
+                language: 'tsx',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous API calls in React',
+          description: '',
+          codeblock: {
+            title: 'Previous API calls in React',
+            tabs: [
+              {
+                title: 'React',
+                code: './examples/upgrading-to-2025-10-rc/apis-old-react.jsx',
+                language: 'tsx',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous API calls in JavaScript',
+          description: '',
+          codeblock: {
+            title: 'Previous API calls in JavaScript',
+            tabs: [
+              {
+                title: 'JavaScript',
+                code: './examples/upgrading-to-2025-10-rc/apis-old-js.js',
+                language: 'ts',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      type: 'GenericAccordion',
+      anchorLink: 'migrate-to-polaris-web-components',
+      title: 'Migrate to Polaris web components',
+      sectionContent:
+        'Polaris web components are exposed as custom HTML elements. Update your React or JavaScript components to custom elements.',
+      accordionContent: [
+        {
+          title: 'New components in Preact',
+          description: '',
+          codeblock: {
+            title: 'New components in Preact',
+            tabs: [
+              {
+                title: 'Preact',
+                code: './examples/upgrading-to-2025-10-rc/components-new.jsx',
+                language: 'tsx',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous components in React',
+          description: '',
+          codeblock: {
+            title: 'Previous components in React',
+            tabs: [
+              {
+                title: 'React',
+                code: './examples/upgrading-to-2025-10-rc/components-old-react.jsx',
+                language: 'tsx',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Previous components in JavaScript',
+          description: '',
+          codeblock: {
+            title: 'Previous components in JavaScript',
+            tabs: [
+              {
+                title: 'JavaScript',
+                code: './examples/upgrading-to-2025-10-rc/components-old-js.js',
+                language: 'ts',
+              },
+            ],
+          },
         },
       ],
     },
@@ -53,7 +254,7 @@ We advise against migrating your production customer account UI extension to Pol
           type: 'blocks',
           name: 'Checkout components',
           subtitle: 'More Polaris web components',
-          url: '/docs/api/checkout-ui-extensions/2025-10-rc/upgrading-to-2025-10',
+          url: '/docs/api/checkout-ui-extensions/polaris-web-components',
         },
       ],
     },


### PR DESCRIPTION
### Background

Update the migration guide with more information, closer matching the [checkout version](https://shopify.dev/docs/api/checkout-ui-extensions/2025-10-rc/upgrading-to-2025-10).

### Tophatting

[See related PR for instructions](https://github.com/Shopify/shopify-dev/pull/63230)
