### PR TITLE
Add POS Dev Console to getting started

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/getting-started.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/getting-started.doc.ts
@@ -115,6 +115,25 @@ You can install your app and preview your extension in Shopify POS from the deve
     },
     {
       type: 'Generic',
+      anchorLink: 'step-4-leverage-developer-tools-to-troubleshoot-and-refine',
+      title: 'Step 4: Leverage developer tools to troubleshoot and refine',
+      sectionContent: `
+The POS Dev Console provides quick access to extension management during your development process. 
+
+To access the POS Dev Console, tap the app icon in the global navigation on the left on tablet experiences, and via the More menu on mobile experiences.
+
+After installing your extension, you may use the console to:
+
+- Check for and identify errors which will appear next to your extension's name
+- Toggle **App persistence** to keep your extension active between POS restarts
+- Preview extension targets without needing to tap through to target locations and
+- **Remove dev extensions** to uninstall all dev extensions
+
+![POS Dev Console and its location in the sidebar](/assets/apps/pos/devconsole-reference.png)
+      `,
+    },
+    {
+      type: 'Generic',
       anchorLink: 'eslint-configuration',
       title: 'Optional ESLint configuration',
       sectionContent: `


### PR DESCRIPTION
### Background
Partially resolves https://github.com/shop/issues-retail/issues/17794 (needs corresponding Shopify-dev PR)

Adds Step 4: Leverage developer tools to troubleshoot and refine to the [Getting started with POS UI extensions](https://shopify.dev/docs/api/pos-ui-extensions/latest/getting-started)

<img width="851" height="831" alt="image" src="https://github.com/user-attachments/assets/3dc7b334-2696-4f12-b10b-ae84994e48a8" />

### Solution
Adds lightweight, action-oriented guide for using the POS Dev Console. Image resizes appropriately when page width changes or in mobile view.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation