### PR TITLE
Fixes last changeset files to patches to correct the version bump

### DIFF
--- a/.changeset/cold-windows-occur.md
+++ b/.changeset/cold-windows-occur.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions': minor
+'@shopify/ui-extensions': patch
 ---
 
 Adds components to point of sale cart LineItem interface to represent product bundle items.

--- a/.changeset/discount-allocations.md
+++ b/.changeset/discount-allocations.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions': minor
+'@shopify/ui-extensions': patch
 ---
 
 Added optional `discountAllocations` field to Cart Line Item API so that POS extensions can see the precise proportion of a discount applied to a particular line item. Only the `allocatedAmount` field is included for this purpose, matching the Storefront API structure. See https://shopify.dev/docs/api/storefront/latest/objects/DiscountAllocation.

--- a/.changeset/hip-seas-change.md
+++ b/.changeset/hip-seas-change.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions': minor
+'@shopify/ui-extensions': patch
 ---
 
 Adds pos.receipt-header.block.render extension target

--- a/.changeset/tough-panthers-impress.md
+++ b/.changeset/tough-panthers-impress.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions': minor
+'@shopify/ui-extensions': patch
 ---
 
 Modified transaction data interface fields to include returnId and refundId to Return and Exchange TransactionData.


### PR DESCRIPTION
Minor changeset files are instructing the automated tool for version bump PRs to increment to the wrong version number. We need to use patch, even for "minor" changes.