### PR TITLE
Adds components to point of sale line items for product bundles

### DIFF
--- a/.changeset/cold-windows-occur.md
+++ b/.changeset/cold-windows-occur.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Adds components to point of sale cart LineItem interface to represent product bundle items.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -49,6 +49,33 @@ export interface LineItem {
   properties: {[key: string]: string};
   isGiftCard: boolean;
   attributedUserId?: number;
+  /**
+   * Bundle components for this line item. Only present for product bundles.
+   * Each component represents an individual item within the bundle with its own tax information.
+   */
+  components?: LineItemComponent[];
+}
+
+/**
+ * Represents a component of a product bundle line item.
+ * Bundle components contain the individual items that make up a bundle,
+ * each with their own pricing and tax information.
+ */
+export interface LineItemComponent {
+  /** The title/name of the component product */
+  title?: string;
+  /** The quantity of this component in the bundle */
+  quantity: number;
+  /** The price of this component */
+  price?: number;
+  /** Whether this component is taxable */
+  taxable: boolean;
+  /** Tax lines applied to this component */
+  taxLines: TaxLine[];
+  /** The variant ID of this component, if applicable */
+  variantId?: number;
+  /** The product ID of this component, if applicable */
+  productId?: number;
 }
 
 export interface Discount {


### PR DESCRIPTION
Backporting new point of sale cart API for line item components to 2025-07. See https://github.com/Shopify/ui-extensions/pull/3536 for the equivalent 2026-01 changes and https://github.com/Shopify/ui-extensions/pull/3537 for 2025-10.