### PR TITLE
Add code examples of POS subscriptions UI extension

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Modal.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Modal.jsx
@@ -1,0 +1,89 @@
+import {render} from 'preact';
+import {useState, useEffect} from 'preact/hooks';
+
+// [START modal.fetch]
+async function fetchSellingPlans(variantId) {
+  const requestBody = {
+    query: `#graphql
+        query GetSellingPlans($variantId: ID!) {
+          productVariant(id: $variantId) {
+            sellingPlanGroups(first: 10) {
+              nodes {
+                name
+                sellingPlans(first: 10) {
+                  nodes {
+                    id
+                    name
+                    category
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+    variables: { variantId: `gid://shopify/ProductVariant/${variantId}`},
+  };
+
+  const res = await fetch('shopify:admin/api/graphql.json', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+  return res.json();
+}
+// [END modal.fetch]
+
+export default function extension() {
+  render(<Modal />, document.body);
+}
+
+function Modal() {
+  // For this example, we'll just use the first selling plan item
+  const sellingPlanItem = shopify.cart.current.value.lineItems
+    .find(lineItem => lineItem.hasSellingPlanGroups === true)
+
+  const [response, setResponse] = useState(undefined)
+
+  useEffect(() => {
+    async function getSellingPlans() {
+      setResponse(await fetchSellingPlans(sellingPlanItem?.variantId))
+    }
+    getSellingPlans()
+  }, [sellingPlanItem])
+
+  // [START modal.handle-click]
+  const handleClick = (plan) => {
+    shopify.cart.addLineItemSellingPlan({
+      lineItemUuid: sellingPlanItem.uuid,
+      // convert from GID to ID
+      sellingPlanId: Number(plan.id.split('/').pop()),
+      sellingPlanName: plan.name,
+    })
+    window.close()
+  }
+  // [END modal.handle-click]
+
+  return (
+    <s-page heading='POS modal'>
+      <s-scroll-box>
+        <s-box padding="small">
+          {response?.data.productVariant.sellingPlanGroups.nodes.map(group => {
+            return (
+              <s-section key={`${group.name}-section`} heading={group.name}>
+              {group.sellingPlans.nodes.map(plan => {
+                return (
+                  <s-clickable key={`${plan.name}-clickable`} onClick={() => {
+                    handleClick(plan)
+                  }}>
+                    <s-text key={`${plan.name}-text`}>{plan.name}</s-text>
+                  </s-clickable>
+                )
+              })}
+            </s-section>
+            )
+          })}
+        </s-box>
+      </s-scroll-box>
+    </s-page>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Tile.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Tile.jsx
@@ -1,0 +1,35 @@
+import {render} from 'preact';
+import {useState} from 'preact/hooks';
+
+export default function extension() {
+  render(<Tile />, document.body);
+}
+
+function Tile() {
+  const [sellingPlanEligible, setSellingPlanEligible] = useState(false);
+
+  // [START tile.subscribe]
+  useEffect(() => {
+    const unsubscribe = shopify.cart.current.subscribe(cart => {
+      const sellingPlanEligibleLineItems = cart.lineItems.filter(lineItem => lineItem.hasSellingPlanGroups === true)
+
+      setSellingPlanEligible(sellingPlanEligibleLineItems.length > 0)
+    })
+    return unsubscribe
+  }, [])
+  // [END tile.subscribe]
+
+  return (
+    <s-tile
+      heading={"Subscriptions"}
+      subheading={sellingPlanEligible
+        ? "Subscriptions available"
+        : "Subscriptions not available"
+      }
+      // [START tile.disabled]
+      disabled={!sellingPlanEligible}
+      // [END tile.disabled]
+      onClick={() => shopify.action.presentModal()}
+    />
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/shopify.extension.toml
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/shopify.extension.toml
@@ -1,0 +1,15 @@
+api_version = "2025-10"
+
+[[extensions]]
+type = "ui_extension"
+name = "Subscription Tutorial"
+handle = "subscription-tutorial"
+description = "POS UI extension subscription tutorial"
+
+[[extensions.targeting]]
+module = "./src/Tile.jsx"
+target = "pos.home.tile.render"
+
+[[extensions.targeting]]
+module = "./src/Modal.jsx"
+target = "pos.home.modal.render"


### PR DESCRIPTION
### Background

This PR adds example code for a Point of Sale UI extension that demos how to implement subscription functionality.

Related to https://github.com/Shopify/shopify-dev/pull/64603 - planning to reference these codeRefs in the doc, but I can't link them until they are actually published. 

### Solution

Added three new files to demonstrate a complete subscription example for Point of Sale UI extensions:

1. `Modal.jsx` - Implements a modal that:
    - Fetches selling plans for a product variant using GraphQL
    - Displays available subscription options
    - Handles selection of a subscription plan
2. `Tile.jsx` - Creates a tile component that:
    - Subscribes to cart updates to detect subscription-eligible items
    - Enables/disables the tile based on whether subscription options are available
    - Opens the modal when clicked
3. `shopify.extension.toml` - Configuration file that:
    - Defines the extension targeting both the POS home tile and modal render targets

The example demonstrates best practices for implementing subscription functionality in POS UI extensions, including proper data fetching, state management, and user interaction patterns.

### 🎩

- Run the example in a development environment
- Add a subscription-eligible product to the cart
- Verify the subscription tile becomes enabled
- Click the tile and confirm the modal displays available subscription options
- Select a subscription plan and verify it's applied to the cart item

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation