### PR TITLE
Added min height for the example in Text with a tooltip

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
@@ -212,11 +212,17 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/interest-for-association.html',
                   language: 'html',
+                  customStyles: {
+                    minHeight: '200px',
+                  },
                 },
 
                 {
                   code: './examples/interest-for-association.jsx',
                   language: 'preview-jsx',
+                  customStyles: {
+                    minHeight: '200px',
+                  },
                 },
               ],
             },


### PR DESCRIPTION
Fixes Text example being cut when Tooltip was showing

## Before

<img width="620" height="415" alt="Screenshot 2025-10-08 at 6 53 56 PM" src="https://github.com/user-attachments/assets/7ec07f06-c457-41c5-bf9a-9dee9ed5837e" />

## After

<img width="609" height="562" alt="Screenshot 2025-10-08 at 6 52 58 PM" src="https://github.com/user-attachments/assets/8608ec4b-027e-419e-96ea-75177372f867" />

