### PR TITLE
make ts steps more obvious in migration guide

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
@@ -81,50 +81,55 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
       ],
     },
     {
-      type: 'GenericAccordion',
-      anchorLink: 'make-typescript-adjustments',
-      title: 'Make TypeScript adjustments',
-      sectionContent: `
-These steps make TypeScript aware of the new global \`shopify\` object. Skip these steps if your app was not built using TypeScript.
-`,
-      accordionContent: [
+      type: 'Generic',
+      anchorLink: 'update-typescript-configuration',
+      title: 'Update TypeScript Configuration',
+      sectionNotice: [
         {
-          title: "Update your extension's tsconfig.json",
-          description:
-            "Update your extension config at a path like `extensions/{extension-name}/tsconfig.json`. You do **not** need to change your app's root `tsconfig.json` file.",
-          codeblock: {
-            title: "Update your extension's tsconfig.json",
-            tabs: [
-              {
-                title: 'New tsconfig.json',
-                code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
-                language: 'json',
-              },
-              {
-                title: 'Old tsconfig.json',
-                code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
-                language: 'json',
-              },
-            ],
-          },
-        },
-        {
-          title:
-            'Generate type definition file to support new global shopify object',
-          description:
-            'These commands generate a `shopify.d.ts` file in your extension directory.',
-          codeblock: {
-            title: 'Support new global shopify object',
-            tabs: [
-              {
-                title: 'CLI',
-                code: './examples/upgrading-to-2025-10/support-new-shopify-global.example.bash',
-                language: 'bash',
-              },
-            ],
-          },
+          title: 'Skip if not using TypeScript',
+          type: 'note',
+          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
         },
       ],
+      sectionContent: `Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.`,
+      codeblock: {
+        title: "Update your extension's tsconfig.json",
+        tabs: [
+          {
+            title: 'New tsconfig.json',
+            code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
+            language: 'json',
+          },
+          {
+            title: 'Old tsconfig.json',
+            code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
+            language: 'json',
+          },
+        ],
+      },
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'generate-type-definitions',
+      title: 'Generate type definition file',
+      sectionNotice: [
+        {
+          title: 'Skip if not using TypeScript',
+          type: 'note',
+          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
+        },
+      ],
+      sectionContent: `These commands generate a \`shopify.d.ts\` file in your extension directory.`,
+      codeblock: {
+        title: 'Support new global shopify object',
+        tabs: [
+          {
+            title: 'CLI',
+            code: './examples/upgrading-to-2025-10/support-new-shopify-global.example.bash',
+            language: 'bash',
+          },
+        ],
+      },
     },
     {
       type: 'GenericAccordion',

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10.doc.ts
@@ -79,50 +79,55 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
       ],
     },
     {
-      type: 'GenericAccordion',
-      anchorLink: 'make-typescript-adjustments',
-      title: 'Make TypeScript adjustments',
-      sectionContent: `
-These steps make TypeScript aware of the new global \`shopify\` object. Skip these steps if your app was not built using TypeScript.
-`,
-      accordionContent: [
+      type: 'Generic',
+      anchorLink: 'update-typescript-configuration',
+      title: 'Update TypeScript Configuration',
+      sectionNotice: [
         {
-          title: "Update your extension's tsconfig.json",
-          description:
-            "Update your extension config at a path like `extensions/{extension-name}/tsconfig.json`. You do **not** need to change your app's root `tsconfig.json` file.",
-          codeblock: {
-            title: "Update your extension's tsconfig.json",
-            tabs: [
-              {
-                title: 'New tsconfig.json',
-                code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
-                language: 'json',
-              },
-              {
-                title: 'Old tsconfig.json',
-                code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
-                language: 'json',
-              },
-            ],
-          },
-        },
-        {
-          title:
-            'Generate type definition file to support new global shopify object',
-          description:
-            'These commands generate a `shopify.d.ts` file in your extension directory.',
-          codeblock: {
-            title: 'Support new global shopify object',
-            tabs: [
-              {
-                title: 'CLI',
-                code: './examples/upgrading-to-2025-10/support-new-shopify-global.example.bash',
-                language: 'bash',
-              },
-            ],
-          },
+          title: 'Skip if not using TypeScript',
+          type: 'note',
+          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
         },
       ],
+      sectionContent: `Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.`,
+      codeblock: {
+        title: "Update your extension's tsconfig.json",
+        tabs: [
+          {
+            title: 'New tsconfig.json',
+            code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
+            language: 'json',
+          },
+          {
+            title: 'Old tsconfig.json',
+            code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
+            language: 'json',
+          },
+        ],
+      },
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'generate-type-definitions',
+      title: 'Generate type definition file',
+      sectionNotice: [
+        {
+          title: 'Skip if not using TypeScript',
+          type: 'note',
+          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
+        },
+      ],
+      sectionContent: `These commands generate a \`shopify.d.ts\` file in your extension directory.`,
+      codeblock: {
+        title: 'Support new global shopify object',
+        tabs: [
+          {
+            title: 'CLI',
+            code: './examples/upgrading-to-2025-10/support-new-shopify-global.example.bash',
+            language: 'bash',
+          },
+        ],
+      },
     },
     {
       type: 'GenericAccordion',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/upgrading-to-2025-10.doc.ts
@@ -81,50 +81,55 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
       ],
     },
     {
-      type: 'GenericAccordion',
-      anchorLink: 'make-typescript-adjustments',
-      title: 'Make TypeScript adjustments',
-      sectionContent: `
-These steps make TypeScript aware of the new global \`shopify\` object. Skip these steps if your app was not built using TypeScript.
-`,
-      accordionContent: [
+      type: 'Generic',
+      anchorLink: 'update-typescript-configuration',
+      title: 'Update TypeScript Configuration',
+      sectionNotice: [
         {
-          title: "1. Update your extension's tsconfig.json",
-          description:
-            "Update your extension config at a path like `extensions/{extension-name}/tsconfig.json`. You do **not** need to change your app's root `tsconfig.json` file.",
-          codeblock: {
-            title: "Update your extension's tsconfig.json",
-            tabs: [
-              {
-                title: 'New tsconfig.json',
-                code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
-                language: 'json',
-              },
-              {
-                title: 'Old tsconfig.json',
-                code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
-                language: 'json',
-              },
-            ],
-          },
-        },
-        {
-          title:
-            '2. Generate type definition file to support new global shopify object',
-          description:
-            'These commands generate a `shopify.d.ts` file in your extension directory. This imports UI Extension component types and declares the shopify API object for each extension target.',
-          codeblock: {
-            title: 'Support new global shopify object',
-            tabs: [
-              {
-                title: 'CLI',
-                code: './examples/upgrading-to-2025-10/support-new-shopify-global.example.bash',
-                language: 'bash',
-              },
-            ],
-          },
+          title: 'Skip if not using TypeScript',
+          type: 'note',
+          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
         },
       ],
+      sectionContent: `Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.`,
+      codeblock: {
+        title: "Update your extension's tsconfig.json",
+        tabs: [
+          {
+            title: 'New tsconfig.json',
+            code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
+            language: 'json',
+          },
+          {
+            title: 'Old tsconfig.json',
+            code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
+            language: 'json',
+          },
+        ],
+      },
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'generate-type-definitions',
+      title: 'Generate type definition file',
+      sectionNotice: [
+        {
+          title: 'Skip if not using TypeScript',
+          type: 'note',
+          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
+        },
+      ],
+      sectionContent: `These commands generate a \`shopify.d.ts\` file in your extension directory. This imports UI Extension component types and declares the shopify API object for each extension target.`,
+      codeblock: {
+        title: 'Support new global shopify object',
+        tabs: [
+          {
+            title: 'CLI',
+            code: './examples/upgrading-to-2025-10/support-new-shopify-global.example.bash',
+            language: 'bash',
+          },
+        ],
+      },
     },
     {
       type: 'GenericAccordion',


### PR DESCRIPTION
Updated migration guides for checkout, pos, and customer accounts. Admin doesn't have one as of now.

Need was based on [slack thread](https://shopify.slack.com/archives/C08H644FPSQ/p1759336938977509) to make each step more obvious and not hidden in a collapsible accordion.

Before:

<img width="1259" height="455" alt="image" src="https://github.com/user-attachments/assets/a6e956df-64af-4b51-8754-3b5ba7f5a010" />

After:

<img width="1259" height="789" alt="image" src="https://github.com/user-attachments/assets/a8c3649d-7dd2-46a9-bd23-d82e08086ba7" />

