### PR TITLE
Add POS Dev Console to getting started

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/getting-started.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/getting-started.doc.ts
@@ -127,7 +127,7 @@ After installing your extension, you may use the console to:
 - Check for and identify errors which will appear next to your extension's name
 - Toggle **App persistence** to keep your extension active between POS restarts
 - Preview extension targets without needing to tap through to target locations and
-- **Remove dev extensions** to uninstall all dev extensions
+- **Remove dev extensions** to clear local instances from POS
 
 ![POS Dev Console and its location in the sidebar](/assets/apps/pos/devconsole-reference.png)
       `,


### PR DESCRIPTION
### Background

Fix language about remove dev extensions for POS dev console in getting started guide

https://github.com/Shopify/shopify-dev/pull/63915#discussion_r2433494725

<img width="677" height="173" alt="Screenshot 2025-10-15 at 11 22 31 AM" src="https://github.com/user-attachments/assets/85abbf48-f125-49ef-941a-77528100898f" />

### Solution


### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
