### PR TITLE
Add handling any error to debugging docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/debugging.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/debugging.doc.ts
@@ -29,6 +29,21 @@ If a component is given an incorrect parameter, the extension will be replaced w
     },
     {
       type: 'Generic',
+      anchorLink: 'handling-any-error',
+      title: 'Handling any error',
+      sectionContent: 'Add `try...catch` blocks to see errors.',
+      codeblock: {
+        title: 'Handling any error',
+        tabs: [
+          {
+            code: './examples/error-handling/handling-any-error.example.ts',
+            language: 'ts',
+          },
+        ],
+      },
+    },
+    {
+      type: 'Generic',
       anchorLink: `debugging-on-android`,
       title: `Debugging on Android`,
       sectionContent: `

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/error-handling/handling-any-error.example.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/examples/error-handling/handling-any-error.example.ts
@@ -1,0 +1,5 @@
+try {
+  // your code
+} catch (error) {
+  console.warn(error);
+}


### PR DESCRIPTION
### Background
Partially resolves https://github.com/shop/issues-retail/issues/17793 (needs corresponding shopify-dev PR)

Updates debugging docs to include Handling any error subsection.

### Solution
- Copies over Checkout UI extensions [Handling every error ](https://shopify.dev/docs/api/checkout-ui-extensions/latest/error-handling#handling-any-error) subsection to [POS UI Extensions Debugging](https://shopify.dev/docs/api/pos-ui-extensions/latest/debugging) with updates to show error messages in both react-dom and react-ui 
- The new section is after the Overview and before Debugging on Android.

<img width="800" height="251" alt="image" src="https://github.com/user-attachments/assets/1ce68cc9-1216-4866-b251-4fc5d6a3f502" />

Errors in CLI examples:
```zsh
15:12:44 │           cart-inspection │ WARN: {
15:12:44 │           cart-inspection │   "name": "GuardError",
15:12:44 │           cart-inspection │   "message": "Invalid prop at position 0 for cart.setCustomer"
15:12:44 │           cart-inspection │ }
```

Error in web inspector:
<img width="526" height="47" alt="image" src="https://github.com/user-attachments/assets/c089b115-05e1-4ef6-bace-cc1090ce0add" />

More details in [google doc](https://docs.google.com/document/d/1WROTD8iDR6yKO57npF-J4Szi-kIHxCU4ToreoTnO2oY/edit?usp=sharing)

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
