### PR TITLE
Pull the latest Polaris web component types

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -5521,7 +5521,7 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName$M]: ColorPickerJSXProps;
+      [tagName$M]: ColorPickerJSXProps & PreactBaseElementProps<ColorPicker>;
     }
   }
 }
@@ -5574,7 +5574,7 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName$L]: DateFieldJSXProps;
+      [tagName$L]: DateFieldJSXProps & PreactBaseElementProps<DateField>;
     }
   }
 }
@@ -5755,7 +5755,7 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName$I]: DropZoneJSXProps;
+      [tagName$I]: DropZoneJSXProps & PreactBaseElementProps<DropZone>;
     }
   }
 }
@@ -6265,7 +6265,7 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName$z]: MenuJSXProps;
+      [tagName$z]: MenuJSXProps & PreactBaseElementPropsWithChildren<Menu>;
     }
   }
 }
@@ -6403,7 +6403,8 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName$y]: Omit<ModalJSXProps, 'primaryAction' | 'secondaryActions'>;
+      [tagName$y]: Omit<ModalJSXProps, 'primaryAction' | 'secondaryActions'> &
+        PreactBaseElementPropsWithChildren<Modal>;
     }
   }
 }
@@ -6871,7 +6872,8 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName$o]: QueryContainerJSXProps;
+      [tagName$o]: QueryContainerJSXProps &
+        PreactBaseElementPropsWithChildren<QueryContainer>;
     }
   }
 }
@@ -8851,28 +8853,28 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$M]: ColorPickerJSXProps;
+      [tagName$M]: ColorPickerJSXProps & ReactBaseElementProps<ColorPicker>;
     }
   }
 }
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$M]: ColorPickerJSXProps;
+      [tagName$M]: ColorPickerJSXProps & ReactBaseElementProps<ColorPicker>;
     }
   }
 }
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$L]: DateFieldJSXProps;
+      [tagName$L]: DateFieldJSXProps & ReactBaseElementProps<DateField>;
     }
   }
 }
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$L]: DateFieldJSXProps;
+      [tagName$L]: DateFieldJSXProps & ReactBaseElementProps<DateField>;
     }
   }
 }
@@ -8907,14 +8909,14 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$I]: DropZoneJSXProps;
+      [tagName$I]: DropZoneJSXProps & ReactBaseElementProps<DropZone>;
     }
   }
 }
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$I]: DropZoneJSXProps;
+      [tagName$I]: DropZoneJSXProps & ReactBaseElementProps<DropZone>;
     }
   }
 }
@@ -9037,28 +9039,30 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$z]: MenuJSXProps;
+      [tagName$z]: MenuJSXProps & ReactBaseElementPropsWithChildren<Menu>;
     }
   }
 }
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$z]: MenuJSXProps;
+      [tagName$z]: MenuJSXProps & ReactBaseElementPropsWithChildren<Menu>;
     }
   }
 }
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$y]: Omit<ModalJSXProps, 'primaryAction' | 'secondaryActions'>;
+      [tagName$y]: Omit<ModalJSXProps, 'primaryAction' | 'secondaryActions'> &
+        ReactBaseElementPropsWithChildren<Modal>;
     }
   }
 }
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$y]: Omit<ModalJSXProps, 'primaryAction' | 'secondaryActions'>;
+      [tagName$y]: Omit<ModalJSXProps, 'primaryAction' | 'secondaryActions'> &
+        ReactBaseElementPropsWithChildren<Modal>;
     }
   }
 }
@@ -9205,14 +9209,16 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$o]: QueryContainerJSXProps;
+      [tagName$o]: QueryContainerJSXProps &
+        ReactBaseElementPropsWithChildren<QueryContainer>;
     }
   }
 }
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$o]: QueryContainerJSXProps;
+      [tagName$o]: QueryContainerJSXProps &
+        ReactBaseElementPropsWithChildren<QueryContainer>;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -5178,6 +5178,15 @@ export interface ChoiceJSXProps
    * any markup or element structure is ignored.
    */
   children?: ComponentChildren;
+  /**
+   * Additional text to provide context or guidance for the input.
+   *
+   * This text is displayed along with the input and its label
+   * to offer more information or instructions to the user.
+   *
+   * @implementation this content should be linked to the input with an `aria-describedby` attribute.
+   */
+  details?: ComponentChildren;
 }
 
 export interface ChoiceListProps
