### PR TITLE
Backport compliance changes to 2025-07

### DIFF
--- a/.changeset/discount-allocations.md
+++ b/.changeset/discount-allocations.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added optional `discountAllocations` field to Cart Line Item API so that POS extensions can see the precise proportion of a discount applied to a particular line item. Only the `allocatedAmount` field is included for this purpose, matching the Storefront API structure. See https://shopify.dev/docs/api/storefront/latest/objects/DiscountAllocation.

--- a/.changeset/hip-seas-change.md
+++ b/.changeset/hip-seas-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Adds pos.receipt-header.block.render extension target

--- a/.changeset/tough-panthers-impress.md
+++ b/.changeset/tough-panthers-impress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Modified transaction data interface fields to include returnId and refundId to Return and Exchange TransactionData.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
@@ -3,6 +3,7 @@ import {LineItem} from '../../types/cart';
 
 export interface ExchangeTransactionData extends BaseTransactionComplete {
   transactionType: 'Exchange';
+  returnId?: number;
   exchangeId?: number;
   lineItemsAdded: LineItem[];
   lineItemsRemoved: LineItem[];

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
@@ -3,6 +3,7 @@ import {LineItem} from '../../types/cart';
 
 export interface ReturnTransactionData extends BaseTransactionComplete {
   transactionType: 'Return';
+  refundId?: number;
   returnId?: number;
   exchangeId?: number;
   lineItems: LineItem[];

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -185,6 +185,10 @@ export interface ExtensionTargets {
     {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
     ReceiptComponents
   >;
+  'pos.receipt-header.block.render': RenderExtension<
+    {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
+    ReceiptComponents
+  >;
 }
 
 export type ExtensionTarget = keyof ExtensionTargets;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -1,5 +1,6 @@
 import {CountryCode} from './country-code';
 import {TaxLine} from './tax-line';
+import {DiscountAllocation} from './discount-allocation';
 
 export interface Cart {
   /**
@@ -40,6 +41,7 @@ export interface LineItem {
   variantId?: number;
   productId?: number;
   discounts: Discount[];
+  discountAllocations?: DiscountAllocation[];
   taxable: boolean;
   taxLines: TaxLine[];
   sku?: string;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-allocation.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-allocation.ts
@@ -1,0 +1,5 @@
+import type {MoneyV2} from './money';
+
+export interface DiscountAllocation {
+  allocatedAmount: MoneyV2;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/money.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/money.ts
@@ -2,3 +2,8 @@ export interface Money {
   amount: number;
   currency: string;
 }
+
+export interface MoneyV2 {
+  amount: string;
+  currencyCode: string;
+}


### PR DESCRIPTION
### Background

This PR adds support for:

- `DiscountAllocations`​ in the Cart Line Item API for POS extensions, allowing developers to see the precise proportion of a discount applied to a particular line item.
- The `pos.receipt-header.block.render`​ target.
- `ExchangeTransactionData`​ with optional `returnId`​ and `ReturnTransactionData`​ with optional `refundId`​.

These changes are cherry-picked from 2025-10.

### Solution

See the following PRs for more information:

- [DiscountAllocations PR](https://github.com/Shopify/ui-extensions/pull/3283)

- [pos.receipt-header.block.render target PR](https://github.com/Shopify/ui-extensions/pull/3053)

- [Return and Refund IDs PR](https://github.com/Shopify/ui-extensions/pull/3178)

### 🎩

- Test that POS extensions can properly access and display discount allocation information
- Verify that existing functionality continues to work with this new optional field
- Test that POS extensions can register for the `pos.receipt-header.block.render`​ target and render components
- Verify that`ExchangeTransactionData` contains optional `returnId` and `ReturnTransactionData` contains optional `refundId`

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation