### PR TITLE
Update flag and min cli version

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
@@ -69,7 +69,7 @@ const data: LandingTemplateSchema = {
       sectionContent:
         'Use the [Shopify CLI](/docs/api/shopify-cli) to [generate a new extension](https://shopify.dev/apps/tools/cli/commands#generate-extension) within your app.\n\n' +
         'If you already have a Shopify app, you can skip right to the last command shown here.\n\n' +
-        'Make sure you’re using Shopify CLI `v3.80.0` or higher. You can check your version by running `shopify version`.',
+        'Make sure you’re using Shopify CLI `v3.85.3` or higher. You can check your version by running `shopify version`.',
       title: 'Getting Started',
       codeblock: {
         title: 'Generate an extension',

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/getting-started.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/getting-started.sh
@@ -1,10 +1,10 @@
 # create an app if you don't already have one:
-POLARIS_UNIFIED=true shopify app init --name my-app
+shopify app init --name my-app
 
 # navigate to your app's root directory:
 cd my-app
 
 # generate a new extension:
-POLARIS_UNIFIED=true shopify app generate extension
+shopify app generate extension
 # follow the steps to create a new
 # extension in ./extensions.

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/getting-started/generate-extension.bash
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/getting-started/generate-extension.bash
@@ -1,2 +1,2 @@
 shopify upgrade
-POLARIS_UNIFIED=true shopify app generate extension
+shopify app generate extension

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/getting-started.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/getting-started.doc.ts
@@ -32,7 +32,7 @@ In this tutorial, you'll learn how to do the following tasks:
       title: 'Requirements',
       sectionContent: `
 - Create a [development store](/docs/apps/tools/development-stores).
-- Install or migrate to [Shopify CLI version 3.0 or higher](/docs/apps/tools/cli).
+- Install or migrate to [Shopify CLI version 3.85.3 or higher](/docs/apps/tools/cli).
 - Create an [app](/docs/apps/getting-started/create).
 - Embed [your app in Shopify POS](/docs/apps/pos/getting-started#embed-your-in-app-in-shopify-pos).
       `,


### PR DESCRIPTION
This pull request updates the documentation and example scripts for UI extensions to require a newer version of Shopify CLI and removes the `POLARIS_UNIFIED` environment variable from CLI commands. These changes help ensure users follow the latest recommended setup process.

**Shopify CLI version updates:**

* Updated the required Shopify CLI version in documentation to `v3.85.3` in both admin and POS surfaces (`admin-extensions.ext.doc.ts`, `getting-started.doc.ts`). [[1]](diffhunk://#diff-728d010e900b001a7156b63c8f58fa877be9909266451551a4aec0bb2d12e271L72-R72) [[2]](diffhunk://#diff-e32f6bc63d737b6a87f0baeaaffcf517ca816a3631b1eb950d323bd0531fe94aL35-R35)

**Command usage updates:**

* Removed the `POLARIS_UNIFIED` environment variable from CLI commands in example scripts for both admin and POS surfaces (`getting-started.sh`, `generate-extension.bash`). [[1]](diffhunk://#diff-6fe85bcef2fa895721994b3be707480e3bdaef856e3db0f91e916a520829e64aL2-R8) [[2]](diffhunk://#diff-a3e845df92a5ba5b0e88cf08e7cf149e6d8b896d0bdc6fcde21d77d750cf2669L2-R2)