### PR TITLE
Document window.close() for pos ui extensions

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -28,6 +28,11 @@ The Navigation API enables POS UI extension to navigate between screens.
       description: '',
       type: 'Navigation',
     },
+    {
+      title: 'Window',
+      description: '',
+      type: 'Window',
+    },
   ],
   category: 'APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -35,3 +35,10 @@ export interface Navigation {
    */
   back(): void;
 }
+
+export interface Window {
+  /**
+   * The close() method of the window interface closes the extension screen.
+   */
+  close(): void;
+}


### PR DESCRIPTION
### Background

We missed documenting window.close in 2025-10, so we're backfilling that, and need to move it forward to 2026-01-rc, too

### Solution

Cherry picks from 2025-10 to make sure the new window.close documentation is in 2026-01-rc and forward


### 🎩

- See companion docs pr: https://github.com/Shopify/shopify-dev/pull/64629

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
