### PR TITLE
[docs]: Removing section regarding rc polaris

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
@@ -266,12 +266,6 @@ These steps make TypeScript aware of the new global \`shopify\` object. Skip the
       ],
     },
     {
-      type: 'Generic',
-      anchorLink: 'polaris-web-components',
-      title: 'Polaris web components',
-      sectionContent: '',
-    },
-    {
       type: 'Markdown',
       anchorLink: 'mapping-legacy-components-to-polaris-web-components',
       title: 'Mapping legacy components to Polaris web components',


### PR DESCRIPTION
### Background

After we removed the banner regarding release candidate components, 

<img width="1690" height="653" alt="Screenshot 2025-10-01 at 10 12 35 AM" src="https://github.com/user-attachments/assets/a141ed84-12d4-422b-bf85-7af58a8f5b4a" />


this section stayed there just floating, removing it now :D

### Solution

- Removing generic section
- Shopify-dev PR: https://github.com/Shopify/shopify-dev/pull/63375

### 🎩

- [LINK](https://pr-63375.shopify-dev.shopify.io/)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
