### PR TITLE
Add link to configuration in getting started guide. Fix links in over…

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/getting-started.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/getting-started.doc.ts
@@ -34,7 +34,7 @@ In this tutorial, you'll learn how to do the following tasks:
 - Create a [development store](/docs/apps/tools/development-stores).
 - Install or migrate to [Shopify CLI version 3.85.3 or higher](/docs/apps/tools/cli).
 - Create an [app](/docs/apps/getting-started/create).
-- Embed [your app in Shopify POS](/docs/apps/pos/getting-started#embed-your-in-app-in-shopify-pos).
+- Configure your app to be [POS embedded](/docs/apps/build/cli-for-apps/app-configuration#pos).
       `,
     },
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pos-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pos-overview.doc.ts
@@ -28,19 +28,19 @@ You can track new releases and update your extensions by referencing the [develo
         {
           subtitle: 'Extension targets',
           name: 'See all available extension targets',
-          url: 'targets',
+          url: '/docs/api/pos-ui-extensions/targets',
           type: 'pickaxe-1',
         },
         {
           subtitle: 'APIs',
           name: 'See all available APIs',
-          url: 'apis',
+          url: '/docs/api/pos-ui-extensions/apis',
           type: 'pickaxe-2',
         },
         {
           subtitle: 'Components',
           name: 'See all available components',
-          url: 'polaris-web-components',
+          url: '/docs/api/pos-ui-extensions/polaris-web-components',
           type: 'blocks',
         },
       ],
@@ -54,7 +54,7 @@ You can track new releases and update your extensions by referencing the [develo
         {
           name: 'Getting started guide',
           subtitle: 'Set up your development environment',
-          url: 'getting-started',
+          url: '/docs/api/pos-ui-extensions/getting-started',
           type: 'blocks',
         },
       ],


### PR DESCRIPTION
…view page.

### Background

Some links were broken and there is no clear reference that configuring the app to be POS embedded is a requirement

### Solution

Fix the links, and add a requirement to make sure the app is POS embedded, with links to the correct configuration page

### 🎩

- See docs PR: https://github.com/Shopify/shopify-dev/pull/63454

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
