### PR TITLE
[NumberField] Improve example

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/examples/default.html
@@ -1,7 +1,7 @@
 <s-number-field
   label="Quantity"
   details="Number of items in stock"
-  placeholder="10"
+  placeholder="0"
   step="5"
   min="0"
   max="100"

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/examples/default.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/examples/default.jsx
@@ -1,8 +1,8 @@
 <s-number-field
   label="Quantity"
   details="Number of items in stock"
-  placeholder={10}
+  placeholder={0}
   step={5}
   min={0}
   max={100}
- />
+/>


### PR DESCRIPTION
Closes https://github.com/shop/issues-polaris/issues/1432

### Background

Currently, the placeholder is set to `10`, but it's confusing when using the input controls since hitting the up arrow sets the value to 5.

### Solution

Simply setting the placeholder to `0`, which is the min value allowed.


https://github.com/user-attachments/assets/0ce58469-131c-4c97-8809-3ccb99f883ca



### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
