### PR TITLE
implement cash drawer api

### DIFF
--- a/.changeset/hip-shirts-drum.md
+++ b/.changeset/hip-shirts-drum.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+implements the cash drawer api to the ui extensions repository

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cash-drawer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cash-drawer-api.doc.ts
@@ -1,0 +1,52 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import {generateJsxCodeBlock} from '../helpers/generateCodeBlock';
+import {TargetLink} from '../types/ExtensionTargetType';
+
+const generateJsxCodeBlockForCashDrawerApi = (
+  title: string,
+  fileName: string,
+) => generateJsxCodeBlock(title, 'cash-drawer-api', fileName);
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Cash Drawer API',
+  description: `
+The Cash Drawer API is an API exposed to extensions for cash drawer functionality, specifically allowing UI extensions to control cash drawer operations.
+
+#### Supporting targets
+- ${TargetLink.PosHomeTileRender}
+- ${TargetLink.PosHomeModalRender}
+- ${TargetLink.PosPurchasePostActionMenuItemRender}
+- ${TargetLink.PosPurchasePostActionRender}
+- ${TargetLink.PosPurchasePostBlockRender}
+- ${TargetLink.PosReturnPostActionMenuItemRender}
+- ${TargetLink.PosReturnPostActionRender}
+- ${TargetLink.PosReturnPostBlockRender}
+- ${TargetLink.PosExchangePostActionMenuItemRender}
+- ${TargetLink.PosExchangePostActionRender}
+- ${TargetLink.PosExchangePostBlockRender}
+`,
+  isVisualComponent: false,
+  type: 'APIs',
+  definitions: [
+    {
+      title: 'CashDrawerApi',
+      description: 'Interface for handling cash drawer operations.',
+      type: 'CashDrawerApi',
+    },
+  ],
+  category: 'APIs',
+  related: [],
+  examples: {
+    description: 'Examples of using the Cash Drawer API',
+    examples: [
+      {
+        codeblock: generateJsxCodeBlockForCashDrawerApi(
+          'Open the cash drawer',
+          'default.example',
+        ),
+      },
+    ],
+  },
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cash-drawer-api/default.example.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cash-drawer-api/default.example.jsx
@@ -1,0 +1,21 @@
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+const Extension = () => {
+  return (
+    <s-page heading="Cash Drawer API">
+      <s-scroll-box>
+        <s-button
+          onClick={() =>
+            shopify.cashDrawer.open()
+          }
+        >
+          Open cash drawer
+        </s-button>
+      </s-scroll-box>
+    </s-page>
+  );
+};

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -7,6 +7,8 @@ export type {
 
 export type {CartLineItemApi} from './api/cart-line-item-api/cart-line-item-api';
 
+export type {CashDrawerApi} from './api/cash-drawer-api/cash-drawer-api';
+
 export type {ActionApi, ActionApiContent} from './api/action-api/action-api';
 
 export type {StandardApi} from './api/standard/standard-api';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cash-drawer-api/cash-drawer-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cash-drawer-api/cash-drawer-api.ts
@@ -1,0 +1,19 @@
+/**
+ * The Cash Drawer API in POS UI extensions includes select cash drawer functionality.
+ */
+export interface CashDrawerApiContent {
+  /**
+   * Opens the connected cash drawer.
+   *
+   * @returns Void
+   *
+   */
+  open(): Promise<void>;
+}
+
+/**
+ * Interface for the Cash Drawer API
+ */
+export interface CashDrawerApi {
+  cashDrawer: CashDrawerApiContent;
+}


### PR DESCRIPTION
## Background
https://github.com/shop/issues-retail/issues/16752

**Note:** [original PR was closed](https://app.graphite.dev/github/pr/Shopify/ui-extensions/3216/Add-Cash-Drawer-Api) due to it being based on unstable, while development has now been moved directly on the RC branches of each release.

**What is the purpose of this API?**
The purpose of this API is to extend register functionality to 3P apps. Specifically, the ability to open the cash drawer.

**What problem is it solving?**
Shopify POS lacks robust cash management capabilities required by mature retail operations. Our current approach works for small merchants but fails to meet the needs of mid-market and enterprise retailers who require stricter controls, better reporting, and more flexible device-to-register relationships. The ability to control the cash drawer is a fundamental feature that will allow for partners to develop apps to meet the needs of mid-market and enterprise retailers.


**API design approval**
https://github.com/Shopify/ui-api-design/pull/1232

**Documentation (To be merged into shopify-dev)**
![Screenshot 2025-09-04 at 4.53.05 PM.png](https://app.graphite.dev/user-attachments/assets/acb2b504-79bf-48ba-9e1f-77127a110de8.png)


🎩
Review documentation and that this API was implemented properly in this repo.
Checklist
[x] I have updated relevant documentation