@@ -5861,7 +5870,7 @@ export interface GridProps
    * Adjust spacing between elements.
    *
    * `gap` can either accept:
-   * - a single SpacingKeyword value applied to both axes (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value applied to both axes (e.g. `large-100`)
    * - OR a pair of values (eg `large-100 large-500`) can be used to set the inline and block axes respectively
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
@@ -5873,7 +5882,7 @@ export interface GridProps
    *
    * This overrides the row value of `gap`.
    * `rowGap` either accepts:
-   * - a single SpacingKeyword value (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value (e.g. `large-100`)
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
    * @default '' - meaning no override
@@ -5884,7 +5893,7 @@ export interface GridProps
    *
    * This overrides the column value of `gap`.
    * `columnGap` either accepts:
-   * - a single SpacingKeyword value (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value (e.g. `large-100`)
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
    * @default '' - meaning no override
@@ -5984,16 +5993,13 @@ export interface GridItemJSXProps
   children?: ComponentChildren;
 }
 
-export type RequiredHeadingProps = Required<HeadingProps$1>;
 export interface HeadingProps
-  extends Pick<
-    HeadingProps$1,
-    'accessibilityRole' | 'accessibilityVisibility' | 'lineClamp'
-  > {
-  accessibilityRole: RequiredHeadingProps['accessibilityRole'];
-  accessibilityVisibility: RequiredHeadingProps['accessibilityVisibility'];
-  lineClamp: RequiredHeadingProps['lineClamp'];
-}
+  extends Required<
+    Pick<
+      HeadingProps$1,
+      'accessibilityRole' | 'accessibilityVisibility' | 'lineClamp'
+    >
+  > {}
 
 declare class Heading extends PreactCustomElement implements HeadingProps {
   accessor accessibilityRole: HeadingProps['accessibilityRole'];
@@ -6209,10 +6215,6 @@ export interface MenuProps
  * (like Popover, Tooltip, Modal, etc.) to communicate with the overlay control system.
  */
 /**
- * Symbol used to invoke the method for overlay commands, e.g. `--show`, `--hide`, etc.
- */
-declare const overlayCommand: unique symbol;
-/**
  * Symbol used to track the open or closed state of the overlay.
  */
 declare const overlayHidden: unique symbol;
@@ -6221,6 +6223,21 @@ declare const overlayHidden: unique symbol;
  */
 declare const overlayActivator: unique symbol;
 declare const overlayHideFrameId: unique symbol;
+export type PolyfillCommandEventInit = EventInit & {
+  source: HTMLElement | null | undefined;
+  command: PreactOverlayControlProps['command'];
+};
+export type PolyfillCommandEvent = Event & {
+  source: PolyfillCommandEventInit['source'];
+  command: PolyfillCommandEventInit['command'];
+  /** Have to use `_s_shadowSource` because `source` is retargeted to the shadow host by browsers */
+  _s_shadowSource: PolyfillCommandEventInit['source'];
+};
+declare global {
+  interface GlobalEventHandlersEventMap {
+    command: PolyfillCommandEvent;
+  }
+}
 
 declare class PreactOverlayElement extends PreactCustomElement {
   constructor(renderImpl: RenderImpl);
@@ -6230,11 +6247,6 @@ declare class PreactOverlayElement extends PreactCustomElement {
   [overlayActivator]: HTMLElement | null | undefined;
   /** @private */
   [overlayHideFrameId]?: number;
-  /** @private */
-  [overlayCommand](
-    command: InteractionProps['command'],
-    overlayActivatorEl: HTMLElement | null | undefined,
-  ): void;
 }
 
 declare class Menu extends PreactOverlayElement implements MenuProps {
@@ -6291,24 +6303,56 @@ export interface ModalProps
   >;
 }
 
+export interface Context<T> {
+  readonly defaultValue: T;
+}
 declare class AddedContext<T> extends EventTarget {
   constructor(defaultValue: T);
   get value(): T;
   set value(value: T);
 }
 
+/**
+ * A callback which is provided by a context requester and is called with the value satisfying the request.
+ * This callback can be called multiple times by context providers as the requested value is changed.
+ */
+export type ContextCallback<T> = (value: T) => void;
+/**
+ * An event fired by a context requester to signal it desires a named context.
+ *
+ * A provider should inspect the `context` property of the event to determine if it has a value that can
+ * satisfy the request, calling the `callback` with the requested value if so.
+ */
+declare class ContextRequestEvent<T> extends Event {
+  readonly context: Context<T>;
+  readonly callback: ContextCallback<T>;
+  constructor(context: Context<T>, callback: ContextCallback<T>);
+}
+declare global {
+  interface HTMLElementEventMap {
+    /**
+     * A 'context-request' event can be emitted by any element which desires
+     * a context value to be injected by an external provider.
+     */
+    'context-request': ContextRequestEvent<unknown>;
+  }
+}
+
 declare const hasOpenChildModal: unique symbol;
 
-declare const open: unique symbol;
 declare const show: unique symbol;
 declare const hide: unique symbol;
+declare const isOpen: unique symbol;
 declare const dialog: unique symbol;
+declare const dismiss: unique symbol;
+declare const focusedElement: unique symbol;
 declare const onEscape: unique symbol;
 declare const nestedModals: unique symbol;
 declare const onBackdropClick: unique symbol;
 declare const abortController: unique symbol;
 declare const onChildModalChange: unique symbol;
 declare const childrenRerenderObserver: unique symbol;
+declare const shadowDomRerenderObserver: unique symbol;
 declare class Modal extends PreactOverlayElement implements ModalProps {
   accessor accessibilityLabel: ModalProps['accessibilityLabel'];
   accessor heading: ModalProps['heading'];
@@ -6319,9 +6363,13 @@ declare class Modal extends PreactOverlayElement implements ModalProps {
   /** @private */
   [dialog]: HTMLDialogElement | null;
   /** @private */
+  [focusedElement]: HTMLElement | null;
+  /** @private */
   [nestedModals]: Map<Modal, boolean>;
   /** @private */
   [childrenRerenderObserver]: MutationObserver;
+  /** @private */
+  [shadowDomRerenderObserver]: MutationObserver;
   /** @private */
   [onEscape]: (event: KeyboardEvent) => void;
   /** @private */
@@ -6329,7 +6377,9 @@ declare class Modal extends PreactOverlayElement implements ModalProps {
   /** @private */
   [onChildModalChange]: EventListenerOrEventListenerObject;
   /** @private */
-  get [open](): boolean;
+  get [isOpen](): boolean;
+  /** @private */
+  [dismiss](): void;
   /** @private */
   get [hasOpenChildModal](): boolean;
   /** @private */
@@ -6375,7 +6425,7 @@ export interface ModalJSXProps
   /**
    * The secondary actions to perform.
    *
-   * Only `ButtonGroup` or `Button` with a variant of `secondary` or `auto` are allowed.
+   * Only `Button` elements with a variant of `secondary` or `auto` are allowed.
    */
   secondaryActions?: ComponentChildren;
   onHide?: ((event: CallbackEvent<typeof tagName$y>) => void) | null;
@@ -6650,7 +6700,6 @@ export interface ParagraphProps
     >
   > {
   color: Extract<ParagraphProps$1['color'], 'base' | 'subdued'>;
-  lineClamp: Extract<ParagraphProps$1['lineClamp'], number>;
 }
 
 declare class Paragraph extends PreactCustomElement implements ParagraphProps {
@@ -7075,7 +7124,7 @@ export interface StackProps
    * Adjust spacing between elements.
    *
    * `gap` can either accept:
-   * - a single SpacingKeyword value applied to both axes (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value applied to both axes (e.g. `large-100`)
    * - OR a pair of values (eg `large-100 large-500`) can be used to set the inline and block axes respectively
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
@@ -7087,7 +7136,7 @@ export interface StackProps
    *
    * This overrides the row value of `gap`.
    * `rowGap` either accepts:
-   * - a single SpacingKeyword value (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value (e.g. `large-100`)
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
    * @default '' - meaning no override
@@ -7098,7 +7147,7 @@ export interface StackProps
    *
    * This overrides the column value of `gap`.
    * `columnGap` either accepts:
-   * - a single SpacingKeyword value (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value (e.g. `large-100`)
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
    * @default '' - meaning no override
@@ -8103,6 +8152,15 @@ export interface ChoiceSlots {
    * any markup or element structure is ignored.
    */
   children?: HTMLElement;
+  /**
+   * Additional text to provide context or guidance for the input.
+   *
+   * This text is displayed along with the input and its label
+   * to offer more information or instructions to the user.
+   *
+   * @implementation this content should be linked to the input with an `aria-describedby` attribute.
+   */
+  details?: HTMLElement;
 }
 
 export interface ChoiceListEvents {
@@ -8274,7 +8332,7 @@ export interface ModalSlots {
   /**
    * The secondary actions to perform.
    *
-   * Only `ButtonGroup` or `Button` with a variant of `secondary` or `auto` are allowed.
+   * Only `Button` elements with a variant of `secondary` or `auto` are allowed.
    */
   'secondary-actions'?: HTMLElement;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Chip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Chip.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -125,7 +125,17 @@ declare module 'preact' {
 declare const tagName = 's-choice';
 export interface ChoiceJSXProps
   extends Partial<ChoiceProps>,
-    Pick<ChoiceProps$1, 'id' | 'details'> {}
+    Pick<ChoiceProps$1, 'id' | 'details'> {
+  /**
+   * Additional text to provide context or guidance for the input.
+   *
+   * This text is displayed along with the input and its label
+   * to offer more information or instructions to the user.
+   *
+   * @implementation this content should be linked to the input with an `aria-describedby` attribute.
+   */
+  details?: ComponentChildren;
+}
 
 export {Choice};
 export type {ChoiceJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/ClickableChip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ClickableChip.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
@@ -16,6 +16,15 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
+/** Used when an element does not have children. */
+export interface PreactBaseElementProps<TClass extends HTMLElement> {
+  /** Assigns a unique key to this element. */
+  key?: preact.Key;
+  /** Assigns a ref (generally from `useRef()`) to this element. */
+  ref?: preact.Ref<TClass>;
+  /** Assigns this element to a parent's slot. */
+  slot?: Lowercase<string>;
+}
 
 export interface ColorPickerProps
   extends Required<
@@ -108,7 +117,7 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: ColorPickerJSXProps;
+      [tagName]: ColorPickerJSXProps & PreactBaseElementProps<ColorPicker>;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
@@ -21,6 +21,15 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
+/** Used when an element does not have children. */
+export interface PreactBaseElementProps<TClass extends HTMLElement> {
+  /** Assigns a unique key to this element. */
+  key?: preact.Key;
+  /** Assigns a ref (generally from `useRef()`) to this element. */
+  ref?: preact.Ref<TClass>;
+  /** Assigns this element to a parent's slot. */
+  slot?: Lowercase<string>;
+}
 
 export type Styles = string;
 export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
@@ -221,7 +230,7 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: DateFieldJSXProps;
+      [tagName]: DateFieldJSXProps & PreactBaseElementProps<DateField>;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -329,7 +329,7 @@ export interface GridProps
    * Adjust spacing between elements.
    *
    * `gap` can either accept:
-   * - a single SpacingKeyword value applied to both axes (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value applied to both axes (e.g. `large-100`)
    * - OR a pair of values (eg `large-100 large-500`) can be used to set the inline and block axes respectively
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
@@ -341,7 +341,7 @@ export interface GridProps
    *
    * This overrides the row value of `gap`.
    * `rowGap` either accepts:
-   * - a single SpacingKeyword value (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value (e.g. `large-100`)
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
    * @default '' - meaning no override
@@ -352,7 +352,7 @@ export interface GridProps
    *
    * This overrides the column value of `gap`.
    * `columnGap` either accepts:
-   * - a single SpacingKeyword value (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value (e.g. `large-100`)
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
    * @default '' - meaning no override

--- a/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -8,16 +8,13 @@
 /// <reference lib="DOM" />
 import type {ComponentChildren, HeadingProps$1} from './shared.d.ts';
 
-export type RequiredHeadingProps = Required<HeadingProps$1>;
 export interface HeadingProps
-  extends Pick<
-    HeadingProps$1,
-    'accessibilityRole' | 'accessibilityVisibility' | 'lineClamp'
-  > {
-  accessibilityRole: RequiredHeadingProps['accessibilityRole'];
-  accessibilityVisibility: RequiredHeadingProps['accessibilityVisibility'];
-  lineClamp: RequiredHeadingProps['lineClamp'];
-}
+  extends Required<
+    Pick<
+      HeadingProps$1,
+      'accessibilityRole' | 'accessibilityVisibility' | 'lineClamp'
+    >
+  > {}
 
 export type Styles = string;
 export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
@@ -15,6 +15,21 @@ import type {
 export interface MenuProps
   extends Required<Pick<MenuProps$1, 'id' | 'accessibilityLabel'>> {}
 
+/** Used when an element does not have children. */
+export interface PreactBaseElementProps<TClass extends HTMLElement> {
+  /** Assigns a unique key to this element. */
+  key?: preact.Key;
+  /** Assigns a ref (generally from `useRef()`) to this element. */
+  ref?: preact.Ref<TClass>;
+  /** Assigns this element to a parent's slot. */
+  slot?: Lowercase<string>;
+}
+/** Used when an element has children. */
+export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
+  extends PreactBaseElementProps<TClass> {
+  children?: preact.ComponentChildren;
+}
+
 export type Styles = string;
 export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
   ShadowRoot: (element: any) => ComponentChildren;
@@ -159,7 +174,7 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: MenuJSXProps;
+      [tagName]: MenuJSXProps & PreactBaseElementPropsWithChildren<Menu>;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -75,15 +75,39 @@ declare abstract class PreactCustomElement extends BaseClass {
   click({sourceEvent}?: ClickOptions): void;
 }
 
+export interface PreactOverlayControlProps
+  extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
+  /**
+   * Sets the action the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this clickable is activated.
+   *
+   * See the documentation of particular components for the actions they support.
+   *
+   * - `--auto`: a default action for the target component.
+   * - `--show`: shows the target component.
+   * - `--hide`: hides the target component.
+   * - `--toggle`: toggles the target component.
+   *
+   * @default '--auto'
+   */
+  command: Extract<
+    InteractionProps['command'],
+    '--show' | '--hide' | '--toggle' | '--auto'
+  >;
+  /**
+   * Sets the element the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this clickable is activated.
+   */
+  commandFor: Extract<InteractionProps['commandFor'], string>;
+  /**
+   * Sets the element the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this clickable is activated.
+   */
+  interestFor: Extract<InteractionProps['interestFor'], string>;
+}
+
 /**
  * Shared symbols for overlay control functionality.
  * These symbols are used by components that implement overlay behavior
  * (like Popover, Tooltip, Modal, etc.) to communicate with the overlay control system.
  */
-/**
- * Symbol used to invoke the method for overlay commands, e.g. `--show`, `--hide`, etc.
- */
-declare const overlayCommand: unique symbol;
 /**
  * Symbol used to track the open or closed state of the overlay.
  */
@@ -93,6 +117,21 @@ declare const overlayHidden: unique symbol;
  */
 declare const overlayActivator: unique symbol;
 declare const overlayHideFrameId: unique symbol;
+export type PolyfillCommandEventInit = EventInit & {
+  source: HTMLElement | null | undefined;
+  command: PreactOverlayControlProps['command'];
+};
+export type PolyfillCommandEvent = Event & {
+  source: PolyfillCommandEventInit['source'];
+  command: PolyfillCommandEventInit['command'];
+  /** Have to use `_s_shadowSource` because `source` is retargeted to the shadow host by browsers */
+  _s_shadowSource: PolyfillCommandEventInit['source'];
+};
+declare global {
+  interface GlobalEventHandlersEventMap {
+    command: PolyfillCommandEvent;
+  }
+}
 
 declare class PreactOverlayElement extends PreactCustomElement {
   constructor(renderImpl: RenderImpl);
@@ -102,11 +141,6 @@ declare class PreactOverlayElement extends PreactCustomElement {
   [overlayActivator]: HTMLElement | null | undefined;
   /** @private */
   [overlayHideFrameId]?: number;
-  /** @private */
-  [overlayCommand](
-    command: InteractionProps['command'],
-    overlayActivatorEl: HTMLElement | null | undefined,
-  ): void;
 }
 
 declare class Menu extends PreactOverlayElement implements MenuProps {

--- a/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
@@ -20,6 +20,20 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
+/** Used when an element does not have children. */
+export interface PreactBaseElementProps<TClass extends HTMLElement> {
+  /** Assigns a unique key to this element. */
+  key?: preact.Key;
+  /** Assigns a ref (generally from `useRef()`) to this element. */
+  ref?: preact.Ref<TClass>;
+  /** Assigns this element to a parent's slot. */
+  slot?: Lowercase<string>;
+}
+/** Used when an element has children. */
+export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
+  extends PreactBaseElementProps<TClass> {
+  children?: preact.ComponentChildren;
+}
 
 export type RequiredAlignedModalProps = Required<ModalProps$1>;
 export interface ModalProps
@@ -268,7 +282,8 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: Omit<ModalJSXProps, 'primaryAction' | 'secondaryActions'>;
+      [tagName]: Omit<ModalJSXProps, 'primaryAction' | 'secondaryActions'> &
+        PreactBaseElementPropsWithChildren<Modal>;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -102,15 +102,39 @@ declare abstract class PreactCustomElement extends BaseClass {
   click({sourceEvent}?: ClickOptions): void;
 }
 
+export interface PreactOverlayControlProps
+  extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
+  /**
+   * Sets the action the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this clickable is activated.
+   *
+   * See the documentation of particular components for the actions they support.
+   *
+   * - `--auto`: a default action for the target component.
+   * - `--show`: shows the target component.
+   * - `--hide`: hides the target component.
+   * - `--toggle`: toggles the target component.
+   *
+   * @default '--auto'
+   */
+  command: Extract<
+    InteractionProps['command'],
+    '--show' | '--hide' | '--toggle' | '--auto'
+  >;
+  /**
+   * Sets the element the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this clickable is activated.
+   */
+  commandFor: Extract<InteractionProps['commandFor'], string>;
+  /**
+   * Sets the element the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this clickable is activated.
+   */
+  interestFor: Extract<InteractionProps['interestFor'], string>;
+}
+
 /**
  * Shared symbols for overlay control functionality.
  * These symbols are used by components that implement overlay behavior
  * (like Popover, Tooltip, Modal, etc.) to communicate with the overlay control system.
  */
-/**
- * Symbol used to invoke the method for overlay commands, e.g. `--show`, `--hide`, etc.
- */
-declare const overlayCommand: unique symbol;
 /**
  * Symbol used to track the open or closed state of the overlay.
  */
@@ -120,6 +144,21 @@ declare const overlayHidden: unique symbol;
  */
 declare const overlayActivator: unique symbol;
 declare const overlayHideFrameId: unique symbol;
+export type PolyfillCommandEventInit = EventInit & {
+  source: HTMLElement | null | undefined;
+  command: PreactOverlayControlProps['command'];
+};
+export type PolyfillCommandEvent = Event & {
+  source: PolyfillCommandEventInit['source'];
+  command: PolyfillCommandEventInit['command'];
+  /** Have to use `_s_shadowSource` because `source` is retargeted to the shadow host by browsers */
+  _s_shadowSource: PolyfillCommandEventInit['source'];
+};
+declare global {
+  interface GlobalEventHandlersEventMap {
+    command: PolyfillCommandEvent;
+  }
+}
 
 declare class PreactOverlayElement extends PreactCustomElement {
   constructor(renderImpl: RenderImpl);
@@ -129,25 +168,52 @@ declare class PreactOverlayElement extends PreactCustomElement {
   [overlayActivator]: HTMLElement | null | undefined;
   /** @private */
   [overlayHideFrameId]?: number;
-  /** @private */
-  [overlayCommand](
-    command: InteractionProps['command'],
-    overlayActivatorEl: HTMLElement | null | undefined,
-  ): void;
+}
+
+export interface Context<T> {
+  readonly defaultValue: T;
+}
+/**
+ * A callback which is provided by a context requester and is called with the value satisfying the request.
+ * This callback can be called multiple times by context providers as the requested value is changed.
+ */
+export type ContextCallback<T> = (value: T) => void;
+/**
+ * An event fired by a context requester to signal it desires a named context.
+ *
+ * A provider should inspect the `context` property of the event to determine if it has a value that can
+ * satisfy the request, calling the `callback` with the requested value if so.
+ */
+declare class ContextRequestEvent<T> extends Event {
+  readonly context: Context<T>;
+  readonly callback: ContextCallback<T>;
+  constructor(context: Context<T>, callback: ContextCallback<T>);
+}
+declare global {
+  interface HTMLElementEventMap {
+    /**
+     * A 'context-request' event can be emitted by any element which desires
+     * a context value to be injected by an external provider.
+     */
+    'context-request': ContextRequestEvent<unknown>;
+  }
 }
 
 declare const hasOpenChildModal: unique symbol;
 
-declare const open: unique symbol;
 declare const show: unique symbol;
 declare const hide: unique symbol;
+declare const isOpen: unique symbol;
 declare const dialog: unique symbol;
+declare const dismiss: unique symbol;
+declare const focusedElement: unique symbol;
 declare const onEscape: unique symbol;
 declare const nestedModals: unique symbol;
 declare const onBackdropClick: unique symbol;
 declare const abortController: unique symbol;
 declare const onChildModalChange: unique symbol;
 declare const childrenRerenderObserver: unique symbol;
+declare const shadowDomRerenderObserver: unique symbol;
 declare class Modal extends PreactOverlayElement implements ModalProps {
   accessor accessibilityLabel: ModalProps['accessibilityLabel'];
   accessor heading: ModalProps['heading'];
@@ -162,9 +228,13 @@ declare class Modal extends PreactOverlayElement implements ModalProps {
   /** @private */
   [dialog]: HTMLDialogElement | null;
   /** @private */
+  [focusedElement]: HTMLElement | null;
+  /** @private */
   [nestedModals]: Map<Modal, boolean>;
   /** @private */
   [childrenRerenderObserver]: MutationObserver;
+  /** @private */
+  [shadowDomRerenderObserver]: MutationObserver;
   /** @private */
   [onEscape]: (event: KeyboardEvent) => void;
   /** @private */
@@ -172,7 +242,9 @@ declare class Modal extends PreactOverlayElement implements ModalProps {
   /** @private */
   [onChildModalChange]: EventListenerOrEventListenerObject;
   /** @private */
-  get [open](): boolean;
+  get [isOpen](): boolean;
+  /** @private */
+  [dismiss](): void;
   /** @private */
   get [hasOpenChildModal](): boolean;
   /** @private */
@@ -214,7 +286,7 @@ export interface ModalJSXProps
   /**
    * The secondary actions to perform.
    *
-   * Only `ButtonGroup` or `Button` with a variant of `secondary` or `auto` are allowed.
+   * Only `Button` elements with a variant of `secondary` or `auto` are allowed.
    */
   secondaryActions?: ComponentChildren;
   onHide?: ((event: CallbackEvent<typeof tagName>) => void) | null;

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -21,7 +21,6 @@ export interface ParagraphProps
     >
   > {
   color: Extract<ParagraphProps$1['color'], 'base' | 'subdued'>;
-  lineClamp: Extract<ParagraphProps$1['lineClamp'], number>;
 }
 
 export type Styles = string;

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
@@ -8,6 +8,21 @@
 /// <reference lib="DOM" />
 import type {ComponentChildren, QueryContainerProps$1} from './shared.d.ts';
 
+/** Used when an element does not have children. */
+export interface PreactBaseElementProps<TClass extends HTMLElement> {
+  /** Assigns a unique key to this element. */
+  key?: preact.Key;
+  /** Assigns a ref (generally from `useRef()`) to this element. */
+  ref?: preact.Ref<TClass>;
+  /** Assigns this element to a parent's slot. */
+  slot?: Lowercase<string>;
+}
+/** Used when an element has children. */
+export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
+  extends PreactBaseElementProps<TClass> {
+  children?: preact.ComponentChildren;
+}
+
 export type Styles = string;
 export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
   ShadowRoot: (element: any) => ComponentChildren;
@@ -88,7 +103,8 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: QueryContainerJSXProps;
+      [tagName]: QueryContainerJSXProps &
+        PreactBaseElementPropsWithChildren<QueryContainer>;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -299,7 +299,7 @@ export interface StackProps
    * Adjust spacing between elements.
    *
    * `gap` can either accept:
-   * - a single SpacingKeyword value applied to both axes (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value applied to both axes (e.g. `large-100`)
    * - OR a pair of values (eg `large-100 large-500`) can be used to set the inline and block axes respectively
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
@@ -311,7 +311,7 @@ export interface StackProps
    *
    * This overrides the row value of `gap`.
    * `rowGap` either accepts:
-   * - a single SpacingKeyword value (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value (e.g. `large-100`)
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
    * @default '' - meaning no override
@@ -322,7 +322,7 @@ export interface StackProps
    *
    * This overrides the column value of `gap`.
    * `columnGap` either accepts:
-   * - a single SpacingKeyword value (e.g. `large-100`)
+   * - a single [SpacingKeyword](https://shopify.dev/docs/api/app-home/using-polaris-components#scale) value (e.g. `large-100`)
    * - OR a [responsive value](https://shopify.dev/docs/api/app-home/using-polaris-components#responsive-values) string with the supported SpacingKeyword as a query value.
    *
    * @default '' - meaning no override

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -95,10 +95,39 @@ declare abstract class PreactCustomElement extends BaseClass {
   click({sourceEvent}?: ClickOptions): void;
 }
 
+export interface Context<T> {
+  readonly defaultValue: T;
+}
 declare class AddedContext<T> extends EventTarget {
   constructor(defaultValue: T);
   get value(): T;
   set value(value: T);
+}
+
+/**
+ * A callback which is provided by a context requester and is called with the value satisfying the request.
+ * This callback can be called multiple times by context providers as the requested value is changed.
+ */
+export type ContextCallback<T> = (value: T) => void;
+/**
+ * An event fired by a context requester to signal it desires a named context.
+ *
+ * A provider should inspect the `context` property of the event to determine if it has a value that can
+ * satisfy the request, calling the `callback` with the requested value if so.
+ */
+declare class ContextRequestEvent<T> extends Event {
+  readonly context: Context<T>;
+  readonly callback: ContextCallback<T>;
+  constructor(context: Context<T>, callback: ContextCallback<T>);
+}
+declare global {
+  interface HTMLElementEventMap {
+    /**
+     * A 'context-request' event can be emitted by any element which desires
+     * a context value to be injected by an external provider.
+     */
+    'context-request': ContextRequestEvent<unknown>;
+  }
 }
 
 declare const actualTableVariantSymbol: unique symbol;

--- a/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -89,15 +89,39 @@ declare abstract class PreactCustomElement extends BaseClass {
   click({sourceEvent}?: ClickOptions): void;
 }
 
+export interface PreactOverlayControlProps
+  extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
+  /**
+   * Sets the action the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this clickable is activated.
+   *
+   * See the documentation of particular components for the actions they support.
+   *
+   * - `--auto`: a default action for the target component.
+   * - `--show`: shows the target component.
+   * - `--hide`: hides the target component.
+   * - `--toggle`: toggles the target component.
+   *
+   * @default '--auto'
+   */
+  command: Extract<
+    InteractionProps['command'],
+    '--show' | '--hide' | '--toggle' | '--auto'
+  >;
+  /**
+   * Sets the element the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this clickable is activated.
+   */
+  commandFor: Extract<InteractionProps['commandFor'], string>;
+  /**
+   * Sets the element the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this clickable is activated.
+   */
+  interestFor: Extract<InteractionProps['interestFor'], string>;
+}
+
 /**
  * Shared symbols for overlay control functionality.
  * These symbols are used by components that implement overlay behavior
  * (like Popover, Tooltip, Modal, etc.) to communicate with the overlay control system.
  */
-/**
- * Symbol used to invoke the method for overlay commands, e.g. `--show`, `--hide`, etc.
- */
-declare const overlayCommand: unique symbol;
 /**
  * Symbol used to track the open or closed state of the overlay.
  */
@@ -107,6 +131,21 @@ declare const overlayHidden: unique symbol;
  */
 declare const overlayActivator: unique symbol;
 declare const overlayHideFrameId: unique symbol;
+export type PolyfillCommandEventInit = EventInit & {
+  source: HTMLElement | null | undefined;
+  command: PreactOverlayControlProps['command'];
+};
+export type PolyfillCommandEvent = Event & {
+  source: PolyfillCommandEventInit['source'];
+  command: PolyfillCommandEventInit['command'];
+  /** Have to use `_s_shadowSource` because `source` is retargeted to the shadow host by browsers */
+  _s_shadowSource: PolyfillCommandEventInit['source'];
+};
+declare global {
+  interface GlobalEventHandlersEventMap {
+    command: PolyfillCommandEvent;
+  }
+}
 
 declare class PreactOverlayElement extends PreactCustomElement {
   constructor(renderImpl: RenderImpl);
@@ -116,11 +155,6 @@ declare class PreactOverlayElement extends PreactCustomElement {
   [overlayActivator]: HTMLElement | null | undefined;
   /** @private */
   [overlayHideFrameId]?: number;
-  /** @private */
-  [overlayCommand](
-    command: InteractionProps['command'],
-    overlayActivatorEl: HTMLElement | null | undefined,
-  ): void;
 }
 
 declare class Tooltip extends PreactOverlayElement implements TooltipProps {

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.20.0 **/
+/** VERSION: 1.21.2 **/
 
 /* eslint-disable @typescript-eslint/ban-types */
 


### PR DESCRIPTION
### Background

We need to pull in the latest Polaris web component types.

### Solution

I pulled `main` in `world` and ran `build:components`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
