### PR TITLE
cut release for 2026-01-rc

### DIFF
--- a/.changeset/brave-falcons-perform.md
+++ b/.changeset/brave-falcons-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+2026.1.0-rc release

--- a/.changeset/cool-socks-cheer.md
+++ b/.changeset/cool-socks-cheer.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Adds components to point of sale cart LineItem interface to represent product bundle items.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@shopify/ui-extensions": "2026.1.0-rc.0"
+  },
+  "changesets": []
+}

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/ui-extensions",
-  "version": "2025.10.6",
+  "version": "2026.1.0-rc.0",
   "scripts": {
     "docs:admin": "node ./docs/surfaces/admin/build-docs.mjs",
     "docs:checkout": "bash ./docs/surfaces/checkout/build-docs.sh",


### PR DESCRIPTION
Attempting to cut 2026-01-rc. Feel like this and the following "versions release" PR from github action is all that's needed based on looking back at Robin Drexler's PRs from cutting 2025-10-rc
