### PR TITLE
Update admin ui extensions, fix TextField children, and add DropZone

### DIFF
--- a/.changeset/nasty-views-flash.md
+++ b/.changeset/nasty-views-flash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Fix missing children property for TextField

--- a/.changeset/whole-pumas-brake.md
+++ b/.changeset/whole-pumas-brake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add DropZone component to admin ui-extensions

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -166,11 +166,11 @@ export interface ExtendableEvent extends Event {
    */
   waitUntil?: (promise: Promise<void>) => void;
 }
-interface AggregateError$1<T extends Error> extends Error {
+export interface AggregateError<T extends Error> extends Error {
   errors: T[];
 }
 export interface AggregateErrorEvent<T extends Error> extends ErrorEvent {
-  error: AggregateError$1<T>;
+  error: AggregateError<T>;
 }
 export type SizeKeyword =
   | 'small-500'
@@ -278,6 +278,7 @@ declare const privateIconArray: readonly [
   'arrow-up-right',
   'arrows-in-horizontal',
   'arrows-out-horizontal',
+  'asterisk',
   'attachment',
   'automation',
   'backspace',
@@ -2026,7 +2027,10 @@ interface ClickableProps$1
    */
   lang?: string;
 }
-interface ClickableChipProps$1 extends ChipProps$1, GlobalProps {
+interface ClickableChipProps$1
+  extends ChipProps$1,
+    GlobalProps,
+    InteractionProps {
   /**
    * Callback when the chip is clicked.
    */
@@ -2035,6 +2039,7 @@ interface ClickableChipProps$1 extends ChipProps$1, GlobalProps {
    * The URL to link to.
    *
    * - If set, it will navigate to the location specified by `href` after executing the `click` event.
+   * - If a `commandFor` is set, the `command` will be executed instead of the navigation.
    */
   href?: string;
   /**
@@ -3105,6 +3110,21 @@ interface NumberFieldProps$1
    * @default 'decimal'
    */
   inputMode?: 'decimal' | 'numeric';
+  /**
+   * Callback when the user has **finished editing** a field, e.g. once they have blurred
+   * the field after changing the value.
+   * Also fired after `onInput` on every step when interacting with the controls or the keyboard up and down arrows.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
+   */
+  onChange?: (event: Event) => void;
+  /**
+   * Callback when the user makes any changes in the field.
+   * Also fired before `onChange` on every step when interacting with the controls or the keyboard up and down arrows.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
+   */
+  onInput?: (event: Event) => void;
 }
 export type NumberAutocompleteField = ExtractStrict<
   AnyAutocompleteField,
@@ -3810,6 +3830,7 @@ type IconType$1 =
   | 'arrow-up-right'
   | 'arrows-in-horizontal'
   | 'arrows-out-horizontal'
+  | 'asterisk'
   | 'attachment'
   | 'automation'
   | 'backspace'
@@ -3890,6 +3911,7 @@ type IconType$1 =
   | 'clipboard-check'
   | 'clipboard-checklist'
   | 'clock'
+  | 'clock-list'
   | 'clock-revert'
   | 'code'
   | 'code-add'
@@ -4086,6 +4108,7 @@ type IconType$1 =
   | 'note'
   | 'note-add'
   | 'notification'
+  | 'number-one'
   | 'order'
   | 'order-batches'
   | 'order-draft'
@@ -4166,6 +4189,7 @@ type IconType$1 =
   | 'profile-filled'
   | 'question-circle'
   | 'question-circle-filled'
+  | 'radio-control'
   | 'receipt'
   | 'receipt-dollar'
   | 'receipt-euro'
@@ -4276,6 +4300,9 @@ type IconType$1 =
   | 'unlock'
   | 'upload'
   | 'variant'
+  | 'variant-list'
+  | 'video'
+  | 'video-list'
   | 'view'
   | 'viewport-narrow'
   | 'viewport-short'
@@ -5333,11 +5360,18 @@ export interface ClickableChipProps
       | 'hidden'
       | 'href'
       | 'disabled'
+      | 'command'
+      | 'commandFor'
+      | 'interestFor'
     >
   > {}
 
+declare const ClickableChip_base: (abstract new (
+  args_0: RenderImpl,
+) => PreactCustomElement & PreactOverlayControlProps) &
+  Pick<typeof PreactCustomElement, 'prototype' | 'observedAttributes'>;
 declare class ClickableChip
-  extends PreactCustomElement
+  extends ClickableChip_base
   implements ClickableChipProps
 {
   accessor color: ClickableChipProps['color'];
@@ -5761,7 +5795,8 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName$I]: DropZoneJSXProps & PreactBaseElementProps<DropZone>;
+      [tagName$I]: DropZoneJSXProps &
+        PreactBaseElementPropsWithChildren<DropZone>;
     }
   }
 }
