### PR TITLE
Update figmakit link for admin

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
@@ -55,6 +55,12 @@ const data: LandingTemplateSchema = {
           url: '#picking-resources',
           type: 'tool',
         },
+        {
+          subtitle: 'Figma kit',
+          name: 'Use the Figma kit to design your extension',
+          url: 'https://www.figma.com/community/file/1554895871000783188/polaris-ui-kit-community',
+          type: 'tool',
+        },
       ],
     },
     {


### PR DESCRIPTION
This pull request introduces a new resource to the static admin extensions documentation, enhancing the available design tools for extension developers.

Design resources update:

* Added a "Figma kit" entry to the `resources` list in `LandingTemplateSchema`, providing a direct link to the Polaris UI kit for extension design.