### PR TITLE
Fix typos and missing component in StandardComponents list

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/StandardComponents.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/StandardComponents.ts
@@ -10,6 +10,7 @@ export type StandardComponents =
   | 'DateField'
   | 'DatePicker'
   | 'DateSpinner'
+  | 'Divider'
   | 'EmailField'
   | 'Heading'
   | 'Icon'
@@ -20,6 +21,7 @@ export type StandardComponents =
   | 'POSBlock'
   | 'PosBlock' // Case is important in 2025-10
   | 'QRCode'
+  | 'QrCode' // Case is important in 2025-10
   | 'Route'
   | 'Router'
   | 'ScrollBox'


### PR DESCRIPTION
### Background

This PR adds missing components to the Point of Sale UI extensions: `Divider` and `QrCode` (case-sensitive alternative to the existing `QRCode`).

### Solution

Added `Divider` and `QrCode` to the `StandardComponents` type in the Point of Sale components. The `QrCode` variant is marked as case-sensitive and important for the 2025-10 release, similar to the existing pattern with `POSBlock` and `PosBlock`.

### 🎩

- Verify that both new components are properly recognized in the type system
- Test that extensions using these components render correctly

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation