### PR TITLE
improve TS section of migration guides

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/new-tsconfig.example.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/examples/upgrading-to-2025-10/new-tsconfig.example.json
@@ -7,5 +7,6 @@
     "allowJs": true,
     "moduleResolution": "node",
     "esModuleInterop": true
-  }
+  },
+  "include": ["./src", "./shopify.d.ts"]
 }

--- a/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/staticPages/upgrading-to-2025-10.doc.ts
@@ -83,11 +83,9 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
     {
       type: 'GenericAccordion',
       anchorLink: 'update-typescript-configuration',
-      title: 'Update TypeScript Configuration',
+      title: 'TypeScript Configuration',
       sectionContent: `
-**Skip this step if not using TypeScript.**
-
-Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.
+Get full IntelliSense and auto-complete support by adding a config file for your extension at \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.
       `,
       accordionContent: [
         {
@@ -127,7 +125,7 @@ Update your extension config at a path like \`extensions/{extension-name}/tsconf
       sectionContent: `
 The new CLI adds supoort for building 2025-10 extensions.
 
-The \`shopify app dev\` command runs your app and also generates a \`shopify.d.ts\` file in your extension directory, adding support for the new global \`shopify\` object in TypeScript projects.
+The \`shopify app dev\` command runs your app and also generates a \`shopify.d.ts\` file in your extension directory, adding support for the new global \`shopify\` object.
       `,
       codeblock: {
         title: 'Support new global shopify object',

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10.doc.ts
@@ -81,11 +81,9 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
     {
       type: 'GenericAccordion',
       anchorLink: 'update-typescript-configuration',
-      title: 'Update TypeScript Configuration',
+      title: 'TypeScript Configuration',
       sectionContent: `
-**Skip this step if not using TypeScript.**
-
-Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.
+Get full IntelliSense and auto-complete support by adding a config file for your extension at \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.
       `,
       accordionContent: [
         {
@@ -125,7 +123,7 @@ Update your extension config at a path like \`extensions/{extension-name}/tsconf
       sectionContent: `
 The new CLI adds supoort for building 2025-10 extensions.
 
-The \`shopify app dev\` command runs your app and also generates a \`shopify.d.ts\` file in your extension directory, adding support for the new global \`shopify\` object in TypeScript projects.
+The \`shopify app dev\` command runs your app and also generates a \`shopify.d.ts\` file in your extension directory, adding support for the new global \`shopify\` object.
       `,
       codeblock: {
         title: 'Support new global shopify object',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/upgrading-to-2025-10.doc.ts
@@ -83,11 +83,9 @@ As of \`2025-10\`, Shopify recommends Preact for UI extensions. Update the depen
     {
       type: 'GenericAccordion',
       anchorLink: 'update-typescript-configuration',
-      title: 'Update TypeScript Configuration',
+      title: 'TypeScript Configuration',
       sectionContent: `
-**Skip this step if not using TypeScript.**
-
-Update your extension config at a path like \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.
+Get full IntelliSense and auto-complete support by adding a config file for your extension at \`extensions/{extension-name}/tsconfig.json\`. You do **not** need to change your app's root \`tsconfig.json\` file.
       `,
       accordionContent: [
         {
@@ -127,7 +125,7 @@ Update your extension config at a path like \`extensions/{extension-name}/tsconf
       sectionContent: `
 The new CLI adds supoort for building 2025-10 extensions.
 
-The \`shopify app dev\` command runs your app and also generates a \`shopify.d.ts\` file in your extension directory, adding support for the new global \`shopify\` object in TypeScript projects.
+The \`shopify app dev\` command runs your app and also generates a \`shopify.d.ts\` file in your extension directory, adding support for the new global \`shopify\` object.
       `,
       codeblock: {
         title: 'Support new global shopify object',


### PR DESCRIPTION
Corresponding shopify-dev [PR](https://app.graphite.dev/github/pr/Shopify/shopify-dev/63526/improve-tsconfig-section-of-ui-extensions-migration-guides)

For 2025-10 migration guides for checkout, customer account, and POS, the tsconfig section was marked as optional for TS projects, but it's still extremely helpful for IDEs to support intellisense.

Also added an include section for Checkout's tsconfig.json as TS wasn't happy without it. [Slack thread](https://shopify.slack.com/archives/C07SL56R6RZ/p1759426660991479)

Before:

<img width="1270" height="450" alt="image" src="https://github.com/user-attachments/assets/b9a3740a-2f14-40ca-8921-7872e7ef73f4" />

After:

<img width="1265" height="436" alt="image" src="https://github.com/user-attachments/assets/b01fe14d-3967-4fc2-b6aa-b669268adb31" />

### 🎩

Checkout migration guide: https://pr-63526.shopify-dev.shopify.io/docs/api/checkout-ui-extensions/latest/upgrading-to-2025-10?accordionItem=typescript-configuration-new-tsconfig.json#update-typescript-configuration

Customer account guide: https://pr-63526.shopify-dev.shopify.io/docs/api/customer-account-ui-extensions/latest/upgrading-to-2025-10?accordionItem=typescript-configuration-new-tsconfig.json#update-typescript-configuration

POS guide: https://pr-63526.shopify-dev.shopify.io/docs/api/pos-ui-extensions/latest/upgrading-to-2025-10?accordionItem=typescript-configuration-new-tsconfig.json#update-typescript-configuration

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
