### PR TITLE
Revert pos navigation event listeners

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -21,16 +21,6 @@ export interface NavigationHistoryEntry {
   getState(): unknown;
 }
 
-/**
- * The NavigationCurrentEntryChangeEvent interface of the Navigation API is the event object for the currententrychange event, which fires when the Navigation.currentEntry has changed.
- */
-export interface NavigationCurrentEntryChangeEvent {
-  /**
-   * Returns the NavigationHistoryEntry that was navigated from.
-   */
-  from: NavigationHistoryEntry;
-}
-
 export interface Navigation {
   /**
    * The navigate() method navigates to a specific URL, updating any provided state in the history entries list.
@@ -44,12 +34,4 @@ export interface Navigation {
    * The back() method of the Navigation interface navigates to the previous entry in the history list.
    */
   back(): void;
-  addEventListener(
-    type: 'currententrychange',
-    cb: (event: NavigationCurrentEntryChangeEvent) => void,
-  ): void;
-  removeEventListener(
-    type: 'currententrychange',
-    cb: (event: NavigationCurrentEntryChangeEvent) => void,
-  ): void;
 }


### PR DESCRIPTION
### Background

We [reverted](https://app.graphite.dev/github/pr/Shopify/pos-next-react-native/69357/Revert-navigation-subscription-logic-to-fix-incorrect-updates) navigation event listener changes on the POS which means this event listeners do not work.

Lets revert this until need to find a proper fix and making it publicly available.




### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
