### PR TITLE
Improve docs and example for PinPad API

### DIFF
--- a/.changeset/lucky-badgers-admire.md
+++ b/.changeset/lucky-badgers-admire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Update amdmin ui-extensions

--- a/.changeset/lucky-badgers-admire.md
+++ b/.changeset/lucky-badgers-admire.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Update amdmin ui-extensions

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/pinpad-api/validation.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/pinpad-api/validation.jsx
@@ -1,3 +1,4 @@
+import { PinPadOptions } from '@shopify/ui-extensions/point-of-sale';
 import { render } from 'preact';
 
 export default async () => {
@@ -7,38 +8,32 @@ export default async () => {
 function Extension() {
   const VALID_PIN = '123456';
 
-  const options = {
-    label: 'Enter PIN to disarm',
-    title: 'Auto-destruct sequence activated',
+  const options: PinPadOptions = {
+    label: 'Enter PIN to proceed',
+    title: 'PIN Pad Demo',
     masked: true,
-    minPinLength: /** @type {6} */ (6),
-    maxPinLength: /** @type {8} */ (8),
-    pinPadAction: {
-      label: 'Emergency Override',
-      onClick: () => {
-        return [1, 2, 3, 4, 5, 6];
-      },
-    },
-    onPinEntry: (pin) => {
-      console.log(`PIN Entry: ${pin}`);
-    },
+    minPinLength: 6,
+    maxPinLength: 8,
   };
 
   const onShowTapped = () => {
     shopify.pinPad.showPinPad((pin) => {
       if (pin.join('') === VALID_PIN) {
         console.log('PIN is valid');
-        return {result: 'accept'};
+        return { result: 'accept' };
       } else {
         console.log('PIN is invalid');
-        return {result: 'reject'};
+        return {
+          result: 'reject',
+          errorMessage: 'Invalid PIN, please try again',
+        };
       }
     }, options);
   };
 
   return (
-    <s-scroll-box>
+    <s-page heading="PIN Pad API">
       <s-button onClick={onShowTapped}>Show Pin Pad</s-button>
-    </s-scroll-box>
+    </s-page>
   );
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
@@ -1,11 +1,18 @@
 import {PinPadOptions, PinValidationResult} from '../types/pin-pad';
 
 export interface PinPadApiContent {
-  /** Shows a pin pad to the user in a modal dialog.
+  /** Shows a PIN pad to the user in a modal dialog.
    *
-   * @param onSubmit the function to be called when the PIN is submitted.
-   * The callback should be used to validate the PIN and return `accept` or `reject`.
-   * @param options the options for the pin pad
+   * `onSubmit` is called when the PIN is submitted for validation by the user. The callback
+   * should validate the PIN and accept or reject it.
+   *
+   * If the PIN is accepted, the modal will be dismissed and the `onDismissed` callback
+   * (provided via `options`) will be called. It is recommended that any post-validation
+   * navigation is performed in this callback rather than in `onSubmit`.
+   *
+   * If the PIN is rejected, the optional `errorMessage` will be displayed to the user and the modal
+   * will not be dismissed.
+   *
    */
   showPinPad(
     onSubmit: (
@@ -16,7 +23,7 @@ export interface PinPadApiContent {
 }
 
 /**
- * Access the Pin Pad API for pin pad functionality in a modal.
+ * Access the PIN Pad API for PIN pad functionality in a modal.
  */
 export interface PinPadApi {
   pinPad: PinPadApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
@@ -26,27 +26,34 @@ export interface PinPadActionType {
 
 export interface PinPadOptions {
   /**
-   * The function to be called when a pin is entered
+   * The function to be called whenever the entered PIN is updated
    */
   onPinEntry?: (pin: number[]) => void;
   /**
-   * The function to be called when the pin pad modal is dismissed
+   * The function to be called when the PIN pad modal is dismissed
    */
   onDismissed?: (result: PinPadResult) => void;
   /**
-   * The content for the prompt on the pin pad
+   * The content for the prompt on the PIN pad. This will be overridden by any
+   * `errorMessage` provided when rejecting a PIN from the `onSubmit` callback.
    */
   label?: string;
   /**
    * Whether the entered PIN should be masked
+   *
+   * @default true
    */
   masked?: boolean;
   /**
    * The minimum length of the PIN
+   *
+   * @default 4
    */
   minPinLength?: PinLength;
   /**
    * The maximum length of the PIN
+   *
+   * @default 6
    */
   maxPinLength?: PinLength;
   /**
@@ -58,7 +65,9 @@ export interface PinPadOptions {
    */
   title?: string;
   /**
-   * Whether the pin should be automatically submitted when the user has entered the maximum PIN length
+   * Whether the PIN should be automatically submitted when the user has entered the maximum PIN length
+   *
+   * @default false
    */
   autoSubmit?: boolean;
 }


### PR DESCRIPTION
### Background

This PR improves the PIN Pad API documentation and example implementation for the Point of Sale UI extensions.

### Solution

- Added TypeScript type annotations to the PIN Pad example
- Improved the PIN Pad API documentation with clearer descriptions of callbacks and behavior
- Added default values to PIN Pad options documentation
- Enhanced the example implementation with better error handling by adding an error message when PIN validation fails
- Updated the example UI from a scroll box to a proper page component with heading
- Simplified the example by removing unnecessary pinPadAction

### 🎩

- Run the PIN Pad example in the Point of Sale surface
- Test PIN validation with both valid and invalid PINs to verify error message display

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation