### PR TITLE
Make sure to use the public npm registry instead of the private shopify one

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+@shopify:registry=https://registry.npmjs.org/

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -129,7 +129,7 @@
   ],
   "devDependencies": {
     "@remote-ui/async-subscription": "^2.1.16",
-    "@shopify/generate-docs": "https://registry.npmjs.org/@shopify/generate-docs/-/generate-docs-0.19.8.tgz",
+    "@shopify/generate-docs": "0.19.8",
     "@quilted/react-testing": "^0.6.11",
     "typescript": "^4.9.0",
     "@faker-js/faker": "^8.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,9 +1916,10 @@
     pkg-dir "^5.0.0"
     pluralize "^8.0.0"
 
-"@shopify/generate-docs@https://registry.npmjs.org/@shopify/generate-docs/-/generate-docs-0.19.8.tgz":
+"@shopify/generate-docs@0.19.8":
   version "0.19.8"
-  resolved "https://registry.npmjs.org/@shopify/generate-docs/-/generate-docs-0.19.8.tgz#1d0475e08e488abee64171a85a438ab1a2142e40"
+  resolved "https://registry.yarnpkg.com/@shopify/generate-docs/-/generate-docs-0.19.8.tgz#1d0475e08e488abee64171a85a438ab1a2142e40"
+  integrity sha512-5sNWz/LWM3ltWlfJphmZHw6Kd4LQuTiEEasmVZXsh6Fm+vExbO36jkvlCOY6zPobW2etvFL22a5Co2D9kNcXJQ==
   dependencies:
     "@types/react" "^18.0.21"
     globby "^11.1.0"


### PR DESCRIPTION
### Background

When trying to install a new module / update an existing one, sometimes this repo was resolving to the private shopify npm registry, which this repo does not have access to. This happens for people who have a user npmrc `~/.npmrc`

### Solution

This explicitly sets the npm registry, overriding any user-defined ones.

### 🎩

- Make sure you have the private registry set
- Delete the entry in yarn.lock for this module
- Run yarn
- Ensure that it resolves to the public registry now, whereas in main, it will not.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation

### Note

Even though I am telling it to use npmjs.org, it is resolving to yarnpkg.com. I asked claude about this, because that was unexpected. It is no longer resolving to the private repo (like it was before), but this was still unexpected. It made it sound like that's expected in yarn v1.

<img width="934" height="432" alt="image" src="https://github.com/user-attachments/assets/c60d927f-acd4-466d-86ce-61efd6196d52" />

