### PR TITLE
Add component method docs for Customer accounts

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/methods-js.example.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/methods-js.example.jsx
@@ -1,0 +1,22 @@
+function Methods() {
+  const button =
+    document.createElement('s-button');
+  const modal = document.createElement('s-modal');
+
+  button.textContent = 'Open Modal';
+  button.commandFor = 'modal-1';
+
+  modal.id = 'modal-1';
+  modal.heading = 'Test Modal';
+
+  const closeButton =
+    document.createElement('s-button');
+
+  closeButton.textContent = 'Close modal';
+  closeButton.onclick = () => modal.hideOverlay();
+
+  modal.appendChild(closeButton);
+
+  document.body.appendChild(button);
+  document.body.appendChild(modal);
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/methods.example.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/examples/methods.example.jsx
@@ -1,0 +1,28 @@
+function Methods() {
+  const modalRef = useRef(null);
+
+  return (
+    <>
+      <s-button
+        command="--show"
+        commandFor="modal-1"
+      >
+        Open modal
+      </s-button>
+      <s-modal
+        id="modal-1"
+        ref={modalRef}
+        heading="Test Modal"
+      >
+        <s-text>Modal content</s-text>
+        <s-button
+          onClick={() => {
+            modalRef.current.hideOverlay();
+          }}
+        >
+          Close modal
+        </s-button>
+      </s-modal>
+    </>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/using-polaris-web-components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/using-polaris-web-components.doc.ts
@@ -278,6 +278,29 @@ By default, the responsive value will query against the closest parent; to look 
     },
     {
       type: 'Generic',
+      anchorLink: 'methods',
+      title: 'Methods',
+      sectionContent: `Methods are functions available on components for programmatic control. Components like \`Modal\`, \`Sheet\`, and \`Announcement\` provide methods such as \`hideOverlay()\` or \`dismiss()\` to control their behavior imperatively when needed.
+
+Use methods when you need to trigger actions that can’t be achieved through property changes alone, such as closing an overlay after an async operation or resetting component state.`,
+      codeblock: {
+        title: 'Example',
+        tabs: [
+          {
+            code: './examples/methods.example.jsx',
+            title: 'JSX',
+            language: 'jsx',
+          },
+          {
+            code: '/examples/methods-js.example.jsx',
+            title: 'JS',
+            language: 'js',
+          },
+        ],
+      },
+    },
+    {
+      type: 'Generic',
       title: 'Using Forms',
       sectionContent: `The [Form](https://shopify.dev/docs/api/checkout-ui-extensions/polaris-web-components/forms/form) component provides a way to manage form state and submit data to your app's backend or directly to Shopify using Direct API access.\n\nWhen the form is submitted or reset the relevant callback in the form component will get triggered.\n\nUsing this, you can control what defines a component to be dirty by utilizing the input's defaultValue property.\n\nRules:\n\n- When the defaultValue is set, the component will be considered dirty if the value of the input is different from the defaultValue. You may update the defaultValue when the form is submitted to reset the dirty state of the form.\n\n- When the defaultValue is not set, the component will be considered dirty if the value of the input is different from the initial value or from the last dynamic update to the input's value that wasn't triggered by user input.
 


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-checkout/issues/8471
Related to https://github.com/Shopify/shopify-dev/pull/64144

This PR adds documentation for using methods in Polaris Web Components within static pages of the customer account surface.

### Solution

Added a new "Methods" section to the Polaris Web Components documentation that explains:

- What methods are (functions for programmatic control)
- When to use methods (for actions that can't be achieved through property changes alone)
- Examples showing how to use methods like `hideOverlay()` with components like Modal

The documentation includes code examples in both JSX and vanilla JavaScript formats, demonstrating how to create and control a modal using methods.

### 🎩

See https://github.com/Shopify/shopify-dev/pull/64144 for details

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation