### PR TITLE
Fix JSDoc description truncation by pinning TypeScript to 4.9.x in generate-docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "./packages/*"
   ],
   "resolutions": {
-    "**/typescript": "4.9.5"
+    "**/typescript": "^4.9.5"
   },
   "scripts": {
     "build": "loom build",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "workspaces": [
     "./packages/*"
   ],
+  "resolutions": {
+    "**/typescript": "4.9.5"
+  },
   "scripts": {
     "build": "loom build",
     "build-consumer": "loom build && ./scripts/build-consumer.sh",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6552,7 +6552,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.9.5, typescript@^4.3.5, "typescript@^4.8.3 || ^5.0.0", typescript@^4.9.0, typescript@^5.6.0:
+typescript@^4.3.5, "typescript@^4.8.3 || ^5.0.0", typescript@^4.9.0, typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6552,15 +6552,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.3.5, typescript@^4.9.0:
+typescript@4.9.5, typescript@^4.3.5, "typescript@^4.8.3 || ^5.0.0", typescript@^4.9.0, typescript@^5.6.0:
   version "4.9.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-"typescript@^4.8.3 || ^5.0.0":
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Problem

JSDoc descriptions containing `@property` (and other JSDoc tags like `@param`, `@returns`) in the middle of sentences are being truncated when generating documentation.

**Example:**
**Before:** 
`Queue a run of the render function. You shouldn't need to call this manually - it should be handled by changes to @property values.`

**After (broken):** 
`Queue a run of the render function. You shouldn't need to call this manually - it should be handled by changes to`

## Root Cause

TypeScript 5.1+ introduced a breaking change in JSDoc parsing where it now treats `@tagname` as a JSDoc tag **even when it appears in the middle of descriptive text** (not just at line starts).

When `@shopify/generate-docs@0.19.8` was published on October 8, 2025, we changed the resolutions to use typescript 5+ as well in this repo. See [this commit](https://github.com/Shopify/ui-extensions/pull/3485/commits/42e445d62ccff1ae83cb3373f91a905574b1b075) from @gwyneplaine.

## Solution

Use Yarn resolutions to force `@shopify/generate-docs` and `@shopify/type-harvester` to use TypeScript 4.9.x instead of 5.9.3:

```json
"resolutions": {
  "**/typescript": "^4.9.5",
}
```

This ensures the bundled TypeScript version uses the working parser behavior from 4.9.x.

## Testing

- Verified TypeScript 4.9.5 preserves full JSDoc text including `@property` mentions
- Verified TypeScript 5.0.4 also works (but 5.1.0+ is broken)
- This fix allows any 4.9.x version while blocking problematic 5.x versions

## Alternative Considered

Escaping `@property` as ``@property`` in the actual source code is the best long term fix, so whenever we update the parsing script to be fully in Typescript 5+ we don't get the issue. We'll solve that in another PR, but we will at least unblock the docs generation.

### 🎩

- Verified documentation generation no longer truncates JSDoc descriptions at `@property` mentions

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation