### PR TITLE
Add cashtracking observe target

### DIFF
--- a/.changeset/famous-windows-unite.md
+++ b/.changeset/famous-windows-unite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add cash tracking observe target

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/CashTrackingSessionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/CashTrackingSessionData.ts
@@ -1,6 +1,28 @@
 import {BaseData} from './BaseData';
 import {BaseApi} from './BaseApi';
 
+export type CashTrackingEventType =
+  | 'opening'
+  | 'closing'
+  | 'mid-session-count'
+  | 'adjustment'
+  | 'sale'
+  | 'refund';
+
+export interface CashTrackingEvent {
+  id: number;
+  type: CashTrackingEventType;
+  countExpectedAmount?: number;
+  countActualAmount?: number;
+  adjustmentAmount?: number;
+  note?: string;
+  orderId?: number;
+}
+
+export interface CashTrackingData extends BaseData, BaseApi {
+  cashTracking: CashTrackingEvent;
+}
+
 export interface CashTrackingSessionStartData extends BaseData, BaseApi {
   cashTrackingSessionStart: {
     id: number;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
@@ -2,6 +2,7 @@ import {BaseOutput} from './event/output';
 import {
   CashTrackingSessionStartData,
   CashTrackingSessionCompleteData,
+  CashTrackingData,
 } from './event/data/CashTrackingSessionData';
 import {TransactionCompleteData} from './event/data/TransactionCompleteData';
 import {CartUpdateEventData} from './event/data/CartUpdateEventData';
@@ -39,6 +40,9 @@ export interface EventExtensionTargets {
   ) => Promise<BaseOutput>;
   'pos.cart-update.event.observe': (
     data: CartUpdateEventData,
+  ) => Promise<BaseOutput>;
+  'pos.cash-tracking.event.observe': (
+    data: CashTrackingData,
   ) => Promise<BaseOutput>;
 }
 


### PR DESCRIPTION
### Background

This PR adds the cash-tracking.event.observe target to the UI-Extensions repo. This new target will replace the existing cash-tracking-session-complete.event.observe and cash-tracking-session-start.event.observe targets, which we will be deprecating in a follow-up PR.

### Solution

This PR follows implementation patterns for .observe targets in the ui-extensions repo. Noting that documentation for observe targets have recently all been removed.

### Checklist

- [x] I have updated relevant documentation
