### PR TITLE
Add code examples of POS subscriptions UI extension

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Action.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Action.jsx
@@ -1,0 +1,56 @@
+import {render} from 'preact';
+import {useState, useEffect} from 'preact/hooks';
+import {fetchSellingPlans} from './FetchSellingPlans';
+
+export default function extension() {
+  render(<Action />, document.body);
+}
+
+function Action() {
+  const [response, setResponse] = useState(undefined);
+
+  useEffect(() => {
+    async function getSellingPlans() {
+      setResponse(await fetchSellingPlans(shopify.cartLineItem?.variantId));
+    }
+    getSellingPlans();
+  }, [shopify.cartLineItem]);
+
+  const handleClick = (plan) => {
+    shopify.cart.addLineItemSellingPlan({
+      lineItemUuid: shopify.cartLineItem.uuid,
+      sellingPlanId: Number(plan.id.split('/').pop()),
+      sellingPlanName: plan.name,
+    });
+    window.close();
+  };
+
+  return (
+    <s-page heading="Subscriptions">
+      <s-scroll-box>
+        <s-box padding="small">
+          {response?.data.productVariant.sellingPlanGroups.nodes.map(
+            (group) => {
+              return (
+                <s-section key={`${group.name}-section`} heading={group.name}>
+                  {group.sellingPlans.nodes.map((plan) => {
+                    return (
+                      <s-clickable
+                        key={`${plan.name}-clickable`}
+                        onClick={() => {
+                          handleClick(plan);
+                        }}
+                      >
+                        <s-text key={`${plan.name}-text`}>{plan.name}</s-text>
+                      </s-clickable>
+                    );
+                  })}
+                </s-section>
+              );
+            },
+          )}
+        </s-box>
+      </s-scroll-box>
+    </s-page>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/FetchSellingPlans.js
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/FetchSellingPlans.js
@@ -1,0 +1,31 @@
+export async function fetchSellingPlans(variantId) {
+  const requestBody = {
+    query: `#graphql
+        query GetSellingPlans($variantId: ID!) {
+          productVariant(id: $variantId) {
+            # Note: For production use, implement pagination to fetch all sellingPlanGroups and sellingPlans as needed.
+            sellingPlanGroups(first: 10) {
+              nodes {
+                name
+                # Handle pagination (see comment above)
+                sellingPlans(first: 10) {
+                  nodes {
+                    id
+                    name
+                    category
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+    variables: {variantId: `gid://shopify/ProductVariant/${variantId}`},
+  };
+
+  const res = await fetch('shopify:admin/api/graphql.json', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+  return res.json();
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/MenuItem.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/MenuItem.jsx
@@ -1,0 +1,17 @@
+import {render} from 'preact';
+
+export default function extension() {
+  render(<MenuItem />, document.body);
+}
+
+function MenuItem() {
+  const handleButtonPress = () => {
+    shopify.action.presentModal();
+  };
+
+  const hasSellingPlanGroups = shopify.cartLineItem?.hasSellingPlanGroups;
+
+  return (
+    <s-button onClick={handleButtonPress} disabled={!hasSellingPlanGroups} />
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Modal.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Modal.jsx
@@ -1,0 +1,67 @@
+import {render} from 'preact';
+import {useState, useEffect} from 'preact/hooks';
+import {fetchSellingPlans} from './FetchSellingPlans';
+
+export default function extension() {
+  render(<Modal />, document.body);
+}
+
+function Modal() {
+  // For this example, we'll just use the first selling plan item
+  // Your app should handle displaying multiple line items with selling plan groups.
+  const sellingPlanItem = shopify.cart.current.value.lineItems.find(
+    (lineItem) => lineItem.hasSellingPlanGroups === true,
+  );
+
+  const [response, setResponse] = useState(undefined);
+
+  useEffect(() => {
+    async function getSellingPlans() {
+      setResponse(await fetchSellingPlans(sellingPlanItem?.variantId));
+    }
+    getSellingPlans();
+  }, [sellingPlanItem]);
+
+  // [START modal.handle-click]
+  const handleClick = (plan) => {
+    shopify.cart.addLineItemSellingPlan({
+      lineItemUuid: sellingPlanItem.uuid,
+      // convert from GID to ID
+      sellingPlanId: Number(plan.id.split('/').pop()),
+      sellingPlanName: plan.name,
+    });
+    window.close();
+  };
+  // [END modal.handle-click]
+
+  // [START modal.display]
+  return (
+    <s-page heading="POS subscription modal">
+      <s-scroll-box>
+        <s-box padding="small">
+          {response?.data.productVariant.sellingPlanGroups.nodes.map(
+            (group) => {
+              return (
+                <s-section key={`${group.name}-section`} heading={group.name}>
+                  {group.sellingPlans.nodes.map((plan) => {
+                    return (
+                      <s-clickable
+                        key={`${plan.name}-clickable`}
+                        onClick={() => {
+                          handleClick(plan);
+                        }}
+                      >
+                        <s-text key={`${plan.name}-text`}>{plan.name}</s-text>
+                      </s-clickable>
+                    );
+                  })}
+                </s-section>
+              );
+            },
+          )}
+        </s-box>
+      </s-scroll-box>
+    </s-page>
+  );
+  // [END modal.display]
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Tile.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Tile.jsx
@@ -1,0 +1,38 @@
+import {render} from 'preact';
+import {useState, useEffect} from 'preact/hooks';
+
+export default function extension() {
+  render(<Tile />, document.body);
+}
+
+function Tile() {
+  const [sellingPlanEligible, setSellingPlanEligible] = useState(false);
+
+  // [START tile.subscribe]
+  useEffect(() => {
+    const unsubscribe = shopify.cart.current.subscribe((cart) => {
+      const sellingPlanEligibleLineItems = cart.lineItems.find(
+        (lineItem) => lineItem.hasSellingPlanGroups === true,
+      );
+
+      setSellingPlanEligible(sellingPlanEligibleLineItems !== undefined);
+    });
+    return unsubscribe;
+  }, []);
+  // [END tile.subscribe]
+
+  return (
+    <s-tile
+      heading={'Subscriptions'}
+      subheading={
+        sellingPlanEligible
+          ? 'Subscriptions available'
+          : 'Subscriptions not available'
+      }
+      // [START tile.disabled]
+      disabled={!sellingPlanEligible}
+      // [END tile.disabled]
+      onClick={() => shopify.action.presentModal()}
+    />
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/shopify.extension.toml
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/shopify.extension.toml
@@ -1,0 +1,28 @@
+api_version = "2025-10"
+
+# [START toml.description]
+[[extensions]]
+type = "ui_extension"
+name = "Subscription Tutorial"
+handle = "subscription-tutorial"
+description = "POS UI extension subscription tutorial"
+# [END toml.description]
+
+[[extensions.targeting]]
+module = "./src/Tile.jsx"
+target = "pos.home.tile.render"
+
+[[extensions.targeting]]
+module = "./src/Modal.jsx"
+target = "pos.home.modal.render"
+
+# [START toml.optional_targets]
+# Optional additional targets for line item details screen
+[[extensions.targeting]]
+module = "./src/Action.jsx"
+target = "pos.cart.line-item-details.action.render"
+
+[[extensions.targeting]]
+module = "./src/MenuItem.jsx"
+target = "pos.cart.line-item-details.action.menu-item.render"
+# [END toml.optional_targets]


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/18596

# Add subscription example for Point of Sale UI extensions

## Background

This PR adds example code for a Point of Sale UI extension that demonstrates how to implement subscription functionality.

Related PR to view the code refs being used: [https://app.graphite.com/github/pr/Shopify/shopify-dev/64603/[POS-UI-Extension]-Build-subscription-UI-extension](https://app.graphite.com/github/pr/Shopify/shopify-dev/64603/%5BPOS-UI-Extension%5D-Build-subscription-UI-extension) 

## Solution

Added example files that demonstrate a complete subscription implementation for Point of Sale UI extensions:

- `Action.jsx` - Implements an action component that fetches and displays selling plans for a cart line item
- `FetchSellingPlans.js` - Contains the GraphQL query to fetch selling plans for a product variant
- `MenuItem.jsx` - Creates a menu item button that is enabled/disabled based on selling plan availability
- `Modal.jsx` - Implements a modal that displays available subscription options and handles selection
- `Tile.jsx` - Creates a tile component that subscribes to cart updates and enables/disables based on subscription eligibility
- `shopify.extension.toml` - Configuration file defining the extension targets including home tile, modal, and line item actions

The example demonstrates how to fetch selling plans via GraphQL, manage subscription state, and implement the UI components needed for a complete subscription flow in Point of Sale.

## 🎩

https://app.graphite.com/github/pr/Shopify/shopify-dev/64603

## Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation