### PR TITLE
Promote 2025-10 to latest

### DIFF
--- a/.changeset/new-foxes-run.md
+++ b/.changeset/new-foxes-run.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+promote 2025-10 to latest


### PR DESCRIPTION
We accidentally merged the new version PR before updating the variable for latest to point to 2025-10. This should just trigger npm to publish again but with 2025-10 to have the 'latest' tag
