### PR TITLE
POS: add documentation for 2025-10 QrCode component

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -14,6 +14,12 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'PosBlock',
     },
     {
+      title: 'QR Code',
+      description:
+        'Renders a QR code when the block is used within a Receipt target.',
+      type: 'QrCode',
+    },
+    {
       title: 'Slots',
       description: '',
       type: 'PosBlockSlots',


### PR DESCRIPTION
### Background

This PR adds documentation for the QR Code component within the PosBlock component.

### Solution

Added the QR Code component to the PosBlock documentation with a description explaining that it renders a QR code when the block is used within a Receipt target. This ensures developers have complete information about available components when using PosBlock.

### 🎩

- Verify the documentation renders correctly in the UI
- Confirm the description accurately reflects the QR Code component's functionality

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation

### Screenshot

![pos-block.png](https://app.graphite.dev/user-attachments/assets/e09d5c33-23bd-45bd-8443-03e48e726473.png)

