### PR TITLE
Add ability to pass the editable boolean to shopify.dev

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -190,7 +190,7 @@ const transformJson = async (filePath, isExtensions) => {
           {
             code: tab.code,
             language: 'html',
-            ...('editable' in tab ? {editable: tab.editable} : {}),
+            editable: tab.editable || false,
           },
           {
             code: previewHTML,
@@ -214,7 +214,11 @@ const transformJson = async (filePath, isExtensions) => {
               const newTabs = [];
 
               newTabs.push(
-                {code: tab.code, language: 'html'},
+                {
+                  code: tab.code,
+                  language: 'html',
+                  editable: tab.editable || false,
+                },
                 {code: previewHTML, language: 'preview'},
               );
 

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -187,8 +187,15 @@ const transformJson = async (filePath, isExtensions) => {
             : templates.default(tab.code, tab.customStyles);
 
         newTabs.push(
-          {code: tab.code, language: 'html'},
-          {code: previewHTML, language: 'preview'},
+          {
+            code: tab.code,
+            language: 'html',
+            ...('editable' in tab ? {editable: tab.editable} : {}),
+          },
+          {
+            code: previewHTML,
+            language: 'preview',
+          },
         );
       });
 

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -129,7 +129,7 @@
   ],
   "devDependencies": {
     "@remote-ui/async-subscription": "^2.1.16",
-    "@shopify/generate-docs": "0.19.6",
+    "@shopify/generate-docs": "0.19.7",
     "@quilted/react-testing": "^0.6.11",
     "typescript": "^4.9.0",
     "@faker-js/faker": "^8.4.1",

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
@@ -32,6 +32,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           code: './examples/default.html',
           language: 'preview',
           layout: 'inline',
+          editable: true,
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/admin/docs-types.ts
+++ b/packages/ui-extensions/src/surfaces/admin/docs-types.ts
@@ -13,6 +13,7 @@ type AllowedCSSProperties = Pick<CSSProperties, 'minHeight' | 'minBlockSize'>;
 type AdminCodeTabType = CodeTabType & {
   layout?: string;
   customStyles?: AllowedCSSProperties;
+  editable?: boolean;
 };
 
 interface CodeLinkType {

--- a/packages/ui-extensions/src/surfaces/admin/docs-types.ts
+++ b/packages/ui-extensions/src/surfaces/admin/docs-types.ts
@@ -13,7 +13,6 @@ type AllowedCSSProperties = Pick<CSSProperties, 'minHeight' | 'minBlockSize'>;
 type AdminCodeTabType = CodeTabType & {
   layout?: string;
   customStyles?: AllowedCSSProperties;
-  editable?: boolean;
 };
 
 interface CodeLinkType {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,7 +1918,7 @@
 
 "@shopify/generate-docs@0.19.7":
   version "0.19.7"
-  resolved "https://npm.shopify.io/node/@shopify/generate-docs/-/generate-docs-0.19.7.tgz#b6a16d24db9a920099f7d524d0db8d4fe4a73331"
+  resolved "https://registry.yarnpkg.com/@shopify/generate-docs/-/generate-docs-0.19.7.tgz#b6a16d24db9a920099f7d524d0db8d4fe4a73331"
   integrity sha512-rQ79OtzcObhcvOUy8Yx3wa2qi4/CwA+LZL2ut9LxlK+9ZQYZE+54/rubuejLdY1AslPZ4+qAMHnRGEI5MfYjcA==
   dependencies:
     "@types/react" "^18.0.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,10 +1916,10 @@
     pkg-dir "^5.0.0"
     pluralize "^8.0.0"
 
-"@shopify/generate-docs@0.19.6":
-  version "0.19.6"
-  resolved "https://registry.yarnpkg.com/@shopify/generate-docs/-/generate-docs-0.19.6.tgz#c7083644f6115b6e138d1022342e284143c2dd0a"
-  integrity sha512-pBlE0/ydehfwM+f5d7IXrUbb5yZeC9sivIaU+Thd0ySpoDFhvj93fQNeImmmP5uOndbg8L24y8RNxZ+IAsO5Vg==
+"@shopify/generate-docs@0.19.7":
+  version "0.19.7"
+  resolved "https://npm.shopify.io/node/@shopify/generate-docs/-/generate-docs-0.19.7.tgz#b6a16d24db9a920099f7d524d0db8d4fe4a73331"
+  integrity sha512-rQ79OtzcObhcvOUy8Yx3wa2qi4/CwA+LZL2ut9LxlK+9ZQYZE+54/rubuejLdY1AslPZ4+qAMHnRGEI5MfYjcA==
   dependencies:
     "@types/react" "^18.0.21"
     globby "^11.1.0"


### PR DESCRIPTION
### Background

Related to [this PR](https://github.com/Shopify/shopify-dev/pull/63457) - we want the ability to mark code blocks as editable so they can be edited live on shopify.dev

### Solution

This updates the docs script to pull across the `editable` flag.

### 🎩

- Run the script to make the json doc and ensure that the `editable` flag is added to the html codeblock

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
