### PR TITLE
Switch last changeset to patch

### DIFF
--- a/.changeset/cool-socks-cheer.md
+++ b/.changeset/cool-socks-cheer.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions': minor
+'@shopify/ui-extensions': patch
 ---
 
 Adds components to point of sale cart LineItem interface to represent product bundle items.


### PR DESCRIPTION
Submitting a minor release results in an incorrect version bump for the package release PR, so we're going to try to release updates to POS cart api as a patch instead. This patch has been tophatted previously and works great!