### PR TITLE
Ignore legacy checkout targets for now

### DIFF
--- a/packages/ui-extensions/buildTargetDts.ts
+++ b/packages/ui-extensions/buildTargetDts.ts
@@ -227,6 +227,17 @@ export function buildTargetsDefinitions(
 
   const targets = extractTargetComponents(sourceFile);
   targets.forEach((target) => {
+    // Filter out legacy checkout targets that begin with 'Checkout::'.
+    //
+    // eslint-disable-next-line no-warning-comments
+    // TODO: remove these targets from the ui-extensions package instead
+    // which requires a checkout-web abstraction for backwards compatibility.
+    if (surface === 'checkout' && target.name.startsWith("'Checkout::")) {
+      // eslint-disable-next-line no-console
+      console.log(`Skipping legacy target: ${target.name}`);
+      return;
+    }
+
     createTargetDefinition({
       srcPaths: componentSrcPaths,
       buildPath,


### PR DESCRIPTION
### Background

Legacy Checkout targets such as `Checkout::Dynamic::Render` were never supported in `2025-10` so we should remove them from the types.

The correct way to fix this is to remove legacy targets from `ui-extensions` and add an abstraction layer to `checkout-web` so it can still support the older targets. That abstraction layer gets a little heavy (see [proof](https://github.com/shop/world/pull/164718)) so I'm not sure if we'll be able to land it soon.

### Solution

This simply ignores `Checkout::` targets when building target files. This does not fix the `ExtensionTargets` type which will still have the legacy targets in it.

### 🎩

First, I ran `yarn build` and made sure no legacy target files were in `packages/ui-extensions/build/ts/surfaces/checkout/targets`.

Next, I installed an extension with the snapshot and made sure it still worked with a supported target ✅ I then tried to use a legacy target in my toml. It presented an error as expected:

<img width="934" height="124" alt="Screenshot 2025-10-17 at 1 03 42 PM" src="https://github.com/user-attachments/assets/464ba2e1-3acb-4709-9c07-11ace04c1e36" />

This error is actually no different than before 🤔 

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
