### PR TITLE
Add onLoad callback example for Thumbnail component

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/examples/with-event-handling.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/examples/with-event-handling.html
@@ -1,5 +1,9 @@
-<s-thumbnail
-  src="https://cdn.shopify.com/static/sample-product/House-Plant1.png"
-  alt="Product"
-  size="base"
-></s-thumbnail>
+  <s-stack direction="inline" gap="base">
+    <s-thumbnail
+      src="https://cdn.shopify.com/static/sample-product/House-Plant1.png"
+      alt="Product"
+      size="small-200"
+      onLoad="setLoading(false)"
+    />
+    <s-paragraph>Image loaded</s-paragraph>
+ </s-stack>

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/examples/with-event-handling.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/examples/with-event-handling.jsx
@@ -1,5 +1,13 @@
-<s-thumbnail
-  src="https://cdn.shopify.com/static/sample-product/House-Plant1.png"
-  alt="Product"
-  size="base"
- />
+const [loading, setLoading] = useState(true)
+
+return (
+  <s-stack direction="inline" gap="base" alignItems="center">
+    <s-thumbnail
+      src="https://cdn.shopify.com/static/sample-product/House-Plant1.png"
+      alt="Product"
+      size="small-200"
+      onLoad={() => setLoading(false)}
+    />
+    <s-paragraph>{loading ? 'Loading...' : 'Image loaded'}</s-paragraph>
+ </s-stack>
+)


### PR DESCRIPTION
## Summary

- Added example showcasing the `onLoad` callback for the Thumbnail component
- Demonstrates how to track image loading state and provide visual feedback when an image loads

<img width="616" height="565" alt="Screenshot 2025-10-08 at 5 59 23 PM" src="https://github.com/user-attachments/assets/6e4af6b3-632c-4f12-9524-8b9366f2e299" />


## Changes

- Updated the `with-event-handling` example for the Thumbnail component in both HTML and JSX formats
- Added state management to track loading status using the `onLoad` callback
- Improved the example with visual feedback showing "Loading..." text that changes to "Image loaded" when the thumbnail finishes loading
- Updated thumbnail size from `base` to `small-200` for better demonstration

## Test plan

- [ ] Verified the examples render correctly in the documentation
- [ ] Tested that the onLoad callback fires when the image loads
- [ ] Confirmed the loading state updates appropriately in the JSX example