### PR TITLE
Expose il8n for POS ui extensions

### DIFF
--- a/.changeset/stupid-carrots-accept.md
+++ b/.changeset/stupid-carrots-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Expose Il8n type to POS UI extensions

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/standard/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/standard/standard-api.ts
@@ -7,9 +7,11 @@ import {ProductSearchApi} from '../product-search-api/product-search-api';
 import {PrintApi} from '../print-api/print-api';
 import {StorageApi} from '../storage-api/storage-api';
 import {PinPadApi} from '../pin-pad-api';
+import type {I18n} from '../../../../api';
 
 export type StandardApi<T> = {[key: string]: any} & {
   extensionPoint: T;
+  i18n: I18n;
 } & LocaleApi &
   ToastApi &
   SessionApi &


### PR DESCRIPTION
Part of https://github.com/shop/issues-retail/issues/20685

### Background

Add the `il8n` object to POS standard API.

<img width="289" height="89" alt="Screenshot 2025-11-07 at 4 52 58 PM" src="https://github.com/user-attachments/assets/d484c202-56e2-4b65-bb6d-390eb88dd06d" />

### 🎩

- checkout this branch
- dev cd pos-mobile
- dev yle add ./your-extension-path

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