@@ -7604,7 +7639,7 @@ declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
       [tagName$9]: Omit<TextFieldJSXProps, 'accessory'> &
-        PreactBaseElementProps<TextField>;
+        PreactBaseElementPropsWithChildren<TextField>;
     }
   }
 }
@@ -8917,14 +8952,16 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$I]: DropZoneJSXProps & ReactBaseElementProps<DropZone>;
+      [tagName$I]: DropZoneJSXProps &
+        ReactBaseElementPropsWithChildren<DropZone>;
     }
   }
 }
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      [tagName$I]: DropZoneJSXProps & ReactBaseElementProps<DropZone>;
+      [tagName$I]: DropZoneJSXProps &
+        ReactBaseElementPropsWithChildren<DropZone>;
     }
   }
 }
@@ -9442,7 +9479,7 @@ declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
       [tagName$9]: Omit<TextFieldJSXProps, 'accessory'> &
-        ReactBaseElementProps<TextField>;
+        ReactBaseElementPropsWithChildren<TextField>;
     }
   }
 }
@@ -9450,7 +9487,7 @@ declare global {
   namespace JSX {
     interface IntrinsicElements {
       [tagName$9]: Omit<TextFieldJSXProps, 'accessory'> &
-        ReactBaseElementProps<TextField>;
+        ReactBaseElementPropsWithChildren<TextField>;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -139,7 +139,12 @@ declare module 'preact' {
 declare const tagName = 's-badge';
 export interface BadgeJSXProps
   extends Partial<BadgeProps>,
-    Pick<BadgeProps$1, 'id'> {}
+    Pick<BadgeProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Badge.
+   */
+  children?: ComponentChildren;
+}
 
 export {Badge};
 export type {BadgeJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -129,7 +129,11 @@ declare module 'preact' {
 declare const tagName = 's-banner';
 export interface BannerJSXProps
   extends Partial<BannerProps>,
-    Pick<BannerProps$1, 'id'> {
+    Pick<BannerProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Banner.
+   */
+  children?: ComponentChildren;
   /**
    * The secondary actions to display at the bottom of the Banner.
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -382,7 +382,12 @@ declare module 'preact' {
 declare const tagName = 's-box';
 export interface BoxJSXProps
   extends Partial<BoxProps>,
-    Pick<BoxProps$1, 'id'> {}
+    Pick<BoxProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Box.
+   */
+  children?: ComponentChildren;
+}
 
 export {Box};
 export type {BoxJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -208,7 +208,11 @@ declare module 'preact' {
 declare const tagName = 's-button';
 export interface ButtonJSXProps
   extends Partial<ButtonProps>,
-    Pick<ButtonProps$1, 'id'> {
+    Pick<ButtonProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Button.
+   */
+  children?: ComponentChildren;
   onClick?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;

--- a/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -114,7 +114,11 @@ declare module 'preact' {
 declare const tagName = 's-button-group';
 export interface ButtonGroupJSXProps
   extends Partial<ButtonGroupProps>,
-    Pick<ButtonGroupProps$1, 'id'> {
+    Pick<ButtonGroupProps$1, 'id' | 'children'> {
+  /**
+   * The content of the ButtonGroup.
+   */
+  children?: ComponentChildren;
   /**
    * The primary action button for the group.
    * Accepts a single Button element with a `variant` of `primary`.

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Chip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Chip.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -108,7 +108,11 @@ declare module 'preact' {
 declare const tagName = 's-chip';
 export interface ChipJSXProps
   extends Partial<ChipProps>,
-    Pick<ChipProps$1, 'id'> {
+    Pick<ChipProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Chip.
+   */
+  children?: ComponentChildren;
   /**
    * The graphic to display in the chip.
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -125,7 +125,15 @@ declare module 'preact' {
 declare const tagName = 's-choice';
 export interface ChoiceJSXProps
   extends Partial<ChoiceProps>,
-    Pick<ChoiceProps$1, 'id' | 'details'> {
+    Pick<ChoiceProps$1, 'id' | 'children' | 'details'> {
+  /**
+   * Content to use as the choice label.
+   *
+   * The label is produced by extracting and
+   * concatenating the text nodes from the provided content;
+   * any markup or element structure is ignored.
+   */
+  children?: ComponentChildren;
   /**
    * Additional text to provide context or guidance for the input.
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -150,7 +150,13 @@ declare module 'preact' {
 declare const tagName = 's-choice-list';
 export interface ChoiceListJSXProps
   extends Partial<ChoiceListProps>,
-    Pick<ChoiceListProps$1, 'id'> {
+    Pick<ChoiceListProps$1, 'id' | 'children'> {
+  /**
+   * The choices a user can select from.
+   *
+   * Accepts `Choice` components.
+   */
+  children?: ComponentChildren;
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -455,7 +455,11 @@ declare module 'preact' {
 declare const tagName = 's-clickable';
 export interface ClickableJSXProps
   extends Partial<ClickableProps>,
-    Pick<ClickableProps$1, 'id'> {
+    Pick<ClickableProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Clickable.
+   */
+  children?: ComponentChildren;
   onClick?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;

--- a/packages/ui-extensions/src/surfaces/admin/components/ClickableChip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ClickableChip.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -6,7 +6,11 @@
 
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, ClickableChipProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  ClickableChipProps$1,
+  InteractionProps,
+} from './shared.d.ts';
 
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
   currentTarget: HTMLElementTagNameMap[T];
@@ -41,6 +45,9 @@ export interface ClickableChipProps
       | 'hidden'
       | 'href'
       | 'disabled'
+      | 'command'
+      | 'commandFor'
+      | 'interestFor'
     >
   > {}
 
@@ -104,8 +111,40 @@ declare abstract class PreactCustomElement extends BaseClass {
   click({sourceEvent}?: ClickOptions): void;
 }
 
+export interface PreactOverlayControlProps
+  extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
+  /**
+   * Sets the action the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this clickable is activated.
+   *
+   * See the documentation of particular components for the actions they support.
+   *
+   * - `--auto`: a default action for the target component.
+   * - `--show`: shows the target component.
+   * - `--hide`: hides the target component.
+   * - `--toggle`: toggles the target component.
+   *
+   * @default '--auto'
+   */
+  command: Extract<
+    InteractionProps['command'],
+    '--show' | '--hide' | '--toggle' | '--auto'
+  >;
+  /**
+   * Sets the element the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this clickable is activated.
+   */
+  commandFor: Extract<InteractionProps['commandFor'], string>;
+  /**
+   * Sets the element the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this clickable is activated.
+   */
+  interestFor: Extract<InteractionProps['interestFor'], string>;
+}
+
+declare const ClickableChip_base: (abstract new (
+  args_0: RenderImpl,
+) => PreactCustomElement & PreactOverlayControlProps) &
+  Pick<typeof PreactCustomElement, 'prototype' | 'observedAttributes'>;
 declare class ClickableChip
-  extends PreactCustomElement
+  extends ClickableChip_base
   implements ClickableChipProps
 {
   accessor color: ClickableChipProps['color'];
@@ -136,7 +175,11 @@ declare module 'preact' {
 declare const tagName = 's-clickable-chip';
 export interface ClickableChipJSXProps
   extends Partial<ClickableChipProps>,
-    Pick<ClickableChipProps$1, 'id'> {
+    Pick<ClickableChipProps$1, 'id' | 'children'> {
+  /**
+   * The content of the clickable chip.
+   */
+  children?: ComponentChildren;
   /**
    * The graphic to display in the clickable chip.
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/DropZone.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DropZone.d.ts
@@ -6,12 +6,7 @@
 
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {
-  TextFieldProps,
-  CheckboxProps,
-  SwitchProps$1,
-  ComponentChildren,
-} from './shared.d.ts';
+import type {ComponentChildren, DropZoneProps$1} from './shared.d.ts';
 
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
   currentTarget: HTMLElementTagNameMap[T];
@@ -30,6 +25,29 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /** Assigns this element to a parent's slot. */
   slot?: Lowercase<string>;
 }
+/** Used when an element has children. */
+export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
+  extends PreactBaseElementProps<TClass> {
+  children?: preact.ComponentChildren;
+}
+
+export interface DropZoneProps
+  extends Required<
+    Pick<
+      DropZoneProps$1,
+      | 'accept'
+      | 'accessibilityLabel'
+      | 'disabled'
+      | 'files'
+      | 'name'
+      | 'error'
+      | 'label'
+      | 'labelAccessibilityVisibility'
+      | 'multiple'
+      | 'required'
+      | 'value'
+    >
+  > {}
 
 export type Styles = string;
 export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
@@ -53,8 +71,8 @@ export interface ClickOptions {
  * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
  * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
  */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
+declare const BaseClass$1: typeof globalThis.HTMLElement;
+declare abstract class PreactCustomElement extends BaseClass$1 {
   /** @private */
   static get observedAttributes(): string[];
   constructor({
@@ -91,95 +109,75 @@ declare abstract class PreactCustomElement extends BaseClass {
   click({sourceEvent}?: ClickOptions): void;
 }
 
+export type ReplaceType<TType, TFrom, TTo> = Exclude<TType, TFrom> | TTo;
+
+declare const setFiles: unique symbol;
+
 declare const internals: unique symbol;
-export type PreactInputProps = Required<
-  Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
->;
-declare class PreactInputElement
-  extends PreactCustomElement
-  implements PreactInputProps
-{
+declare const getFileInput: unique symbol;
+declare class BaseClass extends PreactCustomElement {
   static formAssociated: boolean;
+  constructor(renderImpl: RenderImpl);
   /** @private */
   [internals]: ElementInternals;
-  accessor onchange: CallbackEventListener<'input'>;
-  accessor oninput: CallbackEventListener<'input'>;
-  accessor disabled: PreactInputProps['disabled'];
-  accessor id: PreactInputProps['id'];
-  accessor name: PreactInputProps['name'];
-  get value(): PreactInputProps['value'];
-  set value(value: PreactInputProps['value']);
-  constructor(renderImpl: RenderImpl);
 }
-
-export interface PreactCheckboxProps
-  extends Required<
-    Pick<
-      CheckboxProps,
-      | 'accessibilityLabel'
-      | 'checked'
-      | 'defaultChecked'
-      | 'details'
-      | 'error'
-      | 'label'
-      | 'required'
-      | 'name'
-      | 'disabled'
-    >
-  > {
-  value: Required<CheckboxProps>['value'];
-}
-declare class PreactCheckboxElement
-  extends PreactInputElement
-  implements PreactCheckboxProps
-{
-  get checked(): boolean;
-  set checked(checked: PreactCheckboxProps['checked']);
-  /**
-   * The value used in form data when the checkbox is checked.
-   */
+declare class DropZone extends BaseClass implements DropZoneProps {
+  accessor accept: DropZoneProps['accept'];
+  accessor accessibilityLabel: DropZoneProps['accessibilityLabel'];
+  accessor disabled: DropZoneProps['disabled'];
+  accessor error: DropZoneProps['error'];
+  accessor label: DropZoneProps['label'];
+  accessor labelAccessibilityVisibility: DropZoneProps['labelAccessibilityVisibility'];
+  accessor multiple: DropZoneProps['multiple'];
+  accessor name: DropZoneProps['name'];
+  accessor required: DropZoneProps['required'];
+  accessor onchange: CallbackEventListener<typeof tagName>;
+  accessor oninput: CallbackEventListener<typeof tagName>;
+  accessor ondroprejected: CallbackEventListener<typeof tagName>;
   get value(): string;
-  set value(value: string);
-  accessor defaultChecked: PreactCheckboxProps['defaultChecked'];
-  accessor accessibilityLabel: PreactCheckboxProps['accessibilityLabel'];
-  accessor details: PreactCheckboxProps['details'];
-  accessor error: PreactCheckboxProps['error'];
-  accessor label: PreactCheckboxProps['label'];
-  accessor required: PreactCheckboxProps['required'];
+  /** This sets the input value for a file type, which cannot be set programatically, so it can only be reset. */
+  set value(value: '' | null);
+  get files(): File[];
+  set files(files: File[]);
+  /** @private */
+  [setFiles](files: File[]): void;
+  /** @private */
+  [getFileInput](): ReplaceType<
+    Element | null | undefined,
+    Element,
+    HTMLInputElement
+  >;
+
   /** @private */
   formResetCallback(): void;
-  static get observedAttributes(): string[];
-  constructor(renderImpl: RenderImpl);
-}
-
-export interface SwitchProps
-  extends PreactCheckboxProps,
-    Required<Pick<SwitchProps$1, 'labelAccessibilityVisibility'>> {}
-
-declare class Switch extends PreactCheckboxElement implements SwitchProps {
-  accessor labelAccessibilityVisibility: SwitchProps['labelAccessibilityVisibility'];
   constructor();
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: Switch;
+    [tagName]: DropZone;
   }
 }
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: SwitchJSXProps & PreactBaseElementProps<Switch>;
+      [tagName]: DropZoneJSXProps &
+        PreactBaseElementPropsWithChildren<DropZone>;
     }
   }
 }
 
-declare const tagName = 's-switch';
-export interface SwitchJSXProps
-  extends Partial<SwitchProps>,
-    Pick<SwitchProps$1, 'id'> {
+declare const tagName = 's-drop-zone';
+export interface DropZoneJSXProps
+  extends Partial<DropZoneProps>,
+    Pick<DropZoneProps$1, 'id'> {
+  /**
+   * Content to include inside the DropZone container
+   */
+  children?: ComponentChildren;
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
+  onDropRejected?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }
 
-export {Switch};
-export type {SwitchJSXProps};
+export {DropZone};
+export type {DropZoneJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -511,7 +511,12 @@ declare module 'preact' {
 declare const tagName = 's-grid';
 export interface GridJSXProps
   extends Partial<GridProps>,
-    Pick<GridProps$1, 'id'> {}
+    Pick<GridProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Grid.
+   */
+  children?: ComponentChildren;
+}
 
 export {Grid};
 export type {GridJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -395,7 +395,12 @@ declare module 'preact' {
 declare const tagName = 's-grid-item';
 export interface GridItemJSXProps
   extends Partial<GridItemProps>,
-    Pick<GridItemProps$1, 'id'> {}
+    Pick<GridItemProps$1, 'id' | 'children'> {
+  /**
+   * The content of the GridItem.
+   */
+  children?: ComponentChildren;
+}
 
 export {GridItem};
 export type {GridItemJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -113,7 +113,12 @@ declare module 'preact' {
 declare const tagName = 's-heading';
 export interface HeadingJSXProps
   extends Partial<HeadingProps>,
-    Pick<HeadingProps$1, 'id'> {}
+    Pick<HeadingProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Heading.
+   */
+  children?: ComponentChildren;
+}
 
 export {Heading};
 export type {HeadingJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -172,7 +172,11 @@ declare module 'preact' {
 declare const tagName = 's-link';
 export interface LinkJSXProps
   extends Partial<LinkProps>,
-    Pick<LinkProps$1, 'id' | 'lang'> {
+    Pick<LinkProps$1, 'id' | 'lang' | 'children'> {
+  /**
+   * The content of the Link.
+   */
+  children?: ComponentChildren;
   onClick?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -104,7 +104,12 @@ declare module 'preact' {
 declare const tagName = 's-list-item';
 export interface ListItemJSXProps
   extends Partial<ListItemProps>,
-    Pick<ListItemProps$1, 'id'> {}
+    Pick<ListItemProps$1, 'id' | 'children'> {
+  /**
+   * The content of the ListItem.
+   */
+  children?: ComponentChildren;
+}
 
 export {ListItem};
 export type {ListItemJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -182,7 +182,14 @@ declare module 'preact' {
 declare const tagName = 's-menu';
 export interface MenuJSXProps
   extends Partial<MenuProps>,
-    Pick<MenuProps$1, 'id'> {}
+    Pick<MenuProps$1, 'id' | 'children'> {
+  /**
+   * The Menu items.
+   *
+   * Only accepts `Button` and `Section` components.
+   */
+  children?: ComponentChildren;
+}
 
 export {Menu};
 export type {MenuJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -291,7 +291,11 @@ declare module 'preact' {
 declare const tagName = 's-modal';
 export interface ModalJSXProps
   extends Partial<ModalProps>,
-    Pick<ModalProps$1, 'id'> {
+    Pick<ModalProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Modal.
+   */
+  children?: ComponentChildren;
   /**
    * The primary action to perform.
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -111,7 +111,12 @@ declare module 'preact' {
 declare const tagName = 's-option';
 export interface OptionJSXProps
   extends Partial<OptionProps>,
-    Pick<OptionProps$1, 'id'> {}
+    Pick<OptionProps$1, 'id' | 'children'> {
+  /**
+   * The content to use as the label.
+   */
+  children?: ComponentChildren;
+}
 
 export {Option};
 export type {OptionJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -111,7 +111,14 @@ declare module 'preact' {
 declare const tagName = 's-option-group';
 export interface OptionGroupJSXProps
   extends Partial<OptionGroupProps>,
-    Pick<OptionGroupProps$1, 'id'> {}
+    Pick<OptionGroupProps$1, 'id' | 'children'> {
+  /**
+   * The options a user can select from.
+   *
+   * Accepts `Option` components.
+   */
+  children?: ComponentChildren;
+}
 
 export {OptionGroup};
 export type {OptionGroupJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -107,7 +107,14 @@ declare module 'preact' {
 declare const tagName = 's-ordered-list';
 export interface OrderedListJSXProps
   extends Partial<OrderedListProps>,
-    Pick<OrderedListProps$1, 'id'> {}
+    Pick<OrderedListProps$1, 'id'> {
+  /**
+   * The items of the OrderedList.
+   *
+   * Only ListItems are accepted.
+   */
+  children?: ComponentChildren;
+}
 
 export {OrderedList};
 export type {OrderedListJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -117,7 +117,11 @@ declare module 'preact' {
 declare const tagName = 's-page';
 export interface PageJSXProps
   extends Partial<PageProps>,
-    Pick<PageProps$1, 'id'> {
+    Pick<PageProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Page.
+   */
+  children?: ComponentChildren;
   /**
    * The content to display in the aside section of the page.
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -128,7 +128,12 @@ declare module 'preact' {
 declare const tagName = 's-paragraph';
 export interface ParagraphJSXProps
   extends Partial<ParagraphProps>,
-    Pick<ParagraphProps$1, 'id'> {}
+    Pick<ParagraphProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Paragraph.
+   */
+  children?: ComponentChildren;
+}
 
 export {Paragraph};
 export type {ParagraphJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -112,7 +112,12 @@ declare module 'preact' {
 declare const tagName = 's-query-container';
 export interface QueryContainerJSXProps
   extends Partial<QueryContainerProps$1>,
-    Pick<QueryContainerProps$1, 'id'> {}
+    Pick<QueryContainerProps$1, 'id' | 'children'> {
+  /**
+   * The content of the container.
+   */
+  children?: ComponentChildren;
+}
 
 export {QueryContainer};
 export type {QueryContainerJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -117,7 +117,12 @@ declare module 'preact' {
 declare const tagName = 's-section';
 export interface SectionJSXProps
   extends Partial<SectionProps>,
-    Pick<SectionProps$1, 'id'> {}
+    Pick<SectionProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Section.
+   */
+  children?: ComponentChildren;
+}
 
 export {Section};
 export type {SectionJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -202,7 +202,13 @@ declare module 'preact' {
 declare const tagName = 's-select';
 export interface SelectJSXProps
   extends Partial<SelectProps>,
-    Pick<SelectProps$1, 'id'> {
+    Pick<SelectProps$1, 'id' | 'children'> {
+  /**
+   * The options a user can select from.
+   *
+   * Accepts `Option` and `OptionGroup` components.
+   */
+  children?: ComponentChildren;
   onChange?: (event: CallbackEvent<typeof tagName>) => void;
   onInput?: (event: CallbackEvent<typeof tagName>) => void;
   onBlur?: (event: CallbackEvent<typeof tagName>) => void;

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -471,7 +471,12 @@ declare module 'preact' {
 declare const tagName = 's-stack';
 export interface StackJSXProps
   extends Partial<StackProps>,
-    Pick<StackProps$1, 'id'> {}
+    Pick<StackProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Stack.
+   */
+  children?: ComponentChildren;
+}
 
 export {Stack};
 export type {StackJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/StandardComponents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/StandardComponents.ts
@@ -15,6 +15,7 @@ export type StandardComponents =
   | 'ColorPicker'
   | 'DateField'
   | 'DatePicker'
+  | 'DropZone'
   | 'Divider'
   | 'EmailField'
   | 'Grid'

--- a/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -198,7 +198,11 @@ declare module 'preact' {
 declare const tagName = 's-table';
 export interface TableJSXProps
   extends Partial<TableProps>,
-    Pick<TableProps$1, 'id' | 'onNextPage' | 'onPreviousPage'> {
+    Pick<TableProps$1, 'id' | 'children' | 'onNextPage' | 'onPreviousPage'> {
+  /**
+   * The content of the Table.
+   */
+  children?: ComponentChildren;
   /**
    * Additional filters to display in the table. For example, the `s-search-field` component can be used to filter the table data.
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -104,7 +104,12 @@ declare module 'preact' {
 declare const tagName = 's-table-body';
 export interface TableBodyJSXProps
   extends Partial<TableBodyProps>,
-    Pick<TableBodyProps$1, 'id'> {}
+    Pick<TableBodyProps$1, 'id' | 'children'> {
+  /**
+   * The body of the table. May not have any semantic meaning in the Table's `list` variant.
+   */
+  children?: ComponentChildren;
+}
 
 export {TableBody};
 export type {TableBodyJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -119,7 +119,12 @@ declare module 'preact' {
 declare const tagName = 's-table-cell';
 export interface TableCellJSXProps
   extends Partial<TableCellProps>,
-    Pick<TableCellProps$1, 'id'> {}
+    Pick<TableCellProps$1, 'id' | 'children'> {
+  /**
+   * The content of the table cell.
+   */
+  children?: ComponentChildren;
+}
 
 export {TableCell};
 export type {TableCellJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -121,7 +121,12 @@ declare module 'preact' {
 declare const tagName = 's-table-header';
 export interface TableHeaderJSXProps
   extends Partial<TableHeaderProps>,
-    Pick<TableHeaderProps$1, 'id'> {}
+    Pick<TableHeaderProps$1, 'id' | 'children'> {
+  /**
+   * The heading of the column in the `table` variant, and the label of its data in `list` variant.
+   */
+  children?: ComponentChildren;
+}
 
 export {TableHeader};
 export type {TableHeaderJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -111,7 +111,12 @@ declare module 'preact' {
 declare const tagName = 's-table-header-row';
 export interface TableHeaderRowJSXProps
   extends Partial<TableHeaderRowProps>,
-    Pick<TableHeaderRowProps$1, 'id'> {}
+    Pick<TableHeaderRowProps$1, 'id' | 'children'> {
+  /**
+   * Contents of the table heading row; children should be `TableHeading` components.
+   */
+  children?: ComponentChildren;
+}
 
 export {TableHeaderRow};
 export type {TableHeaderRowJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -106,7 +106,12 @@ declare module 'preact' {
 declare const tagName = 's-table-row';
 export interface TableRowJSXProps
   extends Partial<TableRowProps>,
-    Pick<TableRowProps$1, 'id'> {}
+    Pick<TableRowProps$1, 'id' | 'children'> {
+  /**
+   * The content of a TableRow, which should be `TableCell` components.
+   */
+  children?: ComponentChildren;
+}
 
 export {TableRow};
 export type {TableRowJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -137,7 +137,12 @@ declare module 'preact' {
 declare const tagName = 's-text';
 export interface TextJSXProps
   extends Partial<TextProps>,
-    Pick<TextProps$1, 'id'> {}
+    Pick<TextProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Text.
+   */
+  children?: ComponentChildren;
+}
 
 export {Text};
 export type {TextJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -30,6 +30,11 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
   ref?: preact.Ref<TClass>;
   /** Assigns this element to a parent's slot. */
   slot?: Lowercase<string>;
+}
+/** Used when an element has children. */
+export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
+  extends PreactBaseElementProps<TClass> {
+  children?: preact.ComponentChildren;
 }
 
 export type Styles = string;
@@ -223,7 +228,7 @@ declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
       [tagName]: Omit<TextFieldJSXProps, 'accessory'> &
-        PreactBaseElementProps<TextField>;
+        PreactBaseElementPropsWithChildren<TextField>;
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -176,7 +176,14 @@ declare module 'preact' {
 declare const tagName = 's-tooltip';
 export interface TooltipJSXProps
   extends Partial<TooltipProps>,
-    Pick<TooltipProps$1, 'id'> {}
+    Pick<TooltipProps$1, 'id' | 'children'> {
+  /**
+   * The content of the Tooltip.
+   *
+   * Only accepts `Text`, `Paragraph` components, and raw `textContent`.
+   */
+  children?: ComponentChildren;
+}
 
 export {Tooltip};
 export type {TooltipJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -107,7 +107,14 @@ declare module 'preact' {
 declare const tagName = 's-unordered-list';
 export interface UnorderedListJSXProps
   extends Partial<UnorderedListProps>,
-    Pick<UnorderedListProps$1, 'id'> {}
+    Pick<UnorderedListProps$1, 'id'> {
+  /**
+   * The items of the UnorderedList.
+   *
+   * Only ListItems are accepted.
+   */
+  children?: ComponentChildren;
+}
 
 export {UnorderedList};
 export type {UnorderedListJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
@@ -1,4 +1,4 @@
-/** VERSION: 1.22.1 **/
+/** VERSION: 1.25.0 **/
 
 /* eslint-disable @typescript-eslint/ban-types */
 
@@ -164,11 +164,11 @@ export interface ExtendableEvent extends Event {
    */
   waitUntil?: (promise: Promise<void>) => void;
 }
-interface AggregateError$1<T extends Error> extends Error {
+export interface AggregateError<T extends Error> extends Error {
   errors: T[];
 }
 export interface AggregateErrorEvent<T extends Error> extends ErrorEvent {
-  error: AggregateError$1<T>;
+  error: AggregateError<T>;
 }
 export type SizeKeyword =
   | 'small-500'
@@ -276,6 +276,7 @@ declare const privateIconArray: readonly [
   'arrow-up-right',
   'arrows-in-horizontal',
   'arrows-out-horizontal',
+  'asterisk',
   'attachment',
   'automation',
   'backspace',
@@ -2024,7 +2025,10 @@ interface ClickableProps$1
    */
   lang?: string;
 }
-interface ClickableChipProps$1 extends ChipProps$1, GlobalProps {
+interface ClickableChipProps$1
+  extends ChipProps$1,
+    GlobalProps,
+    InteractionProps {
   /**
    * Callback when the chip is clicked.
    */
@@ -2033,6 +2037,7 @@ interface ClickableChipProps$1 extends ChipProps$1, GlobalProps {
    * The URL to link to.
    *
    * - If set, it will navigate to the location specified by `href` after executing the `click` event.
+   * - If a `commandFor` is set, the `command` will be executed instead of the navigation.
    */
   href?: string;
   /**
@@ -3103,6 +3108,21 @@ interface NumberFieldProps$1
    * @default 'decimal'
    */
   inputMode?: 'decimal' | 'numeric';
+  /**
+   * Callback when the user has **finished editing** a field, e.g. once they have blurred
+   * the field after changing the value.
+   * Also fired after `onInput` on every step when interacting with the controls or the keyboard up and down arrows.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
+   */
+  onChange?: (event: Event) => void;
+  /**
+   * Callback when the user makes any changes in the field.
+   * Also fired before `onChange` on every step when interacting with the controls or the keyboard up and down arrows.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
+   */
+  onInput?: (event: Event) => void;
 }
 export type NumberAutocompleteField = ExtractStrict<
   AnyAutocompleteField,
@@ -3808,6 +3828,7 @@ type IconType$1 =
   | 'arrow-up-right'
   | 'arrows-in-horizontal'
   | 'arrows-out-horizontal'
+  | 'asterisk'
   | 'attachment'
   | 'automation'
   | 'backspace'
@@ -3888,6 +3909,7 @@ type IconType$1 =
   | 'clipboard-check'
   | 'clipboard-checklist'
   | 'clock'
+  | 'clock-list'
   | 'clock-revert'
   | 'code'
   | 'code-add'
@@ -4084,6 +4106,7 @@ type IconType$1 =
   | 'note'
   | 'note-add'
   | 'notification'
+  | 'number-one'
   | 'order'
   | 'order-batches'
   | 'order-draft'
@@ -4164,6 +4187,7 @@ type IconType$1 =
   | 'profile-filled'
   | 'question-circle'
   | 'question-circle-filled'
+  | 'radio-control'
   | 'receipt'
   | 'receipt-dollar'
   | 'receipt-euro'
@@ -4274,6 +4298,9 @@ type IconType$1 =
   | 'unlock'
   | 'upload'
   | 'variant'
+  | 'variant-list'
+  | 'video'
+  | 'video-list'
   | 'view'
   | 'viewport-narrow'
   | 'viewport-short'


### PR DESCRIPTION
### Background

Closes https://github.com/shop/issues-polaris/issues/1468

- Updates Admin UI Extensions
- Fixes missing `children` property for `TextField` which is needed to support the `accessory` slot
- Adds DropZone types

**No more error when trying to use `slot="accessory"` in TextField** 👏 
<img width="835" height="124" alt="Screenshot 2025-10-27 at 1 38 49 PM" src="https://github.com/user-attachments/assets/fb66cd0f-0220-42d8-bc04-6e88ce020f7c" />


**DropZone types are supported 👏 **
<img width="904" height="355" alt="Screenshot 2025-10-28 at 10 29 24 AM" src="https://github.com/user-attachments/assets/dbc36e11-bd7a-475e-9c13-f187b49247db" />


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
