### PR TITLE
Update Customer account ButtonGroup docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup/ButtonGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup/ButtonGroup.doc.ts
@@ -2,8 +2,10 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ButtonGroup',
-  description:
-    'ButtonGroup is used to display multiple buttons in a layout that is contextual based on the screen width or parent component. When there is more than one secondary action, they get collapsed.',
+  description: `ButtonGroup is used to display multiple buttons in a layout that is contextual based on the screen width or parent component. When there is more than one secondary action, they get collapsed.
+    
+When used within a [Section](/docs/api/customer-account-ui-extensions/polaris-web-components/structure/section) component, the buttons will fill the width of the section.
+`,
   thumbnail: 'buttongroup-thumbnail.png',
   requires: '',
   isVisualComponent: true,


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-checkout/issues/7710
Related to https://github.com/Shopify/shopify-dev/pull/63663

This PR updates the documentation for the ButtonGroup component in the customer account UI extensions.

### Solution

Enhances the ButtonGroup documentation by adding information about its behavior when used within a Section component. Specifically, it notes that buttons will fill the width of the section when placed inside a Section component, providing clearer guidance for developers on component layout behavior.

### 🎩

See https://github.com/Shopify/shopify-dev/pull/63663 for details

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation