### PR TITLE
Fix broken JSX in ChoiceList default example

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/examples/default.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/examples/default.jsx
@@ -1,4 +1,3 @@
-<>
 const handleChange = (event) => {
   console.log('Values: ', event.currentTarget.values)
 }
@@ -15,4 +14,3 @@ return (
     <s-choice value="required">Required</s-choice>
   </s-choice-list>
 )
-</>


### PR DESCRIPTION
### Background

The ChoiceList component's default example contained broken JSX syntax that would not render correctly.
| Before | After|
|---|---|
|<img width="610" height="784" alt="Screenshot 2025-10-10 at 5 11 14 PM" src="https://github.com/user-attachments/assets/ff370d36-b9c5-4cd9-a0fd-37a3fd22c3ee" /> |<img width="626" height="708" alt="Screenshot 2025-10-10 at 5 10 30 PM" src="https://github.com/user-attachments/assets/b61654f5-235c-41cb-bd20-934821c3ab54" /> |


### Solution

Fixed the JSX syntax in the ChoiceList default example to ensure it renders properly. This corrects the example code that developers reference when implementing the ChoiceList component.

### 🎩

- Fixed broken JSX in ChoiceList default example
- Verified the example now renders correctly

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation