### PR TITLE
POS: add Divider docs for 2025-10

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -1,0 +1,34 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Divider',
+  description:
+    'Creates a visual separation between content sections. Dividers help organize information and improve content hierarchy by providing clear section boundaries.',
+  thumbnail: 'divider-thumbnail.png',
+  isVisualComponent: true,
+  type: '',
+  definitions: [
+    {
+      title: 'Properties',
+      description: '',
+      type: 'Divider',
+    },
+  ],
+  category: 'Polaris web components',
+  subCategory: 'Structure',
+  defaultExample: {
+    image: 'divider-default.png',
+    codeblock: {
+      title: 'Code',
+      tabs: [
+        {
+          code: './examples/default.html',
+          language: 'HTML',
+        },
+      ],
+    },
+  },
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/examples/default.html
@@ -1,0 +1,1 @@
+<s-divider />


### PR DESCRIPTION
### Background

Adding documentation for the Divider component in the Point of Sale UI extensions.

### Solution

This PR adds documentation for the Divider component, which creates visual separation between content sections. The documentation includes:

- Component description highlighting how dividers help organize information and improve content hierarchy
- Basic properties definition
- Default example with HTML code sample
- Appropriate categorization under "Structure" in the Polaris web components

### 🎩

- Verified the documentation structure matches other component docs
- Confirmed the example code is correct and minimal

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation

### Screenshot

![divider.png](https://app.graphite.dev/user-attachments/assets/f54c5185-0884-4d23-8b4d-d8e12131cf60.png)

