### PR TITLE
Fixed link on s-table to redirect to index table pattern

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
@@ -101,7 +101,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       name: 'Index table',
       subtitle: 'Composition',
-      url: 'docs/api/app-home/patterns/compositions/index-table',
+      url: '/docs/api/app-home/patterns/compositions/index-table',
       type: 'component',
     },
   ],


### PR DESCRIPTION
### Background

Link redirecting to index table pattern was broken.

### Solution
Fixed URL by appending "/"


### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
