### PR TITLE
Fix polaris-web-components link

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/pos-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pages/pos-overview.doc.ts
@@ -40,7 +40,7 @@ You can track new releases and update your extensions by referencing the [develo
         {
           subtitle: 'Components',
           name: 'See all available components',
-          url: 'polaris-web-components',
+          url: 'components',
           type: 'blocks',
         },
       ],


### PR DESCRIPTION
### Background

https://github.com/shop/issues-retail/issues/18923

### Solution

Fix link to polaris-web-components -> components

### 🎩

- See companion docs PR: https://github.com/Shopify/shopify-dev/pull/63548

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
