### PR TITLE
Fix JSX syntax in form-default-value example and update the form component's example

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-default-value.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/form-default-value.jsx
@@ -20,7 +20,7 @@ function Extension() {
         onSubmit={(event) => {
           event.waitUntil(fetch('app:save/data'));
           console.log('submit', {textValue, numberValue});
-        }
+        }}
         onReset={() => console.log('automatically reset values')}
       >
         <s-stack direction="block" gap="base">

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
@@ -19,7 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: '',
       tabs: [
         {
-          code: './examples/default.html',
+          code: '../../../../../docs/surfaces/admin/staticPages/examples/form-default-value.jsx',
           language: 'preview',
         },
       ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/examples/default.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/examples/default.jsx
@@ -1,1 +1,0 @@
-  <s-form></s-form>


### PR DESCRIPTION
The current `form` component example was not useful so we are using the code example from `use form` documentation. Also fixed a syntax error in the code example


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
