### PR TITLE
Add 2025-07 Backport compliance changes documentation

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-receipt-header-block-render.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-receipt-header-block-render.ts
@@ -1,0 +1,34 @@
+import {
+  extension,
+  POSReceiptBlock,
+  QRCode,
+  Text,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.receipt-header.block.render', (root, api) => {
+  const block = root.createComponent(POSReceiptBlock);
+  const transaction = api.transaction;
+  const textTransactionType = root.createComponent(
+    Text,
+    {},
+    `Transaction type: ${transaction.transactionType}`,
+  );
+  const textTaxTotal = root.createComponent(
+    Text,
+    {},
+    `Total tax (${transaction.taxTotal.currency}): ${transaction.taxTotal.amount}`,
+  );
+  const qrCodeValue =
+    transaction.transactionType === 'Exchange'
+      ? `exampleExchange=${encodeURIComponent(transaction.exchangeId ?? '')}`
+      : `exampleOrder=${encodeURIComponent(transaction.orderId ?? '')}`;
+
+  const qrCode = root.createComponent(QRCode, {
+    value: `https://www.shopify.com?${qrCodeValue}`,
+  });
+
+  block.append(textTransactionType);
+  block.append(textTaxTotal);
+  block.append(qrCode);
+  root.append(block);
+});

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-receipt-header-block-render.tsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/targets/pos-receipt-header-block-render.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import {
+  reactExtension,
+  useApi,
+  POSReceiptBlock,
+  QRCode,
+  Text,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Block = () => {
+  const {transaction} = useApi<'pos.receipt-header.block.render'>();
+  const qrCodeValue =
+    transaction.transactionType === 'Exchange'
+      ? `exampleExchange=${encodeURIComponent(transaction.exchangeId ?? '')}`
+      : `exampleOrder=${encodeURIComponent(transaction.orderId ?? '')}`;
+
+  return (
+    <POSReceiptBlock>
+      <Text>{`Transaction type: ${transaction.transactionType}`}</Text>
+      <Text>{`Total tax (${transaction.taxTotal.currency}): ${transaction.taxTotal.amount}`}</Text>
+      <QRCode value={`https://www.shopify.com?${qrCodeValue}`} />
+    </POSReceiptBlock>
+  );
+};
+
+export default reactExtension('pos.receipt-header.block.render', () => (
+  <Block />
+));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-header.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-header.block.render.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReceiptHeaderBlockRender,
   description: `Renders a custom section within the POS receipt header
   > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come. This target is available in POS 10.8.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come. This target and \`transaction.lineItems.discounts.discountAllocations\` are available in POS 10.8 and later.`,
   defaultExample: {
     codeblock: generateCodeBlock(
       'Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-header.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-header.block.render.doc.ts
@@ -1,0 +1,33 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateCodeBlock} from '../helpers/generateCodeBlock';
+import {CUSTOM_DATA} from '../helpers/helper.docs';
+import {ExtensionTargetType} from '../types/ExtensionTargetType';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: ExtensionTargetType.PosReceiptHeaderBlockRender,
+  description: `Renders a custom section within the POS receipt header
+  > Note:
+  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come. This target is available in POS 10.8.`,
+  defaultExample: {
+    codeblock: generateCodeBlock(
+      'Block',
+      'targets',
+      'pos-receipt-header-block-render',
+    ),
+  },
+  category: 'Targets',
+  subCategory: 'Receipts',
+  isVisualComponent: false,
+  related: [
+    {
+      name: 'POSReceiptBlock',
+      subtitle: 'Component',
+      type: 'apps',
+      url: '/docs/api/pos-ui-extensions/components/posreceiptblock',
+    },
+  ],
+  type: 'Target',
+  definitions: [CUSTOM_DATA('TransactionCompleteWithReprintData')],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/types/ExtensionTargetType.ts
@@ -27,6 +27,7 @@ export enum ExtensionTargetType {
   PosCashTrackingSessionCompleteObserve = 'pos.cash-tracking-session-complete.event.observe',
   PosCartUpdateObserve = 'pos.cart-update.event.observe',
   PosReceiptFooterBlockRender = 'pos.receipt-footer.block.render',
+  PosReceiptHeaderBlockRender = 'pos.receipt-header.block.render',
   PosCartLineItemDetailsActionMenuItemRender = 'pos.cart.line-item-details.action.menu-item.render',
   PosCartLineItemDetailsActionRender = 'pos.cart.line-item-details.action.render',
 }
@@ -60,6 +61,7 @@ export enum TargetLink {
   PosCashTrackingSessionCompleteObserve = '[pos.cash-tracking-session-complete.event.observe](/docs/api/pos-ui-extensions/targets/cash-tracking/pos-cash-tracking-session-complete-event-observe)',
   PosCartUpdateObserve = '[pos.cart-update.event.observe](/docs/api/pos-ui-extensions/targets/cart-details/pos-cart-update-event-observe)',
   PosReceiptFooterBlockRender = '[pos.receipt-footer.block.render](/docs/api/pos-ui-extensions/targets/receipts/pos-receipt-footer-block-render)',
+  PosReceiptHeaderBlockRender = '[pos.receipt-header.block.render](/docs/api/pos-ui-extensions/targets/receipts/pos-receipt-header-block-render)',
   PosCartLineItemDetailsActionMenuItemRender = '[pos.cart.line-item-details.action.menu-item.render](/docs/api/pos-ui-extensions/targets/cart-details/pos-cart-line-item-details-action-menu-item-render)',
   PosCartLineItemDetailsActionRender = '[pos.cart.line-item-details.action.render](/docs/api/pos-ui-extensions/targets/cart-details/pos-cart-line-item-details-action-render)',
 }


### PR DESCRIPTION
### Background

This PR adds documentation for the 2025-07 backport PR [here](https://github.com/Shopify/ui-extensions/pull/3477)

### Solution

Added the necessary files to support the new `pos.receipt-header.block.render` target:
- Created example implementations in both TypeScript and React
- Added documentation for the new target
- Updated the `ExtensionTargetType` enum to include the new target

The examples demonstrate how to display transaction information in the receipt header, showing developers how to access transaction data and render components within this new target.

### 🎩

- Test the new target in POS 10.8+ by creating an extension that uses `pos.receipt-header.block.render`
- Verify that custom content appears in the receipt header as expected
- Test with different transaction types to ensure the conditional QR code logic works correctly

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation