### PR TITLE
add eslint docs to overview and migration guides

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.ext.doc.ts
@@ -84,6 +84,24 @@ const data: LandingTemplateSchema = {
     },
     {
       type: 'Generic',
+      anchorLink: 'eslint-configuration',
+      title: 'Optional ESLint configuration',
+      sectionContent: `
+If your app is using ESLint, update your configuration to include the new global \`shopify\` object.
+        `,
+      codeblock: {
+        title: '.eslintrc.cjs',
+        tabs: [
+          {
+            code: './examples/eslint-configuration.example.ts',
+            language: 'js',
+          },
+        ],
+      },
+      initialLanguage: 'js',
+    },
+    {
+      type: 'Generic',
       title: 'Scaffolded with Preact',
       sectionContent: `UI Extensions are scaffolded with [Preact](https://preactjs.com/) by default.
       \nThis means that you can use Preact patterns and principles within your extension. Since Preact is included as a standard dependency, you have access to all of its features including [hooks](https://preactjs.com/guide/v10/hooks/) like \`useState\` and \`useEffect\` for managing component state and side effects.

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/eslint-configuration.example.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/eslint-configuration.example.ts
@@ -1,0 +1,5 @@
+module.exports = {
+  globals: {
+    shopify: 'readonly',
+  },
+};

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/eslint-configuration.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/eslint-configuration.example.ts
@@ -1,0 +1,5 @@
+module.exports = {
+  globals: {
+    shopify: "readonly"
+  },
+};

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/overview.doc.ts
@@ -37,6 +37,24 @@ Make sure you’re using Shopify CLI \`v3.85.3\` or higher. You can check your v
     },
     {
       type: 'Generic',
+      anchorLink: 'eslint-configuration',
+      title: 'Optional ESLint configuration',
+      sectionContent: `
+If your app is using ESLint, update your configuration to include the new global \`shopify\` object.
+        `,
+      codeblock: {
+        title: '.eslintrc.cjs',
+        tabs: [
+          {
+            code: './examples/eslint-configuration.example.ts',
+            language: 'js',
+          },
+        ],
+      },
+      initialLanguage: 'js',
+    },
+    {
+      type: 'Generic',
       anchorLink: 'configuration-file',
       title: 'Configuration file',
       sectionContent: `When you create a UI extension, the \`shopify.extension.toml\` file is generated in your extension directory. Use this file to configure your extension name, extension targets, metafields, capabilities, and settings definition.

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
@@ -81,45 +81,54 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
       ],
     },
     {
-      type: 'Generic',
+      type: 'GenericAccordion',
       anchorLink: 'update-typescript-configuration',
       title: 'Update TypeScript Configuration',
-      sectionNotice: [
+      sectionContent: `
+**Skip this step if not using TypeScript.**
+
+Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.
+      `,
+      accordionContent: [
         {
-          title: 'Skip if not using TypeScript',
-          type: 'note',
-          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
+          title: 'New tsconfig.json',
+          description: '',
+          codeblock: {
+            title: 'New tsconfig.json',
+            tabs: [
+              {
+                title: 'tsconfig.json',
+                code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Old tsconfig.json',
+          description: '',
+          codeblock: {
+            title: 'Old tsconfig.json',
+            tabs: [
+              {
+                title: 'tsconfig.json',
+                code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
+                language: 'json',
+              },
+            ],
+          },
         },
       ],
-      sectionContent: `Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.`,
-      codeblock: {
-        title: "Update your extension's tsconfig.json",
-        tabs: [
-          {
-            title: 'New tsconfig.json',
-            code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
-            language: 'json',
-          },
-          {
-            title: 'Old tsconfig.json',
-            code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
-            language: 'json',
-          },
-        ],
-      },
     },
     {
       type: 'Generic',
-      anchorLink: 'generate-type-definitions',
-      title: 'Generate type definition file',
-      sectionNotice: [
-        {
-          title: 'Skip if not using TypeScript',
-          type: 'note',
-          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
-        },
-      ],
-      sectionContent: `These commands generate a \`shopify.d.ts\` file in your extension directory.`,
+      anchorLink: 'upgrading-shopify-cli',
+      title: 'Upgrade the Shopifiy CLI',
+      sectionContent: `
+The new CLI adds supoort for building 2025-10 extensions.
+
+The \`shopify app dev\` command runs your app and also generates a \`shopify.d.ts\` file in your extension directory, adding support for the new global \`shopify\` object in TypeScript projects.
+      `,
       codeblock: {
         title: 'Support new global shopify object',
         tabs: [
@@ -130,6 +139,24 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
           },
         ],
       },
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'eslint-configuration',
+      title: 'Optional ESLint configuration',
+      sectionContent: `
+If your app is using ESLint, update your configuration to include the new global \`shopify\` object.
+        `,
+      codeblock: {
+        title: '.eslintrc.cjs',
+        tabs: [
+          {
+            code: './examples/eslint-configuration.example.ts',
+            language: 'js',
+          },
+        ],
+      },
+      initialLanguage: 'js',
     },
     {
       type: 'GenericAccordion',

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/eslint-configuration.example.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/eslint-configuration.example.ts
@@ -1,0 +1,5 @@
+module.exports = {
+  globals: {
+    shopify: 'readonly',
+  },
+};

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
@@ -38,6 +38,24 @@ Make sure you’re using Shopify CLI \`v3.85.3\` or higher. You can check your v
     },
     {
       type: 'Generic',
+      anchorLink: 'eslint-configuration',
+      title: 'Optional ESLint configuration',
+      sectionContent: `
+If your app is using ESLint, update your configuration to include the new global \`shopify\` object.
+        `,
+      codeblock: {
+        title: '.eslintrc.cjs',
+        tabs: [
+          {
+            code: './examples/eslint-configuration.example.ts',
+            language: 'js',
+          },
+        ],
+      },
+      initialLanguage: 'js',
+    },
+    {
+      type: 'Generic',
       anchorLink: 'configuration-file',
       title: 'Configuration file',
       sectionContent: `When you create a customer account UI extension, the \`shopify.extension.toml\` file is automatically generated in your extension directory. Use this file to configure your extension name, extension targets, metafields, capabilities, and settings definition.

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10.doc.ts
@@ -79,45 +79,54 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
       ],
     },
     {
-      type: 'Generic',
+      type: 'GenericAccordion',
       anchorLink: 'update-typescript-configuration',
       title: 'Update TypeScript Configuration',
-      sectionNotice: [
+      sectionContent: `
+**Skip this step if not using TypeScript.**
+
+Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.
+      `,
+      accordionContent: [
         {
-          title: 'Skip if not using TypeScript',
-          type: 'note',
-          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
+          title: 'New tsconfig.json',
+          description: '',
+          codeblock: {
+            title: 'New tsconfig.json',
+            tabs: [
+              {
+                title: 'tsconfig.json',
+                code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Old tsconfig.json',
+          description: '',
+          codeblock: {
+            title: 'Old tsconfig.json',
+            tabs: [
+              {
+                title: 'tsconfig.json',
+                code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
+                language: 'json',
+              },
+            ],
+          },
         },
       ],
-      sectionContent: `Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.`,
-      codeblock: {
-        title: "Update your extension's tsconfig.json",
-        tabs: [
-          {
-            title: 'New tsconfig.json',
-            code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
-            language: 'json',
-          },
-          {
-            title: 'Old tsconfig.json',
-            code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
-            language: 'json',
-          },
-        ],
-      },
     },
     {
       type: 'Generic',
-      anchorLink: 'generate-type-definitions',
-      title: 'Generate type definition file',
-      sectionNotice: [
-        {
-          title: 'Skip if not using TypeScript',
-          type: 'note',
-          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
-        },
-      ],
-      sectionContent: `These commands generate a \`shopify.d.ts\` file in your extension directory.`,
+      anchorLink: 'upgrading-shopify-cli',
+      title: 'Upgrade the Shopifiy CLI',
+      sectionContent: `
+The new CLI adds supoort for building 2025-10 extensions.
+
+The \`shopify app dev\` command runs your app and also generates a \`shopify.d.ts\` file in your extension directory, adding support for the new global \`shopify\` object in TypeScript projects.
+      `,
       codeblock: {
         title: 'Support new global shopify object',
         tabs: [
@@ -128,6 +137,24 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
           },
         ],
       },
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'eslint-configuration',
+      title: 'Optional ESLint configuration',
+      sectionContent: `
+If your app is using ESLint, update your configuration to include the new global \`shopify\` object.
+        `,
+      codeblock: {
+        title: '.eslintrc.cjs',
+        tabs: [
+          {
+            code: './examples/eslint-configuration.example.ts',
+            language: 'js',
+          },
+        ],
+      },
+      initialLanguage: 'js',
     },
     {
       type: 'GenericAccordion',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/eslint-configuration.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/eslint-configuration.ts
@@ -1,0 +1,5 @@
+module.exports = {
+  globals: {
+    shopify: 'readonly',
+  },
+};

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/getting-started.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/getting-started.doc.ts
@@ -115,6 +115,19 @@ You can install your app and preview your extension in Shopify POS from the deve
     },
     {
       type: 'Generic',
+      anchorLink: 'eslint-configuration',
+      title: 'Optional ESLint configuration',
+      sectionContent: `
+If your app is using ESLint, update your configuration to include the new global \`shopify\` object.
+        `,
+      codeblock: {
+        title: '.eslintrc.cjs',
+        tabs: [{code: './examples/eslint-configuration.ts', language: 'js'}],
+      },
+      initialLanguage: 'js',
+    },
+    {
+      type: 'Generic',
       anchorLink: 'updating',
       title: 'Updating',
       sectionContent: `

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/upgrading-to-2025-10.doc.ts
@@ -81,45 +81,54 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
       ],
     },
     {
-      type: 'Generic',
+      type: 'GenericAccordion',
       anchorLink: 'update-typescript-configuration',
       title: 'Update TypeScript Configuration',
-      sectionNotice: [
+      sectionContent: `
+**Skip this step if not using TypeScript.**
+
+Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.
+      `,
+      accordionContent: [
         {
-          title: 'Skip if not using TypeScript',
-          type: 'note',
-          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
+          title: 'New tsconfig.json',
+          description: '',
+          codeblock: {
+            title: 'New tsconfig.json',
+            tabs: [
+              {
+                title: 'tsconfig.json',
+                code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
+                language: 'json',
+              },
+            ],
+          },
+        },
+        {
+          title: 'Old tsconfig.json',
+          description: '',
+          codeblock: {
+            title: 'Old tsconfig.json',
+            tabs: [
+              {
+                title: 'tsconfig.json',
+                code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
+                language: 'json',
+              },
+            ],
+          },
         },
       ],
-      sectionContent: `Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.`,
-      codeblock: {
-        title: "Update your extension's tsconfig.json",
-        tabs: [
-          {
-            title: 'New tsconfig.json',
-            code: './examples/upgrading-to-2025-10/new-tsconfig.example.json',
-            language: 'json',
-          },
-          {
-            title: 'Old tsconfig.json',
-            code: './examples/upgrading-to-2025-10/old-tsconfig.example.json',
-            language: 'json',
-          },
-        ],
-      },
     },
     {
       type: 'Generic',
-      anchorLink: 'generate-type-definitions',
-      title: 'Generate type definition file',
-      sectionNotice: [
-        {
-          title: 'Skip if not using TypeScript',
-          type: 'note',
-          sectionContent: `These steps make TypeScript aware of the new global \`shopify\` object. Skip this step if your app was not built using TypeScript.`,
-        },
-      ],
-      sectionContent: `These commands generate a \`shopify.d.ts\` file in your extension directory. This imports UI Extension component types and declares the shopify API object for each extension target.`,
+      anchorLink: 'upgrading-shopify-cli',
+      title: 'Upgrade the Shopifiy CLI',
+      sectionContent: `
+The new CLI adds supoort for building 2025-10 extensions.
+
+The \`shopify app dev\` command runs your app and also generates a \`shopify.d.ts\` file in your extension directory, adding support for the new global \`shopify\` object in TypeScript projects.
+      `,
       codeblock: {
         title: 'Support new global shopify object',
         tabs: [
@@ -130,6 +139,24 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
           },
         ],
       },
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'eslint-configuration',
+      title: 'Optional ESLint configuration',
+      sectionContent: `
+If your app is using ESLint, update your configuration to include the new global \`shopify\` object.
+        `,
+      codeblock: {
+        title: '.eslintrc.cjs',
+        tabs: [
+          {
+            code: './examples/eslint-configuration.ts',
+            language: 'js',
+          },
+        ],
+      },
+      initialLanguage: 'js',
     },
     {
       type: 'GenericAccordion',


### PR DESCRIPTION
Corresponding shopify-dev [PR](https://app.graphite.dev/github/pr/Shopify/shopify-dev/63474/add-eslint-config-section-to-overview-and-migration-pages)

Adds section in docs for eslint configuration needed to support `shopify` global in apps that use eslint. This was particularly important because Shopify apps generated in the last couple months using [shopify-app-template-react-router](https://github.com/Shopify/shopify-app-template-react-router) use eslint, but didn't include this like the old remix template used to use.

These changes are for Checkout, customer accounts, pos, and admin.

Admin
- overview page: https://pr-63474.shopify-dev.shopify.io/docs/api/admin-extensions

POS
- getting started page: https://pr-63474.shopify-dev.shopify.io/docs/api/pos-ui-extensions/latest/getting-started
- upgrading to 2025-10 guide: https://pr-63474.shopify-dev.shopify.io/docs/api/pos-ui-extensions/latest/upgrading-to-2025-10

Customer Accounts
- overview page: https://pr-63474.shopify-dev.shopify.io/docs/api/customer-account-ui-extensions/latest#eslint-configuration
- upgrading to 2025-10 guide: https://pr-63474.shopify-dev.shopify.io/docs/api/customer-account-ui-extensions/latest/upgrading-to-2025-10

Checkout
- overview page: https://pr-63474.shopify-dev.shopify.io/docs/api/checkout-ui-extensions/latest#eslint-configuration
- upgrading to 2025-10 guide: https://pr-63474.shopify-dev.shopify.io/docs/api/checkout-ui-extensions/latest/upgrading-to-2025-10#eslint-configuration

Example Admin Change:

![image.png](https://app.graphite.dev/user-attachments/assets/b8113493-2b6a-41f8-b3fa-821aaf738bfb.png)

[PR](https://github.com/Shopify/shopify-app-template-react-router/pull/81) that fixed the template

