### PR TITLE
Update link to POS UI extensions developer preview for 2025-04 docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSReceiptBlock.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSReceiptBlock.doc.ts
@@ -8,7 +8,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'POSReceiptBlock',
   description: `A component used to group other components together for display on POS receipts.
   > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.
+  > This is part of a [[POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.
   >
   > This component only accepts \`Text\` and \`QRCode\` components as children.`,
   isVisualComponent: true,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSReceiptBlock.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSReceiptBlock.doc.ts
@@ -8,7 +8,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'POSReceiptBlock',
   description: `A component used to group other components together for display on POS receipts.
   > Note:
-  > This is part of a [[POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.
+  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.
   >
   > This component only accepts \`Text\` and \`QRCode\` components as children.`,
   isVisualComponent: true,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/QRCode.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/QRCode.doc.ts
@@ -8,7 +8,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'QRCode',
   description: `A component that renders a QR code in Shopify POS.
   > Note:
-  > This is part of a [[POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
   requires: 'use within a `POSReceiptBlock` component',
   isVisualComponent: true,
   type: 'component',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/QRCode.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/QRCode.doc.ts
@@ -8,7 +8,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'QRCode',
   description: `A component that renders a QR code in Shopify POS.
   > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
+  > This is part of a [[POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
   requires: 'use within a `POSReceiptBlock` component',
   isVisualComponent: true,
   type: 'component',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-update.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-update.event.observe.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCartUpdateObserve,
   description: `An event extension target that observes cart updates
   > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
   category: 'Targets',
   subCategory: 'Cart details',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-complete.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-complete.event.observe.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCashTrackingSessionCompleteObserve,
   description: `An event extension target that observes when cash tracking session completes
   > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
   category: 'Targets',
   subCategory: 'Cash tracking',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-start.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-start.event.observe.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCashTrackingSessionStartObserve,
   description: `An event extension target that observes when cash tracking session starts
   > Note:
-  > This is part of a [[POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
   category: 'Targets',
   subCategory: 'Cash tracking',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-start.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cash-tracking-session-start.event.observe.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCashTrackingSessionStartObserve,
   description: `An event extension target that observes when cash tracking session starts
   > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
+  > This is part of a [[POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
   category: 'Targets',
   subCategory: 'Cash tracking',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-footer.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-footer.block.render.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReceiptFooterBlockRender,
   description: `Renders a custom section within the POS receipt footer
   > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
   defaultExample: {
     codeblock: generateCodeBlock(
       'Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.transaction-complete.event.observe.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.transaction-complete.event.observe.doc.ts
@@ -6,7 +6,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosTransactionCompleteObserve,
   description: `An event extension target that observes completed transactions
   > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/developer-previews#pos-ui-extensions-developer-preview). More information to come.`,
+  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
   category: 'Targets',
   subCategory: 'Post-purchase',
   isVisualComponent: false,


### PR DESCRIPTION
### Background
This resolves [#19282](https://github.com/shop/issues-retail/issues/19282).
The associated PR for `shopify-dev` is [here](https://github.com/Shopify/shopify-dev/pull/63745).

### Solution
The preview links for the [POS UI extensions preview](https://shopify.dev/docs/api/feature-previews#pos-ui-extensions-preview) were pointing to the wrong anchor for the 2025-04 version. This PR updates the route.
### 🎩
To tophat you can either:

1. View the preview link from `shopify-argocd-staging` bot in this [PR](https://github.com/Shopify/shopify-dev/pull/63745).
2. If you want to test the flow yourself and generate the changes, you’ll need to first clone `shopify-dev`. Run `yarn docs:point-of-sale <version>` in the `ui-extensions` repo and then it will update the `shopify-dev` docs. Now you can get a server running on `shopify-dev` to see the changes.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
