### PR TITLE
[POS UI extensions]: Improved target, API, component descriptions for 2025-10

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -21,6 +21,24 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        "- **Use modals for complex workflows:** Reserve modals for operations that genuinely require more screen space, multiple steps, or complex interactions that can't be handled by simple button actions.\n" +
+        '- **Provide clear entry points:** Use descriptive button labels and titles that clearly indicate what the modal will contain or what action it will perform, helping users understand what to expect.\n' +
+        '- **Handle modal dismissal gracefully:** Ensure your modal-based workflows handle user dismissal, saving progress when possible and providing clear feedback about incomplete operations.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        'Each extension can only present one modal at a time. Subsequent calls to `presentModal()` while a modal is already open may be ignored or replace the current modal.',
+    },
+  ],
   examples: {
     description:
       'Learn how to present full-screen modals from tiles and menu items using the Action API.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -19,7 +19,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ActionApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Standard APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -7,28 +7,15 @@ const generateJsxCodeBlockForActionApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Action API',
-  description: `
-The Action API allows an action extension to modally present its corresponding modal target.
-
-#### Supporting targets
-- ${TargetLink.PosHomeTileRender}
-- ${TargetLink.PosPurchasePostActionMenuItemRender}
-- ${TargetLink.PosPurchasePostBlockRender}
-- ${TargetLink.PosOrderDetailsActionMenuItemRender}
-- ${TargetLink.PosOrderDetailsBlockRender}
-- ${TargetLink.PosProductDetailsActionMenuItemRender}
-- ${TargetLink.PosProductDetailsBlockRender}
-- ${TargetLink.PosCustomerDetailsActionMenuItemRender}
-- ${TargetLink.PosCustomerDetailsBlockRender}
-- ${TargetLink.PosDraftOrderDetailsActionMenuItemRender}
-- ${TargetLink.PosDraftOrderDetailsBlockRender}
-`,
+  description:
+    'The Action API provides modal presentation functionality for POS UI extensions, allowing you to launch full-screen modal interfaces from menu items, tiles, and block targets. The API enables navigation between different targets within your extension.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'ActionApi',
-      description: '',
+      description:
+        'The `ActionApi` object provides methods for presenting modal interfaces. Access these methods through `shopify.action` to launch full-screen modal experiences.',
       type: 'ActionApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -22,19 +22,24 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the Action API.',
+    description:
+      'Learn how to present full-screen modals from tiles and menu items using the Action API.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForActionApi(
-          'Present a modal from post purchase.',
+          'Open a modal from a post-purchase action',
           'present-modal',
         ),
+        description:
+          "Create an action menu item that appears after a purchase is completed. When pressed, it launches a full-screen modal view using the Action API's `presentModal()` method, allowing you to display custom workflows or additional functionality in the post-purchase flow.",
       },
       {
         codeblock: generateJsxCodeBlockForActionApi(
-          'Present a modal from smart grid.',
+          'Open a modal from a smart grid tile',
           'present-modal-tile',
         ),
+        description:
+          "Create a smart grid tile on the POS home screen that launches a full-screen modal when tapped. This example shows how to use the Action API to present detailed views or workflows from your app's home tile, providing quick access to extended functionality.",
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -21,6 +21,28 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Handle cart state reactively:** Use the signal-based interface to automatically update your extension UI when cart changes occur.\n' +
+        '- **Validate operations before execution:** Check cart editability and validate input data before performing cart operations to prevent errors.\n' +
+        '- **Use bulk operations for efficiency:** When performing multiple related operations, use bulk methods like `bulkCartUpdate`, `bulkSetLineItemDiscounts`, and `bulkAddLineItemProperties` for better performance and reduced API calls.\n' +
+        '- **Handle errors gracefully:** Implement proper error handling for all cart operations, as they may fail due to inventory constraints, validation errors, oversell protection, or business rule violations.\n' +
+        '- **Manage selling plans appropriately:** When working with subscription products, validate selling plan compatibility and handle selling plan requirements.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Cart operations may fail due to business rules, inventory constraints, oversell protection, or validation errors—always implement appropriate error handling.\n' +
+        '- Some operations require specific preconditions. For example, customer must be present for address operations and selling plans must be compatible with line items.\n' +
+        '- Selling plan operations are only available for products that support selling plans and may have additional validation requirements.',
+    },
+  ],
   examples: {
     description:
       'Learn how to manage cart contents, apply discounts, handle customer information, and track cart changes in real time.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -22,163 +22,216 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the Cart API',
+    description:
+      'Learn how to manage cart contents, apply discounts, handle customer information, and track cart changes in real time.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForCartApi(
-          'Subscribe to cart changes.',
-          'subscribe',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Check editable state of the cart',
-          'check-cart-editable',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Apply a cart level discount',
-          'apply-cart-discount',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Apply a cart level discount code',
-          'apply-cart-code-discount',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Remove all the discounts on the cart and line items',
-          'remove-all-discounts',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Set a custom discount on a line item',
-          'set-line-item-discount',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Set a custom discount on multiple line items',
-          'bulk-set-line-item-discounts',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Remove a discount on a line item',
-          'remove-line-item-discount',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Clear the entire cart',
-          'clear-cart',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Set the customer in the cart',
-          'set-customer',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Remove the customer in the cart',
-          'remove-customer',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Add a custom sale to the cart',
+          'Add a custom sale item to the cart',
           'add-custom-sale',
         ),
+        description:
+          "Create and add a custom sale item that isn't tied to an existing product in your catalog. This example demonstrates using `addCustomSale()` to add a line item with a custom title, quantity, price, and tax settings—useful for services, custom orders, or special charges.",
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
-          'Add a line item to the cart',
+          'Add a new address to the customer',
+          'add-address',
+        ),
+        description:
+          "Create and add a new address to the customer associated with the cart. This example shows how to use `addAddress()` to add a complete address with street, city, province, name, and country information to the customer's profile for shipping or billing purposes.",
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Add a product to the cart',
           'add-line-item',
         ),
+        description:
+          "Add a product to the cart by specifying its variant ID and quantity. This example uses `addLineItem()` to add a product variant with the specified quantity, returning the new line item's UUID for future reference or manipulation.",
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
-          'Remove a line item from the cart',
-          'remove-line-item',
+          'Add a subscription selling plan to a line item',
+          'add-line-item-selling-plan',
         ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Add custom properties to the cart',
-          'add-cart-properties',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Remove custom properties from the cart',
-          'remove-cart-properties',
-        ),
+        description:
+          'Attach a selling plan to a line item to enable subscription or recurring payment options. This example demonstrates using `addLineItemSellingPlan()` to add a subscription plan to a specific product, allowing customers to purchase items on a recurring basis.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
           'Add custom properties to a line item',
           'add-line-item-properties',
         ),
+        description:
+          "Attach custom key-value metadata to a specific line item using its UUID. This example uses `addLineItemProperties()` to add an 'Engraving' property to a particular line item, useful for storing item-specific customizations, notes, or tracking data.",
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
           'Add custom properties to multiple line items',
           'bulk-add-line-item-properties',
         ),
+        description:
+          'Attach different custom properties to multiple line items simultaneously in a single operation. This example shows how to use `bulkAddLineItemProperties()` to efficiently add unique engraving text to multiple items at once, reducing API calls and improving performance.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Add custom properties to the cart',
+          'add-cart-properties',
+        ),
+        description:
+          "Attach custom key-value metadata to the cart for tracking, integrations, or additional context. This example uses `addCartProperties()` to add an 'Engraving' property to the cart, which merges with existing properties and overwrites duplicate keys.",
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Apply a discount code to the cart',
+          'apply-cart-code-discount',
+        ),
+        description:
+          "Add a discount to the cart using a discount code. This example shows how to apply the discount code 'SUMMER_2024' using the `addCartCodeDiscount()` method, which validates and applies the code server-side if it's valid and applicable to the current cart.",
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Apply a discount to a line item',
+          'set-line-item-discount',
+        ),
+        description:
+          "Add a discount to an individual line item in the cart using its UUID. This example applies a 10% discount titled 'Summer discount' to a specific line item using the `setLineItemDiscount()` method, allowing you to target discounts at particular products.",
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Apply a percentage discount to the cart',
+          'apply-cart-discount',
+        ),
+        description:
+          "Add a cart-level discount that applies to the total cart value. This example demonstrates applying a 10% discount titled 'Summer discount' to the cart using the `applyCartDiscount()` method with the `Percentage` discount type.",
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Apply different discounts to multiple line items',
+          'bulk-set-line-item-discounts',
+        ),
+        description:
+          'Add discounts to multiple line items simultaneously using a single operation. This example shows how to use `bulkSetLineItemDiscounts()` to apply different discount types and amounts to multiple items efficiently—one gets a 10% percentage discount while another receives a $15 fixed amount discount.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Associate a customer with the cart',
+          'set-customer',
+        ),
+        description:
+          'Associate a customer with the cart using their ID to enable customer-specific features. This example shows how to use `setCustomer()` to associate a customer, which enables personalized pricing, applicable discounts, loyalty benefits, and streamlines the checkout process.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Attribute a staff member to a line item',
+          'set-attributed-staff-to-line-item',
+        ),
+        description:
+          'Assign a staff member to an individual line item for detailed sales tracking. This example demonstrates using `setAttributedStaffToLineItem()` to track which staff member was responsible for selling a specific item, enabling item-level commission tracking and performance analysis.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Attribute a staff member to the cart',
+          'set-attributed-staff',
+        ),
+        description:
+          'Assign a staff member to the cart for sales tracking and commission purposes. This example uses `setAttributedStaff()` with a staff member ID to track who facilitated or managed the sale, useful for performance metrics and incentive calculations.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Check if the cart is editable',
+          'check-cart-editable',
+        ),
+        description:
+          'Check whether the cart can be modified before attempting cart operations. This example demonstrates using `cart.editable` to verify editability, preventing errors from operations attempted on locked or finalized carts during payment processing or order completion.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Clear all items from the cart',
+          'clear-cart',
+        ),
+        description:
+          'Empty the cart completely, removing all line items, discounts, and properties. This example uses `clearCart()` to reset the cart to its initial empty state while preserving the customer association if present, useful for starting a new transaction or canceling a sale.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Delete a customer address',
+          'delete-address',
+        ),
+        description:
+          "Remove an address from the customer's profile using its address ID. This example demonstrates using `deleteAddress()` to permanently delete an address, which is useful for maintaining accurate customer records and removing outdated or incorrect addresses.",
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Monitor cart changes in real time',
+          'subscribe',
+        ),
+        description:
+          'Subscribe to cart state changes to build reactive UI components that automatically update when the cart is modified. This example shows how to use the `cart.subscribe()` method to receive real-time notifications whenever line items, discounts, customer information, or other cart properties change.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Remove a discount from a line item',
+          'remove-line-item-discount',
+        ),
+        description:
+          'Remove a discount from a specific line item using its UUID. This example demonstrates using `removeLineItemDiscount()` to clear the discount from a particular item, restoring it to its standard price while leaving other cart discounts intact.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Remove a product from the cart',
+          'remove-line-item',
+        ),
+        description:
+          'Remove a specific line item from the cart using its UUID. This example demonstrates using `removeLineItem()` to delete an item from the cart, including any associated discounts or properties on that item.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Remove a subscription selling plan from a line item',
+          'remove-line-item-selling-plan',
+        ),
+        description:
+          'Remove the selling plan from a line item to convert it back to a one-time purchase. This example shows how to use `removeLineItemSellingPlan()` to clear subscription settings from a specific item while keeping the item in the cart.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForCartApi(
+          'Remove all discounts from the cart and line items',
+          'remove-all-discounts',
+        ),
+        description:
+          'Clear all discounts from the cart and its line items in a single operation. This example uses `removeAllDiscounts()` to remove cart-level discounts, line item discounts, and any applied discount codes, resetting pricing to standard amounts.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
           'Remove custom properties from a line item',
           'remove-line-item-properties',
         ),
+        description:
+          'Remove specific custom properties from a line item by providing its UUID and an array of property keys to delete. This example demonstrates using `removeLineItemProperties()` to clear particular metadata fields from an item while keeping other properties intact.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
-          'Set an attributed staff member on the cart',
-          'set-attributed-staff',
+          'Remove custom properties from the cart',
+          'remove-cart-properties',
         ),
+        description:
+          'Remove specific custom properties from the cart by providing an array of property keys. This example shows how to use `removeCartProperties()` to delete particular metadata fields while preserving other cart properties and data.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
-          'Set an attributed staff member on a line item',
-          'set-attributed-staff-to-line-item',
+          'Remove the customer from the cart',
+          'remove-customer',
         ),
+        description:
+          'Disassociate the current customer from the cart while preserving cart contents. This example uses `removeCustomer()` to clear customer information, which removes customer-specific pricing and discounts but keeps all line items and other cart data intact.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
-          'Add an address to the customer in the cart',
-          'add-address',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Delete an address corresponding to an ID',
-          'delete-address',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Set the default address of the customer in the cart',
+          'Update the default address for the customer',
           'update-default-address',
         ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Add a selling plan to a line item in the cart',
-          'add-line-item-selling-plan',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForCartApi(
-          'Remove a selling plan from a line item in the cart',
-          'remove-line-item-selling-plan',
-        ),
+        description:
+          "Set a specific address as the customer's default address using its address ID. This example shows how to use `updateDefaultAddress()` to designate which address should be used by default for shipping or billing in future transactions.",
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -7,31 +7,15 @@ const generateJsxCodeBlockForCartApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Cart API',
-  description: `
-The Cart API enables UI Extensions to manage and interact with POS cart contents, such as discounts, line items, and customer details. It provides a comprehensive set of functions for adding and removing items, alongside a subscribable object that keeps the UI Extension updated with real-time changes to the cart.
-
-#### Supporting targets
-- ${TargetLink.PosHomeTileRender}
-- ${TargetLink.PosHomeModalRender}
-- ${TargetLink.PosProductDetailsActionMenuItemRender}
-- ${TargetLink.PosProductDetailsActionRender}
-- ${TargetLink.PosProductDetailsBlockRender}
-- ${TargetLink.PosCustomerDetailsActionMenuItemRender}
-- ${TargetLink.PosCustomerDetailsActionRender}
-- ${TargetLink.PosCustomerDetailsBlockRender}
-- ${TargetLink.PosOrderDetailsActionMenuItemRender}
-- ${TargetLink.PosOrderDetailsActionRender}
-- ${TargetLink.PosOrderDetailsBlockRender}
-- ${TargetLink.PosDraftOrderDetailsActionMenuItemRender}
-- ${TargetLink.PosDraftOrderDetailsActionRender}
-- ${TargetLink.PosDraftOrderDetailsBlockRender}
-`,
+  description:
+    'The Cart API provides comprehensive access to POS cart management functionality, enabling extensions to read cart state, modify line items, apply discounts, manage customer information, and handle cart properties. The API supports both individual and bulk operations for efficient cart manipulation, with [selling plan functionality](/docs/apps/build/purchase-options/subscriptions/selling-plans) and error handling.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'CartApi',
-      description: '',
+      description:
+        'The `CartApi` object provides access to cart management functionality and real-time cart state monitoring. Access these properties through `shopify.cart` to interact with the current POS cart.',
       type: 'CartApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -19,7 +19,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'CartApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Contextual APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
@@ -9,19 +9,15 @@ const generateJsxCodeBlockForCartLineItemApi = (
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Cart Line Item API',
-  description: `
-The Cart Line Item API provides an extension with data about the current Cart Line Item.
-
-#### Supporting targets
-- ${TargetLink.PosCartLineItemDetailsActionMenuItemRender}
-- ${TargetLink.PosCartLineItemDetailsActionRender}
-`,
+  description:
+    'The Cart Line Item API provides read-only access to a specific line item in the cart. Use this API to get line item details like product information, pricing, discounts, and custom properties. This allows you to build features that respond to the specific item a customer is viewing or interacting with.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'CartLineItemApi',
-      description: '',
+      description:
+        'The `CartLineItemApi` object provides access to the current line item. Access this property through `api.cartLineItem` to interact with the current line item context.',
       type: 'CartLineItemApi',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
@@ -36,14 +36,27 @@ const data: ReferenceEntityTemplateSchema = {
     ],
   },
   category: 'APIs',
-  related: [
+  related: [],
+  subSections: [
     {
-      name: ExtensionTargetType.PosCartLineItemDetailsActionMenuItemRender,
-      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-action-menu-item-render',
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Handle optional properties gracefully:** Check for `undefined` values in optional properties like `price`, `productId`, `title`, `sku`, `vendor`, and selling plan-related fields before using them in your extension logic.\n' +
+        '- **Use line item context effectively:** Use the line item data to create contextual experiences—for example, showing different interfaces for gift cards versus regular products, subscription items versus one-time purchases, or displaying vendor-specific information.\n' +
+        '- **Implement item-specific validation:** Use line item properties like `taxable`, `isGiftCard`, `requiresSellingPlan`, and `hasSellingPlanGroups` to implement appropriate validation and business logic for different item types.\n' +
+        '- **Handle selling plans appropriately:** When working with subscription products, check `requiresSellingPlan` and `sellingPlan` properties.\n' +
+        '- **Access related data efficiently:** Use `productId` and `variantId` to fetch additional product information when needed, but avoid unnecessary API calls by using the data already available in the line item.',
     },
     {
-      name: ExtensionTargetType.PosCartLineItemDetailsActionRender,
-      url: '/docs/api/pos-ui-extensions/targets/pos-cart-line-item-details-action-render',
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- The API provides read-only access to line item data—use the Cart API for modifying line item properties, discounts, selling plans, or other attributes.\n' +
+        '- Line item data reflects the current state and may not include real-time inventory, pricing, or selling plan updates until the cart is refreshed.\n' +
+        "- Selling plan information may be limited during refund or exchange operations where digest values aren't available.",
     },
   ],
 };

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
@@ -22,13 +22,16 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   examples: {
-    description: 'Examples of using the Cart Line Item API.',
+    description:
+      'Learn how to access line item information in cart line item action contexts.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForCartLineItemApi(
-          'Retrieve the ID of the cart line item.',
+          'Display the line item ID',
           'id',
         ),
+        description:
+          'Access the unique identifier of the current line item in a cart line item action context. This example shows how to use `shopify.cartLineItem.id` to retrieve the line item ID, which can be used for tracking, analytics, or performing operations on the specific item.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
@@ -35,7 +35,8 @@ const data: ReferenceEntityTemplateSchema = {
       },
     ],
   },
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Contextual APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -23,13 +23,16 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the Connectivity API',
+    description:
+      'Learn how to monitor Internet connectivity status and respond to network changes.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForConnectivityApi(
-          'Subscribe to connectivity changes.',
+          'Monitor Internet connectivity status',
           'subscribe',
         ),
+        description:
+          'Subscribe to connectivity state changes to build network-aware extensions that respond to connectivity changes. This example shows how to use `shopify.connectivity.subscribe()` to receive real-time notifications when the device goes online or offline, allowing you to adapt your UI or disable features when Internet access is unavailable.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -9,13 +9,14 @@ const generateJsxCodeBlockForConnectivityApi = (
 const data: ReferenceEntityTemplateSchema = {
   name: 'Connectivity API',
   description:
-    'The Connectivity API enables POS UI extensions to retrieve device connectivity information, such as whether the device has an internet connection.',
+    'The Connectivity API provides access to device connectivity information, allowing you to monitor Internet connection status and respond to connectivity changes in real-time. The API enables both immediate connectivity checks and dynamic updates when network conditions change.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'ConnectivityApi',
-      description: '',
+      description:
+        'The `ConnectivityApi` object provides access to current connectivity information and change notifications. Access these properties through `shopify.connectivity` to monitor network status.',
       type: 'ConnectivityApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -20,7 +20,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ConnectivityApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -39,9 +39,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- The Connectivity API provides read-only access to connectivity information and can\'t be used to control or modify network settings on the device.\n' +
+        "- The Connectivity API provides read-only access to connectivity information and can't be used to control or modify network settings on the device.\n" +
         '- Connectivity status reflects Internet connectivity only and may not indicate the quality or speed of the connection, which could affect API performance.\n' +
-        '- The API monitors general Internet connectivity but doesn\'t provide specific information about Shopify service availability or API endpoint availability.',
+        "- The API monitors general Internet connectivity but doesn't provide specific information about Shopify service availability or API endpoint availability.",
     },
   ],
   examples: {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -22,6 +22,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Handle connectivity changes gracefully:** Use the `subscribe` method to automatically adapt your extension behavior when connectivity changes.\n' +
+        '- **Design for connectivity awareness:** Design your extension to handle network interruptions, informing users when network-dependent features are unavailable and providing clear guidance on next steps.\n' +
+        '- **Provide clear connectivity feedback:** Display connectivity status to users when it affects functionality, helping them understand why certain features may be limited or unavailable.\n' +
+        '- **Queue operations during outages:** Implement queuing mechanisms for non-critical operations that can be deferred until connectivity is restored.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- The Connectivity API provides read-only access to connectivity information and can\'t be used to control or modify network settings on the device.\n' +
+        '- Connectivity status reflects Internet connectivity only and may not indicate the quality or speed of the connection, which could affect API performance.\n' +
+        '- The API monitors general Internet connectivity but doesn\'t provide specific information about Shopify service availability or API endpoint availability.',
+    },
+  ],
   examples: {
     description:
       'Learn how to monitor Internet connectivity status and respond to network changes.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -34,14 +34,24 @@ const data: ReferenceEntityTemplateSchema = {
     ],
   },
   category: 'APIs',
-  related: [
+  related: [],
+  subSections: [
     {
-      name: ExtensionTargetType.PosCustomerDetailsActionMenuItemRender,
-      url: '/docs/api/pos-ui-extensions/targets/pos-customer-details-action-menu-item-render',
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use customer ID for data lookups:** Use the customer ID to fetch additional customer information from external systems, CRM platforms, or Shopify APIs when building comprehensive customer experiences.\n' +
+        '- **Implement customer-specific features:** Use the customer context to enable personalized functionality like customer-specific pricing, loyalty program integration, or customized product recommendations.\n' +
+        '- **Validate customer access:** Verify that the customer ID is valid before performing customer-specific operations or external API calls.',
     },
     {
-      name: ExtensionTargetType.PosCustomerDetailsActionRender,
-      url: '/docs/api/pos-ui-extensions/targets/pos-customer-details-action-render',
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- The API provides only the customer identifier—use Shopify APIs or external systems to fetch additional customer details like name, email, or purchase history.\n' +
+        '- Customer data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.',
     },
   ],
 };

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -7,20 +7,15 @@ const generateJsxCodeBlockForCustomerApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Customer API',
-  description: `
-The customer API provides an extension with data about the current customer.
-
-#### Supporting targets
-- ${TargetLink.PosCustomerDetailsActionMenuItemRender}
-- ${TargetLink.PosCustomerDetailsActionRender}
-- ${TargetLink.PosCustomerDetailsBlockRender}
-`,
+  description:
+    'The Customer API provides read-only access to customer data. Use this API to get customer information and build personalized experiences based on the selected customer context. The API offers the customer identifier for linking to customer data and enabling customer-specific features.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'CustomerApi',
-      description: '',
+      description:
+        'The `CustomerApi` object provides access to customer data. Access this property through `shopify.customer` to interact with the current customer context.',
       type: 'CustomerApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -33,7 +33,8 @@ const data: ReferenceEntityTemplateSchema = {
       },
     ],
   },
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Contextual APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -20,13 +20,16 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   examples: {
-    description: 'Examples of using the Customer API.',
+    description:
+      'Learn how to access customer information in customer detail contexts.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForCustomerApi(
-          'Retrieve the ID of the customer.',
+          'Display the customer ID',
           'id',
         ),
+        description:
+          'Access the unique identifier of the current customer in a customer detail action context. This example shows how to use `shopify.customer.id` to retrieve the customer ID, which can be used for personalization, fetching additional customer data, or building customer-specific features.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -7,13 +7,14 @@ const generateJsxCodeBlockForDeviceApi = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Device API',
   description:
-    'The Device API allows the UI Extension to retrieve device information including the device name and ID.',
+    'The Device API provides access to device information and capabilities, allowing you to retrieve device details, check device types, and adapt your extension behavior based on the POS hardware characteristics. The API enables device-aware functionality and responsive design based on device form factors.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'DeviceApi',
-      description: '',
+      description:
+        'The `DeviceApi` object provides access to device information and capabilities. Access these properties and methods through `shopify.device` to retrieve device details and check device characteristics.',
       type: 'DeviceApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -21,25 +21,32 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the Device API.',
+    description:
+      'Learn how to access device information and adapt your extension based on device characteristics.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForDeviceApi(
-          'Retrieve name of the device.',
-          'name',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForDeviceApi(
-          'Retrieve the ID of the device.',
-          'device-id',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForDeviceApi(
-          'Check if device is a tablet.',
+          'Check if the device is a tablet',
           'tablet',
         ),
+        description:
+          'Determine whether the extension is running on a tablet form factor. This example shows how to use `shopify.device.isTablet()` to check the device type, allowing you to adapt your UI layout, component sizes, or features based on whether the device is a tablet or other form factor.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForDeviceApi(
+          'Display the device ID',
+          'device-id',
+        ),
+        description:
+          'Access the unique identifier of the POS device. This example demonstrates using `shopify.device.id` to retrieve the device ID, which can be used for device-specific configurations, tracking, or associating data with particular devices.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForDeviceApi(
+          'Display the device name',
+          'name',
+        ),
+        description:
+          'Access the name of the POS device running your extension. This example shows how to use `shopify.device.name` to retrieve the device name, which can be useful for debugging, analytics, or displaying device-specific information to users.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -38,8 +38,8 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent:
         '- Device information queries are asynchronous and may take time to resolve, so always handle the Promise-based responses appropriately in your extension logic.\n' +
-        '- The Device API provides read-only access to device information and can\'t be used to modify device settings or capabilities.\n' +
-        '- Device type detection is limited to basic form factor identification (tablet vs. non-tablet) and doesn\'t provide detailed hardware specifications or capabilities.',
+        "- The Device API provides read-only access to device information and can't be used to modify device settings or capabilities.\n" +
+        "- Device type detection is limited to basic form factor identification (tablet vs. non-tablet) and doesn't provide detailed hardware specifications or capabilities.",
     },
   ],
   examples: {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -20,6 +20,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Implement responsive design:** Use device type information to adapt your interface layouts, component sizes, and interaction patterns based on the device form factor and capabilities.\n' +
+        '- **Handle async device queries:** Handle the Promise-based device methods with async/await or `.then()` patterns, and implement appropriate error handling for device query failures.\n' +
+        '- **Cache device information appropriately:** Consider caching device information after the initial query to avoid repeated async calls, but ensure you handle cases where device characteristics might change during the session.\n' +
+        '- **Provide device-appropriate experiences:** Design different user experiences for tablets versus other devices, taking advantage of larger screens while ensuring functionality works across all supported device types.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Device information queries are asynchronous and may take time to resolve, so always handle the Promise-based responses appropriately in your extension logic.\n' +
+        '- The Device API provides read-only access to device information and can\'t be used to modify device settings or capabilities.\n' +
+        '- Device type detection is limited to basic form factor identification (tablet vs. non-tablet) and doesn\'t provide detailed hardware specifications or capabilities.',
+    },
+  ],
   examples: {
     description:
       'Learn how to access device information and adapt your extension based on device characteristics.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -18,7 +18,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'DeviceApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
@@ -37,6 +37,25 @@ const data: ReferenceEntityTemplateSchema = {
   },
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use draft order ID for data lookups:** Use the draft order ID to fetch additional draft order information from external systems, order management platforms, or Shopify APIs when building comprehensive draft order experiences.\n' +
+        '- **Implement draft order-specific features:** Use the draft order context to enable specialized functionality like draft order conversion, customer assignment, or order modification workflows.\n' +
+        '- **Validate draft order access:** Verify that the draft order ID is valid before performing draft order-specific operations or external API calls.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- The API provides only basic draft order information—use Shopify APIs or external systems to fetch additional draft order details like line items, totals, or timestamps.\n' +
+        '- Draft order data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.',
+    },
+  ],
 };
 
 export default data;

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
@@ -22,13 +22,16 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   examples: {
-    description: 'Examples of using the Draft Order API.',
+    description:
+      'Learn how to access draft order information in draft order detail contexts.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForDraftOrderApi(
-          'Retrieve the ID of the draft order.',
+          'Display the draft order ID',
           'id',
         ),
+        description:
+          'Access the unique identifier of the current draft order in a draft order detail action context. This example shows how to use `shopify.draftOrder.id` to retrieve the draft order ID, which can be used for tracking, fetching additional order data, or implementing draft order-specific workflows.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
@@ -9,21 +9,15 @@ const generateJsxCodeBlockForDraftOrderApi = (
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Draft Order API',
-  description: `
-The Draft Order API provides an extension with data about the current draft order.
-
-
-#### Supporting targets
-- ${TargetLink.PosDraftOrderDetailsActionMenuItemRender}
-- ${TargetLink.PosDraftOrderDetailsActionRender}
-- ${TargetLink.PosDraftOrderDetailsBlockRender}
-`,
+  description:
+    'The Draft Order API provides read-only access to draft order data. Use this API to get draft order information and build contextual experiences based on the selected draft order context. The API offers draft order details for implementing order-specific functionality and workflows.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'DraftOrderApi',
-      description: '',
+      description:
+        'The `DraftOrderApi` object provides access to draft order data. Access this property through `api.draftOrder` to interact with the current draft order context.',
       type: 'DraftOrderApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
@@ -35,7 +35,8 @@ const data: ReferenceEntityTemplateSchema = {
       },
     ],
   },
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Contextual APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -7,13 +7,14 @@ const generateJsxCodeBlockForLocaleApi = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Locale API',
   description:
-    "The Locale API allows the extension to retrieve the merchant's locale.",
+    "The Locale API provides access to the merchant's current locale information in [IETF format](https://en.wikipedia.org/wiki/IETF_language_tag), allowing you to internationalize your extension content and respond to locale changes in real time. The API enables both immediate locale access and dynamic updates when merchants change their language settings.",
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'LocaleApi',
-      description: '',
+      description:
+        'The `LocaleApi` object provides access to current locale information and change notifications. Access these properties through `shopify.locale` to retrieve and monitor locale data.',
       type: 'LocaleApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -20,6 +20,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Handle locale changes reactively:** Use the `subscribe` method to automatically update your extension content when merchants change their language settings.\n' +
+        '- **Implement proper formatting:** Use the IETF locale format to implement proper date formatting, number formatting, currency display, and text direction based on the merchant\'s language and region preferences.\n' +
+        '- **Cache localized content:** Consider caching translated content and locale-specific formatting to improve performance, but ensure you invalidate caches when locale changes occur through subscription updates.\n' +
+        '- **Provide fallback locale handling:** Implement fallback behavior for unsupported locales or when localization resources are unavailable, defaulting to a supported language like English.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- The Locale API provides read-only access to locale information and can\'t be used to change the merchant\'s locale settings, which must be configured through POS system settings.\n' +
+        '- Locale changes are detected through the subscription mechanism, but the API doesn\'t provide historical locale information or change timestamps.\n' +
+        '- The locale format follows IETF standards, but the specific locales available depend on POS system configuration and may vary between different Shopify POS installations.',
+    },
+  ],
   examples: {
     description:
       'Learn how to access locale information and respond to language changes for internationalization.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -28,7 +28,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Handle locale changes reactively:** Use the `subscribe` method to automatically update your extension content when merchants change their language settings.\n' +
-        '- **Implement proper formatting:** Use the IETF locale format to implement proper date formatting, number formatting, currency display, and text direction based on the merchant\'s language and region preferences.\n' +
+        "- **Implement proper formatting:** Use the IETF locale format to implement proper date formatting, number formatting, currency display, and text direction based on the merchant's language and region preferences.\n" +
         '- **Cache localized content:** Consider caching translated content and locale-specific formatting to improve performance, but ensure you invalidate caches when locale changes occur through subscription updates.\n' +
         '- **Provide fallback locale handling:** Implement fallback behavior for unsupported locales or when localization resources are unavailable, defaulting to a supported language like English.',
     },
@@ -37,8 +37,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- The Locale API provides read-only access to locale information and can\'t be used to change the merchant\'s locale settings, which must be configured through POS system settings.\n' +
-        '- Locale changes are detected through the subscription mechanism, but the API doesn\'t provide historical locale information or change timestamps.\n' +
+        "- The Locale API provides read-only access to locale information and can't be used to change the merchant's locale settings, which must be configured through POS system settings.\n" +
+        "- Locale changes are detected through the subscription mechanism, but the API doesn't provide historical locale information or change timestamps.\n" +
         '- The locale format follows IETF standards, but the specific locales available depend on POS system configuration and may vary between different Shopify POS installations.',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -21,13 +21,16 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the Locale API',
+    description:
+      'Learn how to access locale information and respond to language changes for internationalization.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForLocaleApi(
-          'Subscribe to locale changes.',
+          'Monitor locale changes',
           'subscribe',
         ),
+        description:
+          "Subscribe to locale changes to build internationalized extensions that automatically adapt to the merchant's language settings. This example shows how to use `shopify.locale.subscribe()` to receive real-time notifications when the merchant changes their language, allowing you to update your UI text, date formats, and number formats accordingly.",
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -18,7 +18,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'LocaleApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Standard APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -30,25 +30,32 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the Navigation API',
+    description:
+      'Learn how to navigate between screens and manage navigation state within modal interfaces.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForNavigationApi(
-          'Navigate between two screens',
+          'Navigate between multiple screens',
           'two-screen',
         ),
+        description:
+          'Create multi-screen modal experiences by navigating between different URLs within your extension. This example demonstrates using `navigation.navigate()` to move between screens and handle back navigation, enabling complex workflows with multiple steps or views.',
       },
       {
         codeblock: generateJsxCodeBlockForNavigationApi(
-          'Navigate to a POS native screen with uri',
+          'Navigate to a native POS screen',
           'native-screen',
         ),
+        description:
+          'Launch native POS screens using URI schemes to access built-in functionality. This example shows how to use `navigation.navigate()` with a `pos://` URI to open native POS screens like product details or customer profiles, allowing seamless integration between your extension and native POS features.',
       },
       {
         codeblock: generateJsxCodeBlockForNavigationApi(
-          'Navigate to a screen with state parameters',
+          'Pass state parameters between screens',
           'state-params',
         ),
+        description:
+          'Share data between screens using navigation state parameters. This example demonstrates how to pass state objects when navigating, allowing you to transfer information between different screens in your modal workflow without relying on external storage or global variables.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -44,8 +44,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- The Navigation API is only available in action (modal) targets and can\'t be used in action (menu item), block, or tile targets that don\'t support multi-screen navigation.\n' +
-        '- Navigation state is limited to serializable data and can\'t contain functions, complex objects, or circular references.\n' +
+        "- The Navigation API is only available in action (modal) targets and can't be used in action (menu item), block, or tile targets that don't support multi-screen navigation.\n" +
+        "- Navigation state is limited to serializable data and can't contain functions, complex objects, or circular references.\n" +
         '- The API follows web platform standards but operates within the POS modal context, so some web navigation behaviors may differ from standard browser navigation.',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -29,6 +29,25 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use URL-based navigation:** Implement URL-based navigation patterns that allow for deep-linking, bookmarking, and intuitive browser-like navigation within your modal workflows.\n' +
+        '- **Manage navigation state effectively:** Use the `state` parameter in navigation options to pass data between screens, maintaining workflow context and user progress across navigation changes.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- The Navigation API is only available in action (modal) targets and can\'t be used in action (menu item), block, or tile targets that don\'t support multi-screen navigation.\n' +
+        '- Navigation state is limited to serializable data and can\'t contain functions, complex objects, or circular references.\n' +
+        '- The API follows web platform standards but operates within the POS modal context, so some web navigation behaviors may differ from standard browser navigation.',
+    },
+  ],
   examples: {
     description:
       'Learn how to navigate between screens and manage navigation state within modal interfaces.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -27,7 +27,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Window',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -9,28 +9,21 @@ const generateJsxCodeBlockForNavigationApi = (
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Navigation API',
-  description: `
-The Navigation API enables POS UI extension to navigate between screens.
-
-#### Supporting targets
-- ${TargetLink.PosHomeModalRender}
-- ${TargetLink.PosPurchasePostActionRender}
-- ${TargetLink.PosProductDetailsActionRender}
-- ${TargetLink.PosOrderDetailsActionRender}
-- ${TargetLink.PosDraftOrderDetailsActionRender}
-- ${TargetLink.PosCustomerDetailsActionRender}
-`,
+  description:
+    'The Navigation API provides web-standard navigation functionality for POS UI extensions, allowing you to navigate between URLs, manage navigation history, and handle navigation events within modal interfaces. The API is available globally as the `navigation` object and follows web platform standards.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'NavigationApi',
-      description: '',
+      description:
+        'The global `navigation` object provides web-standard navigation functionality. Access these properties and methods directly through the global `navigation` object to manage navigation within modal interfaces.',
       type: 'Navigation',
     },
     {
       title: 'Window',
-      description: '',
+      description:
+        'The global `window` object provides control over the extension screen lifecycle. Access these properties and methods directly through the global `window` object to manage the modal interface.',
       type: 'Window',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -22,13 +22,16 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the Order API.',
+    description:
+      'Learn how to access order information in order detail contexts.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForOrderApi(
-          'Retrieve the ID of the order.',
+          'Display the order ID',
           'id',
         ),
+        description:
+          'Access the unique identifier of the current order in an order detail action context. This example shows how to use `shopify.order.id` to retrieve the order ID, which can be used for fetching additional order data, tracking, or implementing order-specific functionality and post-purchase workflows.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -7,23 +7,15 @@ const generateJsxCodeBlockForOrderApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Order API',
-  description: `
-The Order API provides an extension with data about the current order.
-
-#### Supporting targets
-- ${TargetLink.PosPurchasePostActionMenuItemRender}
-- ${TargetLink.PosPurchasePostActionRender}
-- ${TargetLink.PosPurchasePostBlockRender}
-- ${TargetLink.PosOrderDetailsActionMenuItemRender}
-- ${TargetLink.PosOrderDetailsActionRender}
-- ${TargetLink.PosOrderDetailsBlockRender}
-`,
+  description:
+    'The Order API provides read-only access to order data. Use this API to get order information and build contextual experiences based on the selected order context. The API offers order details for implementing order-specific functionality and workflows.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'OrderApi',
-      description: '',
+      description:
+        'The `OrderApi` object provides access to order data. Access this property through `shopify.order` to interact with the current order context.',
       type: 'OrderApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -19,7 +19,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'OrderApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Contextual APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -21,6 +21,25 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use order ID for data lookups:** Use the order ID to fetch additional order information from external systems, order management platforms, or Shopify APIs when building comprehensive order experiences.\n' +
+        '- **Implement order-specific features:** Use the order context to enable specialized functionality like order fulfillment, customer communication, or order modification workflows.\n' +
+        '- **Validate order access:** Verify that the order ID is valid before performing order-specific operations or external API calls.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- The API provides only basic order information—use Shopify APIs or external systems to fetch additional order details like line items, totals, or fulfillment status.\n' +
+        '- Order data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.',
+    },
+  ],
   examples: {
     description:
       'Learn how to access order information in order detail contexts.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
@@ -21,13 +21,16 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the PinPad API',
+    description:
+      'Learn how to display secure PIN entry interfaces and handle PIN validation.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForToastApi(
-          'Display a PinPad and validate the PIN',
+          'Display a PIN pad and validate user input',
           'validation',
         ),
+        description:
+          'Present a secure PIN pad interface to collect and validate user PINs for authentication or verification. This example shows how to use `shopify.pinPad.show()` to display a PIN entry modal with customizable options, handle the entered PIN securely, and process the result for secure authentication workflows.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
@@ -20,6 +20,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Implement secure PIN validation:** Validate PINs securely on your backend service rather than in client-side code, using the `onSubmit` callback to communicate with your secure validation endpoint.\n' +
+        '- **Provide clear user feedback:** Use appropriate labels, titles, and error messages to guide users through the PIN entry process.\n' +
+        '- **Handle PIN entry appropriately:** Implement proper error handling for PIN validation failures, provide retry mechanisms, and ensure sensitive PIN data is handled securely throughout the process.\n' +
+        '- **Configure appropriate PIN constraints:** Set reasonable PIN length requirements and masking options based on your security requirements and user experience considerations.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- PIN validation must be handled through the `onSubmit` callback and should be performed securely on your backend service rather than in client-side extension code.\n' +
+        '- The PinPad API displays a modal interface that takes over the entire screen until PIN entry is complete or the modal is dismissed.\n' +
+        '- PIN data is provided as an array of numbers and must be handled securely, following appropriate data protection and privacy practices.',
+    },
+  ],
   examples: {
     description:
       'Learn how to display secure PIN entry interfaces and handle PIN validation.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
@@ -7,13 +7,14 @@ const generateJsxCodeBlockForToastApi = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'PinPad API',
   description:
-    'The PinPad API allows the display of a PinPad component for PIN validation.',
+    'The PinPad API provides secure PIN entry functionality for POS UI extensions, allowing you to display modal PIN pad interfaces for secure PIN collection, validation, and processing with customizable options and callback handling. The API enables secure authentication workflows within your extensions.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'PinPadApi',
-      description: '',
+      description:
+        'The `PinPadApi` object provides methods for displaying secure PIN entry interfaces. Access these methods through `shopify.pinPad` to show PIN pad modals and handle PIN validation.',
       type: 'PinPadApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
@@ -18,7 +18,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'PinPadApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
@@ -37,25 +37,32 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   examples: {
-    description: 'Examples of using the Print API',
+    description:
+      'Learn how to trigger document printing for receipts, labels, and custom documents.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForPrintApi(
-          'Print directly from the tile',
+          'Print a document directly from a tile',
           'print',
         ),
+        description:
+          'Trigger the native print dialog from a smart grid tile action. This example shows how to use `shopify.print()` to print a document specified by a relative path, allowing quick printing of receipts, labels, or reports directly from the POS home screen.',
       },
       {
         codeblock: generateJsxCodeBlockForPrintApi(
-          'Print with relative path',
-          'print-relative',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForPrintApi(
-          'Print with full URL',
+          'Print from a remote URL',
           'print-full-url',
         ),
+        description:
+          'Print documents hosted on external servers using full URLs. This example shows how to use `shopify.print()` with a complete URL to print remotely hosted documents, enabling dynamic content generation or printing from external services.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForPrintApi(
+          'Print using a relative file path',
+          'print-relative',
+        ),
+        description:
+          'Print documents using relative paths within your extension bundle. This example demonstrates using `shopify.print()` with a relative path to reference HTML, text, image, or PDF files included in your extension, making it easy to print pre-defined templates or documents.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
@@ -24,16 +24,26 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'APIs',
-  related: [
+  related: [],
+  subSections: [
     {
-      name: 'PrintPreview Component',
-      subtitle: 'Preview documents before printing',
-      url: '/api/pos-ui-extensions/components/printpreview',
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use appropriate document formats:** Choose HTML for rich formatting and responsive design, text for simple content, images for graphics, and PDFs for complex documents while considering platform limitations.\n' +
+        '- **Handle printing errors gracefully:** Implement proper error handling for print operations, including network failures, unsupported document types, or printer connectivity issues.\n' +
+        '- **Optimize documents for printing:** Design your printable documents with appropriate sizing, margins, and formatting that work well with printers and standard paper sizes.\n' +
+        '- **Provide user feedback:** Give users clear feedback about print operations, including loading states, success confirmations, and error messages when printing fails.',
     },
     {
-      name: 'Build a Print Extension',
-      subtitle: 'Learn how to implement printing',
-      url: '/docs/apps/build/pos/build-print-extension?extension=preact',
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- PDF printing on Android devices requires downloading the file and using an external application, which may interrupt the user workflow.\n' +
+        '- Print operations depend on device printer connectivity and configuration, which may not be available in all POS setups.\n' +
+        '- Document formatting and appearance may vary depending on the printer type, paper size, and device capabilities.',
     },
   ],
   examples: {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
@@ -23,7 +23,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'PrintApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
@@ -6,23 +6,20 @@ const generateJsxCodeBlockForPrintApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Print API',
-  description: `The Print API enables document printing functionality in your point of sale extension. Use this API to trigger the native print dialog for your documents.
-
-The \`print()\` method accepts either:
-- A relative path that will be appended to your app's [application_url](/docs/apps/build/cli-for-apps/app-configuration#application_url)
-- A full URL to your app's backend that will be used to return the document to print
-
-Supported document types:
-- HTML documents (recommended for best printing experience)
-- Text files
-- Image files (PNG, JPEG, etc.)
-- PDF files (Note: On Android devices, PDFs will be downloaded and must be printed using an external application)`,
+  description:
+    'The Print API enables document printing functionality in your POS UI extension. Use this API to trigger the native print dialog for your documents.' +
+    '\n\nSupported document types:' +
+    '\n\n- **HTML documents** (`.html`, `.htm`) - Best printing experience with full CSS styling, embedded images, and complex layouts. Use for receipts, invoices, and formatted reports.' +
+    '\n\n- **Text files** (`.txt`, `.csv`) - Plain text with basic content and tabular data support. Use for simple receipts and data exports.' +
+    '\n\n- **Image files** (`.png`, `.jpg`, `.jpeg`, `.gif`, `.bmp`, `.webp`) - Common web formats with format-specific optimizations. Use for logos, charts, QR codes, and barcodes.' +
+    '\n\n- **PDF files** (`.pdf`) - Behavior varies by platform: prints directly on iOS/desktop, but downloads to external viewer on Android. Use for complex documents and compliance requirements.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'PrintApi',
-      description: 'Interface for handling print operations',
+      description:
+        'The `PrintApi` object provides methods for triggering document printing. Access these methods through `shopify.print` to initiate print operations with various document types.',
       type: 'PrintApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -20,13 +20,16 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   examples: {
-    description: 'Examples of using the Product API.',
+    description:
+      'Learn how to access product information in product detail contexts.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForProductApi(
-          'Retrieve the ID of the product.',
+          'Display the product ID',
           'id',
         ),
+        description:
+          'Access the unique identifier of the current product in a product detail action context. This example shows how to use `shopify.product.id` to retrieve the product ID, which can be used for fetching additional product data, analytics, or implementing product-specific features and workflows.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -33,7 +33,8 @@ const data: ReferenceEntityTemplateSchema = {
       },
     ],
   },
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Contextual APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -34,14 +34,24 @@ const data: ReferenceEntityTemplateSchema = {
     ],
   },
   category: 'APIs',
-  related: [
+  related: [],
+  subSections: [
     {
-      name: ExtensionTargetType.PosProductDetailsActionMenuItemRender,
-      url: '/docs/api/pos-ui-extensions/targets/pos-product-details-action-menu-item-render',
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use product ID for data lookups:** Use the product ID to fetch additional product information from external systems, inventory management platforms, or Shopify APIs when building comprehensive product experiences.\n' +
+        '- **Implement variant-specific features:** Use the variant ID to enable specialized functionality like variant-specific pricing, inventory checks, or cart operations.\n' +
+        '- **Validate product access:** Verify that the product ID and variant ID are valid before performing product-specific operations or external API calls.',
     },
     {
-      name: ExtensionTargetType.PosProductDetailsActionRender,
-      url: '/docs/api/pos-ui-extensions/targets/pos-product-details-action-render',
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- The API provides only basic product identifiers—use Shopify APIs or external systems to fetch additional product details like title, description, pricing, or inventory levels.\n' +
+        '- Product data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.',
     },
   ],
 };

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -7,20 +7,15 @@ const generateJsxCodeBlockForProductApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Product API',
-  description: `
-The Product API provides an extension with data about the current Product.
-
-#### Supporting targets
-- ${TargetLink.PosProductDetailsActionMenuItemRender}
-- ${TargetLink.PosProductDetailsActionRender}
-- ${TargetLink.PosProductDetailsBlockRender}
-`,
+  description:
+    'The Product API provides read-only access to product data. Use this API to get product information and build contextual experiences based on the selected product context. The API offers product details for implementing product-specific functionality and workflows.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'ProductApi',
-      description: '',
+      description:
+        'The `ProductApi` object provides access to product data. Access this property through `shopify.product` to interact with the current product context.',
       type: 'ProductApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -22,6 +22,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Implement efficient pagination:** Use appropriate page sizes and cursor-based pagination to balance performance with user experience, especially for large product catalogs.\n' +
+        '- **Handle search results gracefully:** Check for undefined results and empty result sets.\n' +
+        '- **Optimize search performance:** Consider caching frequently accessed product data and implementing debounced search to reduce API calls while users are typing search queries.\n' +
+        '- **Provide relevant search options:** Use appropriate sorting options based on your use case - relevance for user searches, alphabetical for browsing, or recently added for highlighting new products.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Product search results are limited to products available on the current POS device and may not include the complete shop catalog if products aren\'t synced locally.\n' +
+        '- Bulk operations (`fetchProductsWithIds` and `fetchProductVariantsWithIds`) are limited to 50 items maximum, with additional IDs automatically removed from requests.\n' +
+        '- Search functionality depends on local product data synchronization and may not reflect real-time inventory or pricing changes until the next sync.',
+    },
+  ],
   examples: {
     description:
       'Learn how to search for products, fetch product details, and retrieve variants.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -39,7 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Product search results are limited to products available on the current POS device and may not include the complete shop catalog if products aren\'t synced locally.\n' +
+        "- Product search results are limited to products available on the current POS device and may not include the complete shop catalog if products aren't synced locally.\n" +
         '- Bulk operations (`fetchProductsWithIds` and `fetchProductVariantsWithIds`) are limited to 50 items maximum, with additional IDs automatically removed from requests.\n' +
         '- Search functionality depends on local product data synchronization and may not reflect real-time inventory or pricing changes until the next sync.',
     },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -20,7 +20,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ProductSearchApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Standard APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -28,22 +28,6 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(
-          'Fetch a single product by ID',
-          'fetch-product-with-id',
-        ),
-        description:
-          'Retrieve detailed information for a specific product using its ID. This example demonstrates using `shopify.productSearch.fetchById()` to get complete product data including variants, pricing, and inventory information for a single product.',
-      },
-      {
-        codeblock: generateJsxCodeBlockForProductSearchApi(
-          'Fetch a single variant by ID',
-          'fetch-product-variant-with-id',
-        ),
-        description:
-          'Retrieve detailed information for a specific product variant using its ID. This example demonstrates using `shopify.productSearch.fetchVariantById()` to get variant-specific data including pricing, inventory, and options for a particular variant.',
-      },
-      {
-        codeblock: generateJsxCodeBlockForProductSearchApi(
           'Fetch multiple products by IDs',
           'fetch-products-with-ids',
         ),
@@ -65,6 +49,22 @@ const data: ReferenceEntityTemplateSchema = {
         ),
         description:
           'Retrieve product variants with pagination support for products with many variants. This example demonstrates using `shopify.productSearch.fetchVariantsByProductId()` with pagination parameters to load variants page by page, improving performance and user experience for products with large variant catalogs.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForProductSearchApi(
+          'Fetch a single product by ID',
+          'fetch-product-with-id',
+        ),
+        description:
+          'Retrieve detailed information for a specific product using its ID. This example demonstrates using `shopify.productSearch.fetchById()` to get complete product data including variants, pricing, and inventory information for a single product.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForProductSearchApi(
+          'Fetch a single variant by ID',
+          'fetch-product-variant-with-id',
+        ),
+        description:
+          'Retrieve detailed information for a specific product variant using its ID. This example demonstrates using `shopify.productSearch.fetchVariantById()` to get variant-specific data including pricing, inventory, and options for a particular variant.',
       },
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -9,13 +9,14 @@ const generateJsxCodeBlockForProductSearchApi = (
 const data: ReferenceEntityTemplateSchema = {
   name: 'ProductSearch API',
   description:
-    'The ProductSearch API gives extensions access to the native product search and fetching functionality of Shopify POS. The interface provides numerous functions to search for products by query, or to fetch the details of one or more products or product variants.',
+    'The Product Search API provides access to POS native product search functionality, allowing you to search for products, fetch product details, and retrieve product variants with pagination support and flexible sorting options. The API enables both text-based search and direct product lookups by ID.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'ProductSearchApi',
-      description: '',
+      description:
+        'The `ProductSearchApi` object provides methods for searching and retrieving product information. Access these methods through `shopify.productSearch` to search products and fetch detailed product data.',
       type: 'ProductSearchApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -23,43 +23,56 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the Cart API',
+    description:
+      'Learn how to search for products, fetch product details, and retrieve variants.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(
-          'Search for products with a search bar',
-          'search-products',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForProductSearchApi(
-          'Fetch a specific product with a product ID',
+          'Fetch a single product by ID',
           'fetch-product-with-id',
         ),
+        description:
+          'Retrieve detailed information for a specific product using its ID. This example demonstrates using `shopify.productSearch.fetchById()` to get complete product data including variants, pricing, and inventory information for a single product.',
       },
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(
-          'Fetch multiple products by specifying product IDs',
-          'fetch-products-with-ids',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForProductSearchApi(
-          'Fetch a specific product variant with a variant ID',
+          'Fetch a single variant by ID',
           'fetch-product-variant-with-id',
         ),
+        description:
+          'Retrieve detailed information for a specific product variant using its ID. This example demonstrates using `shopify.productSearch.fetchVariantById()` to get variant-specific data including pricing, inventory, and options for a particular variant.',
       },
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(
-          'Fetch multiple product variants by specifying variant IDs',
+          'Fetch multiple products by IDs',
+          'fetch-products-with-ids',
+        ),
+        description:
+          'Retrieve detailed information for multiple products in a single request using their IDs. This example shows how to use `shopify.productSearch.fetchByIds()` to efficiently fetch data for multiple products at once, improving performance when displaying product lists or related items.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForProductSearchApi(
+          'Fetch multiple variants by IDs',
           'fetch-product-variants-with-ids',
         ),
+        description:
+          'Retrieve detailed information for multiple product variants in a single request using their IDs. This example shows how to use `shopify.productSearch.fetchVariantsByIds()` to efficiently fetch data for multiple variants at once, useful for displaying variant lists or comparisons.',
       },
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(
-          'Fetch a page of product variants with a specific product ID',
+          'Fetch paginated variants for a product',
           'fetch-paginated-product-variants-with-product-id',
         ),
+        description:
+          'Retrieve product variants with pagination support for products with many variants. This example demonstrates using `shopify.productSearch.fetchVariantsByProductId()` with pagination parameters to load variants page by page, improving performance and user experience for products with large variant catalogs.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForProductSearchApi(
+          'Search for products using a search bar',
+          'search-products',
+        ),
+        description:
+          'Search for products using text queries with real-time results. This example shows how to use `shopify.productSearch.search()` to perform text-based product searches with pagination support, allowing users to find products by name, SKU, or other searchable attributes.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -22,13 +22,16 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of receiving updates from the Scanner API',
+    description:
+      'Learn how to handle barcode and QR code scans and access scanner information.',
     examples: [
       {
         codeblock: generateCodeBlockForScannerApi(
-          'Conditional scanner source rendering example',
+          'Respond to scan events based on scanner source',
           'conditional-scanner-example',
         ),
+        description:
+          'Subscribe to scan events and adapt behavior based on the scanner source. This example shows how to use `shopify.scanner.subscribe()` to receive scan events and check `shopify.scanner.source` to determine which scanner type was used (camera, external scanner, or embedded hardware), allowing you to customize handling based on the scanning method.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -21,6 +21,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Handle scan events reactively:** Use the `subscribe` methods to automatically process scan events as they occur.\n' +
+        '- **Validate scanned data appropriately:** Validate scanned data before processing, implementing proper error handling for invalid codes, unsupported formats, or scanning errors.\n' +
+        '- **Provide clear scanning feedback:** Give users clear feedback about scan results, including success confirmations, error messages, and guidance when scans fail or produce invalid data.\n' +
+        '- **Adapt to available scanner sources:** Check available scanner sources and adapt your interface accordingly.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        "- The Scanner API is only available in action (modal) targets where scanning functionality is supported and can't be used in other targets.\n" +
+        '- Scanning availability depends on device hardware capabilities and may vary between different POS devices and configurations.\n' +
+        '- Scan data processing is reactive and requires proper subscription management to avoid memory leaks or unexpected behavior when components unmount.',
+    },
+  ],
   examples: {
     description:
       'Learn how to handle barcode and QR code scans and access scanner information.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -7,23 +7,15 @@ const generateCodeBlockForScannerApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Scanner API',
-  description: `
-The Scanner API enables an extension to access scanner data and available scanning sources supported by the device.
-
-#### Supporting targets
-- ${TargetLink.PosHomeModalRender}
-- ${TargetLink.PosPurchasePostActionRender}
-- ${TargetLink.PosProductDetailsActionRender}
-- ${TargetLink.PosOrderDetailsActionRender}
-- ${TargetLink.PosDraftOrderDetailsActionRender}
-- ${TargetLink.PosCustomerDetailsActionRender}
-`,
+  description:
+    'The Scanner API provides access to barcode and QR code scanning functionality on POS devices, allowing you to subscribe to scan events, monitor available scanner sources, and process scanned data in real-time. The API enables integration with device cameras, external scanners, and embedded scanning hardware.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'ScannerApi',
-      description: '',
+      description:
+        'The `ScannerApi` object provides access to scanning functionality and scanner source information. Access these properties through `shopify.scanner` to monitor scan events and available scanner sources.',
       type: 'ScannerApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -19,7 +19,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ScannerApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -18,7 +18,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'SessionApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Standard APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -37,9 +37,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Session tokens are only available when the authenticated user has proper app permissions enabled. Staff members who are pinned in but not authenticated can\'t generate tokens.\n' +
-        '- Session data is read-only and can\'t be modified through the API. Changes to shop settings, locations, or staff assignments require POS application updates.\n' +
-        '- Session tokens should only be used for communication with your app\'s configured backend service and can\'t be used for direct Shopify API calls from the client side.',
+        "- Session tokens are only available when the authenticated user has proper app permissions enabled. Staff members who are pinned in but not authenticated can't generate tokens.\n" +
+        "- Session data is read-only and can't be modified through the API. Changes to shop settings, locations, or staff assignments require POS application updates.\n" +
+        "- Session tokens should only be used for communication with your app's configured backend service and can't be used for direct Shopify API calls from the client side.",
     },
   ],
   examples: {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -20,6 +20,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Handle authentication properly:** Check for undefined session tokens and implement proper fallback behavior when authentication fails or permissions are insufficient.\n' +
+        '- **Use appropriate identifiers:** Distinguish between `userId` (authenticated account) and `staffMemberId` (pinned staff member) to implement correct permissions and personalization logic.\n' +
+        '- **Implement location-aware features:** Use `locationId` and `currency` information.\n' +
+        '- **Secure backend communication:** Use session tokens exclusively for backend API calls and never expose them in client-side logs or storage. Validate tokens on your backend before processing requests.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Session tokens are only available when the authenticated user has proper app permissions enabled. Staff members who are pinned in but not authenticated can\'t generate tokens.\n' +
+        '- Session data is read-only and can\'t be modified through the API. Changes to shop settings, locations, or staff assignments require POS application updates.\n' +
+        '- Session tokens should only be used for communication with your app\'s configured backend service and can\'t be used for direct Shopify API calls from the client side.',
+    },
+  ],
   examples: {
     description:
       'Learn how to access session information and generate authentication tokens for secure API calls.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -7,13 +7,14 @@ const generateJsxCodeBlockForSessionApi = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Session API',
   description:
-    'The Session API contains the information about the current user session, and allows to fetch a fresh session token for communication with your apps backend service.',
+    'The Session API provides access to current POS session information and secure authentication tokens, allowing you to retrieve shop details, user information, location data, and generate tokens for secure backend communication. The API includes both static session data and dynamic token generation for authenticated API calls.',
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'SessionApi',
-      description: '',
+      description:
+        'The `SessionApi` object provides access to current session information and authentication methods. Access these properties and methods through `shopify.session` to retrieve shop data and generate secure tokens. These methods enable secure API calls while maintaining user privacy and [app permissions](https://help.shopify.com/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).',
       type: 'SessionApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -21,13 +21,16 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the Session API',
+    description:
+      'Learn how to access session information and generate authentication tokens for secure API calls.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForSessionApi(
-          'Retrieve the current session data',
+          'Access session data and generate authentication tokens',
           'token',
         ),
+        description:
+          'Retrieve current session information and generate secure authentication tokens for backend API calls. This example shows how to access shop details, user information, and location data through `shopify.session`, and use `shopify.session.getSessionToken()` to generate tokens for authenticated requests to your backend services.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -22,37 +22,48 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   examples: {
-    description: 'Examples of using the Storage API',
+    description:
+      'Learn how to store and retrieve persistent data that persists across sessions.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForStorageApi(
-          'Getting a single value from storage',
-          'get',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForStorageApi(
-          'Setting a single value in storage',
-          'set',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForStorageApi(
-          'Deleting a single value from storage',
-          'delete',
-        ),
-      },
-      {
-        codeblock: generateJsxCodeBlockForStorageApi(
-          'Clear all entries for an extension from storage',
+          'Clear all stored values',
           'clear',
         ),
+        description:
+          'Remove all stored data for your extension from persistent storage. This example demonstrates using `shopify.storage.clear()` to delete all key-value pairs stored by your extension, useful for reset functionality or clearing user preferences.',
       },
       {
         codeblock: generateJsxCodeBlockForStorageApi(
-          'Retrieve all entries for an extension from storage',
+          'Remove a value from storage',
+          'delete',
+        ),
+        description:
+          'Delete a specific value from storage using its key. This example shows how to use `shopify.storage.delete()` to remove a stored item, permanently clearing the data associated with that key while leaving other stored values intact.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForStorageApi(
+          'Retrieve all stored entries',
           'entries',
         ),
+        description:
+          'Fetch all key-value pairs stored by your extension. This example shows how to use `shopify.storage.entries()` to retrieve an array of all stored items, useful for displaying saved data, performing bulk operations, or exporting stored information.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForStorageApi(
+          'Retrieve a value from storage',
+          'get',
+        ),
+        description:
+          'Read a stored value using its key from persistent storage. This example shows how to use `shopify.storage.get()` to retrieve a previously saved value, which returns the stored data with automatic JSON deserialization or undefined if the key does not exist.',
+      },
+      {
+        codeblock: generateJsxCodeBlockForStorageApi(
+          'Save a value to storage',
+          'set',
+        ),
+        description:
+          'Store a value in persistent storage using a key-value pair. This example demonstrates using `shopify.storage.set()` to save data that will persist across user sessions, device restarts, and extension reloads, with automatic JSON serialization of the value.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -13,6 +13,28 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Design consistent key naming patterns:** Use hierarchical key names like `settings.user.theme` or `cache.products.${id}` to organize related data and make storage contents easier to understand and maintain.\n' +
+        '- **Validate retrieved data:** Check data structure and types after calling `get()` since stored data may be outdated or corrupted. Provide sensible defaults and handle missing properties.\n' +
+        '- **Plan for data evolution:** Design your stored data structures to handle future changes. Include version fields in complex objects and implement migration logic to handle schema updates between extension versions.\n' +
+        '- **Keep sensitive data out of local storage:** Never store passwords, API keys, or other sensitive information. Use the Session API for secure backend communication and limit stored data to user preferences and non-sensitive workflow state.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- POS UI extensions can store up to a maximum of 100 entries.\n' +
+        '- The maximum key size is ~1 KB and the maximum value size is ~1 MB.\n' +
+        '- Data persists even when extension targets are disabled or removed.\n' +
+        '- Stored extension data is automatically cleared after 30 days of inactivity.',
+    },
+  ],
   definitions: [
     {
       title: 'StorageApi',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Design consistent key naming patterns:** Use hierarchical key names like `settings.user.theme` or `cache.products.${id}` to organize related data and make storage contents easier to understand and maintain.\n' +
+        "- **Design consistent key naming patterns:** Use hierarchical key names like `settings.user.theme` or `cache.products.$" + "{id}` to organize related data and make storage contents easier to understand and maintain.\n" +
         '- **Validate retrieved data:** Check data structure and types after calling `get()` since stored data may be outdated or corrupted. Provide sensible defaults and handle missing properties.\n' +
         '- **Plan for data evolution:** Design your stored data structures to handle future changes. Include version fields in complex objects and implement migration logic to handle schema updates between extension versions.\n' +
         '- **Keep sensitive data out of local storage:** Never store passwords, API keys, or other sensitive information. Use the Session API for secure backend communication and limit stored data to user preferences and non-sensitive workflow state.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -11,7 +11,8 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nThe API supports key-value storage with automatic JSON serialization, type safety through TypeScript interfaces, and built-in error handling for storage constraint violations.',
   isVisualComponent: false,
   type: 'APIs',
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Standard APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -6,11 +6,9 @@ const generateJsxCodeBlockForStorageApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Storage API',
-  description: `The Storage API allows fetching, setting, updating, and clearing an extension's data from the POS local storage.
-  - An extension can store up to 100 entries.
-  - The maximum size for a key is ~1 KB, and for a value is ~1 MB.
-  - If a target (such as \`pos.home.tile.render\`) is disabled or removed, the extension data remains.
-  - All stored extension data that has not been updated for a month is cleared automatically after that period.`,
+  description:
+    'The Storage API provides persistent local storage for POS UI extensions, allowing you to store, retrieve, and manage extension data that persists across user sessions, device restarts, and extension target state changes. Data is stored locally on the POS device in an isolated namespace specific to your extension.' +
+    '\n\nThe API supports key-value storage with automatic JSON serialization, type safety through TypeScript interfaces, and built-in error handling for storage constraint violations.',
   isVisualComponent: false,
   type: 'APIs',
   category: 'APIs',
@@ -18,7 +16,8 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'StorageApi',
-      description: '',
+      description:
+        'The `StorageApi` object provides access to persistent local storage methods for your POS UI extension. Access these methods through `shopify.storage` to store, retrieve, and manage data that persists across sessions.',
       type: 'Storage',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -20,7 +20,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Design consistent key naming patterns:** Use hierarchical key names like `settings.user.theme` or `cache.products.$" + "{id}` to organize related data and make storage contents easier to understand and maintain.\n" +
+        '- **Design consistent key naming patterns:** Use hierarchical key names like `settings.user.theme` or `cache.products.$' +
+        '{id}` to organize related data and make storage contents easier to understand and maintain.\n' +
         '- **Validate retrieved data:** Check data structure and types after calling `get()` since stored data may be outdated or corrupted. Provide sensible defaults and handle missing properties.\n' +
         '- **Plan for data evolution:** Design your stored data structures to handle future changes. Include version fields in complex objects and implement migration logic to handle schema updates between extension versions.\n' +
         '- **Keep sensitive data out of local storage:** Never store passwords, API keys, or other sensitive information. Use the Session API for secure backend communication and limit stored data to user preferences and non-sensitive workflow state.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -20,6 +20,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'APIs',
   related: [],
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Write clear, concise messages:** Keep toast content brief and actionable since users have limited time to read the message before it disappears automatically.\n' +
+        '- **Use appropriate timing:** Choose duration values that give users enough time to read the message without keeping notifications visible longer than necessary.\n' +
+        '- **Provide meaningful feedback:** Use toast messages to confirm successful actions, explain errors clearly, or communicate important status changes that users need to know about.\n' +
+        '- **Avoid overuse:** Reserve toast notifications for important feedback and avoid showing multiple toasts simultaneously, as this can overwhelm users and reduce the effectiveness of the notifications.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Toast messages are temporary and can\'t be made persistent. For important information that users need to reference later, consider using other UI components or storage mechanisms.\n' +
+        '- Multiple toast messages may overlap or interfere with each other if shown in rapid succession. Consider queuing or spacing out notifications appropriately.\n' +
+        '- Toast content is limited to plain text and can\'t include rich formatting, links, or interactive elements.',
+    },
+  ],
   examples: {
     description:
       'Learn how to display temporary notification messages for user feedback.',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -21,13 +21,16 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'APIs',
   related: [],
   examples: {
-    description: 'Examples of using the Toast API',
+    description:
+      'Learn how to display temporary notification messages for user feedback.',
     examples: [
       {
         codeblock: generateJsxCodeBlockForToastApi(
-          'Display a Toast component from the tile',
+          'Display a toast notification from a tile',
           'show',
         ),
+        description:
+          "Show a temporary notification message to provide user feedback. This example demonstrates using `shopify.toast.show()` to display a brief, non-intrusive message that automatically disappears after a specified duration, useful for confirmations, status updates, or success messages that don't require user interaction.",
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -6,13 +6,15 @@ const generateJsxCodeBlockForToastApi = (title: string, fileName: string) =>
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Toast API',
-  description: 'The Toast API allows the display of a Toast component.',
+  description:
+    "The Toast API provides temporary notification functionality for POS UI extensions, allowing you to display brief, non-intrusive messages to users for feedback, confirmations, and status updates that automatically disappear after a specified duration. Toast messages appear as overlay notifications that don't interrupt the user's workflow.",
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
     {
       title: 'ToastApi',
-      description: '',
+      description:
+        'The `ToastApi` object provides methods for displaying temporary notification messages. Access these methods through `shopify.toast` to show user feedback and status updates.',
       type: 'ToastApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -18,7 +18,8 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ToastApiContent',
     },
   ],
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Standard APIs',
   related: [],
   subSections: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -37,9 +37,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Toast messages are temporary and can\'t be made persistent. For important information that users need to reference later, consider using other UI components or storage mechanisms.\n' +
+        "- Toast messages are temporary and can't be made persistent. For important information that users need to reference later, consider using other UI components or storage mechanisms.\n" +
         '- Multiple toast messages may overlap or interfere with each other if shown in rapid succession. Consider queuing or spacing out notifications appropriately.\n' +
-        '- Toast content is limited to plain text and can\'t include rich formatting, links, or interactive elements.',
+        "- Toast content is limited to plain text and can't include rich formatting, links, or interactive elements.",
     },
   ],
   examples: {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-menu-item-render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-menu-item-render.doc.ts
@@ -19,12 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Cart line item',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosCartLineItemDetailsActionRender,
-      url: 'pos-cart-line-item-details-action-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-menu-item-render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-menu-item-render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCartLineItemDetailsActionMenuItemRender,
   description:
-    'A static extension target that renders as a menu item on the cart line item details screen',
+    'Renders a single interactive button component as a menu item in the cart line item action menu. Use this target for item-specific operations like applying discounts, adding custom properties, or launching verification workflows for individual cart items.' +
+    '\n\nExtensions at this target can access detailed line item information including title, quantity, price, discounts, properties, and product metadata through the Cart Line Item API. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Action Menu Item',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-menu-item-render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-menu-item-render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target can access detailed line item information including title, quantity, price, discounts, properties, and product metadata through the Cart Line Item API. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Action Menu Item',
+      'Create a cart line item action menu item',
       'targets',
       'pos-cart-line-item-details-action-menu-item-render',
     ),
+    description:
+      'Add an interactive menu item to the cart line item action menu for item-specific operations. This example shows how to create a menu item that accesses line item data and launches modal workflows for tasks like applying discounts, adding custom properties, or verification workflows.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Cart line item',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target have access to detailed line item data through the Cart Line Item API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Action Render',
+      'Create a cart line item action modal',
       'targets',
       'pos-cart-line-item-details-action-render',
     ),
+    description:
+      'Build a full-screen modal workflow launched from a cart line item action menu item. This example demonstrates creating line item-specific experiences with multi-step processes, forms, and detailed line item data access for operations like customization or verification.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Cart line item',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCartLineItemDetailsActionRender,
   description:
-    'A full-screen extension target that renders when a `pos.cart.line-item-details.action.menu-item.render` target calls for it',
+    'Renders a full-screen modal interface launched from cart line item menu items. Use this target for complex line item workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.' +
+    '\n\nExtensions at this target have access to detailed line item data through the Cart Line Item API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Action Render',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.cart-line-item-details-action-render.doc.ts
@@ -19,12 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Cart line item',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosCartLineItemDetailsActionMenuItemRender,
-      url: 'pos-cart-line-item-details-action-menu-item-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.menu-item.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target can access the customer identifier through the Customer API to perform customer-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete customer workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Menu item',
+      'Create a customer details action menu item',
       'targets',
       'customer-details-menu-item',
     ),
+    description:
+      'Add an interactive menu item to the customer details action menu for customer-specific operations. This example shows how to create a menu item that accesses customer data and launches modal workflows for tasks like applying loyalty rewards, updating profiles, or managing customer preferences.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Customer details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.menu-item.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCustomerDetailsActionMenuItemRender,
   description:
-    'A static extension target that renders as a menu item on the customer details screen',
+    'Renders a single interactive button component as a menu item in the customer details action menu. Use this target for customer-specific operations like applying customer discounts, processing loyalty redemptions, or launching profile update workflows.' +
+    '\n\nExtensions at this target can access the customer identifier through the Customer API to perform customer-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete customer workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Menu item',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.menu-item.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Customer details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosCustomerDetailsActionRender,
-      url: 'pos-customer-details-action-render',
-    },
-    {
-      name: ExtensionTargetType.PosCustomerDetailsBlockRender,
-      url: '../block/pos-customer-details-block-render',
-    },
-    {
-      name: 'Customer API',
-      url: '../../apis/customer-api',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Customer details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosCustomerDetailsActionMenuItemRender,
-      url: 'pos-customer-details-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosCustomerDetailsBlockRender,
-      url: '../block/pos-customer-details-block-render',
-    },
-    {
-      name: 'Customer API',
-      url: '../../apis/customer-api',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCustomerDetailsActionRender,
   description:
-    'A full-screen extension target that renders when a `pos.customer-details.action.menu-item.render` target calls for it',
+    'Renders a full-screen modal interface launched from customer details menu items. Use this target for complex customer workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.' +
+    '\n\nExtensions at this target have access to customer data through the Customer API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Action',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.action.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target have access to customer data through the Customer API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Action',
+      'Create a customer details action modal',
       'targets',
       'customer-details-action',
     ),
+    description:
+      'Build a full-screen modal workflow launched from a customer details action menu item. This example demonstrates creating customer-specific experiences with multi-step processes, forms, and customer data access for operations like loyalty management or profile updates.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Customer details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.block.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target appear as persistent blocks within the customer details interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex customer operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Block',
+      'Create a customer details information block',
       'targets',
       'pos-customer-details-block-render',
     ),
+    description:
+      'Add a custom information section to the customer details screen for displaying supplementary customer data. This example shows how to create a block that shows loyalty status, points balance, or personalized information alongside standard customer details.',
   },
   category: 'Targets',
-  subCategory: 'Block',
+  subCategory: 'Customer details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.block.render.doc.ts
@@ -4,7 +4,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosCustomerDetailsBlockRender,
-  description: 'Renders a custom section within customer details screen',
+  description:
+    'Renders a custom information section within the customer details screen. Use this target for displaying supplementary customer data like loyalty status, points balance, or personalized information alongside standard customer details.' +
+    '\n\nExtensions at this target appear as persistent blocks within the customer details interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex customer operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.customer-details.block.render.doc.ts
@@ -19,16 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Customer details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosCustomerDetailsActionMenuItemRender,
-      url: '../action/pos-customer-details-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosCustomerDetailsActionRender,
-      url: '../action/pos-customer-details-action-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.menu-item.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosDraftOrderDetailsActionMenuItemRender,
   description:
-    'A static extension target that renders as a menu item on the draft order details screen',
+    'Renders a single interactive button component as a menu item in the draft order details action menu. Use this target for draft order-specific operations like sending invoices, updating payment status, or launching custom workflow processes for pending orders.' +
+    '\n\nExtensions at this target can access draft order information including order ID, name, and associated customer through the Draft Order API. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete draft order workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Menu item',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.menu-item.render.doc.ts
@@ -19,16 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Draft order details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosDraftOrderDetailsActionRender,
-      url: 'pos-draft-order-details-action-render',
-    },
-    {
-      name: ExtensionTargetType.PosDraftOrderDetailsBlockRender,
-      url: '../block/pos-draft-order-details-block-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.menu-item.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target can access draft order information including order ID, name, and associated customer through the Draft Order API. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete draft order workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Menu item',
+      'Create a draft order details action menu item',
       'targets',
       'pos-draft-order-details-action-menu-item',
     ),
+    description:
+      'Add an interactive menu item to the draft order details action menu for draft order-specific operations. This example shows how to create a menu item that accesses draft order data and launches modal workflows for tasks like sending invoices, updating payment status, or custom workflow processes.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Draft order details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Draft order details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosDraftOrderDetailsActionMenuItemRender,
-      url: 'pos-draft-order-details-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosDraftOrderDetailsBlockRender,
-      url: '../block/pos-draft-order-details-block-render',
-    },
-    {
-      name: 'Draft order details API',
-      url: '../../apis/draft-order-api',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosDraftOrderDetailsActionRender,
   description:
-    'A full-screen extension target that renders when a `pos.draft-order-details.action.menu-item.render` target calls for it',
+    'Renders a full-screen modal interface launched from draft order details menu items. Use this target for complex draft order workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.' +
+    '\n\nExtensions at this target have access to draft order data through the Draft Order API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Draft order details action',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.action.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target have access to draft order data through the Draft Order API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Draft order details action',
+      'Create a draft order details action modal',
       'targets',
       'pos-draft-order-details-action',
     ),
+    description:
+      'Build a full-screen modal workflow launched from a draft order details action menu item. This example demonstrates creating draft order-specific experiences with multi-step processes, forms, and draft order data access for operations like payment processing or order modifications.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Draft order details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.block.render.doc.ts
@@ -19,16 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Draft order details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosDraftOrderDetailsActionMenuItemRender,
-      url: '../action/pos-draft-order-details-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosDraftOrderDetailsActionRender,
-      url: '../action/pos-draft-order-details-action-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.block.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosDraftOrderDetailsBlockRender,
   description:
-    'Renders a custom section within the native draft order details screen',
+    'Renders a custom information section within the draft order details screen. Use this target for displaying supplementary order information like processing status, payment status, or workflow indicators alongside standard draft order details.' +
+    '\n\nExtensions at this target appear as persistent blocks within the draft order interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex draft order operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.draft-order-details.block.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target appear as persistent blocks within the draft order interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex draft order operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Block',
+      'Create a draft order details information block',
       'targets',
       'pos-draft-order-details-block-render',
     ),
+    description:
+      'Add a custom information section to the draft order details screen for displaying supplementary draft order data. This example shows how to create a block that provides additional draft order information, payment status, or custom order notes alongside standard draft order details.',
   },
   category: 'Targets',
-  subCategory: 'Block',
+  subCategory: 'Draft order details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.menu-item.render.doc.ts
@@ -4,9 +4,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosExchangePostActionMenuItemRender,
-  description: `A static extension target that renders as a menu item on the post-exchange screen
-  > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
+  description:
+    'Renders a single interactive button component as a menu item in the post-exchange action menu. Use this target for post-exchange operations like generating exchange receipts, processing restocking workflows, or collecting exchange feedback.' +
+    '\n\nExtensions at this target can access the order identifier through the Order API to perform exchange-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-exchange workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Exchange Post Action Menu Item',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.menu-item.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Post-exchange',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosExchangePostActionRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: 'pos-exchange-post-action-render',
-    },
-    {
-      name: ExtensionTargetType.PosExchangePostBlockRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: '../block/pos-exchange-post-block-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.menu-item.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target can access the order identifier through the Order API to perform exchange-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-exchange workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Exchange Post Action Menu Item',
+      'Create a post-exchange action menu item',
       'targets',
       'pos-exchange-post-action-menu-item-render',
     ),
+    description:
+      'Add an interactive menu item to the post-exchange action menu for operations after completing an exchange. This example shows how to create a menu item that accesses order data and launches modal workflows for tasks like generating exchange receipts, processing restocking, or collecting feedback.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Post-exchange',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Post-exchange',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosExchangePostActionMenuItemRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: 'pos-exchange-post-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosExchangePostBlockRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: '../block/pos-exchange-post-block-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.render.doc.ts
@@ -4,10 +4,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosExchangePostActionRender,
-  description: `A full-screen extension target that renders when a \`pos.exchange.post.action.menu-item.render\` target calls for it
-
-  > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
+  description:
+    'Renders a full-screen modal interface launched from post-exchange menu items. Use this target for complex post-exchange workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.' +
+    '\n\nExtensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Exchange Post Action',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.action.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Exchange Post Action',
+      'Create a post-exchange action modal',
       'targets',
       'pos-exchange-post-action-render',
     ),
+    description:
+      'Build a full-screen modal workflow launched from a post-exchange action menu item. This example demonstrates creating complex post-exchange experiences with multi-step processes, forms, and order data access for operations like inventory management or exchange analytics.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Post-exchange',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.block.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target appear as persistent blocks within the post-exchange interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-exchange operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Exchange Post Block',
+      'Create a post-exchange information block',
       'targets',
       'pos-exchange-post-block-render',
     ),
+    description:
+      'Add a custom information section to the post-exchange screen for displaying exchange details or status. This example shows how to create a block that provides supplementary information after completing an exchange, with interactive elements that can launch modal workflows.',
   },
   category: 'Targets',
-  subCategory: 'Block',
+  subCategory: 'Post-exchange',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.block.render.doc.ts
@@ -4,9 +4,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosExchangePostBlockRender,
-  description: `Renders a custom section within the native post exchange screen
-  > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
+  description:
+    'Renders a custom information section within the post-exchange screen. Use this target for displaying supplementary exchange data like completion status, payment adjustments, or follow-up workflows alongside standard exchange details.' +
+    '\n\nExtensions at this target appear as persistent blocks within the post-exchange interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-exchange operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Exchange Post Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.exchange.post.block.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Post-exchange',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosExchangePostActionMenuItemRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: '../action/pos-exchange-post-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosExchangePostActionRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: '../action/pos-exchange-post-action-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.modal.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.modal.render.doc.ts
@@ -4,7 +4,8 @@ import {generateJsxCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'pos.home.modal.render',
   description:
-    'A full-screen extension target that renders when a `pos.home.tile.render` target calls for it',
+    'Renders a full-screen modal interface launched from smart grid tiles. The modal appears when users tap a companion tile. Use this target for complete workflow experiences that require more space and functionality than the tile interface provides, such as multi-step processes, detailed information displays, or complex user interactions.' +
+    '\n\nExtensions at this target support full navigation hierarchies with multiple screens, scroll views, and interactive components to handle sophisticated workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Modal',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.modal.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.modal.render.doc.ts
@@ -8,13 +8,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target support full navigation hierarchies with multiple screens, scroll views, and interactive components to handle sophisticated workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Modal',
+      'Create a full-screen modal for a smart grid tile',
       'targets',
       'pos-home-modal-render',
     ),
+    description:
+      'Build a complete workflow experience launched from a smart grid tile. This example demonstrates creating a full-screen modal with navigation, multiple screens, and interactive components for sophisticated workflows that require more space than the tile interface provides.',
   },
   category: 'Targets',
-  subCategory: 'Tile',
+  subCategory: 'Smart grid',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.modal.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.modal.render.doc.ts
@@ -18,12 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Smart grid',
   isVisualComponent: false,
-  related: [
-    {
-      name: 'pos.home.tile.render',
-      url: 'pos-home-tile-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.tile.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.tile.render.doc.ts
@@ -7,10 +7,16 @@ const data: ReferenceEntityTemplateSchema = {
     "Renders a single interactive tile component on the POS home screen's smart grid. The tile appears once during home screen initialization and remains persistent until navigation occurs. Use this target for high-frequency actions, status displays, or entry points to workflows that merchants need daily." +
     '\n\nExtensions at this target can dynamically update properties like enabled state and badge values in response to cart changes or device conditions. Tiles typically invoke `shopify.action.presentModal()` to launch the companion modal for complete workflows.',
   defaultExample: {
-    codeblock: generateJsxCodeBlock('Tile', 'targets', 'pos-home-tile-render'),
+    codeblock: generateJsxCodeBlock(
+      'Create a smart grid tile',
+      'targets',
+      'pos-home-tile-render',
+    ),
+    description:
+      'Add an interactive tile to the POS home screen smart grid for high-frequency actions. This example shows how to create a persistent tile that can dynamically update its enabled state and badge values, providing merchants with quick access to daily workflows and status displays.',
   },
   category: 'Targets',
-  subCategory: 'Tile',
+  subCategory: 'Smart grid',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.tile.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.tile.render.doc.ts
@@ -18,12 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Smart grid',
   isVisualComponent: false,
-  related: [
-    {
-      name: 'pos.home.modal.render',
-      url: 'pos-home-modal-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.tile.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.home.tile.render.doc.ts
@@ -3,7 +3,9 @@ import {generateJsxCodeBlock} from '../helpers/generateCodeBlock';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'pos.home.tile.render',
-  description: 'A static extension target that renders as a smart grid tile',
+  description:
+    "Renders a single interactive tile component on the POS home screen's smart grid. The tile appears once during home screen initialization and remains persistent until navigation occurs. Use this target for high-frequency actions, status displays, or entry points to workflows that merchants need daily." +
+    '\n\nExtensions at this target can dynamically update properties like enabled state and badge values in response to cart changes or device conditions. Tiles typically invoke `shopify.action.presentModal()` to launch the companion modal for complete workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock('Tile', 'targets', 'pos-home-tile-render'),
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.menu-item.render.doc.ts
@@ -19,16 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Order details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosOrderDetailsActionRender,
-      url: 'pos-order-details-action-render',
-    },
-    {
-      name: ExtensionTargetType.PosOrderDetailsBlockRender,
-      url: '../block/pos-order-details-block-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.menu-item.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target can access the order identifier through the Order API to perform order-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete order workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Order details action menu item',
+      'Create an order details action menu item',
       'targets',
       'pos-order-details-action-menu-item-render',
     ),
+    description:
+      'Add an interactive menu item to the order details action menu for order-specific operations. This example shows how to create a menu item that accesses order data and launches modal workflows for tasks like reprints, refunds, exchanges, or fulfillment processes.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Order details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.menu-item.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosOrderDetailsActionMenuItemRender,
   description:
-    'A static extension target that renders as a menu item on the order details screen',
+    'Renders a single interactive button component as a menu item in the order details action menu. Use this target for order-specific operations like reprints, refunds, exchanges, or launching fulfillment workflows.' +
+    '\n\nExtensions at this target can access the order identifier through the Order API to perform order-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete order workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Order details action menu item',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosOrderDetailsActionRender,
   description:
-    'A full-screen extension target that renders when a `pos.order-details.action.menu-item.render` target calls for it',
+    'Renders a full-screen modal interface launched from order details menu items. Use this target for complex order workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.' +
+    '\n\nExtensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Order details action',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Order details action',
+      'Create an order details action modal',
       'targets',
       'pos-order-details-action-render',
     ),
+    description:
+      'Build a full-screen modal workflow launched from an order details action menu item. This example demonstrates creating order-specific experiences with multi-step processes, forms, and order data access for operations like refund processing or fulfillment management.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Order details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.action.render.doc.ts
@@ -19,16 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Order details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosOrderDetailsActionMenuItemRender,
-      url: 'pos-order-details-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosOrderDetailsBlockRender,
-      url: '../block/pos-order-details-block-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.block.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target appear as persistent blocks within the order details interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex order operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Block',
+      'Create an order details information block',
       'targets',
       'pos-order-details-block-render',
     ),
+    description:
+      'Add a custom information section to the order details screen for displaying supplementary order data. This example shows how to create a block that provides additional order information, tracking details, or order-specific status alongside standard order details.',
   },
   category: 'Targets',
-  subCategory: 'Block',
+  subCategory: 'Order details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.block.render.doc.ts
@@ -19,16 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Order details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosOrderDetailsActionMenuItemRender,
-      url: '../action/pos-order-details-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosOrderDetailsActionRender,
-      url: '../action/pos-order-details-action-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.order-details.block.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosOrderDetailsBlockRender,
   description:
-    'Renders a custom section within the native order details screen',
+    'Renders a custom information section within the order details screen. Use this target for displaying supplementary order data like fulfillment status, tracking numbers, or custom order analytics alongside standard order details.' +
+    '\n\nExtensions at this target appear as persistent blocks within the order details interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex order operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.menu-item.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target can access the product identifier through the Product API to perform product-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete product workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Menu item',
+      'Create a product details action menu item',
       'targets',
       'product-details-menu-item',
     ),
+    description:
+      'Add an interactive menu item to the product details action menu for product-specific operations. This example shows how to create a menu item that accesses product data and launches modal workflows for tasks like inventory adjustments, product analytics, or integration with external systems.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Product details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.menu-item.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosProductDetailsActionMenuItemRender,
   description:
-    'A static extension target that renders as a menu item on the product details screen',
+    'Renders a single interactive button component as a menu item in the product details action menu. Use this target for product-specific operations like inventory adjustments, product analytics, or integration with external product management systems.' +
+    '\n\nExtensions at this target can access the product identifier through the Product API to perform product-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete product workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Menu item',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.menu-item.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Product details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosProductDetailsActionRender,
-      url: 'pos-product-details-action-render',
-    },
-    {
-      name: ExtensionTargetType.PosProductDetailsBlockRender,
-      url: '../block/pos-product-details-block-render',
-    },
-    {
-      name: 'ProductAPI',
-      url: '../../apis/product-api',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosProductDetailsActionRender,
   description:
-    'A full-screen extension target that renders when a `pos.product-details.action.menu-item.render` target calls for it',
+    'Renders a full-screen modal interface launched from product details menu items. Use this target for complex product workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.' +
+    '\n\nExtensions at this target have access to product and cart data through the Product API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Action',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target have access to product and cart data through the Product API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Action',
+      'Create a product details action modal',
       'targets',
       'product-details-action',
     ),
+    description:
+      'Build a full-screen modal workflow launched from a product details action menu item. This example demonstrates creating product-specific experiences with multi-step processes, forms, and product data access for operations like inventory management or product customization.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Product details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.action.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Product details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosProductDetailsActionMenuItemRender,
-      url: 'pos-product-details-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosProductDetailsBlockRender,
-      url: 'pos-product-details-block-render',
-    },
-    {
-      name: 'ProductAPI',
-      url: '../../apis/product-api',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.block.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Product details',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosProductDetailsActionMenuItemRender,
-      url: '../action/pos-product-details-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosProductDetailsActionRender,
-      url: '../action/pos-product-details-action-render',
-    },
-    {
-      name: 'ProductAPI',
-      url: '../../apis/product-api',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.block.render.doc.ts
@@ -4,7 +4,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosProductDetailsBlockRender,
-  description: 'Renders a custom section within the product details screen',
+  description:
+    'Renders a custom information section within the product details screen. Use this target for displaying supplementary product data like detailed specifications, inventory status, or related product recommendations alongside standard product details.' +
+    '\n\nExtensions at this target appear as persistent blocks within the product details interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex product operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.product-details.block.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target appear as persistent blocks within the product details interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex product operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Block',
+      'Create a product details information block',
       'targets',
       'pos-product-details-block-render',
     ),
+    description:
+      'Add a custom information section to the product details screen for displaying supplementary product data. This example shows how to create a block that provides additional product information, inventory status, or custom product attributes alongside standard product details.',
   },
   category: 'Targets',
-  subCategory: 'Block',
+  subCategory: 'Product details',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.menu-item.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target can access the order identifier through the Order API to perform purchase-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-purchase workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Menu item',
+      'Create a post-purchase action menu item',
       'targets',
       'pos-purchase-post-action-menu-item-render',
     ),
+    description:
+      'Add an interactive menu item to the post-purchase action menu for operations after completing a sale. This example shows how to create a menu item that accesses order data and launches modal workflows for tasks like sending receipts, collecting feedback, or follow-up processes.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Post-purchase',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.menu-item.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosPurchasePostActionMenuItemRender,
   description:
-    'A static extension target that renders as a menu item on the post-purchase screen',
+    'Renders a single interactive button component as a menu item in the post-purchase action menu. Use this target for post-purchase operations like sending receipts, collecting customer feedback, or launching follow-up workflows after completing a sale.' +
+    '\n\nExtensions at this target can access the order identifier through the Order API to perform purchase-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-purchase workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Menu item',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.menu-item.render.doc.ts
@@ -19,16 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Post-purchase',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosPurchasePostActionRender,
-      url: 'pos-purchase-post-action-render',
-    },
-    {
-      name: ExtensionTargetType.PosPurchasePostBlockRender,
-      url: '../block/pos-purchase-post-block-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosPurchasePostActionRender,
   description:
-    'A full-screen extension target that renders when a `pos.purchase.post.action.menu-item.render` target calls for it',
+    'Renders a full-screen modal interface launched from post-purchase menu items. Use this target for complex post-purchase workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.' +
+    '\n\nExtensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Action',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.render.doc.ts
@@ -19,16 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Post-purchase',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosPurchasePostActionMenuItemRender,
-      url: 'pos-purchase-post-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosPurchasePostBlockRender,
-      url: '../block/pos-purchase-post-block-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.action.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Action',
+      'Create a post-purchase action modal',
       'targets',
       'pos-purchase-post-action-render',
     ),
+    description:
+      'Build a full-screen modal workflow launched from a post-purchase action menu item. This example demonstrates creating complex post-purchase experiences with multi-step processes, forms, and order data access for operations like receipt customization or customer engagement.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Post-purchase',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.block.render.doc.ts
@@ -5,7 +5,8 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosPurchasePostBlockRender,
   description:
-    'Renders a custom section within the native post purchase screen',
+    'Renders a custom information section within the post-purchase screen. Use this target for displaying supplementary purchase data like completion status, customer feedback prompts, or next-step workflows alongside standard purchase details.' +
+    '\n\nExtensions at this target appear as persistent blocks within the post-purchase interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-purchase operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.block.render.doc.ts
@@ -19,16 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Post-purchase',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosPurchasePostActionMenuItemRender,
-      url: '../action/pos-purchase-post-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosPurchasePostActionRender,
-      url: '../action/pos-purchase-post-action-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.purchase.post.block.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target appear as persistent blocks within the post-purchase interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-purchase operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Block',
+      'Create a post-purchase information block',
       'targets',
       'pos-purchase-post-block-render',
     ),
+    description:
+      'Add a custom information section to the post-purchase screen for displaying order details or status. This example shows how to create a block that provides supplementary information after completing a sale, with interactive elements that can launch modal workflows.',
   },
   category: 'Targets',
-  subCategory: 'Block',
+  subCategory: 'Post-purchase',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-footer.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-footer.block.render.doc.ts
@@ -10,13 +10,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target appear in the receipt footer area and support limited components optimized for print formatting, including text content for information display.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Receipt Footer Block',
+      'Create a receipt footer block',
       'targets',
       'pos-receipt-footer-block-render',
     ),
+    description:
+      'Add a custom section to the footer of printed receipts for contact information, policies, or marketing. This example shows how to create a footer block that displays text content optimized for print formatting, useful for return policies, social media links, or customer engagement elements.',
   },
   category: 'Targets',
-  subCategory: 'Block',
+  subCategory: 'Receipt',
   isVisualComponent: false,
   related: [],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-footer.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-footer.block.render.doc.ts
@@ -5,9 +5,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReceiptFooterBlockRender,
-  description: `Renders a custom section within the POS receipt footer
-  > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
+  description:
+    'Renders a custom section in the footer of printed receipts. Use this target for adding contact details, return policies, social media links, or customer engagement elements like survey links or marketing campaigns at the bottom of receipts.' +
+    '\n\nExtensions at this target appear in the receipt footer area and support limited components optimized for print formatting, including text content for information display.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Receipt Footer Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-header.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-header.block.render.doc.ts
@@ -5,9 +5,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReceiptHeaderBlockRender,
-  description: `Renders a custom section within the POS receipt header
-  > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
+  description:
+    'Renders a custom section in the header of printed receipts. Use this target for adding custom branding, logos, promotional messages, or store-specific information at the top of receipts.' +
+    '\n\nExtensions at this target appear in the receipt header area and support limited components optimized for print formatting, including text content for information display.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Receipt Header Block',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-header.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.receipt-header.block.render.doc.ts
@@ -10,13 +10,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target appear in the receipt header area and support limited components optimized for print formatting, including text content for information display.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Receipt Header Block',
+      'Create a receipt header block',
       'targets',
       'pos-receipt-header-block-render',
     ),
+    description:
+      'Add a custom section to the header of printed receipts for branding or important information. This example shows how to create a header block that displays text content optimized for print formatting, useful for store branding, promotional messages, or important notices at the top of receipts.',
   },
   category: 'Targets',
-  subCategory: 'Block',
+  subCategory: 'Receipt',
   isVisualComponent: false,
   related: [],
   type: 'Target',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.menu-item.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target can access the order identifier through the Order API to perform return-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-return workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Return Post Action Menu Item',
+      'Create a post-return action menu item',
       'targets',
       'pos-return-post-action-menu-item-render',
     ),
+    description:
+      'Add an interactive menu item to the post-return action menu for operations after completing a return. This example shows how to create a menu item that accesses order data and launches modal workflows for tasks like generating return receipts, processing restocking, or collecting feedback.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Post-return',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.menu-item.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Post-return',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosReturnPostActionRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: 'pos-return-post-action-render',
-    },
-    {
-      name: ExtensionTargetType.PosReturnPostBlockRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: '../block/pos-return-post-block-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.menu-item.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.menu-item.render.doc.ts
@@ -4,9 +4,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReturnPostActionMenuItemRender,
-  description: `A static extension target that renders as a menu item on the post-return screen
-  > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
+  description:
+    'Renders a single interactive button component as a menu item in the post-return action menu. Use this target for post-return operations like generating return receipts, processing restocking workflows, or collecting return feedback.' +
+    '\n\nExtensions at this target can access the order identifier through the Order API to perform return-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-return workflows.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Return Post Action Menu Item',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Return Post Action',
+      'Create a post-return action modal',
       'targets',
       'pos-return-post-action-render',
     ),
+    description:
+      'Build a full-screen modal workflow launched from a post-return action menu item. This example demonstrates creating complex post-return experiences with multi-step processes, forms, and order data access for operations like restocking workflows or return analytics.',
   },
   category: 'Targets',
-  subCategory: 'Action',
+  subCategory: 'Post-return',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Post-return',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosReturnPostActionMenuItemRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: 'pos-return-post-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosReturnPostBlockRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: '../block/pos-return-post-block-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.action.render.doc.ts
@@ -4,10 +4,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReturnPostActionRender,
-  description: `A full-screen extension target that renders when a \`pos.return.post.action.menu-item.render\` target calls for it
-
-  > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
+  description:
+    'Renders a full-screen modal interface launched from post-return menu items. Use this target for complex post-return workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.' +
+    '\n\nExtensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Return Post Action',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.block.render.doc.ts
@@ -19,20 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Targets',
   subCategory: 'Post-return',
   isVisualComponent: false,
-  related: [
-    {
-      name: ExtensionTargetType.PosReturnPostActionMenuItemRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: '../action/pos-return-post-action-menu-item-render',
-    },
-    {
-      name: ExtensionTargetType.PosReturnPostActionRender,
-      subtitle: 'Target',
-      type: 'blocks',
-      url: '../action/pos-return-post-action-render',
-    },
-  ],
+  related: [],
   type: 'Target',
 };
 

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.block.render.doc.ts
@@ -9,13 +9,15 @@ const data: ReferenceEntityTemplateSchema = {
     '\n\nExtensions at this target appear as persistent blocks within the post-return interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-return operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
-      'Return Post Block',
+      'Create a post-return information block',
       'targets',
       'pos-return-post-block-render',
     ),
+    description:
+      'Add a custom information section to the post-return screen for displaying return details or status. This example shows how to create a block that provides supplementary information after completing a return, with interactive elements that can launch modal workflows.',
   },
   category: 'Targets',
-  subCategory: 'Block',
+  subCategory: 'Post-return',
   isVisualComponent: false,
   related: [
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.block.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/targets/pos.return.post.block.render.doc.ts
@@ -4,9 +4,9 @@ import {ExtensionTargetType} from '../types/ExtensionTargetType';
 
 const data: ReferenceEntityTemplateSchema = {
   name: ExtensionTargetType.PosReturnPostBlockRender,
-  description: `Renders a custom section within the native post return screen
-  > Note:
-  > This is part of a [POS UI Extensions developer preview](/docs/api/feature-previews#pos-ui-extensions-preview). More information to come.`,
+  description:
+    'Renders a custom information section within the post-return screen. Use this target for displaying supplementary return data like completion status, refund confirmations, or follow-up workflows alongside standard return details.' +
+    '\n\nExtensions at this target appear as persistent blocks within the post-return interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-return operations.',
   defaultExample: {
     codeblock: generateJsxCodeBlock(
       'Return Post Block',

--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -940,15 +940,25 @@ export interface GraphQLError {
 }
 
 /**
- * Represents a read-only value managed on the main thread that an extension can subscribe to.
+ * Represents a reactive signal interface that provides both immediate value access and subscription-based updates. Enables real-time synchronization with changing data through the observer pattern.
  *
- * Example: Checkout uses this to manage the state of an object and
- * communicate state changes to extensions running in a sandboxed web worker.
- *
- * This interface is compatible with [Preact's ReadonlySignal](https://github.com/preactjs/signals/blob/a023a132a81bd4ba4a0bebb8cbbeffbd8c8bbafc/packages/core/src/index.ts#L700-L709).
- *
+ * This interface is compatible with [Preact's `ReadonlySignal`](https://github.com/preactjs/signals/blob/a023a132a81bd4ba4a0bebb8cbbeffbd8c8bbafc/packages/core/src/index.ts#L700-L709), allowing integration with Preact's reactive primitives.
  */
 export interface ReadonlySignalLike<T> {
+  /**
+   * The current value of the signal at this moment in time. This property provides immediate, synchronous access to the current state without requiring subscription setup or callbacks.
+   *
+   * The value is read-only—it cannot be modified directly and changes only through the underlying data source (for example, when locale changes, connectivity state toggles, or cart updates occur). Reading this property does not trigger any side effects or subscriptions—it simply returns the current value.
+   *
+   * Commonly accessed for one-time value checks, initial setup, synchronous conditional logic, or when subscriptions aren't needed (for example, reading current locale once during initialization, checking connectivity status before an operation, or displaying current cart total in a snapshot).
+   */
   readonly value: T;
+  /**
+   * Subscribes to value changes and executes the provided callback function whenever the underlying value updates. The callback receives the new value as its parameter and is invoked immediately with the current value upon subscription, then again each time the value changes thereafter.
+   *
+   * Returns a cleanup function that, when called, unsubscribes from further updates and prevents memory leaks. The cleanup function should be called when the component unmounts, the subscription is no longer needed, or when setting up a new subscription to replace the old one.
+   *
+   * Subscriptions are passive—they don't trigger changes, only react to them. Multiple subscriptions can exist simultaneously, each receiving updates independently. Commonly used to automatically update UI when data changes (reactive rendering), implement event-driven logic, keep multiple parts of the extension synchronized, or respond to external state changes without polling.
+   */
   subscribe(fn: (value: T) => void): () => void;
 }

--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -941,24 +941,14 @@ export interface GraphQLError {
 
 /**
  * Represents a reactive signal interface that provides both immediate value access and subscription-based updates. Enables real-time synchronization with changing data through the observer pattern.
- *
- * This interface is compatible with [Preact's `ReadonlySignal`](https://github.com/preactjs/signals/blob/a023a132a81bd4ba4a0bebb8cbbeffbd8c8bbafc/packages/core/src/index.ts#L700-L709), allowing integration with Preact's reactive primitives.
  */
 export interface ReadonlySignalLike<T> {
   /**
-   * The current value of the signal at this moment in time. This property provides immediate, synchronous access to the current state without requiring subscription setup or callbacks.
-   *
-   * The value is read-only—it cannot be modified directly and changes only through the underlying data source (for example, when locale changes, connectivity state toggles, or cart updates occur). Reading this property does not trigger any side effects or subscriptions—it simply returns the current value.
-   *
-   * Commonly accessed for one-time value checks, initial setup, synchronous conditional logic, or when subscriptions aren't needed (for example, reading current locale once during initialization, checking connectivity status before an operation, or displaying current cart total in a snapshot).
+   * The current value of the locale string in IETF format. For example, `"en-US"`, `"fr-CA"`, or `"de-DE"`. This property provides immediate access to the current locale without requiring subscription setup. Use for one-time locale checks or initial internationalization setup.
    */
   readonly value: T;
   /**
-   * Subscribes to value changes and executes the provided callback function whenever the underlying value updates. The callback receives the new value as its parameter and is invoked immediately with the current value upon subscription, then again each time the value changes thereafter.
-   *
-   * Returns a cleanup function that, when called, unsubscribes from further updates and prevents memory leaks. The cleanup function should be called when the component unmounts, the subscription is no longer needed, or when setting up a new subscription to replace the old one.
-   *
-   * Subscriptions are passive—they don't trigger changes, only react to them. Multiple subscriptions can exist simultaneously, each receiving updates independently. Commonly used to automatically update UI when data changes (reactive rendering), implement event-driven logic, keep multiple parts of the extension synchronized, or respond to external state changes without polling.
+   * Subscribes to locale changes and calls the provided function whenever the locale updates. Returns an unsubscribe function to clean up the subscription. Use to automatically update your extension content when merchants change their language settings during POS sessions.
    */
   subscribe(fn: (value: T) => void): () => void;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/action-api/action-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/action-api/action-api.ts
@@ -1,10 +1,6 @@
 export interface ActionApiContent {
   /**
-   * Presents the corresponding action (modal) target extension target as a full-screen modal overlay on top of the current view. The modal target is automatically determined based on the current extension point—for example, calling this from `pos.purchase.post.action.menu-item.render` presents the `pos.purchase.post.action.render` modal target.
-   *
-   * The modal appears with a standard header (typically including a close button and title), occupies the full screen with proper backdrop/overlay, and blocks interaction with the underlying content until dismissed. The modal can be closed programmatically using `window.close()` or by the user dismissing it through UI controls. The method returns immediately without waiting for modal dismissal.
-   *
-   * Commonly used to launch detailed workflows requiring full screen space (multi-step wizards, complex forms, detailed product configuration), display rich content (product galleries, reports, charts), or present flows that need user focus without distractions from the main POS interface.
+   * Presents the corresponding action (modal) target on top of the current view as a full-screen modal. For example, calling this method from `pos.purchase.post.action.menu-item.render` presents `pos.purchase.post.action.render`. Use to launch detailed workflows, complex forms, or multi-step processes that require more screen space than simple components provide.
    */
   presentModal(): void;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/action-api/action-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/action-api/action-api.ts
@@ -1,14 +1,16 @@
 export interface ActionApiContent {
-  /** Presents the `action-overlay.render` extension target on top of present view.
+  /**
+   * Presents the corresponding action (modal) target extension target as a full-screen modal overlay on top of the current view. The modal target is automatically determined based on the current extension point—for example, calling this from `pos.purchase.post.action.menu-item.render` presents the `pos.purchase.post.action.render` modal target.
    *
-   * For example: if we are calling presentModal() from pos.purchase.post.action.menu-item.render,
-   * it should present pos.purchase.post.action.render.
+   * The modal appears with a standard header (typically including a close button and title), occupies the full screen with proper backdrop/overlay, and blocks interaction with the underlying content until dismissed. The modal can be closed programmatically using `window.close()` or by the user dismissing it through UI controls. The method returns immediately without waiting for modal dismissal.
+   *
+   * Commonly used to launch detailed workflows requiring full screen space (multi-step wizards, complex forms, detailed product configuration), display rich content (product galleries, reports, charts), or present flows that need user focus without distractions from the main POS interface.
    */
   presentModal(): void;
 }
 
 /**
- * Access the Action API to present your app in a full screen modal.
+ * The `ActionApi` object provides methods for presenting modal interfaces. Access these methods through `shopify.action` to launch full-screen modal experiences.
  */
 export interface ActionApi {
   action: ActionApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -11,31 +11,38 @@ import type {
 } from '../../types/cart';
 
 /**
- * Access and modify the merchant’s current cart.
+ * The `CartApi` object provides access to cart management functionality and real-time cart state monitoring. Access these properties through `shopify.cart` to interact with the current POS cart.
  */
 export interface CartApi {
   cart: CartApiContent;
 }
 
+/**
+ * Defines the type of discount applied at the cart level. Specifies whether the discount is percentage-based, fixed amount, or discount code redemption.
+ */
 export type CartDiscountType = 'Percentage' | 'FixedAmount' | 'Code';
 
+/**
+ * Defines the type of discount applied to individual line items. Specifies whether the discount is percentage-based or a fixed amount reduction.
+ */
 export type LineItemDiscountType = 'Percentage' | 'FixedAmount';
 
 export interface CartApiContent {
   /**
-   * Provides read-only access to the current cart state and allows subscribing to cart changes.
-   * The `value` property provides the current cart state, and `subscribe` allows listening to changes.
+   * Provides read-only access to the current cart state and allows subscribing to cart changes. The `value` property provides the current cart state, and `subscribe` allows listening to changes.
    */
   current: ReadonlySignalLike<Cart>;
 
-  /** Bulk update the cart
+  /**
+   * Perform a bulk update of the entire cart state including note, discounts, customer, line items, and properties. Returns the updated cart object after the operation completes.
    *
    * @param cartState the cart state to set
    * @returns the updated cart
    */
   bulkCartUpdate(cartState: CartUpdateInput): Promise<Cart>;
 
-  /** Apply a cart level discount
+  /**
+   * Apply a cart-level discount with the specified type (`'Percentage'`, `'FixedAmount'`, or `'Code'`), title, and optional amount. For discount codes, omit the `amount` parameter. Enhanced validation ensures proper discount application.
    *
    * @param type the type of discount applied (example: 'Percentage')
    * @param title the title attributed with the discount
@@ -48,84 +55,82 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Add a code discount to the cart
+   * Apply a discount code to the cart. The system will validate the code and apply the appropriate discount if the code is valid and applicable to the current cart contents.
    *
    * @param code the code for the discount to add to the cart
    */
   addCartCodeDiscount(code: string): Promise<void>;
 
   /**
-   * Remove the cart discount
+   * Remove the current cart-level discount. This only affects cart-level discounts and doesn't impact line item discounts or automatic discount eligibility.
    */
   removeCartDiscount(): Promise<void>;
 
   /**
-   * Remove all cart and line item discounts
+   * Remove all discounts from both the cart and individual line items. Set `disableAutomaticDiscounts` to `true` to prevent automatic discounts from being reapplied after removal.
    *
    * @param disableAutomaticDiscounts Whether or not automatic discounts should be enabled after removing the discounts.
    */
   removeAllDiscounts(disableAutomaticDiscounts: boolean): Promise<void>;
 
   /**
-   * Clear the cart
+   * Remove all line items and reset the cart to an empty state. This action can't be undone and will clear all cart contents including line items, discounts, properties, and selling plans.
    */
   clearCart(): Promise<void>;
 
   /**
-   * Set the customer in the cart
+   * Associate a customer with the current cart using the customer object containing the customer `ID`. This enables customer-specific pricing, discounts, and checkout features with customer data validation.
    *
    * @param customer the customer object to add to the cart
    */
   setCustomer(customer: Customer): Promise<void>;
 
   /**
-   * Remove the current customer from the cart
+   * Remove the currently associated customer from the cart, converting it back to a guest cart without customer-specific benefits or information while preserving cart contents.
    */
   removeCustomer(): Promise<void>;
 
   /**
-   * Add a custom sale to the cart
+   * Add a custom sale item to the cart with specified quantity, title, price, and taxable status. Returns the [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) of the created line item for future operations and property management.
    *
    * @param customSale the custom sale object to add to the cart
-   * @returns {string} the uuid of the line item added
+   * @returns {string} the UUID of the line item added
    */
   addCustomSale(customSale: CustomSale): Promise<string>;
 
   /**
-   * Add a line item by variant ID to the cart.
-   * Returns the uuid of the line item added, or the empty string if the user dismissed an oversell guard modal without adding anything.
-   * Throws if POS fails to add the line item. Throws if POS fails to add the line item.
+   * Add a product variant to the cart by its numeric `ID` with the specified quantity. Returns the [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) of the newly added line item, or an empty string if the user dismissed an oversell guard modal. Throws an error if POS fails to add the line item due to validation or system errors.
    *
    * @param variantId the product variant's numeric ID to add to the cart
    * @param quantity the number of this variant to add to the cart
-   * @returns {string} the uuid of the line item added, or the empty string if the user dismissed an oversell guard modal
+   * @returns {string} the UUID of the line item added, or the empty string if the user dismissed an oversell guard modal
    * @throws {Error} if POS fails to add the line item
    */
   addLineItem(variantId: number, quantity: number): Promise<string>;
 
   /**
-   * Remove the line item at this uuid from the cart
+   * Remove a specific line item from the cart using its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier). The line item will be completely removed from the cart along with any associated discounts, properties, or selling plans.
    *
    * @param uuid the uuid of the line item that should be removed
    */
   removeLineItem(uuid: string): Promise<void>;
 
   /**
-   * Adds custom properties to the cart
+   * Add custom key-value properties to the cart for storing metadata, tracking information, or integration data. Properties are merged with existing cart properties.
    *
    * @param properties the custom key to value object to attribute to the cart
    */
   addCartProperties(properties: Record<string, string>): Promise<void>;
 
   /**
-   * Removes the specified cart properties
+   * Remove specific cart properties by their keys. Only the specified property keys will be removed while other properties remain intact.
    *
    * @param keys the collection of keys to be removed from the cart properties
    */
   removeCartProperties(keys: string[]): Promise<void>;
 
   /**
-   * Adds custom properties to the specified line item
+   * Add custom properties to a specific line item using its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier). Properties are merged with existing line item properties for metadata storage and tracking.
    *
    * @param uuid the uuid of the line item to which the properties should be stringd
    * @param properties the custom key to value object to attribute to the line item
@@ -136,7 +141,7 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Adds custom properties to multiple line items at the same time.
+   * Add properties to multiple line items simultaneously using an array of inputs containing line item [UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier) and their respective properties for efficient bulk operations.
    *
    * @param lineItemProperties the collection of custom line item properties to apply to their respective line items.
    */
@@ -145,7 +150,7 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Removes the specified line item properties
+   * Remove specific properties from a line item by `UUID` and property keys. Only the specified keys will be removed while other properties remain intact.
    *
    * @param uuid the uuid of the line item to which the properties should be removed
    * @param keys the collection of keys to be removed from the line item properties
@@ -153,7 +158,7 @@ export interface CartApiContent {
   removeLineItemProperties(uuid: string, keys: string[]): Promise<void>;
 
   /**
-   * Add a discount on a line item to the cart
+   * Apply a discount to a specific line item using its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier). Specify the discount type (`'Percentage'` or `'FixedAmount'`), title, and amount value.
    *
    * @param uuid the uuid of the line item that should receive a discount
    * @param type the type of discount applied (example: 'Percentage')
@@ -168,7 +173,7 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Set line item discounts to multiple line items at the same time.
+   * Apply discounts to multiple line items simultaneously. Each input specifies the line item `UUID` and discount details for efficient bulk discount operations.
    *
    * @param lineItemDiscounts a map of discounts to add. They key is the uuid of the line item you want to add the discount to. The value is the discount input.
    */
@@ -177,14 +182,14 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Sets an attributed staff to all line items in the cart.
+   * Set the attributed staff member for all line items in the cart using the staff `ID`. Pass `undefined` to clear staff attribution from all line items.
    *
    * @param staffId the ID of the staff. Providing undefined will clear the attributed staff from all line items.
    */
   setAttributedStaff(staffId: number | undefined): Promise<void>;
 
   /**
-   * Sets an attributed staff to a specific line items in the cart.
+   * Set the attributed staff member for a specific line item using the staff `ID` and line item `UUID`. Pass `undefined` as `staffId` to clear attribution from the line item.
    *
    * @param staffId the ID of the staff. Providing undefined will clear the attributed staff on the line item.
    * @param lineItemUuid the UUID of the line item.
@@ -195,35 +200,35 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Remove all discounts from a line item
+   * Remove all discounts from a specific line item identified by its `UUID`. This will clear any custom discounts applied to the line item while preserving discount allocation history.
    *
    * @param uuid the uuid of the line item whose discounts should be removed
    */
   removeLineItemDiscount(uuid: string): Promise<void>;
 
   /**
-   * Add an address to the customer (Customer must be present)
+   * Add a new address to the customer associated with the cart. The customer must be present in the cart before adding addresses.
    *
    * @param address the address object to add to the customer in cart
    */
   addAddress(address: Address): Promise<void>;
 
   /**
-   * Delete an address from the customer (Customer must be present)
+   * Delete an existing address from the customer using the address `ID`. The customer must be present in the cart to perform this operation.
    *
    * @param addressId the address ID to delete
    */
   deleteAddress(addressId: number): Promise<void>;
 
   /**
-   * Update the default address for the customer (Customer must be present)
+   * Set a specific address as the default address for the customer using the address `ID`. The customer must be present in the cart to update the default address.
    *
    * @param addressId the address ID to set as the default address
    */
   updateDefaultAddress(addressId: number): Promise<void>;
 
   /**
-   * Add a selling plan to a line item in the cart.
+   * Add a selling plan to a line item in the cart using the line item `UUID` and selling plan `ID`. Optionally provide the selling plan name, otherwise POS will fetch it after syncing the cart.
    *
    * @param uuid the uuid of the line item that should receive the selling plan
    * @param sellingPlanId the ID of the selling plan to add to the line item
@@ -231,7 +236,7 @@ export interface CartApiContent {
   addLineItemSellingPlan(input: SetLineItemSellingPlanInput): Promise<void>;
 
   /**
-   * Remove the selling plan from a line item in the cart.
+   * Remove the selling plan from a line item in the cart using the line item `UUID`. This will clear any subscription or recurring purchase configuration from the line item.
    *
    * @param uuid the uuid of the line item whose selling plan should be removed
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -29,12 +29,12 @@ export type LineItemDiscountType = 'Percentage' | 'FixedAmount';
 
 export interface CartApiContent {
   /**
-   * Provides read-only access to the current cart state and allows subscribing to cart changes. The `value` property provides the current cart state, and `subscribe` allows listening to changes.
+   * Provides read-only access to the current cart state and allows subscribing to cart changes. The `value` property provides the current cart state, and `subscribe` allows listening to changes with improved performance and memory management.
    */
   current: ReadonlySignalLike<Cart>;
 
   /**
-   * Perform a bulk update of the entire cart state including note, discounts, customer, line items, and properties. Returns the updated cart object after the operation completes.
+   * Perform a bulk update of the entire cart state including note, discounts, customer, line items, and properties. Returns the updated cart object after the operation completes with enhanced validation and error handling.
    *
    * @param cartState the cart state to set
    * @returns the updated cart
@@ -55,19 +55,19 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Apply a discount code to the cart. The system will validate the code and apply the appropriate discount if the code is valid and applicable to the current cart contents.
+   * Apply a discount code to the cart. The system will validate the code and apply the appropriate discount if the code is valid and applicable to the current cart contents with improved error messaging.
    *
    * @param code the code for the discount to add to the cart
    */
   addCartCodeDiscount(code: string): Promise<void>;
 
   /**
-   * Remove the current cart-level discount. This only affects cart-level discounts and doesn't impact line item discounts or automatic discount eligibility.
+   * Remove the current cart-level discount. This only affects cart-level discounts and does not impact line item discounts or automatic discount eligibility.
    */
   removeCartDiscount(): Promise<void>;
 
   /**
-   * Remove all discounts from both the cart and individual line items. Set `disableAutomaticDiscounts` to `true` to prevent automatic discounts from being reapplied after removal.
+   * Remove all discounts from both the cart and individual line items. Set `disableAutomaticDiscounts` to `true` to prevent automatic discounts from being reapplied after removal with enhanced discount allocation handling.
    *
    * @param disableAutomaticDiscounts Whether or not automatic discounts should be enabled after removing the discounts.
    */
@@ -79,7 +79,7 @@ export interface CartApiContent {
   clearCart(): Promise<void>;
 
   /**
-   * Associate a customer with the current cart using the customer object containing the customer `ID`. This enables customer-specific pricing, discounts, and checkout features with customer data validation.
+   * Associate a customer with the current cart using the customer object containing the customer `ID`. This enables customer-specific pricing, discounts, and checkout features with enhanced customer data validation.
    *
    * @param customer the customer object to add to the cart
    */
@@ -91,7 +91,7 @@ export interface CartApiContent {
   removeCustomer(): Promise<void>;
 
   /**
-   * Add a custom sale item to the cart with specified quantity, title, price, and taxable status. Returns the [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) of the created line item for future operations and property management.
+   * Add a custom sale item to the cart with specified quantity, title, price, and taxable status. Returns the `UUID` of the created line item for future operations and property management.
    *
    * @param customSale the custom sale object to add to the cart
    * @returns {string} the UUID of the line item added
@@ -99,7 +99,7 @@ export interface CartApiContent {
   addCustomSale(customSale: CustomSale): Promise<string>;
 
   /**
-   * Add a product variant to the cart by its numeric `ID` with the specified quantity. Returns the [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) of the newly added line item, or an empty string if the user dismissed an oversell guard modal. Throws an error if POS fails to add the line item due to validation or system errors.
+   * Add a product variant to the cart by its numeric `ID` with the specified quantity. Returns the `UUID` of the newly added line item, or an empty string if the user dismissed an oversell guard modal. Throws an error if POS fails to add the line item due to validation or system errors.
    *
    * @param variantId the product variant's numeric ID to add to the cart
    * @param quantity the number of this variant to add to the cart
@@ -109,28 +109,28 @@ export interface CartApiContent {
   addLineItem(variantId: number, quantity: number): Promise<string>;
 
   /**
-   * Remove a specific line item from the cart using its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier). The line item will be completely removed from the cart along with any associated discounts, properties, or selling plans.
+   * Remove a specific line item from the cart using its `UUID`. The line item will be completely removed from the cart along with any associated discounts, properties, or selling plans.
    *
    * @param uuid the uuid of the line item that should be removed
    */
   removeLineItem(uuid: string): Promise<void>;
 
   /**
-   * Add custom key-value properties to the cart for storing metadata, tracking information, or integration data. Properties are merged with existing cart properties.
+   * Add custom key-value properties to the cart for storing metadata, tracking information, or integration data. Properties are merged with existing cart properties with enhanced validation and conflict resolution.
    *
    * @param properties the custom key to value object to attribute to the cart
    */
   addCartProperties(properties: Record<string, string>): Promise<void>;
 
   /**
-   * Remove specific cart properties by their keys. Only the specified property keys will be removed while other properties remain intact.
+   * Remove specific cart properties by their keys. Only the specified property keys will be removed while other properties remain intact with improved error handling for non-existent keys.
    *
    * @param keys the collection of keys to be removed from the cart properties
    */
   removeCartProperties(keys: string[]): Promise<void>;
 
   /**
-   * Add custom properties to a specific line item using its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier). Properties are merged with existing line item properties for metadata storage and tracking.
+   * Add custom properties to a specific line item using its `UUID`. Properties are merged with existing line item properties for metadata storage and tracking with enhanced validation.
    *
    * @param uuid the uuid of the line item to which the properties should be stringd
    * @param properties the custom key to value object to attribute to the line item
@@ -141,7 +141,7 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Add properties to multiple line items simultaneously using an array of inputs containing line item [UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier) and their respective properties for efficient bulk operations.
+   * Add properties to multiple line items simultaneously using an array of inputs containing line item `UUIDs` and their respective properties for efficient bulk operations with enhanced validation and error reporting.
    *
    * @param lineItemProperties the collection of custom line item properties to apply to their respective line items.
    */
@@ -150,7 +150,7 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Remove specific properties from a line item by `UUID` and property keys. Only the specified keys will be removed while other properties remain intact.
+   * Remove specific properties from a line item by `UUID` and property keys. Only the specified keys will be removed while other properties remain intact with improved error handling.
    *
    * @param uuid the uuid of the line item to which the properties should be removed
    * @param keys the collection of keys to be removed from the line item properties
@@ -158,7 +158,7 @@ export interface CartApiContent {
   removeLineItemProperties(uuid: string, keys: string[]): Promise<void>;
 
   /**
-   * Apply a discount to a specific line item using its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier). Specify the discount type (`'Percentage'` or `'FixedAmount'`), title, and amount value.
+   * Apply a discount to a specific line item using its `UUID`. Specify the discount type (`'Percentage'` or `'FixedAmount'`), title, and amount value with improved discount allocation tracking.
    *
    * @param uuid the uuid of the line item that should receive a discount
    * @param type the type of discount applied (example: 'Percentage')
@@ -173,7 +173,7 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Apply discounts to multiple line items simultaneously. Each input specifies the line item `UUID` and discount details for efficient bulk discount operations.
+   * Apply discounts to multiple line items simultaneously. Each input specifies the line item `UUID` and discount details for efficient bulk discount operations with enhanced validation and allocation tracking.
    *
    * @param lineItemDiscounts a map of discounts to add. They key is the uuid of the line item you want to add the discount to. The value is the discount input.
    */
@@ -182,14 +182,14 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Set the attributed staff member for all line items in the cart using the staff `ID`. Pass `undefined` to clear staff attribution from all line items.
+   * Set the attributed staff member for all line items in the cart using the staff `ID`. Pass `undefined` to clear staff attribution from all line items with enhanced staff validation and tracking.
    *
    * @param staffId the ID of the staff. Providing undefined will clear the attributed staff from all line items.
    */
   setAttributedStaff(staffId: number | undefined): Promise<void>;
 
   /**
-   * Set the attributed staff member for a specific line item using the staff `ID` and line item `UUID`. Pass `undefined` as `staffId` to clear attribution from the line item.
+   * Set the attributed staff member for a specific line item using the staff `ID` and line item `UUID`. Pass `undefined` as `staffId` to clear attribution from the line item with improved validation and error handling.
    *
    * @param staffId the ID of the staff. Providing undefined will clear the attributed staff on the line item.
    * @param lineItemUuid the UUID of the line item.
@@ -207,28 +207,28 @@ export interface CartApiContent {
   removeLineItemDiscount(uuid: string): Promise<void>;
 
   /**
-   * Add a new address to the customer associated with the cart. The customer must be present in the cart before adding addresses.
+   * Add a new address to the customer associated with the cart. The customer must be present in the cart before adding addresses with enhanced address validation and formatting.
    *
    * @param address the address object to add to the customer in cart
    */
   addAddress(address: Address): Promise<void>;
 
   /**
-   * Delete an existing address from the customer using the address `ID`. The customer must be present in the cart to perform this operation.
+   * Delete an existing address from the customer using the address `ID`. The customer must be present in the cart to perform this operation with improved error handling for invalid address `IDs`.
    *
    * @param addressId the address ID to delete
    */
   deleteAddress(addressId: number): Promise<void>;
 
   /**
-   * Set a specific address as the default address for the customer using the address `ID`. The customer must be present in the cart to update the default address.
+   * Set a specific address as the default address for the customer using the address `ID`. The customer must be present in the cart to update the default address with enhanced validation.
    *
    * @param addressId the address ID to set as the default address
    */
   updateDefaultAddress(addressId: number): Promise<void>;
 
   /**
-   * Add a selling plan to a line item in the cart using the line item `UUID` and selling plan `ID`. Optionally provide the selling plan name, otherwise POS will fetch it after syncing the cart.
+   * Add a selling plan to a line item in the cart using the line item `UUID`, selling plan `ID`, and selling plan name. Optionally provide delivery interval and interval count for improved performance, otherwise POS will fetch them after syncing the cart.
    *
    * @param uuid the uuid of the line item that should receive the selling plan
    * @param sellingPlanId the ID of the selling plan to add to the line item

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-line-item-api/cart-line-item-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-line-item-api/cart-line-item-api.ts
@@ -1,15 +1,11 @@
 import type {LineItem} from '../../types/cart';
 
 /**
- * The `CartLineItemApi` object provides access to the current cart line item in line item-specific extension contexts. Access this property through `shopify.cartLineItem` to retrieve detailed information about the specific cart line item currently being viewed or interacted with.
+ * The `CartLineItemApi` object provides access to the current line item. Access this property through `api.cartLineItem` to interact with the current line item context.
  */
 export interface CartLineItemApi {
   /**
-   * The complete line item object representing the selected item in the merchant's current cart. Contains all line item data including product identification (`productId`, `variantId`), display information (`title`, `vendor`, `sku`), pricing details (`price`), quantity, tax information (`taxable`, `taxLines`), applied discounts (`discounts`, `discountAllocations`), custom properties (`properties`), selling plan configuration (`sellingPlan`), and unique identifier (`uuid`).
-   *
-   * This represents the line item's current state at the moment the extension is triggered, reflecting all modifications, discounts, and properties. The line item object is read-only in this context—modifications should be made through the Cart API methods using the line item's `uuid`.
-   *
-   * Commonly used for displaying detailed item information, implementing item-specific business logic (restrictions, validations, special handling), showing custom line item properties, calculating item-level totals with discounts, or building line item configuration interfaces.
+   * The selected line item in the merchant's current cart. Provides complete line item data including product information, pricing, discounts, properties, and metadata. Use for displaying item details and implementing item-specific functionality.
    */
   cartLineItem: LineItem;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-line-item-api/cart-line-item-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-line-item-api/cart-line-item-api.ts
@@ -1,11 +1,15 @@
 import type {LineItem} from '../../types/cart';
 
 /**
- * Access to the selected line item in the merchant’s current cart.
+ * The `CartLineItemApi` object provides access to the current cart line item in line item-specific extension contexts. Access this property through `shopify.cartLineItem` to retrieve detailed information about the specific cart line item currently being viewed or interacted with.
  */
 export interface CartLineItemApi {
   /**
-   * The selected line item in the merchant’s current cart.
+   * The complete line item object representing the selected item in the merchant's current cart. Contains all line item data including product identification (`productId`, `variantId`), display information (`title`, `vendor`, `sku`), pricing details (`price`), quantity, tax information (`taxable`, `taxLines`), applied discounts (`discounts`, `discountAllocations`), custom properties (`properties`), selling plan configuration (`sellingPlan`), and unique identifier (`uuid`).
+   *
+   * This represents the line item's current state at the moment the extension is triggered, reflecting all modifications, discounts, and properties. The line item object is read-only in this context—modifications should be made through the Cart API methods using the line item's `uuid`.
+   *
+   * Commonly used for displaying detailed item information, implementing item-specific business logic (restrictions, validations, special handling), showing custom line item properties, calculating item-level totals with discounts, or building line item configuration interfaces.
    */
   cartLineItem: LineItem;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/connectivity-api/connectivity-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/connectivity-api/connectivity-api.ts
@@ -2,23 +2,33 @@ import type {ReadonlySignalLike} from '../../../../shared';
 
 export type ConnectivityStateSeverity = 'Connected' | 'Disconnected';
 
+/**
+ * Represents the current Internet connectivity status of the device. Indicates whether the device has an active Internet connection or is offline.
+ */
 export interface ConnectivityState {
   /**
-   * Whether the device is connected to the internet
+   * Whether the device is connected to the Internet. Returns `'Connected'` when the device has an active Internet connection and can communicate with remote servers, or `'Disconnected'` when the device is offline and can't reach the Internet.
+   *
+   * This state reflects the actual network connectivity, not just WiFi/cellular availability—a device can be connected to WiFi but still show `'Disconnected'` if that network has no Internet access.
+   *
+   * Commonly used for implementing offline-aware functionality (queuing operations, showing cached data), displaying connectivity indicators in the UI, disabling network-dependent features when offline, or providing user feedback about connection status.
    */
   internetConnected: ConnectivityStateSeverity;
 }
 
 export interface ConnectivityApiContent {
   /**
-   * Provides read-only access to the current connectivity state and allows subscribing to connectivity changes.
-   * The `value` property provides the current connectivity state, and `subscribe` allows listening to changes.
+   * Provides read-only access to the current connectivity state with subscription support for real-time connectivity changes. The `value` property contains the current connectivity status (`'Connected'` or `'Disconnected'`), and the `subscribe` method allows listening for connectivity transitions.
+   *
+   * This enables reactive connectivity handling where your extension can respond immediately when the device goes online or offline. Subscriptions fire when connectivity state changes (for example, WiFi connects, network drops), not continuously.
+   *
+   * Commonly used for implementing offline-aware functionality (queuing operations when offline, syncing when online), displaying connectivity indicators in the UI, showing offline mode warnings, or enabling/disabling network-dependent features based on connectivity status.
    */
   current: ReadonlySignalLike<ConnectivityState>;
 }
 
 /**
- * Access information about the device connectivity
+ * The `ConnectivityApi` object provides access to current connectivity information and change notifications. Access these properties through `shopify.connectivity` to monitor network status.
  */
 export interface ConnectivityApi {
   connectivity: ConnectivityApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/connectivity-api/connectivity-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/connectivity-api/connectivity-api.ts
@@ -3,26 +3,18 @@ import type {ReadonlySignalLike} from '../../../../shared';
 export type ConnectivityStateSeverity = 'Connected' | 'Disconnected';
 
 /**
- * Represents the current Internet connectivity status of the device. Indicates whether the device has an active Internet connection or is offline.
+ * Represents the current Internet connectivity status of the device. Indicates whether the device is connected or disconnected from the Internet.
  */
 export interface ConnectivityState {
   /**
-   * Whether the device is connected to the Internet. Returns `'Connected'` when the device has an active Internet connection and can communicate with remote servers, or `'Disconnected'` when the device is offline and can't reach the Internet.
-   *
-   * This state reflects the actual network connectivity, not just WiFi/cellular availability—a device can be connected to WiFi but still show `'Disconnected'` if that network has no Internet access.
-   *
-   * Commonly used for implementing offline-aware functionality (queuing operations, showing cached data), displaying connectivity indicators in the UI, disabling network-dependent features when offline, or providing user feedback about connection status.
+   * The Internet connection status of the POS device.
    */
   internetConnected: ConnectivityStateSeverity;
 }
 
 export interface ConnectivityApiContent {
   /**
-   * Provides read-only access to the current connectivity state with subscription support for real-time connectivity changes. The `value` property contains the current connectivity status (`'Connected'` or `'Disconnected'`), and the `subscribe` method allows listening for connectivity transitions.
-   *
-   * This enables reactive connectivity handling where your extension can respond immediately when the device goes online or offline. Subscriptions fire when connectivity state changes (for example, WiFi connects, network drops), not continuously.
-   *
-   * Commonly used for implementing offline-aware functionality (queuing operations when offline, syncing when online), displaying connectivity indicators in the UI, showing offline mode warnings, or enabling/disabling network-dependent features based on connectivity status.
+   * Provides read-only access to the current connectivity state and allows subscribing to connectivity changes. Use for implementing connectivity-aware functionality and reactive connectivity handling.
    */
   current: ReadonlySignalLike<ConnectivityState>;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/customer-api/customer-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/customer-api/customer-api.ts
@@ -7,9 +7,7 @@ export interface CustomerApi {
 
 export interface CustomerApiContent {
   /**
-   * The unique numeric identifier for the customer currently in context. This ID is consistent across all Shopify systems and APIs, allowing you to retrieve full customer details using GraphQL queries, link to customer records in external systems, or perform customer-specific operations. The ID corresponds to the customer whose details page is currently open in POS or the customer associated with the current context.
-   *
-   * Commonly used for loading additional customer data (purchase history, addresses, tags), applying customer-specific pricing or discounts, personalizing the extension experience based on customer segments or loyalty tiers, tracking customer-specific analytics, or integrating customer data with external CRM or loyalty systems.
+   * The unique identifier for the customer. Use for customer lookups, applying customer-specific pricing, enabling personalized features, and integrating with external systems.
    */
   id: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/customer-api/customer-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/customer-api/customer-api.ts
@@ -1,10 +1,15 @@
+/**
+ * The `CustomerApi` object provides access to customer data in customer-specific extension contexts. Access this property through `shopify.customer` to retrieve information about the customer currently being viewed or interacted with in the POS interface.
+ */
 export interface CustomerApi {
   customer: CustomerApiContent;
 }
 
 export interface CustomerApiContent {
   /**
-   * The unique identifier for the customer
+   * The unique numeric identifier for the customer currently in context. This ID is consistent across all Shopify systems and APIs, allowing you to retrieve full customer details using GraphQL queries, link to customer records in external systems, or perform customer-specific operations. The ID corresponds to the customer whose details page is currently open in POS or the customer associated with the current context.
+   *
+   * Commonly used for loading additional customer data (purchase history, addresses, tags), applying customer-specific pricing or discounts, personalizing the extension experience based on customer segments or loyalty tiers, tracking customer-specific analytics, or integrating customer data with external CRM or loyalty systems.
    */
   id: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
@@ -1,20 +1,24 @@
 export interface DeviceApiContent {
   /**
-   * The name of the device
+   * The friendly name of the device as configured by the merchant or system administrator (for example, "Front Counter iPad", "Mobile Register 3", "Checkout Station A"). This name is displayed in device lists, admin interfaces, and device selection screens to help merchants identify which physical device is being used. The name is static for the session and reflects the device's configuration in Shopify admin.
    */
   name: string;
   /**
-   * The string ID of the device
+   * Retrieves the unique string identifier for this specific POS device. Returns a promise that resolves to the device ID, which is a persistent identifier that remains constant across sessions and app updates. The ID format is implementation-specific but guaranteed unique within the merchant's shop.
+   *
+   * Commonly used for device-specific data storage (storing preferences per device), analytics tracking (grouping events by device), implementing device-based permissions, or creating device-specific configurations. The async nature allows the system to fetch the ID from secure storage if not immediately available.
    */
   getDeviceId(): Promise<string>;
   /**
-   * Whether the device is a tablet
+   * Determines whether the current device is a tablet form factor (for example, iPad, Android tablet). Returns a promise that resolves to `true` for touchscreen tablet devices, or `false` for other device types like desktop POS terminals, mobile phones, or specialized POS hardware.
+   *
+   * Commonly used for implementing responsive design (adjusting layouts for tablet screens), optimizing touch target sizes (larger buttons on tablets), or enabling/disabling features based on device capabilities. The async nature accounts for cases where form factor detection requires system queries.
    */
   isTablet(): Promise<boolean>;
 }
 
 /**
- * Access information about the device, like name and ID
+ * The `DeviceApi` object provides access to device information and capabilities. Access these properties and methods through `shopify.device` to retrieve device details and check device characteristics.
  */
 export interface DeviceApi {
   device: DeviceApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
@@ -1,18 +1,14 @@
 export interface DeviceApiContent {
   /**
-   * The friendly name of the device as configured by the merchant or system administrator (for example, "Front Counter iPad", "Mobile Register 3", "Checkout Station A"). This name is displayed in device lists, admin interfaces, and device selection screens to help merchants identify which physical device is being used. The name is static for the session and reflects the device's configuration in Shopify admin.
+   * The name of the device as configured by the merchant or system. Use for displaying device information in interfaces, logging, or support contexts where device identification is helpful.
    */
   name: string;
   /**
-   * Retrieves the unique string identifier for this specific POS device. Returns a promise that resolves to the device ID, which is a persistent identifier that remains constant across sessions and app updates. The ID format is implementation-specific but guaranteed unique within the merchant's shop.
-   *
-   * Commonly used for device-specific data storage (storing preferences per device), analytics tracking (grouping events by device), implementing device-based permissions, or creating device-specific configurations. The async nature allows the system to fetch the ID from secure storage if not immediately available.
+   * Retrieves the unique string identifier for the device. Returns a promise that resolves to the device ID. Use for device-specific data storage, analytics tracking, or implementing device-based permissions and configurations.
    */
   getDeviceId(): Promise<string>;
   /**
-   * Determines whether the current device is a tablet form factor (for example, iPad, Android tablet). Returns a promise that resolves to `true` for touchscreen tablet devices, or `false` for other device types like desktop POS terminals, mobile phones, or specialized POS hardware.
-   *
-   * Commonly used for implementing responsive design (adjusting layouts for tablet screens), optimizing touch target sizes (larger buttons on tablets), or enabling/disabling features based on device capabilities. The async nature accounts for cases where form factor detection requires system queries.
+   * Determines whether the device is a tablet form factor. Returns a promise that resolves to `true` for tablets, `false` for other device types. Use for implementing responsive design, optimizing touch targets, or providing device-appropriate user experiences.
    */
   isTablet(): Promise<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/draft-order-api/draft-order-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/draft-order-api/draft-order-api.ts
@@ -7,25 +7,17 @@ export interface DraftOrderApi {
 
 export interface DraftOrderApiContent {
   /**
-   * The unique numeric identifier for the draft order currently in context. This ID is consistent across all Shopify systems and APIs, allowing you to retrieve full draft order details using GraphQL queries or link to draft order records in external systems.
-   *
-   * Draft orders are preliminary orders that merchants create and save before finalizing them into actual orders—they can be edited, sent as invoices to customers, or converted to completed orders later. The ID corresponds to the draft order whose details page is currently open in POS.
-   *
-   * Commonly used for loading complete draft order information (line items, pricing, customer, notes), tracking draft order status, implementing draft order workflows, or integrating with external order preparation systems.
+   * The unique identifier for the draft order. Use for draft order lookups, implementing order-specific functionality, and integrating with external systems.
    */
   id: number;
 
   /**
-   * The human-readable draft order name or number as configured by the merchant (for example, "#D1", "#DRAFT-1001"). This is the identifier shown in draft order lists, admin interfaces, and invoices sent to customers. The naming scheme follows the merchant's draft order configuration in Shopify settings.
-   *
-   * Commonly used for displaying the draft order reference in UI, searching for draft orders, communicating draft order identifiers to customers using invoices, or including in administrative workflows. This is different from the `id` which is an internal numeric identifier.
+   * The name of the draft order as configured by the merchant. Use for draft order identification, displays, and customer-facing interfaces.
    */
   name: string;
 
   /**
-   * The unique numeric identifier of the customer associated with this draft order. This links the draft order to a customer account in Shopify. Returns `undefined` when no customer is associated with the draft order—draft orders can exist without customer association if the merchant hasn't assigned a customer yet.
-   *
-   * When present, this ID can be used to retrieve full customer details, load customer purchase history, apply customer-specific pricing, or link to customer records in external CRM systems. The customer can be assigned to the draft order before it's converted to a completed order.
+   * The unique identifier of the customer associated with the draft order. Returns `undefined` if no customer is associated. Use for customer-specific functionality and personalized experiences.
    */
   customerId?: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/draft-order-api/draft-order-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/draft-order-api/draft-order-api.ts
@@ -1,20 +1,31 @@
+/**
+ * The `DraftOrderApi` object provides access to draft order data in draft order-specific extension contexts. Access this property through `shopify.draftOrder` to retrieve information about the draft order currently being viewed or interacted with in the POS interface.
+ */
 export interface DraftOrderApi {
   draftOrder: DraftOrderApiContent;
 }
 
 export interface DraftOrderApiContent {
   /**
-   * The unique identifier for the draft order
+   * The unique numeric identifier for the draft order currently in context. This ID is consistent across all Shopify systems and APIs, allowing you to retrieve full draft order details using GraphQL queries or link to draft order records in external systems.
+   *
+   * Draft orders are preliminary orders that merchants create and save before finalizing them into actual orders—they can be edited, sent as invoices to customers, or converted to completed orders later. The ID corresponds to the draft order whose details page is currently open in POS.
+   *
+   * Commonly used for loading complete draft order information (line items, pricing, customer, notes), tracking draft order status, implementing draft order workflows, or integrating with external order preparation systems.
    */
   id: number;
 
   /**
-   * The name of the draft order
+   * The human-readable draft order name or number as configured by the merchant (for example, "#D1", "#DRAFT-1001"). This is the identifier shown in draft order lists, admin interfaces, and invoices sent to customers. The naming scheme follows the merchant's draft order configuration in Shopify settings.
+   *
+   * Commonly used for displaying the draft order reference in UI, searching for draft orders, communicating draft order identifiers to customers using invoices, or including in administrative workflows. This is different from the `id` which is an internal numeric identifier.
    */
   name: string;
 
   /**
-   * The unique identifier of the customer associated with the draft order
+   * The unique numeric identifier of the customer associated with this draft order. This links the draft order to a customer account in Shopify. Returns `undefined` when no customer is associated with the draft order—draft orders can exist without customer association if the merchant hasn't assigned a customer yet.
+   *
+   * When present, this ID can be used to retrieve full customer details, load customer purchase history, apply customer-specific pricing, or link to customer records in external CRM systems. The customer can be assigned to the draft order before it's converted to a completed order.
    */
   customerId?: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/locale-api/locale-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/locale-api/locale-api.ts
@@ -2,7 +2,7 @@ import type {ReadonlySignalLike} from '../../../../shared';
 
 export interface LocaleApiContent {
   /**
-   * Provides read-only access to the current [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) formatted locale and allows subscribing to locale changes. The `value` property provides the current locale, and `subscribe` allows listening to changes. Commonly used for internationalization, locale-specific formatting, and reactive updates when merchants change language settings.
+   * Provides read-only access to the current IETF-formatted locale and allows subscribing to locale changes. The `value` property provides the current locale, and `subscribe` allows listening to changes. Use for internationalization, locale-specific formatting, and reactive updates when merchants change language settings.
    */
   current: ReadonlySignalLike<string>;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/locale-api/locale-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/locale-api/locale-api.ts
@@ -2,14 +2,13 @@ import type {ReadonlySignalLike} from '../../../../shared';
 
 export interface LocaleApiContent {
   /**
-   * Provides read-only access to the current IETF-formatted locale and allows subscribing to locale changes.
-   * The `value` property provides the current locale, and `subscribe` allows listening to changes.
+   * Provides read-only access to the current [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) formatted locale and allows subscribing to locale changes. The `value` property provides the current locale, and `subscribe` allows listening to changes. Commonly used for internationalization, locale-specific formatting, and reactive updates when merchants change language settings.
    */
   current: ReadonlySignalLike<string>;
 }
 
 /**
- * Access the merchant’s current locale (in [IETF format](https://en.wikipedia.org/wiki/IETF_language_tag)) to internationalize your extension content.
+ * The `LocaleApi` object provides access to current locale information and change notifications. Access these properties through `shopify.locale` to retrieve and monitor locale data.
  */
 export interface LocaleApi {
   locale: LocaleApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -1,44 +1,74 @@
+/**
+ * Specifies configuration options for navigation operations. Allows passing custom state data that persists with the navigation entry in the history stack.
+ */
 export interface NavigationNavigateOptions {
   /**
-   * Developer-defined information to be stored in the associated NavigationHistoryEntry once the navigation is complete, retrievable via getState().
+   * Developer-defined data to be stored in the associated `NavigationHistoryEntry` once navigation completes. This can be any serializable data structure (objects, arrays, primitives) that you want to associate with this navigation state. The state is stored with the history entry and can be retrieved later using `getState()` on the history entry object. State persists across forward/back navigation and survives page refreshes in some implementations.
+   *
+   * Commonly used to pass data between navigation states without URL parameters (complex objects, sensitive data, UI state), implement stateful navigation workflows (wizard steps, form data preservation), restore previous view state when navigating back, or maintain context across navigation transitions. The state is cloned when stored to prevent mutation issues.
    */
   state?: unknown;
 }
 
 /**
- * The NavigationHistoryEntry interface of the Navigation API represents a single navigation history entry.
+ * Represents a single entry in the navigation history stack. Each entry corresponds to a navigation action and contains the destination URL, unique identifier, and optional state data. The history stack enables browser-like back/forward navigation within the extension.
  */
 export interface NavigationHistoryEntry {
-  /** Returns the key of the history entry. This is a unique, UA-generated value that represents the history entry's slot in the entries list rather than the entry itself. */
+  /**
+   * A unique identifier for this position in the navigation history stack. This is a user-agent-generated string that represents the entry's slot in the history list rather than identifying the URL or state itself. The key remains constant for this history position even if the URL or state changes. Two different navigations to the same URL will have different keys.
+   *
+   * The key is primarily used internally by navigation APIs and isn't typically useful for application logic—URLs and state are more practical for navigation decisions. Commonly used by frameworks for tracking history position or implementing navigation-based caching.
+   */
   key: string;
   /**
-   * Returns the URL of this history entry.
+   * The URL associated with this navigation history entry. For modal navigations within extensions, this is typically a path relative to the extension (for example, `/product/123`, `/settings`). Returns `null` when this history entry doesn't have an associated URL, which can occur for initial entries or certain navigation types.
+   *
+   * Commonly used for URL-based navigation logic (showing different views based on URL), implementing deep-linking (navigating directly to specific states using URL), displaying current location in breadcrumbs or address bars, or analyzing navigation patterns.
    */
   url: string | null;
   /**
-   * Returns a clone of the available state associated with this history entry.
+   * Returns a clone of the state data associated with this history entry. The returned value is a deep copy of the state object that was passed during navigation using `NavigationNavigateOptions.state`, preventing accidental mutations of the historical state. Returns `undefined` when no state was provided during navigation. The state can contain any data structure you stored—type assertions or runtime validation may be needed since the return type is `unknown`.
+   *
+   * Commonly used to retrieve navigation context (wizard step data, filter settings, scroll positions), restore previous view state when navigating back, implement state-based navigation logic, or access data passed from previous screens without URL parameters.
    */
   getState(): unknown;
 }
 
 export interface Navigation {
   /**
-   * The navigate() method navigates to a specific URL, updating any provided state in the history entries list.
+   * Navigates to a specific URL within the extension, creating a new entry in the navigation history stack. The URL parameter specifies the destination path (for example, `/products`, `/settings/account`), and optional state data can be attached to the history entry.
+   *
+   * The method returns a promise that resolves when the navigation transition completes and the new view is rendered. Navigation is asynchronous to allow for animation transitions, data loading, or cleanup operations before the new view appears. If navigation fails (invalid URL, navigation prevented), the promise rejects with an error.
+   *
+   * Commonly used for programmatic navigation between extension screens (navigating on button clicks, redirecting after save operations), implementing custom navigation controls (sidebar navigation, breadcrumbs), handling navigation logic based on user actions or data state, or deep-linking to specific modal states with preserved context using the state parameter.
    */
   navigate: (url: string, options?: NavigationNavigateOptions) => Promise<void>;
   /**
-   * The currentEntry read-only property of the Navigation interface returns a NavigationHistoryEntry object representing the location the user is currently navigated to right now.
+   * The `NavigationHistoryEntry` object representing the current location where the user is navigated. This entry contains the current URL, navigation state, and unique position key. The object updates automatically when navigation occurs—reading this property always returns the current entry, not a cached value.
+   *
+   * Commonly used to access the current URL (determining which view is active, conditional rendering based on route), retrieve current navigation state (restoring UI state, reading passed parameters), implement navigation-aware UI (highlighting active nav items, showing contextual actions), or tracking navigation for analytics (page views, user flow analysis).
    */
   currentEntry: NavigationHistoryEntry;
   /**
-   * The back() method of the Navigation interface navigates to the previous entry in the history list.
+   * Navigates backward to the previous entry in the navigation history stack, similar to a browser's back button. This moves the user to the screen they were viewing before the current one, restoring that screen's URL and state. The method returns immediately without waiting for the navigation to complete.
+   *
+   * If there is no previous entry (already at the first entry in the stack), this method has no effect—it doesn't throw an error or close the modal. The back navigation is treated as a new navigation event and may trigger navigation guards or callbacks if implemented.
+   *
+   * Commonly used for implementing back buttons (header back buttons, cancel actions that return to previous screen), providing escape routes from multi-step workflows, navigating up the breadcrumb hierarchy, or allowing users to undo navigation mistakes.
    */
   back(): void;
 }
 
+/**
+ * The global `window` object provides control over the extension modal lifecycle. Access these properties and methods directly through the global `window` object to manage the modal interface programmatically.
+ */
 export interface Window {
   /**
-   * The close() method of the window interface closes the extension screen.
+   * Closes the extension modal and dismisses the full-screen interface, returning the user to the underlying POS screen. This method terminates the extension's execution context—any running timers, subscriptions, or pending operations are cleaned up. The modal dismissal may include closing animations depending on the platform. The method returns immediately without waiting for the modal to fully close.
+   *
+   * Once called, no further extension code executes, so ensure all necessary cleanup or save operations complete before calling `close()`.
+   *
+   * Commonly used to programmatically dismiss the modal after workflow completion (form submitted successfully, selection confirmed), cancel operations (user clicks cancel, invalid state detected), timeout scenarios (auto-close after period of inactivity), or when continued user interaction isn't required. This provides the same behavior and lifecycle as when the user dismisses the modal through the UI close button.
    */
   close(): void;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -1,60 +1,42 @@
 /**
- * Specifies configuration options for navigation operations. Allows passing custom state data that persists with the navigation entry in the history stack.
+ * Specifies configuration options for navigation operations. Allows passing state data that persists across navigation transitions.
  */
 export interface NavigationNavigateOptions {
   /**
-   * Developer-defined data to be stored in the associated `NavigationHistoryEntry` once navigation completes. This can be any serializable data structure (objects, arrays, primitives) that you want to associate with this navigation state. The state is stored with the history entry and can be retrieved later using `getState()` on the history entry object. State persists across forward/back navigation and survives page refreshes in some implementations.
-   *
-   * Commonly used to pass data between navigation states without URL parameters (complex objects, sensitive data, UI state), implement stateful navigation workflows (wizard steps, form data preservation), restore previous view state when navigating back, or maintain context across navigation transitions. The state is cloned when stored to prevent mutation issues.
+   * Developer-defined information to be stored in the associated `NavigationHistoryEntry` once the navigation is complete, retrievable using `getState()`. Use to pass data between navigation states or implement stateful navigation workflows.
    */
   state?: unknown;
 }
 
 /**
- * Represents a single entry in the navigation history stack. Each entry corresponds to a navigation action and contains the destination URL, unique identifier, and optional state data. The history stack enables browser-like back/forward navigation within the extension.
+ * Represents a single entry in the navigation history stack. Contains the URL and unique identifier for tracking navigation state and implementing history-based navigation.
  */
 export interface NavigationHistoryEntry {
   /**
-   * A unique identifier for this position in the navigation history stack. This is a user-agent-generated string that represents the entry's slot in the history list rather than identifying the URL or state itself. The key remains constant for this history position even if the URL or state changes. Two different navigations to the same URL will have different keys.
-   *
-   * The key is primarily used internally by navigation APIs and isn't typically useful for application logic—URLs and state are more practical for navigation decisions. Commonly used by frameworks for tracking history position or implementing navigation-based caching.
+   * A unique, UA-generated value that represents the history entry's slot in the entries list rather than the entry itself. Use for tracking navigation history or implementing navigation-based logic.
    */
   key: string;
   /**
-   * The URL associated with this navigation history entry. For modal navigations within extensions, this is typically a path relative to the extension (for example, `/product/123`, `/settings`). Returns `null` when this history entry doesn't have an associated URL, which can occur for initial entries or certain navigation types.
-   *
-   * Commonly used for URL-based navigation logic (showing different views based on URL), implementing deep-linking (navigating directly to specific states using URL), displaying current location in breadcrumbs or address bars, or analyzing navigation patterns.
+   * The URL of this history entry. Returns `null` if no URL is associated with the entry. Use for URL-based navigation logic, deep-linking, or displaying current location information.
    */
   url: string | null;
   /**
-   * Returns a clone of the state data associated with this history entry. The returned value is a deep copy of the state object that was passed during navigation using `NavigationNavigateOptions.state`, preventing accidental mutations of the historical state. Returns `undefined` when no state was provided during navigation. The state can contain any data structure you stored—type assertions or runtime validation may be needed since the return type is `unknown`.
-   *
-   * Commonly used to retrieve navigation context (wizard step data, filter settings, scroll positions), restore previous view state when navigating back, implement state-based navigation logic, or access data passed from previous screens without URL parameters.
+   * Returns a clone of the available state associated with this history entry. Use to retrieve navigation state data that was passed during navigation or to implement state-based navigation logic.
    */
   getState(): unknown;
 }
 
 export interface Navigation {
   /**
-   * Navigates to a specific URL within the extension, creating a new entry in the navigation history stack. The URL parameter specifies the destination path (for example, `/products`, `/settings/account`), and optional state data can be attached to the history entry.
-   *
-   * The method returns a promise that resolves when the navigation transition completes and the new view is rendered. Navigation is asynchronous to allow for animation transitions, data loading, or cleanup operations before the new view appears. If navigation fails (invalid URL, navigation prevented), the promise rejects with an error.
-   *
-   * Commonly used for programmatic navigation between extension screens (navigating on button clicks, redirecting after save operations), implementing custom navigation controls (sidebar navigation, breadcrumbs), handling navigation logic based on user actions or data state, or deep-linking to specific modal states with preserved context using the state parameter.
+   * Navigates to a specific URL, updating any provided state in the history entries list. Returns a promise that resolves when navigation is complete. Use for programmatic navigation between screens, implementing custom navigation controls, or deep-linking to specific modal states.
    */
   navigate: (url: string, options?: NavigationNavigateOptions) => Promise<void>;
   /**
-   * The `NavigationHistoryEntry` object representing the current location where the user is navigated. This entry contains the current URL, navigation state, and unique position key. The object updates automatically when navigation occurs—reading this property always returns the current entry, not a cached value.
-   *
-   * Commonly used to access the current URL (determining which view is active, conditional rendering based on route), retrieve current navigation state (restoring UI state, reading passed parameters), implement navigation-aware UI (highlighting active nav items, showing contextual actions), or tracking navigation for analytics (page views, user flow analysis).
+   * Returns a `NavigationHistoryEntry` object representing the location the user is currently navigated to. Use to access current URL, navigation state, or implement navigation-aware functionality based on the current location.
    */
   currentEntry: NavigationHistoryEntry;
   /**
-   * Navigates backward to the previous entry in the navigation history stack, similar to a browser's back button. This moves the user to the screen they were viewing before the current one, restoring that screen's URL and state. The method returns immediately without waiting for the navigation to complete.
-   *
-   * If there is no previous entry (already at the first entry in the stack), this method has no effect—it doesn't throw an error or close the modal. The back navigation is treated as a new navigation event and may trigger navigation guards or callbacks if implemented.
-   *
-   * Commonly used for implementing back buttons (header back buttons, cancel actions that return to previous screen), providing escape routes from multi-step workflows, navigating up the breadcrumb hierarchy, or allowing users to undo navigation mistakes.
+   * Navigates to the previous entry in the history list. Use for implementing back buttons, breadcrumb navigation, or allowing users to return to previous screens in multi-step workflows.
    */
   back(): void;
 }
@@ -64,11 +46,7 @@ export interface Navigation {
  */
 export interface Window {
   /**
-   * Closes the extension modal and dismisses the full-screen interface, returning the user to the underlying POS screen. This method terminates the extension's execution context—any running timers, subscriptions, or pending operations are cleaned up. The modal dismissal may include closing animations depending on the platform. The method returns immediately without waiting for the modal to fully close.
-   *
-   * Once called, no further extension code executes, so ensure all necessary cleanup or save operations complete before calling `close()`.
-   *
-   * Commonly used to programmatically dismiss the modal after workflow completion (form submitted successfully, selection confirmed), cancel operations (user clicks cancel, invalid state detected), timeout scenarios (auto-close after period of inactivity), or when continued user interaction isn't required. This provides the same behavior and lifecycle as when the user dismisses the modal through the UI close button.
+   * Closes the extension screen and dismisses the modal interface. Use to programmatically close the modal after completing a workflow, canceling an operation, or when user action is no longer required. This provides the same behavior as the user dismissing the modal through the UI.
    */
   close(): void;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.ts
@@ -1,26 +1,32 @@
 /**
- * Interface to access the order
+ * The `OrderApi` object provides access to order data in order-specific extension contexts. Access this property through `shopify.order` to retrieve information about the order currently being viewed or interacted with in the POS interface.
  */
 export interface OrderApi {
   order: OrderApiContent;
 }
 
 /**
- * Interface for Order details
+ * Contains order identification and basic metadata for the order currently in context.
  */
 export interface OrderApiContent {
   /**
-   * The unique identifier for the order
+   * The unique numeric identifier for the order currently in context. This ID is consistent across all Shopify systems and APIs, allowing you to retrieve full order details using GraphQL queries, link to order records in external systems, or perform order-specific operations. The ID corresponds to the order whose details page is currently open in POS or the order associated with the current extension context.
+   *
+   * Commonly used for loading complete order information (line items, fulfillment status, payments, shipping), fetching order data from external order management systems, implementing order-based business logic (special handling for certain order types), tracking order-specific analytics, or integrating order data with shipping carriers or accounting systems.
    */
   id: number;
 
   /**
-   * The name of the order
+   * The human-readable order name or number as configured by the merchant (for example, "#1001", "#1002"). This is the customer-facing order identifier shown on receipts, confirmation emails, and in the customer's order history. The name follows the merchant's order numbering scheme configured in Shopify settings and is typically sequential.
+   *
+   * Commonly used for displaying the order reference in UI, communicating order numbers to customers, searching for orders, or including in customer communications and support interactions. This is different from the `id` which is an internal numeric identifier.
    */
   name: string;
 
   /**
-   * The unique identifier of the customer associated with the order
+   * The unique numeric identifier of the customer associated with this order. This links the order to a customer account in Shopify. Returns `undefined` for guest orders where no customer account was selected or created during checkout, or when the order doesn't have customer association.
+   *
+   * When present, this ID can be used to retrieve full customer details, load customer history, apply customer-specific logic, or link to customer records in external systems. The customer ID corresponds to the same customer available through the Customer API if accessed in customer contexts.
    */
   customerId?: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.ts
@@ -6,27 +6,21 @@ export interface OrderApi {
 }
 
 /**
- * Contains order identification and basic metadata for the order currently in context.
+ * The `OrderApi` object provides access to order data. Access this property through `shopify.order` to interact with the current order context.
  */
 export interface OrderApiContent {
   /**
-   * The unique numeric identifier for the order currently in context. This ID is consistent across all Shopify systems and APIs, allowing you to retrieve full order details using GraphQL queries, link to order records in external systems, or perform order-specific operations. The ID corresponds to the order whose details page is currently open in POS or the order associated with the current extension context.
-   *
-   * Commonly used for loading complete order information (line items, fulfillment status, payments, shipping), fetching order data from external order management systems, implementing order-based business logic (special handling for certain order types), tracking order-specific analytics, or integrating order data with shipping carriers or accounting systems.
+   * The unique identifier for the order. Use for order lookups, implementing order-specific functionality, and integrating with external systems.
    */
   id: number;
 
   /**
-   * The human-readable order name or number as configured by the merchant (for example, "#1001", "#1002"). This is the customer-facing order identifier shown on receipts, confirmation emails, and in the customer's order history. The name follows the merchant's order numbering scheme configured in Shopify settings and is typically sequential.
-   *
-   * Commonly used for displaying the order reference in UI, communicating order numbers to customers, searching for orders, or including in customer communications and support interactions. This is different from the `id` which is an internal numeric identifier.
+   * The name of the order as configured by the merchant. Use for order identification, displays, and customer-facing interfaces.
    */
   name: string;
 
   /**
-   * The unique numeric identifier of the customer associated with this order. This links the order to a customer account in Shopify. Returns `undefined` for guest orders where no customer account was selected or created during checkout, or when the order doesn't have customer association.
-   *
-   * When present, this ID can be used to retrieve full customer details, load customer history, apply customer-specific logic, or link to customer records in external systems. The customer ID corresponds to the same customer available through the Customer API if accessed in customer contexts.
+   * The unique identifier of the customer associated with the order. Returns `undefined` if no customer is associated. Use for customer-specific functionality and personalized experiences.
    */
   customerId?: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
@@ -3,9 +3,12 @@ import {PinPadOptions, PinValidationResult} from '../types/pin-pad';
 export interface PinPadApiContent {
   /**
    * Shows a PIN pad to the user in a modal dialog. The `onSubmit` function is called when the PIN is submitted and should validate the PIN, returning `'accept'` or `'reject'`.
+   *
    * • **When accepted**: Modal dismisses and triggers the `onDismissed` callback—perform any post-validation navigation in this callback rather than in `onSubmit`.
+   *
    * • **When rejected**: Displays the optional `errorMessage` and keeps the modal open.
-   * Commonly used for implementing secure authentication workflows, access control, or PIN-based verification systems.
+   *
+   * Use for implementing secure authentication workflows, access control, or PIN-based verification systems.
    */
   showPinPad(
     onSubmit: (

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
@@ -1,18 +1,11 @@
 import {PinPadOptions, PinValidationResult} from '../types/pin-pad';
 
 export interface PinPadApiContent {
-  /** Shows a PIN pad to the user in a modal dialog.
-   *
-   * `onSubmit` is called when the PIN is submitted for validation by the user. The callback
-   * should validate the PIN and accept or reject it.
-   *
-   * If the PIN is accepted, the modal will be dismissed and the `onDismissed` callback
-   * (provided via `options`) will be called. It is recommended that any post-validation
-   * navigation is performed in this callback rather than in `onSubmit`.
-   *
-   * If the PIN is rejected, the optional `errorMessage` will be displayed to the user and the modal
-   * will not be dismissed.
-   *
+  /**
+   * Shows a PIN pad to the user in a modal dialog. The `onSubmit` function is called when the PIN is submitted and should validate the PIN, returning `'accept'` or `'reject'`.
+   * • **When accepted**: Modal dismisses and triggers the `onDismissed` callback—perform any post-validation navigation in this callback rather than in `onSubmit`.
+   * • **When rejected**: Displays the optional `errorMessage` and keeps the modal open.
+   * Commonly used for implementing secure authentication workflows, access control, or PIN-based verification systems.
    */
   showPinPad(
     onSubmit: (
@@ -23,7 +16,7 @@ export interface PinPadApiContent {
 }
 
 /**
- * Access the PIN Pad API for PIN pad functionality in a modal.
+ * The `PinPadApi` object provides methods for displaying secure PIN entry interfaces. Access these methods through `shopify.pinPad` to show PIN pad modals and handle PIN validation.
  */
 export interface PinPadApi {
   pinPad: PinPadApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/print-api/print-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/print-api/print-api.ts
@@ -3,17 +3,13 @@
  */
 export interface PrintApiContent {
   /**
-   * Trigger a print dialog.
+   * Triggers the native print dialog for the specified document source. The `print()` method accepts either:
+   * • A relative path (for example, `/print-receipt`) that will be appended to your app's [`application_url`](/docs/apps/build/cli-for-apps/app-configuration) configured in your app settings.
+   * • A full URL to your app's backend (for example, `https://myapp.com/api/print/receipt/123`) that returns the document to print.
    *
-   * The src must be either:
-   * - A relative path that will be appended to your app's [application_url](/docs/apps/build/cli-for-apps/app-configuration#application_url)
-   * - A full URL to your app's backend that will be used to return the document to print
+   * The method returns a promise that resolves when the document content has loaded and the native print dialog appears on screen. The actual printing happens when the user confirms in the print dialog—this method doesn't wait for print completion. The document at the source URL should return printable HTML content.
    *
-   * Supported document types:
-   * - HTML documents (recommended for best printing experience)
-   * - Text files
-   * - Image files (PNG, JPEG, etc.)
-   * - PDF files (Note: On Android devices, PDFs will be downloaded and must be printed using an external application)
+   * Commonly used for printing custom receipts, shipping labels, packing slips, invoices, or reports with custom formatting. Print failures (network errors, invalid URLs, or unloadable content) reject the promise with an error.
    *
    * @param src the source URL of the content to print.
    * @returns Promise<void> that resolves when content is ready and native print dialog appears.
@@ -22,8 +18,11 @@ export interface PrintApiContent {
 }
 
 /**
- * Interface for printing
+ * The `PrintApi` object provides methods for triggering document printing. Access these methods through `shopify.print` to initiate print operations with various document types.
  */
 export interface PrintApi {
+  /**
+   * Provides access to print functionality for triggering the native print dialog with custom documents.
+   */
   print: PrintApiContent;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/print-api/print-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/print-api/print-api.ts
@@ -1,15 +1,15 @@
 /**
- * Access the print API for printing functionality
+ * The `PrintApi` object provides methods for triggering document printing. Access these methods through `shopify.print` to initiate print operations with various document types.
  */
 export interface PrintApiContent {
   /**
-   * Triggers the native print dialog for the specified document source. The `print()` method accepts either:
-   * • A relative path (for example, `/print-receipt`) that will be appended to your app's [`application_url`](/docs/apps/build/cli-for-apps/app-configuration) configured in your app settings.
-   * • A full URL to your app's backend (for example, `https://myapp.com/api/print/receipt/123`) that returns the document to print.
+   * Triggers a print dialog for the specified document source. The `print()` method accepts either:
    *
-   * The method returns a promise that resolves when the document content has loaded and the native print dialog appears on screen. The actual printing happens when the user confirms in the print dialog—this method doesn't wait for print completion. The document at the source URL should return printable HTML content.
+   * • A relative path that will be appended to your app's [`application_url`](/docs/apps/build/cli-for-apps/app-configuration)
    *
-   * Commonly used for printing custom receipts, shipping labels, packing slips, invoices, or reports with custom formatting. Print failures (network errors, invalid URLs, or unloadable content) reject the promise with an error.
+   * • A full URL to your app's backend that will be used to return the document to print
+   *
+   * Returns a promise that resolves when content is ready and the native print dialog appears. Use for printing custom documents, receipts, labels, or reports.
    *
    * @param src the source URL of the content to print.
    * @returns Promise<void> that resolves when content is ready and native print dialog appears.
@@ -22,7 +22,7 @@ export interface PrintApiContent {
  */
 export interface PrintApi {
   /**
-   * Provides access to print functionality for triggering the native print dialog with custom documents.
+   * The `PrintApi` object provides methods for triggering document printing. Access these methods through `shopify.print` to initiate print operations with various document types.
    */
   print: PrintApiContent;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/product-api/product-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/product-api/product-api.ts
@@ -1,14 +1,21 @@
+/**
+ * The `ProductApi` object provides access to product and variant data in product-specific extension contexts. Access this property through `shopify.product` to retrieve information about the product or variant currently being viewed or interacted with in the POS interface.
+ */
 export interface ProductApi {
   product: ProductApiContent;
 }
 
 export interface ProductApiContent {
   /**
-   * The unique identifier for the product.
+   * The unique numeric identifier for the product currently in context. This ID is consistent across all Shopify systems and APIs, allowing you to retrieve full product details using the Product Search API or GraphQL queries. The ID corresponds to the product whose details page is currently open in POS or the product associated with the current extension context.
+   *
+   * Commonly used for loading complete product information (title, description, all variants, images, inventory), fetching product-specific data from external systems, implementing product-based business logic (restrictions, special handling, upsells), tracking product-specific analytics, or displaying additional product details not available in the basic context.
    */
   id: number;
   /**
-   * The unique identifier for the product variant.
+   * The unique numeric identifier for the specific product variant currently in context. This ID identifies a particular configuration of the product (specific size/color/material combination). The variant ID is consistent across all Shopify systems and APIs, allowing you to retrieve full variant details including pricing, inventory, SKU, and barcode.
+   *
+   * Commonly used for adding this specific variant to cart, checking variant-specific inventory levels, displaying variant details (price, availability, options), implementing variant-based business logic, or loading variant data from external systems. When the product has only one default variant, this ID represents that single variant.
    */
   variantId: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/product-api/product-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/product-api/product-api.ts
@@ -7,15 +7,11 @@ export interface ProductApi {
 
 export interface ProductApiContent {
   /**
-   * The unique numeric identifier for the product currently in context. This ID is consistent across all Shopify systems and APIs, allowing you to retrieve full product details using the Product Search API or GraphQL queries. The ID corresponds to the product whose details page is currently open in POS or the product associated with the current extension context.
-   *
-   * Commonly used for loading complete product information (title, description, all variants, images, inventory), fetching product-specific data from external systems, implementing product-based business logic (restrictions, special handling, upsells), tracking product-specific analytics, or displaying additional product details not available in the basic context.
+   * The unique identifier for the product. Use for product lookups, implementing product-specific functionality, and integrating with external systems.
    */
   id: number;
   /**
-   * The unique numeric identifier for the specific product variant currently in context. This ID identifies a particular configuration of the product (specific size/color/material combination). The variant ID is consistent across all Shopify systems and APIs, allowing you to retrieve full variant details including pricing, inventory, SKU, and barcode.
-   *
-   * Commonly used for adding this specific variant to cart, checking variant-specific inventory levels, displaying variant details (price, availability, options), implementing variant-based business logic, or loading variant data from external systems. When the product has only one default variant, this ID represents that single variant.
+   * The unique identifier for the product variant. Use for variant-specific operations, cart additions, and inventory management.
    */
   variantId: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
@@ -2,6 +2,14 @@ import type {MultipleResourceResult} from '../../types/multiple-resource-result'
 import type {PaginatedResult} from '../../types/paginated-result';
 import type {Product, ProductVariant} from '../../types/product';
 
+/**
+ * Specifies the order in which products should be sorted. When a `queryString` is provided, `sortType` won't have any effect, as the results will be returned in order by relevance to the `queryString`. Available options:
+ *
+ * - **`RECENTLY_ADDED`** - Sorts products by creation date in descending order, displaying the most recently added products first. Commonly used to highlight new inventory additions or showcase latest product arrivals.
+ * - **`RECENTLY_ADDED_ASCENDING`** - Sorts products by creation date in ascending order, displaying the oldest products first. Typically applied when prioritizing established products or implementing chronological browsing from earliest to newest
+ * - **`ALPHABETICAL_A_TO_Z`** - Sorts products alphabetically by title from A to Z. Commonly used for product catalogs where alphabetical organization improves browsing efficiency and helps users locate products by name quickly.
+ * - **`ALPHABETICAL_Z_TO_A`** - Sorts products alphabetically by title from Z to A in reverse order. Typically applied when reverse alphabetical sorting is needed for specialized browsing patterns or user preferences.
+ */
 export type ProductSortType =
   | 'RECENTLY_ADDED'
   | 'RECENTLY_ADDED_ASCENDING'
@@ -9,75 +17,119 @@ export type ProductSortType =
   | 'ALPHABETICAL_Z_TO_A';
 
 /**
- * Base interface for pagination.
+ * Specifies parameters for cursor-based pagination. Includes the cursor position and the number of results to retrieve per page.
  */
 export interface PaginationParams {
   /**
-   * Specifies the number of results to be returned in this page. The maximum number of items that will be returned is 50.
+   * Specifies the number of results to be returned in this page. The maximum value is 50—values above 50 are clamped to 50. Smaller page sizes (10-20) provide faster initial response times and lower memory usage. Larger page sizes (40-50) reduce the number of API calls needed but increase initial load time and memory consumption. The actual number of items returned may be less than requested if fewer items exist or if you're on the last page.
+   *
+   * Commonly used to control page size based on UI layout (items per screen), performance requirements (device capabilities), or user preference (configurable pagination).
    */
   first?: number;
   /**
-   * Specifies the page cursor. Items after this cursor will be returned.
+   * The pagination cursor pointing to a specific position in the result set. When provided, the API returns items that come after this cursor position, enabling sequential page navigation. This is an opaque string token obtained from the `lastCursor` field of previous search results—its internal format is implementation-specific and shouldn't be parsed or constructed manually.
+   *
+   * To fetch the next page, the `lastCursor` from the current page is passed as the `afterCursor` for the next request. Returns items from the beginning of the result set when omitted. The cursor is only valid for the same search query and sort order—changing query parameters invalidates previous cursors.
    */
   afterCursor?: string;
 }
 
 /**
- * Interface for product search
+ * Specifies the parameters for searching products. Includes query text, pagination options, and sorting preferences for product search operations.
  */
 export interface ProductSearchParams extends PaginationParams {
   /**
-   * The search term to be used to search for POS products.
+   * The search term used to find products by name, description, SKU, barcode, tags, or other searchable product fields. The search is case-insensitive and supports partial matches—searching for "blue shirt" will find products with "Blue Cotton Shirt" or "Shirt - Blue". When provided, results are automatically sorted by relevance to the query (most relevant first), overriding any `sortType` setting.
+   *
+   * When omitted or empty, all products are returned subject to `sortType` and pagination. Special characters and punctuation are normalized during search. Commonly used for implementing text-based product search, autocomplete suggestions, or filtered product browsing.
    */
   queryString?: string;
   /**
-   * Specifies the order in which products should be sorted. When a `queryString` is provided, sortType will not have any effect, as the results will be returned in order by relevance to the `queryString`.
+   * Specifies the order in which product results are returned when no `queryString` is provided. Options include recently added (newest/oldest first) and alphabetical (A-Z/Z-A). The `sortType` has no effect when `queryString` is specified—relevance sorting always takes precedence for search queries. When omitted, the default sort order is typically creation date descending (newest products first).
+   *
+   * Commonly used for organizing product listings, creating sorted catalogs, or implementing browsing interfaces where users explore products without searching.
    */
   sortType?: ProductSortType;
 }
 
 export interface ProductSearchApiContent {
-  /** Search for products on the POS device.
+  /**
+   * Searches for products stored locally on the POS device using text queries, sorting options, and pagination. Returns paginated results with up to 50 products per page. The search operates on the device's local product database (synced from Shopify), ensuring fast results even offline.
+   *
+   * When a `queryString` is provided, results are automatically sorted by relevance to the search term. When no query is provided, returns all available products in the specified sort order. The search includes product titles, descriptions, SKUs, barcodes, and tags. Results only include products that are available to this POS location based on inventory settings.
+   *
+   * Commonly used for implementing custom product search interfaces, building product catalogs, implementing barcode-based product lookup, or creating filtered product selection workflows.
+   *
    * @param searchParams The parameters for the product search.
    */
   searchProducts(
     searchParams: ProductSearchParams,
   ): Promise<PaginatedResult<Product>>;
 
-  /** Fetches a single product's details.
+  /**
+   * Retrieves complete detailed information for a single product by its unique numeric ID. Returns a full `Product` object with all product data including title, description, images, variants, pricing, inventory, and options. Returns `undefined` if the product doesn't exist in Shopify, isn't synced to this POS device, or isn't available to this location. The product data is fetched from the device's local database for fast access.
+   *
+   * Commonly used for displaying full product details, validating product availability before adding to cart, loading product information by ID from external sources, or building product-specific features that need complete product data.
+   *
    * @param productId The ID of the product to lookup.
    */
   fetchProductWithId(productId: number): Promise<Product | undefined>;
 
-  /** Fetches multiple products' details.
+  /**
+   * Retrieves detailed information for multiple products in a single bulk operation by their IDs. Limited to 50 products maximum—if more than 50 IDs are provided, only the first 50 are processed and additional IDs are automatically removed. Returns a `MultipleResourceResult` containing two arrays: `fetchedResources` with successfully found products, and `idsForResourcesNotFound` with IDs that couldn't be found.
+   *
+   * This allows handling partial success scenarios where some IDs are valid and others aren't. Products may be missing because they don't exist, aren't synced to this device, or aren't available to this location.
+   *
+   * Commonly used for bulk product lookups (validating lists of IDs), building product collections from ID arrays, displaying multiple products simultaneously, or validating product availability across multiple items.
+   *
    * @param productIds Specifies the array of product IDs to lookup. This is limited to 50 products. All excess requested IDs will be removed from the array.
    */
   fetchProductsWithIds(
     productIds: number[],
   ): Promise<MultipleResourceResult<Product>>;
 
-  /** Fetches a single product variant's details.
+  /**
+   * Retrieves complete detailed information for a single product variant by its unique numeric ID. Returns a full `ProductVariant` object with all variant data including pricing, inventory levels, SKU, barcode, weight, options (size, color), and images. Returns `undefined` if the variant doesn't exist in Shopify, isn't synced to this POS device, or isn't available to this location. The variant data is fetched from the device's local database.
+   *
+   * Commonly used for displaying variant-specific details when a specific variant is already known, loading variant information when adding specific configurations to cart, checking inventory for a particular variant, or retrieving variant details by scanned barcode.
+   *
    * @param productVariantId The ID of the product variant to lookup.
    */
   fetchProductVariantWithId(
     productVariantId: number,
   ): Promise<ProductVariant | undefined>;
 
-  /** Fetches multiple product variants' details.
+  /**
+   * Retrieves detailed information for multiple product variants in a single bulk operation by their IDs. Limited to 50 variants maximum—if more than 50 IDs are provided, only the first 50 are processed and additional IDs are automatically removed. Returns a `MultipleResourceResult` containing two arrays: `fetchedResources` with successfully found variants, and `idsForResourcesNotFound` with IDs that couldn't be found.
+   *
+   * This allows handling partial success scenarios where some variant IDs are valid and others aren't. Variants may be missing because they don't exist, were deleted, aren't synced to this device, or aren't available to this location.
+   *
+   * Commonly used for bulk variant inventory checks across multiple products, validating variant ID lists before operations, loading variant data for multiple cart items, or building variant comparison features.
+   *
    * @param productVariantIds Specifies the array of product variant IDs to lookup. This is limited to 50 product variants. All excess requested IDs will be removed from the array.
    */
   fetchProductVariantsWithIds(
     productVariantIds: number[],
   ): Promise<MultipleResourceResult<ProductVariant>>;
 
-  /** Fetches all product variants associated with a product.
+  /**
+   * Retrieves all product variants associated with a specific product ID in a single call without pagination. Returns a complete array of all variants for the product, regardless of how many variants exist. For products with many variants (50+), this loads all variants at once which may impact performance and memory usage—consider using `fetchPaginatedProductVariantsWithProductId` instead for products with extensive variant catalogs. The variant order in the returned array follows the product's variant configuration.
+   *
+   * Commonly used for displaying complete variant selection interfaces (showing all available size/color/material combinations), building variant comparison tables, loading all variant options upfront for product detail pages, or when the complete variant set is needed immediately.
+   *
    * @param productId The product ID. All variants' details associated with this product ID are returned.
    */
   fetchProductVariantsWithProductId(
     productId: number,
   ): Promise<ProductVariant[]>;
 
-  /** Fetches a page of product variants associated with a product.
+  /**
+   * Retrieves product variants for a specific product with pagination support, loading variants in pages rather than all at once. Returns paginated results with up to 50 variants per page. The method accepts a product ID and pagination parameters (`first` for page size, `afterCursor` for position). Each page includes a cursor for fetching the next page and a flag indicating whether more pages exist.
+   *
+   * Typically applied when a product has many variants (100+) and loading them all at once would impact performance, memory usage, or user experience. This is ideal for products with extensive variant collections (for example, apparel with hundreds of size/color/style combinations, configurable products with many option permutations) that would be too large or slow to load in a single request.
+   *
+   * Enables implementing progressive loading patterns like infinite scroll, "Load more" buttons, or lazy loading of additional variants as users browse.
+   *
    * @param paginationParams The parameters for pagination.
    */
   fetchPaginatedProductVariantsWithProductId(
@@ -87,7 +139,7 @@ export interface ProductSearchApiContent {
 }
 
 /**
- * Access Point of Sale's native product search functionality.
+ * The `ProductSearchApi` object provides methods for searching and retrieving product information. Access these methods through `shopify.productSearch` to search products and fetch detailed product data.
  */
 export interface ProductSearchApi {
   productSearch: ProductSearchApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
@@ -13,15 +13,11 @@ export type ProductSortType =
  */
 export interface PaginationParams {
   /**
-   * Specifies the number of results to be returned in this page. The maximum value is 50—values above 50 are clamped to 50. Smaller page sizes (10-20) provide faster initial response times and lower memory usage. Larger page sizes (40-50) reduce the number of API calls needed but increase initial load time and memory consumption. The actual number of items returned may be less than requested if fewer items exist or if you're on the last page.
-   *
-   * Commonly used to control page size based on UI layout (items per screen), performance requirements (device capabilities), or user preference (configurable pagination).
+   * Specifies the number of results to be returned in this page. The maximum number of items that will be returned is 50.
    */
   first?: number;
   /**
-   * The pagination cursor pointing to a specific position in the result set. When provided, the API returns items that come after this cursor position, enabling sequential page navigation. This is an opaque string token obtained from the `lastCursor` field of previous search results—its internal format is implementation-specific and shouldn't be parsed or constructed manually.
-   *
-   * To fetch the next page, the `lastCursor` from the current page is passed as the `afterCursor` for the next request. Returns items from the beginning of the result set when omitted. The cursor is only valid for the same search query and sort order—changing query parameters invalidates previous cursors.
+   * Specifies the page cursor. Items after this cursor will be returned.
    */
   afterCursor?: string;
 }
@@ -31,29 +27,18 @@ export interface PaginationParams {
  */
 export interface ProductSearchParams extends PaginationParams {
   /**
-   * The search term used to find products by name, description, SKU, barcode, tags, or other searchable product fields. The search is case-insensitive and supports partial matches—searching for "blue shirt" will find products with "Blue Cotton Shirt" or "Shirt - Blue". When provided, results are automatically sorted by relevance to the query (most relevant first), overriding any `sortType` setting.
-   *
-   * When omitted or empty, all products are returned subject to `sortType` and pagination. Special characters and punctuation are normalized during search. Commonly used for implementing text-based product search, autocomplete suggestions, or filtered product browsing.
+   * The search term to be used to search for POS products.
    */
   queryString?: string;
   /**
-   * Specifies the order in which products should be sorted. When a `queryString` is provided, `sortType` won't have any effect, as the results will be returned in order by relevance to the `queryString`. Available options:
-   *
-   * - **`RECENTLY_ADDED`** - Sorts products by creation date in descending order, displaying the most recently added products first. Commonly used to highlight new inventory additions or showcase latest product arrivals.
-   * - **`RECENTLY_ADDED_ASCENDING`** - Sorts products by creation date in ascending order, displaying the oldest products first. Typically applied when prioritizing established products or implementing chronological browsing from earliest to newest
-   * - **`ALPHABETICAL_A_TO_Z`** - Sorts products alphabetically by title from A to Z. Commonly used for product catalogs where alphabetical organization improves browsing efficiency and helps users locate products by name quickly.
-   * - **`ALPHABETICAL_Z_TO_A`** - Sorts products alphabetically by title from Z to A in reverse order. Typically applied when reverse alphabetical sorting is needed for specialized browsing patterns or user preferences.
+   * Specifies the order in which products should be sorted. When a `queryString` is provided, sortType will not have any effect, as the results will be returned in order by relevance to the `queryString`.
    */
   sortType?: ProductSortType;
 }
 
 export interface ProductSearchApiContent {
   /**
-   * Searches for products stored locally on the POS device using text queries, sorting options, and pagination. Returns paginated results with up to 50 products per page. The search operates on the device's local product database (synced from Shopify), ensuring fast results even offline.
-   *
-   * When a `queryString` is provided, results are automatically sorted by relevance to the search term. When no query is provided, returns all available products in the specified sort order. The search includes product titles, descriptions, SKUs, barcodes, and tags. Results only include products that are available to this POS location based on inventory settings.
-   *
-   * Commonly used for implementing custom product search interfaces, building product catalogs, implementing barcode-based product lookup, or creating filtered product selection workflows.
+   * Searches for products on the POS device using text queries and sorting options. Returns paginated results with up to 50 products per page. When a query string is provided, results are sorted by relevance. Use for implementing custom search interfaces, product discovery features, or filtered product listings.
    *
    * @param searchParams The parameters for the product search.
    */
@@ -62,20 +47,14 @@ export interface ProductSearchApiContent {
   ): Promise<PaginatedResult<Product>>;
 
   /**
-   * Retrieves complete detailed information for a single product by its unique numeric ID. Returns a full `Product` object with all product data including title, description, images, variants, pricing, inventory, and options. Returns `undefined` if the product doesn't exist in Shopify, isn't synced to this POS device, or isn't available to this location. The product data is fetched from the device's local database for fast access.
-   *
-   * Commonly used for displaying full product details, validating product availability before adding to cart, loading product information by ID from external sources, or building product-specific features that need complete product data.
+   * Retrieves detailed information for a single product by its ID. Returns `undefined` if the product doesn't exist or isn't available on the POS device. Use for displaying product details, validating product availability, or building product-specific workflows.
    *
    * @param productId The ID of the product to lookup.
    */
   fetchProductWithId(productId: number): Promise<Product | undefined>;
 
   /**
-   * Retrieves detailed information for multiple products in a single bulk operation by their IDs. Limited to 50 products maximum—if more than 50 IDs are provided, only the first 50 are processed and additional IDs are automatically removed. Returns a `MultipleResourceResult` containing two arrays: `fetchedResources` with successfully found products, and `idsForResourcesNotFound` with IDs that couldn't be found.
-   *
-   * This allows handling partial success scenarios where some IDs are valid and others aren't. Products may be missing because they don't exist, aren't synced to this device, or aren't available to this location.
-   *
-   * Commonly used for bulk product lookups (validating lists of IDs), building product collections from ID arrays, displaying multiple products simultaneously, or validating product availability across multiple items.
+   * Retrieves detailed information for multiple products by their IDs. Limited to 50 products maximum—additional IDs are automatically removed. Returns results with both found and not found products clearly identified. Use for bulk product lookups, building product collections, or validating product lists.
    *
    * @param productIds Specifies the array of product IDs to lookup. This is limited to 50 products. All excess requested IDs will be removed from the array.
    */
@@ -84,9 +63,7 @@ export interface ProductSearchApiContent {
   ): Promise<MultipleResourceResult<Product>>;
 
   /**
-   * Retrieves complete detailed information for a single product variant by its unique numeric ID. Returns a full `ProductVariant` object with all variant data including pricing, inventory levels, SKU, barcode, weight, options (size, color), and images. Returns `undefined` if the variant doesn't exist in Shopify, isn't synced to this POS device, or isn't available to this location. The variant data is fetched from the device's local database.
-   *
-   * Commonly used for displaying variant-specific details when a specific variant is already known, loading variant information when adding specific configurations to cart, checking inventory for a particular variant, or retrieving variant details by scanned barcode.
+   * Retrieves detailed information for a single product variant by its ID. Returns `undefined` if the variant doesn't exist or isn't available. Use for displaying variant-specific details like pricing, inventory, or options when working with specific product configurations.
    *
    * @param productVariantId The ID of the product variant to lookup.
    */
@@ -95,11 +72,7 @@ export interface ProductSearchApiContent {
   ): Promise<ProductVariant | undefined>;
 
   /**
-   * Retrieves detailed information for multiple product variants in a single bulk operation by their IDs. Limited to 50 variants maximum—if more than 50 IDs are provided, only the first 50 are processed and additional IDs are automatically removed. Returns a `MultipleResourceResult` containing two arrays: `fetchedResources` with successfully found variants, and `idsForResourcesNotFound` with IDs that couldn't be found.
-   *
-   * This allows handling partial success scenarios where some variant IDs are valid and others aren't. Variants may be missing because they don't exist, were deleted, aren't synced to this device, or aren't available to this location.
-   *
-   * Commonly used for bulk variant inventory checks across multiple products, validating variant ID lists before operations, loading variant data for multiple cart items, or building variant comparison features.
+   * Retrieves detailed information for multiple product variants by their IDs. Limited to 50 variants maximum—additional IDs are automatically removed. Returns results with both found and not found variants clearly identified. Use for bulk variant lookups or building variant-specific collections.
    *
    * @param productVariantIds Specifies the array of product variant IDs to lookup. This is limited to 50 product variants. All excess requested IDs will be removed from the array.
    */
@@ -108,9 +81,7 @@ export interface ProductSearchApiContent {
   ): Promise<MultipleResourceResult<ProductVariant>>;
 
   /**
-   * Retrieves all product variants associated with a specific product ID in a single call without pagination. Returns a complete array of all variants for the product, regardless of how many variants exist. For products with many variants (50+), this loads all variants at once which may impact performance and memory usage—consider using `fetchPaginatedProductVariantsWithProductId` instead for products with extensive variant catalogs. The variant order in the returned array follows the product's variant configuration.
-   *
-   * Commonly used for displaying complete variant selection interfaces (showing all available size/color/material combinations), building variant comparison tables, loading all variant options upfront for product detail pages, or when the complete variant set is needed immediately.
+   * Retrieves all product variants associated with a specific product ID. Returns all variants at once without pagination. Use for displaying complete variant options, building variant selectors, or analyzing all available configurations for a product.
    *
    * @param productId The product ID. All variants' details associated with this product ID are returned.
    */
@@ -119,11 +90,7 @@ export interface ProductSearchApiContent {
   ): Promise<ProductVariant[]>;
 
   /**
-   * Retrieves product variants for a specific product with pagination support, loading variants in pages rather than all at once. Returns paginated results with up to 50 variants per page. The method accepts a product ID and pagination parameters (`first` for page size, `afterCursor` for position). Each page includes a cursor for fetching the next page and a flag indicating whether more pages exist.
-   *
-   * Typically applied when a product has many variants (100+) and loading them all at once would impact performance, memory usage, or user experience. This is ideal for products with extensive variant collections (for example, apparel with hundreds of size/color/style combinations, configurable products with many option permutations) that would be too large or slow to load in a single request.
-   *
-   * Enables implementing progressive loading patterns like infinite scroll, "Load more" buttons, or lazy loading of additional variants as users browse.
+   * Retrieves product variants for a specific product with pagination support. Use when a product has many variants and you need to load them incrementally for better performance. Ideal for products with extensive variant collections that would be too large to load at once.
    *
    * @param paginationParams The parameters for pagination.
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
@@ -2,14 +2,6 @@ import type {MultipleResourceResult} from '../../types/multiple-resource-result'
 import type {PaginatedResult} from '../../types/paginated-result';
 import type {Product, ProductVariant} from '../../types/product';
 
-/**
- * Specifies the order in which products should be sorted. When a `queryString` is provided, `sortType` won't have any effect, as the results will be returned in order by relevance to the `queryString`. Available options:
- *
- * - **`RECENTLY_ADDED`** - Sorts products by creation date in descending order, displaying the most recently added products first. Commonly used to highlight new inventory additions or showcase latest product arrivals.
- * - **`RECENTLY_ADDED_ASCENDING`** - Sorts products by creation date in ascending order, displaying the oldest products first. Typically applied when prioritizing established products or implementing chronological browsing from earliest to newest
- * - **`ALPHABETICAL_A_TO_Z`** - Sorts products alphabetically by title from A to Z. Commonly used for product catalogs where alphabetical organization improves browsing efficiency and helps users locate products by name quickly.
- * - **`ALPHABETICAL_Z_TO_A`** - Sorts products alphabetically by title from Z to A in reverse order. Typically applied when reverse alphabetical sorting is needed for specialized browsing patterns or user preferences.
- */
 export type ProductSortType =
   | 'RECENTLY_ADDED'
   | 'RECENTLY_ADDED_ASCENDING'
@@ -45,9 +37,12 @@ export interface ProductSearchParams extends PaginationParams {
    */
   queryString?: string;
   /**
-   * Specifies the order in which product results are returned when no `queryString` is provided. Options include recently added (newest/oldest first) and alphabetical (A-Z/Z-A). The `sortType` has no effect when `queryString` is specified—relevance sorting always takes precedence for search queries. When omitted, the default sort order is typically creation date descending (newest products first).
+   * Specifies the order in which products should be sorted. When a `queryString` is provided, `sortType` won't have any effect, as the results will be returned in order by relevance to the `queryString`. Available options:
    *
-   * Commonly used for organizing product listings, creating sorted catalogs, or implementing browsing interfaces where users explore products without searching.
+   * - **`RECENTLY_ADDED`** - Sorts products by creation date in descending order, displaying the most recently added products first. Commonly used to highlight new inventory additions or showcase latest product arrivals.
+   * - **`RECENTLY_ADDED_ASCENDING`** - Sorts products by creation date in ascending order, displaying the oldest products first. Typically applied when prioritizing established products or implementing chronological browsing from earliest to newest
+   * - **`ALPHABETICAL_A_TO_Z`** - Sorts products alphabetically by title from A to Z. Commonly used for product catalogs where alphabetical organization improves browsing efficiency and helps users locate products by name quickly.
+   * - **`ALPHABETICAL_Z_TO_A`** - Sorts products alphabetically by title from Z to A in reverse order. Typically applied when reverse alphabetical sorting is needed for specialized browsing patterns or user preferences.
    */
   sortType?: ProductSortType;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
@@ -3,40 +3,67 @@ import type {ReadonlySignalLike} from '../../../../shared';
 /** The scanner source the POS device supports. */
 export type ScannerSource = 'camera' | 'external' | 'embedded';
 
+/**
+ * Represents the data from a scanner event. Contains the scanned string data and the hardware source that captured the scan.
+ */
 export interface ScannerSubscriptionResult {
-  /** The string data from the last scanner event received. */
+  /**
+   * The string data from the last scanner event received. Contains the decoded content from the scanned barcode, QR code, or other machine-readable format. The format and content depend on what was scanned—product barcodes return product identifiers (UPC, EAN), QR codes return their encoded text or URL, and other formats return their respective data encodings. The string is already decoded and ready to use (no additional parsing of barcode formats needed). Returns `undefined` when no scan has occurred yet or when the scan data isn't available.
+   *
+   * Commonly used to look up products by barcode, process QR code data, implement scan-to-add-to-cart workflows, or trigger actions based on scanned content.
+   */
   data?: string;
-  /** The scanning source from which the scan event came. */
+  /**
+   * The scanning hardware source from which the scan event originated. Identifies which scanner captured the data:
+   * • **`'camera'`** - Device camera used for scanning through the camera interface. Available on most mobile POS devices (smartphones, tablets). Typically requires the user to position the camera over the barcode/QR code and capture an image.
+   * • **`'external'`** - External scanner hardware connected to the POS device using USB, Bluetooth, or other connection methods. Includes handheld barcode scanners, ring scanners, and dedicated scanning devices. These are typically faster and more reliable than camera scanning for high-volume scanning.
+   * • **`'embedded'`** - Built-in scanning hardware integrated directly into the POS device. Found in specialized POS terminals and all-in-one devices with dedicated scanning components. These scanners are always available and don't require additional setup.
+   *
+   * Returns `undefined` when the scan source can't be determined or when no scan has occurred yet.
+   *
+   * The source information can be used to implement source-specific logic (different behaviors for camera vs hardware scanners), provide user feedback about which scanning method was used, or track scanning method preferences for analytics.
+   */
   source?: ScannerSource;
 }
 
+/**
+ * Represents the available scanner hardware sources on the device. Provides reactive access to the list of scanners that can be used for scanning operations.
+ */
 export interface ScannerSources {
   /**
-   * The current available scanner sources.
-   * The `value` property provides the current sources, and `subscribe` allows listening to changes.
+   * Provides read-only access to the array of currently available scanner sources with subscription support for real-time updates. The `value` property contains an array of scanner types currently accessible on this device (for example, `['camera', 'external']` if both camera and an external scanner are available). The `subscribe` method allows listening for changes in scanner availability, which can occur when hardware scanners are connected/disconnected or when permissions change. The array is empty when no scanners are available.
+   *
+   * Commonly used to monitor which scanning methods are available, show/hide scanner-related UI based on availability, or select the preferred scanner for scanning operations.
    */
   current: ReadonlySignalLike<ScannerSource[]>;
 }
 
+/**
+ * Represents the scanner interface for accessing scan events and subscription management. Provides real-time access to scanned data through a reactive signal pattern.
+ */
 export interface ScannerData {
   /**
-   * The current scan data.
-   * The `value` property provides the current scan result, and `subscribe` allows listening to new scans.
+   * Provides read-only access to the current scan data with subscription support for real-time updates. The `value` property contains the most recent scan result including the scanned data string and the source that captured it. The `subscribe` method allows listening for new scan events as they occur.
+   *
+   * This enables reactive scan handling where your extension responds immediately to barcode or QR code scans from any available scanner source (camera, external, embedded). The data updates each time a new scan is captured, replacing the previous scan result. Subscriptions fire only when new scans occur, not continuously.
    */
   current: ReadonlySignalLike<ScannerSubscriptionResult>;
 }
 
 export interface ScannerApiContent {
   /**
-   * Provides read-only access to scanner data and allows subscribing to new scan events.
+   * Provides access to current scan data and subscription capabilities for receiving real-time scan events. The `scannerData` object contains the most recent scan result and allows subscribing to future scans. Commonly used to receive and process barcode or QR code data as it's scanned, implementing scan-based product lookup, adding items to cart using scan, or triggering workflows based on scanned codes.
    */
   scannerData: ScannerData;
   /**
-   * Provides read-only access to the available scanner sources on the POS device.
+   * Provides access to information about available scanner hardware sources on the device. The `sources` object contains an array of currently available scanning methods and allows subscribing to availability changes. Commonly used to check which scanner types are available (camera, external hardware, embedded), adapt UI based on scanner availability (showing/hiding scan buttons), or selecting the preferred scanner source for operations.
    */
   sources: ScannerSources;
 }
 
+/**
+ * The `ScannerApi` object provides access to scanning functionality and scanner source information. Access these properties through `shopify.scanner` to monitor scan events and available scanner sources.
+ */
 export interface ScannerApi {
   scanner: ScannerApiContent;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
@@ -8,20 +8,15 @@ export type ScannerSource = 'camera' | 'external' | 'embedded';
  */
 export interface ScannerSubscriptionResult {
   /**
-   * The string data from the last scanner event received. Contains the decoded content from the scanned barcode, QR code, or other machine-readable format. The format and content depend on what was scanned—product barcodes return product identifiers (UPC, EAN), QR codes return their encoded text or URL, and other formats return their respective data encodings. The string is already decoded and ready to use (no additional parsing of barcode formats needed). Returns `undefined` when no scan has occurred yet or when the scan data isn't available.
-   *
-   * Commonly used to look up products by barcode, process QR code data, implement scan-to-add-to-cart workflows, or trigger actions based on scanned content.
+   * The string data from the last scanner event received. Contains the scanned barcode, QR code, or other scannable data. Returns `undefined` when no scan data is available. Use to process scanned content and implement scan-based business logic.
    */
   data?: string;
   /**
-   * The scanning hardware source from which the scan event originated. Identifies which scanner captured the data:
-   * • **`'camera'`** - Device camera used for scanning through the camera interface. Available on most mobile POS devices (smartphones, tablets). Typically requires the user to position the camera over the barcode/QR code and capture an image.
-   * • **`'external'`** - External scanner hardware connected to the POS device using USB, Bluetooth, or other connection methods. Includes handheld barcode scanners, ring scanners, and dedicated scanning devices. These are typically faster and more reliable than camera scanning for high-volume scanning.
-   * • **`'embedded'`** - Built-in scanning hardware integrated directly into the POS device. Found in specialized POS terminals and all-in-one devices with dedicated scanning components. These scanners are always available and don't require additional setup.
+   * The scanning source from which the scan event came. Returns one of the following scanner types:
    *
-   * Returns `undefined` when the scan source can't be determined or when no scan has occurred yet.
-   *
-   * The source information can be used to implement source-specific logic (different behaviors for camera vs hardware scanners), provide user feedback about which scanning method was used, or track scanning method preferences for analytics.
+   * • `'camera'` - Built-in device camera used for scanning
+   * • `'external'` - External scanner hardware connected to the device
+   * • `'embedded'` - Embedded scanner hardware built into the device
    */
   source?: ScannerSource;
 }
@@ -31,9 +26,7 @@ export interface ScannerSubscriptionResult {
  */
 export interface ScannerSources {
   /**
-   * Provides read-only access to the array of currently available scanner sources with subscription support for real-time updates. The `value` property contains an array of scanner types currently accessible on this device (for example, `['camera', 'external']` if both camera and an external scanner are available). The `subscribe` method allows listening for changes in scanner availability, which can occur when hardware scanners are connected/disconnected or when permissions change. The array is empty when no scanners are available.
-   *
-   * Commonly used to monitor which scanning methods are available, show/hide scanner-related UI based on availability, or select the preferred scanner for scanning operations.
+   * Current available scanner sources with subscription support. The `value` property provides current sources, and `subscribe` listens for changes. Use to monitor which scanners are available.
    */
   current: ReadonlySignalLike<ScannerSource[]>;
 }
@@ -43,20 +36,18 @@ export interface ScannerSources {
  */
 export interface ScannerData {
   /**
-   * Provides read-only access to the current scan data with subscription support for real-time updates. The `value` property contains the most recent scan result including the scanned data string and the source that captured it. The `subscribe` method allows listening for new scan events as they occur.
-   *
-   * This enables reactive scan handling where your extension responds immediately to barcode or QR code scans from any available scanner source (camera, external, embedded). The data updates each time a new scan is captured, replacing the previous scan result. Subscriptions fire only when new scans occur, not continuously.
+   * Current available scanner sources with subscription support. The `value` property provides current sources, and `subscribe` listens for changes. Use to monitor which scanners are available.
    */
   current: ReadonlySignalLike<ScannerSubscriptionResult>;
 }
 
 export interface ScannerApiContent {
   /**
-   * Provides access to current scan data and subscription capabilities for receiving real-time scan events. The `scannerData` object contains the most recent scan result and allows subscribing to future scans. Commonly used to receive and process barcode or QR code data as it's scanned, implementing scan-based product lookup, adding items to cart using scan, or triggering workflows based on scanned codes.
+   * Access current scan data and subscribe to new scan events. Use to receive real-time scan results.
    */
   scannerData: ScannerData;
   /**
-   * Provides access to information about available scanner hardware sources on the device. The `sources` object contains an array of currently available scanning methods and allows subscribing to availability changes. Commonly used to check which scanner types are available (camera, external hardware, embedded), adapt UI based on scanner availability (showing/hiding scan buttons), or selecting the preferred scanner source for operations.
+   * Access available scanner sources on the device. Use to check which scanners are available (camera, external, or embedded).
    */
   sources: ScannerSources;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
@@ -2,20 +2,17 @@ import type {Session} from '../../types/session';
 
 export interface SessionApiContent {
   /**
-   * Access information on the current POS session.
+   * Provides comprehensive information about the current POS session including shop details, user authentication, location data, staff member information, currency settings, and POS version. This data is static for the duration of the session and updates when users switch locations or staff members change.
    */
   currentSession: Session;
   /**
-   * Get a fresh session token for communication with your app's backend service.
-   * When the authenticated user (the user that logged into Shopify POS with their email address) doesn't have the correct app permissions enabled for your app, null will be returned. This is irrelevant of which POS Staff member is pinned in, as those are not authenticated users.
-   * For more information, see our [app permissions documentation](https://help.shopify.com/en/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).
-   * Calls to Shopify APIs must be made by your app’s backend service.
+   * Generates a fresh session token for secure communication with your app's backend service. Returns `undefined` when the authenticated user lacks proper app permissions. The token is a Shopify [OpenID Connect](https://en.wikipedia.org/wiki/OpenID#OpenID_Connect_(OIDC)) ID Token that should be used in `Authorization` headers for backend API calls. This is based on the authenticated user, not the pinned staff member.
    */
   getSessionToken: () => Promise<string | undefined>;
 }
 
 /**
- * Access information on the current Session, including data on the current shop, user, staff and location.
+ * The `SessionApi` object provides access to current session information and authentication methods. Access these properties and methods through `shopify.session` to retrieve shop data and generate secure tokens. These methods enable secure API calls while maintaining user privacy and [app permissions](https://help.shopify.com/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).
  */
 export interface SessionApi {
   session: SessionApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
@@ -6,7 +6,7 @@ export interface SessionApiContent {
    */
   currentSession: Session;
   /**
-   * Generates a fresh session token for secure communication with your app's backend service. Returns `undefined` when the authenticated user lacks proper app permissions. The token is a Shopify [OpenID Connect](https://en.wikipedia.org/wiki/OpenID#OpenID_Connect_(OIDC)) ID Token that should be used in `Authorization` headers for backend API calls. This is based on the authenticated user, not the pinned staff member.
+   * Generates a fresh session token for secure communication with your app's backend service. Returns `undefined` when the authenticated user lacks proper app permissions. The token is a Shopify OpenID Connect ID Token that should be used in `Authorization` headers for backend API calls. This is based on the authenticated user, not the pinned staff member.
    */
   getSessionToken: () => Promise<string | undefined>;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/storage-api/storage-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/storage-api/storage-api.ts
@@ -1,5 +1,8 @@
 import {Storage} from '../../types/storage';
 
+/**
+ * The `StorageApi` object provides access to persistent local storage methods for your POS UI extension. Access these methods through `shopify.storage` to store, retrieve, and manage data that persists across sessions.
+ */
 export interface StorageApi {
   storage: Storage;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
@@ -3,18 +3,14 @@
  */
 export interface ShowToastOptions {
   /**
-   * The duration in milliseconds that the toast message remains visible before automatically dismissing. If not specified, the toast uses the default system duration (typically 3-5 seconds depending on the platform).
-   *
-   * Shorter durations (1000-2000ms) work well for simple confirmations like "Item added" or "Saved". Longer durations (5000-7000ms) provide adequate reading time for important messages or multi-sentence notifications. Very short durations (< 1000ms) may not give users enough time to read the message. The toast dismisses automatically after the specified duration, but users may also manually dismiss it if the system supports swipe-to-dismiss gestures.
+   * The duration in milliseconds that the toast message should remain visible before automatically dismissing. If not specified, the toast will use the default system duration. Use shorter durations for simple confirmations and longer durations for important messages that users need time to read.
    */
   duration?: number;
 }
 
 export interface ToastApiContent {
   /**
-   * Displays a toast notification with the specified text content. The message appears as a temporary, non-blocking overlay (typically at the top or bottom of the screen) that automatically dismisses after the specified duration. The toast doesn't interrupt the user's workflow—users can continue interacting with the POS while the toast is visible. Toast messages should be brief and scannable (1-2 short sentences maximum) since they disappear automatically.
-   *
-   * Commonly used for providing immediate user feedback ("Product added to cart"), confirming actions ("Changes saved"), displaying success messages ("Order completed"), or communicating status updates ("Syncing inventory") without requiring user acknowledgment. Multiple toasts may queue or stack depending on the platform implementation.
+   * Displays a toast notification with the specified text content. The message appears as a temporary overlay that automatically dismisses after the specified duration. Use for providing immediate user feedback, confirming actions, or communicating status updates without interrupting the user's workflow.
    *
    * @param content The text content to display.
    * @param options An object containing ShowToastOptions.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
@@ -1,16 +1,30 @@
+/**
+ * Specifies configuration options for displaying toast notifications. Controls the duration and display behavior of temporary notification messages.
+ */
 export interface ShowToastOptions {
+  /**
+   * The duration in milliseconds that the toast message remains visible before automatically dismissing. If not specified, the toast uses the default system duration (typically 3-5 seconds depending on the platform).
+   *
+   * Shorter durations (1000-2000ms) work well for simple confirmations like "Item added" or "Saved". Longer durations (5000-7000ms) provide adequate reading time for important messages or multi-sentence notifications. Very short durations (< 1000ms) may not give users enough time to read the message. The toast dismisses automatically after the specified duration, but users may also manually dismiss it if the system supports swipe-to-dismiss gestures.
+   */
   duration?: number;
 }
 
 export interface ToastApiContent {
   /**
-   * Show a toast.
+   * Displays a toast notification with the specified text content. The message appears as a temporary, non-blocking overlay (typically at the top or bottom of the screen) that automatically dismisses after the specified duration. The toast doesn't interrupt the user's workflow—users can continue interacting with the POS while the toast is visible. Toast messages should be brief and scannable (1-2 short sentences maximum) since they disappear automatically.
+   *
+   * Commonly used for providing immediate user feedback ("Product added to cart"), confirming actions ("Changes saved"), displaying success messages ("Order completed"), or communicating status updates ("Syncing inventory") without requiring user acknowledgment. Multiple toasts may queue or stack depending on the platform implementation.
+   *
    * @param content The text content to display.
    * @param options An object containing ShowToastOptions.
    */
   show: (content: string, options?: ShowToastOptions) => void;
 }
 
+/**
+ * The `ToastApi` object provides methods for displaying temporary notification messages. Access these methods through `shopify.toast` to show user feedback and status updates.
+ */
 export interface ToastApi {
   toast: ToastApiContent;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
@@ -12,84 +12,101 @@
  * TODO: Update `any` type here after this is resolved
  * https://github.com/Shopify/ui-api-design/issues/139
  */
+/**
+ * Represents any valid child content that can be rendered within a component.
+ */
 export type ComponentChildren = any;
+/**
+ * Represents text-only child content.
+ */
 export type StringChildren = string;
+/**
+ * Properties that are available on all components.
+ */
 export interface GlobalProps {
   /**
-   * A unique identifier for the element.
+   * A unique identifier for the element within the document. This ID is used for multiple purposes: targeting the element from JavaScript code, creating relationships between elements (using `commandFor`, `interestFor`, ARIA attributes), linking labels to form controls, enabling fragment navigation with URL anchors (for example, `#section-id`), and applying element-specific styles. The ID must be unique across the entire page—duplicate IDs will cause unexpected behavior and accessibility issues. Use descriptive, semantic IDs that indicate the element's purpose (for example, `"checkout-button"`, `"main-nav"`, `"product-details-modal"`) rather than generic numbers or arbitrary strings. IDs are case-sensitive and should only contain letters, digits, hyphens, and underscores. If you don't need to reference the element externally, you can omit the ID.
    */
   id?: string;
 }
+/**
+ * Provides slots for primary and secondary action elements.
+ */
 export interface ActionSlots {
   /**
-   * The primary action to perform, provided as a button or link type element.
+   * The primary action element to display, typically a `Button` or clickable link representing the most important action the user can take in the current context. This action should align with the user's primary goal or the main purpose of the interface. For example, "Save changes", "Checkout", "Add to cart", or "Submit order". The primary action typically receives visual emphasis through styling to draw user attention. Only one primary action should be provided to avoid confusion about the main call-to-action. If no primary action is needed, omit this property rather than providing an empty or placeholder action.
    */
   primaryAction?: ComponentChildren;
   /**
-   * The secondary actions to perform, provided as button or link type elements.
+   * Secondary action elements to display, typically `Button` or clickable link elements representing alternative or supporting actions that are less important than the primary action. These might include "Cancel", "Save draft", "Skip", "Learn more", or other optional actions. Secondary actions receive less visual prominence than the primary action to maintain clear hierarchy. Multiple secondary actions can be provided and will typically be displayed together, often in a different visual style or position than the primary action. If no secondary actions are needed, omit this property. The order of actions in the array may affect their display order depending on the component.
    */
   secondaryActions?: ComponentChildren;
 }
+/**
+ * Properties for overlay lifecycle callbacks.
+ */
 export interface BaseOverlayProps {
   /**
-   * Callback fired after the overlay is shown.
+   * A callback function executed when the overlay begins to appear, immediately after `showOverlay()` is called or the `hidden` property changes to `false`, but before any show animations start. The element may not be visible yet. Use this for initializing overlay content, fetching data needed for display, setting focus on the first interactive element, or tracking analytics events for when users begin viewing the overlay. Avoid layout calculations here as the element may not have final dimensions yet.
    */
   onShow?: (event: Event) => void;
   /**
-   * Callback fired when the overlay is shown **after** any animations to show the overlay have finished.
+   * A callback function executed after the overlay is fully visible and all show animations have completed. At this point, the overlay is completely rendered with final dimensions and positioning. Use this for operations that require the overlay to be fully displayed, such as focusing specific elements after animations complete, measuring rendered content dimensions, triggering secondary animations, or initializing interactive features that depend on final layout. This is the safest place for DOM measurements and layout-dependent operations.
    */
   onAfterShow?: (event: Event) => void;
   /**
-   * Callback fired after the overlay is hidden.
+   * A callback function executed when the overlay begins to hide, immediately after `hideOverlay()` is called or the `hidden` property changes to `true`, but before any hide animations start. The element is still visible. Use this for cleanup operations, saving overlay state before it disappears, canceling pending requests, or preparing for the post-hide state. This is your last opportunity to interact with the visible overlay before animations begin.
    */
   onHide?: (event: Event) => void;
   /**
-   * Callback fired when the overlay is hidden **after** any animations to hide the overlay have finished.
+   * A callback function executed after the overlay is completely hidden and all hide animations have finished. The element is no longer visible or interactive. Use this for final cleanup, focusing the element that triggered the overlay, navigating to another view, freeing resources, or performing operations that should only occur after the overlay is completely dismissed. This is the appropriate place for post-dismissal navigation or state updates that would be jarring if they occurred during animations.
    */
   onAfterHide?: (event: Event) => void;
 }
 /**
- * Shared interfaces for web component methods.
- *
- * Methods are required (not optional) because:
+ * Methods for controlling overlay visibility. These methods are required (not optional) because:
  * - Components implementing this interface must provide all methods
- * - Unlike props/attributes, methods are not rendered in HTML but are JavaScript APIs
+ * - Unlike props/attributes, methods aren't rendered in HTML but are JavaScript APIs
  * - Consumers expect these methods to be consistently available on all instances
  */
 export interface BaseOverlayMethods {
   /**
-   * Method to show an overlay.
+   * Programmatically displays the overlay element. When called, the overlay becomes visible and triggers any associated `onShow` and `onAfterShow` callbacks. Use this method to open modals, dialogs, or other overlay components in response to user actions or application state changes.
    *
    * @implementation This is a method to be called on the element and not a callback and should hence be camelCase
    */
   showOverlay: () => void;
   /**
-   * Method to hide an overlay.
+   * Programmatically hides the overlay element. When called, the overlay becomes hidden and triggers any associated `onHide` and `onAfterHide` callbacks. Use this method to close modals, dismiss dialogs, or hide overlay components programmatically rather than waiting for user interaction.
    *
    * @implementation This is a method to be called on the element and not a callback and should hence be camelCase
    */
   hideOverlay: () => void;
   /**
-   * Method to toggle the visiblity of an overlay.
+   * Programmatically toggles the overlay's visibility state. If currently visible, the overlay will be hidden; if currently hidden, it will be shown. This triggers the appropriate show/hide callbacks based on the resulting state. Use this method to create toggle buttons or cycle through overlay visibility states.
    *
    * @implementation This is a method to be called on the element and not a callback and should hence be camelCase
    */
   toggleOverlay: () => void;
 }
+/**
+ * Properties for focus event callbacks.
+ */
 export interface FocusEventProps {
   /**
-   * Callback when the element loses focus.
+   * A callback function executed when focus is removed from the element, either by the user moving to another field (tabbing, clicking elsewhere) or programmatically using `blur()`. This event fires before `onChange` for modified fields. The event contains information about which element is receiving focus next (`relatedTarget`). Use this for triggering validation, saving in-progress changes, hiding related UI elements like autocomplete dropdowns, or tracking field interaction analytics. Common pattern: validate and show errors on blur to avoid disrupting users while they're still typing.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event
+   * Learn more about [blur events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
    */
   onBlur?: (event: FocusEvent) => void;
   /**
-   * Callback when the element receives focus.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event
+   * A callback function executed when the element receives focus through user interaction (clicking, tabbing) or programmatic methods like `focus()`. This event fires before any input occurs. The event contains information about which element previously had focus (`relatedTarget`). Use this for showing helper text, highlighting the active field, displaying related UI like autocomplete suggestions, preselecting content, or tracking which fields users interact with. Common pattern: clear errors on focus to provide a fresh start when users re-attempt input after validation failure. Learn more about [focus events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
    */
   onFocus?: (event: FocusEvent) => void;
 }
+/**
+ * A size scale keyword ranging from smallest (`'small-500'`) to largest (`'large-500'`).
+ */
 export type SizeKeyword =
   | 'small-500'
   | 'small-400'
@@ -104,18 +121,27 @@ export type SizeKeyword =
   | 'large-300'
   | 'large-400'
   | 'large-500';
+/**
+ * A color intensity keyword from subtle (`'subdued'`) to prominent (`'strong'`).
+ */
 export type ColorKeyword = 'subdued' | 'base' | 'strong';
+/**
+ * A background color keyword including transparent option.
+ */
 export type BackgroundColorKeyword = 'transparent' | ColorKeyword;
+/**
+ * Properties for controlling the background color of an element.
+ */
 export interface BackgroundProps {
   /**
-   * Adjust the background of the element.
+   * Sets the background color intensity of the element. Controls how the element stands out from its surroundings.
    *
    * @default 'transparent'
    */
   background?: BackgroundColorKeyword;
 }
 /**
- * Tone is a property for defining the color treatment of a component.
+ * A property for defining the color treatment and semantic meaning of a component.
  *
  * A tone can apply a grouping of colors to a component. For example,
  * critical may have a specific text color and background color.
@@ -683,17 +709,29 @@ declare const privateIconArray: readonly [
   'x-circle',
   'x-circle-filled',
 ];
+/**
+ * A valid icon identifier from the available icon set.
+ */
 export type IconType = (typeof privateIconArray)[number];
 /**
  * Like `Extract`, but ensures that the extracted type is a strict subtype of the input type.
  */
 export type ExtractStrict<T, U extends T> = Extract<T, U>;
+/**
+ * A utility type for properties that support 1-to-4-value shorthand syntax.
+ */
 export type MaybeAllValuesShorthandProperty<T extends string> =
   | T
   | `${T} ${T}`
   | `${T} ${T} ${T}`
   | `${T} ${T} ${T} ${T}`;
+/**
+ * A utility type for properties that support 1-to-2-value shorthand syntax.
+ */
 export type MaybeTwoValuesShorthandProperty<T extends string> = T | `${T} ${T}`;
+/**
+ * A utility type for values that can be responsive using container queries.
+ */
 export type MaybeResponsive<T> = T | `@container${string}`;
 /**
  * Prevents widening string literal types in a union to `string`.
@@ -705,41 +743,42 @@ export type MaybeResponsive<T> = T | `@container${string}`;
  */
 export type AnyString = string & {};
 /**
- * This is purely to give the ability
- * to have a space or not in the string literal types.
+ * A utility type that allows optional spacing in string literal values.
  *
- * For example in the `aspectRatio` property, `16/9` and `16 / 9` are both valid.
+ * For example, in the `aspectRatio` property, `16/9` and `16 / 9` are both valid.
  */
 export type optionalSpace = '' | ' ';
 export interface BadgeProps extends GlobalProps {
   /**
-   * The content of the Badge.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Sets the tone of the Badge, based on the intention of the information being conveyed.
+   * The semantic tone of the badge, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the badge. Controls how prominent or subtle the badge appears within the interface.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
   /**
-   * The type of icon to be displayed in the badge.
+   * The icon identifier specifying which icon to display within the badge. Accepts any valid icon name from the icon set.
    *
    * @default ''
    */
   icon?: IconType | AnyString;
   /**
-   * The position of the icon in relation to the text.
+   * The position of the icon relative to the badge text content:
+   * - `'start'`: Icon appears before the text
+   * - `'end'`: Icon appears after the text
    */
   iconPosition?: 'start' | 'end';
   /**
-   * Adjusts the size.
+   * Adjusts the size of the badge and its icon. Available sizes range from `'small-500'` (smallest) through `'base'` (default) to `'large-500'` (largest), allowing you to match badge size to your interface hierarchy.
    *
    * @default 'base'
    */
@@ -747,60 +786,46 @@ export interface BadgeProps extends GlobalProps {
 }
 export interface BannerProps extends GlobalProps, ActionSlots {
   /**
-   * The title of the banner.
+   * The title text displayed prominently at the top of the banner. Should be concise and clearly communicate the main message or purpose of the banner.
    *
    * @default ''
    */
   heading?: string;
   /**
-   * The content of the Banner.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Sets the tone of the Banner, based on the intention of the information being conveyed.
+   * Sets the visual appearance and accessibility behavior of the banner. The tone determines both the color scheme and how screen readers announce the banner. Available options:
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context
+   * - `'success'` - Green styling for positive outcomes and successful operations. Creates an informative live region for screen readers
+   * - `'info'` - Blue styling for general information and neutral updates. Creates an informative live region for screen readers
+   * - `'warning'` - Orange styling for important notices that require attention. Creates an informative live region for screen readers
+   * - `'critical'` - Red styling for errors and urgent issues requiring immediate action. Creates an assertive live region that is announced immediately by screen readers.
    *
-   * The banner is a live region and the type of status will be dictated by the Tone selected.
-   *
-   * - `critical` creates an [assertive live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) that is announced by screen readers immediately.
-   * - `neutral`, `info`, `success`, `warning` and `caution` creates an [informative live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) that is announced by screen readers after the current message.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
-   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
-   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role
+   * Learn more about [ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions), [alert role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role), and [status role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) on MDN.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Makes the content collapsible.
-   * A collapsible banner will conceal child elements initially, but allow the user to expand the banner to see them.
+   * Whether the banner content can be collapsed and expanded. When `true`, the banner displays a collapse/expand toggle control and child elements are initially hidden. Users can click the toggle to reveal or hide the content. Use for lengthy banners or supplementary information that users can choose to view. Collapsed state persists during the component lifecycle but resets on re-render.
    *
    * @default false
    */
   collapsible?: boolean;
   /**
-   * Determines whether the close button of the banner is present.
-   *
-   * When the close button is pressed, the `dismiss` event will fire,
-   * then `hidden` will be true,
-   * any animation will complete,
-   * and the `afterhide` event will fire.
+   * Whether a close button is displayed in the banner. When `true`, a close (X) button appears allowing users to permanently dismiss the banner. Once dismissed, the banner triggers the `onDismiss` callback and remains hidden until the component is re-rendered or the `hidden` property is changed. Use for non-critical notifications or messages that users can choose to dismiss after reading.
    *
    * @default false
    */
   dismissible?: boolean;
   /**
-   * Event handler when the banner is dismissed by the user.
-   *
-   * This does not fire when setting `hidden` manually.
-   *
-   * The `hidden` property will be `false` when this event fires.
+   * A callback function executed when the user dismisses the banner by clicking the close (X) button. This only fires for user-initiated dismissals through the UI close button, not when the banner is hidden programmatically using the `hidden` property. The callback fires after the user clicks but before hide animations begin. Use this for tracking dismissal metrics, saving user preferences to avoid showing the banner again, performing cleanup when banners are dismissed, or triggering follow-up actions. The banner remains in the DOM after dismissal (just hidden) until re-rendered—to completely remove it, control rendering at the component level based on dismissal state.
    */
   onDismiss?: (event: Event) => void;
   /**
-   * Event handler when the banner has fully hidden.
-   *
-   * The `hidden` property will be `true` when this event fires.
+   * A callback function executed after the element is fully hidden and all hide animations have completed.
    *
    * @implementation If implementations animate the hiding of the banner,
    * this event must fire after the banner has fully hidden.
@@ -808,35 +833,30 @@ export interface BannerProps extends GlobalProps, ActionSlots {
    */
   onAfterHide?: (event: Event) => void;
   /**
-   * Determines whether the banner is hidden.
-   *
-   * If this property is being set on each framework render (as in 'controlled' usage),
-   * and the banner is `dismissible`,
-   * ensure you update app state for this property when the `dismiss` event fires.
-   *
-   * If the banner is not `dismissible`, it can still be hidden by setting this property.
+   * Whether the banner is visible or hidden. When set to `true`, the banner is completely hidden from view and removed from the accessibility tree, meaning screen readers won't announce it. Changing this value triggers hide/show animations if configured. Unlike temporary dismissal with the close button, this provides programmatic control for conditional visibility based on application state, user permissions, or other dynamic conditions.
    *
    * @default false
    */
   hidden?: boolean;
 }
+/**
+ * Properties for controlling the display behavior of an element.
+ */
 export interface DisplayProps {
   /**
-   * Sets the outer display type of the component. The outer type sets a component’s participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
+   * Sets the outer display type controlling the element's participation in flow layout. Use `'auto'` for default behavior or `'none'` to hide the element and remove it from the accessibility tree.
+   * Learn more about the [CSS display property on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
    *
-   * - `auto`: the component’s initial value. The actual value depends on the component and context.
-   * - `none`: hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
    * @default 'auto'
    */
   display?: MaybeResponsive<'auto' | 'none'>;
 }
-export interface AccessibilityRoleProps {
+/**
+ * Properties for defining the semantic role of an element for assistive technologies.
+ */
+export interface AccessibilityRoleProps{
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help users
-   * navigate the page.
+   * Sets the semantic role for assistive technologies. Helps screen reader users navigate and understand page structure.
    *
    * @implementation Although, in HTML hosts, this property changes the element used,
    * changing this property must not impact the visual styling of inside or outside of the box.
@@ -926,7 +946,7 @@ export type AccessibilityRole =
    */
   | 'separator'
   /**
-   * Used to define a live region containing advisory information for the user that is not important enough to be an alert.
+   * Used to define a live region containing advisory information for the user that isn't important enough to be an alert.
    *
    * In an HTML host `status` will render as `<div role="status">`.
    * Learn more about the [`status` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) in the MDN web docs.
@@ -940,44 +960,48 @@ export type AccessibilityRole =
    */
   | 'alert'
   /**
-   * Used to create a nameless container element which has no semantic meaning on its own.
+   * Used to create a container element with no specific semantic meaning.
    *
    * In an HTML host `generic'` will render a `<div>` element.
    * Learn more about the [`generic` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/generic_role) in the MDN web docs.
    */
   | 'generic'
   /**
-   * Used to strip the semantic meaning of an element, but leave the visual styling intact.
+   * Used to remove semantic meaning from an element while preserving its visual styling.
    *
    * Synonym for `none`
    * Learn more about the [`presentation` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) in the MDN web docs.
    */
   | 'presentation'
   /**
-   * Used to strip the semantic meaning of an element, but leave the visual styling intact.
+   * Used to remove semantic meaning from an element while preserving its visual styling.
    *
    * Synonym for `presentation`
    * Learn more about the [`none` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/none_role) in the MDN web docs.
    */
   | 'none';
+/**
+ * Properties for controlling visibility to assistive technologies.
+ */
 export interface AccessibilityVisibilityProps {
   /**
-   * Changes the visibility of the element.
-   *
-   * - `visible`: the element is visible to all users.
-   * - `hidden`: the element is removed from the accessibility tree but remains visible.
-   * - `exclusive`: the element is visually hidden but remains in the accessibility tree.
+   * Controls visibility for assistive technologies:
+   * - `'visible'`: Announced normally by screen readers
+   * - `'hidden'`: Hidden from screen readers while remaining visually visible
+   * - `'exclusive'`: Only this element is announced to screen readers, hiding other content
    *
    * @default 'visible'
    */
   accessibilityVisibility?: 'visible' | 'hidden' | 'exclusive';
 }
+/**
+ * Properties for controlling the visibility of field labels to screen readers.
+ */
 export interface LabelAccessibilityVisibilityProps {
   /**
-   * Changes the visibility of the component's label.
-   *
-   * - `visible`: the label is visible to all users.
-   * - `exclusive`: the label is visually hidden but remains in the accessibility tree.
+   * Controls whether the label is announced to screen readers:
+   * - `'visible'`: Label is announced normally by screen readers
+   * - `'exclusive'`: Only the label is announced, hiding other related content from screen readers
    *
    * @default 'visible'
    */
@@ -986,35 +1010,34 @@ export interface LabelAccessibilityVisibilityProps {
     'visible' | 'exclusive'
   >;
 }
+/**
+ * A padding size keyword including the option for no padding.
+ */
 export type PaddingKeyword = SizeKeyword | 'none';
+/**
+ * Properties for controlling the padding (internal spacing) of an element.
+ */
 export interface PaddingProps {
   /**
-   * Adjust the padding of all edges.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
+   * The padding applied to all edges of the element. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
+   * - 1 value: all edges
    *
    * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   * - `large` applies `large` padding to all edges.
+   * - `large none` applies `large` to block edges and `none` to inline edges.
+   * - `large none large` applies `large` to block-start, `none` to inline edges, `large` to block-end.
+   * - `large none large small` applies different padding to each edge in order.
    *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>;
   /**
-   * Adjust the block-padding.
-   *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
-   * This overrides the block value of `padding`.
+   * The block-axis padding for the element (typically vertical in horizontal writing modes). Supports two-value syntax where `large none` sets block-start to `large` and block-end to `none`. Overrides the block axis values from the `padding` property.
    *
    * @default '' - meaning no override
    */
@@ -1022,27 +1045,19 @@ export interface PaddingProps {
     MaybeTwoValuesShorthandProperty<PaddingKeyword> | ''
   >;
   /**
-   * Adjust the block-start padding.
-   *
-   * This overrides the block-start value of `paddingBlock`.
+   * The block-start padding for the element (typically top in horizontal writing modes). Overrides the block-start value from the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * Adjust the block-end padding.
-   *
-   * This overrides the block-end value of `paddingBlock`.
+   * The block-end padding for the element (typically bottom in horizontal writing modes). Overrides the block-end value from the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * Adjust the inline padding.
-   *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
-   * This overrides the inline value of `padding`.
+   * The inline-axis padding for the element (typically horizontal in horizontal writing modes). Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline axis values from the `padding` property.
    *
    * @default '' - meaning no override
    */
@@ -1050,82 +1065,93 @@ export interface PaddingProps {
     MaybeTwoValuesShorthandProperty<PaddingKeyword> | ''
   >;
   /**
-   * Adjust the inline-start padding.
-   *
-   * This overrides the inline-start value of `paddingInline`.
+   * The inline-start padding for the element (typically left in LTR, right in RTL). Overrides the inline-start value from the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * Adjust the inline-end padding.
-   *
-   * This overrides the inline-end value of `paddingInline`.
+   * The inline-end padding for the element (typically right in LTR, left in RTL). Overrides the inline-end value from the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: MaybeResponsive<PaddingKeyword | ''>;
 }
+/**
+ * A size value in pixels, percentage, or zero.
+ */
 export type SizeUnits = `${number}px` | `${number}%` | `0`;
+/**
+ * A size value with automatic sizing option.
+ */
 export type SizeUnitsOrAuto = SizeUnits | 'auto';
+/**
+ * A size value with no constraint option.
+ */
 export type SizeUnitsOrNone = SizeUnits | 'none';
+/**
+ * Properties for controlling the dimensions of an element.
+ */
 export interface SizingProps {
   /**
-   * Adjust the block size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/block-size
+   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * Learn more about [`block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
    *
    * @default 'auto'
    */
   blockSize?: MaybeResponsive<SizeUnitsOrAuto>;
   /**
-   * Adjust the minimum block size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size
+   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * Learn more about [`min-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    *
    * @default '0'
    */
   minBlockSize?: MaybeResponsive<SizeUnits>;
   /**
-   * Adjust the maximum block size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size
+   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * Learn more about [`max-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    *
    * @default 'none'
    */
   maxBlockSize?: MaybeResponsive<SizeUnitsOrNone>;
   /**
-   * Adjust the inline size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size
+   * The inline size (width in horizontal writing modes) of the element.
+   * Learn more about [`inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    *
    * @default 'auto'
    */
   inlineSize?: MaybeResponsive<SizeUnitsOrAuto>;
   /**
-   * Adjust the minimum inline size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size
+   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * Learn more about [`min-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    *
    * @default '0'
    */
   minInlineSize?: MaybeResponsive<SizeUnits>;
   /**
-   * Adjust the maximum inline size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size
+   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * Learn more about [`max-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    *
    * @default 'none'
    */
   maxInlineSize?: MaybeResponsive<SizeUnitsOrNone>;
 }
+/**
+ * A border line style keyword.
+ */
 export type BorderStyleKeyword =
   | 'none'
   | 'solid'
   | 'dashed'
   | 'dotted'
   | 'auto';
+/**
+ * A border thickness keyword.
+ */
 export type BorderSizeKeyword = SizeKeyword | 'none';
+/**
+ * A border radius keyword including maximum rounding option.
+ */
 export type BorderRadiusKeyword = SizeKeyword | 'max' | 'none';
 /**
  * Represents a shorthand for defining a border. It can be a combination of size, optionally followed by color, optionally followed by style.
@@ -1134,17 +1160,12 @@ export type BorderShorthand =
   | BorderSizeKeyword
   | `${BorderSizeKeyword} ${ColorKeyword}`
   | `${BorderSizeKeyword} ${ColorKeyword} ${BorderStyleKeyword}`;
+/**
+ * Properties for controlling the border styling of an element.
+ */
 export interface BorderProps {
   /**
-   * Set the border via the shorthand property.
-   *
-   * This can be a size, optionally followed by a color, optionally followed by a style.
-   *
-   * If the color is not specified, it will be `base`.
-   *
-   * If the style is not specified, it will be `auto`.
-   *
-   * Values can be overridden by `borderWidth`, `borderStyle`, and `borderColor`.
+   * Sets the border style, width, and color using shorthand syntax. Accepts a size keyword, optionally followed by a color keyword, optionally followed by a style keyword.
    *
    * @example
    * // The following are equivalent:
@@ -1155,82 +1176,49 @@ export interface BorderProps {
    */
   border?: BorderShorthand;
   /**
-   * Set the width of the border.
-   *
-   * If set, it takes precedence over the `border` property's width.
-   *
-   * Like CSS, up to 4 values can be specified.
-   *
-   * If one value is specified, it applies to all sides.
-   *
-   * If two values are specified, they apply to the block sides and inline sides respectively.
-   *
-   * If three values are specified, they apply to the block-start, both inline sides, and block-end respectively.
-   *
-   * If four values are specified, they apply to the block-start, block-end, inline-start, and inline-end sides respectively.
+   * Sets the thickness of the border using size keywords. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per edge.
    *
    * @default '' - meaning no override
    */
   borderWidth?: MaybeAllValuesShorthandProperty<BorderSizeKeyword> | '';
   /**
-   * Set the style of the border.
-   *
-   * If set, it takes precedence over the `border` property's style.
-   *
-   * Like CSS, up to 4 values can be specified.
-   *
-   * If one value is specified, it applies to all sides.
-   *
-   * If two values are specified, they apply to the block sides and inline sides respectively.
-   *
-   * If three values are specified, they apply to the block-start, both inline sides, and block-end respectively.
-   *
-   * If four values are specified, they apply to the block-start, block-end, inline-start, and inline-end sides respectively.
+   * Sets the line style of the border. Controls the visual pattern of the border lines (for example, solid, dashed, dotted). Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per edge.
    *
    * @default '' - meaning no override
    */
   borderStyle?: MaybeAllValuesShorthandProperty<BorderStyleKeyword> | '';
   /**
-   * Set the color of the border.
-   *
-   * If set, it takes precedence over the `border` property's color.
+   * Sets the color intensity of the border. Controls how prominent the border appears.
    *
    * @default '' - meaning no override
    */
   borderColor?: ColorKeyword | '';
   /**
-   * Set the radius of the border.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
-   * - 4 values: `start-start start-end end-end end-start`
-   * - 3 values: `start-start (start-end & end-start) start-end`
-   * - 2 values: `(start-start & end-end) (start-end & end-start)`
-   *
-   * For example:
-   * - `small-100` means start-start, start-end, end-end and end-start border radii are `small-100`.
-   * - `small-100 none` means start-start and end-end border radii are `small-100`, start-end and end-start border radii are `none`.
-   * - `small-100 none large-100` means start-start border radius is `small-100`, start-end border radius is `none`, end-end border radius is `large-100` and end-start border radius is `none`.
-   * - `small-100 none large-100 small-100` means start-start border radius is `small-100`, start-end border radius is `none`, end-end border radius is `large-100` and end-start border radius is `small-100`.
+   * Sets the corner rounding radius of the border. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner.
    *
    * @defaultValue 'none'
    */
   borderRadius?: MaybeAllValuesShorthandProperty<BorderRadiusKeyword>;
 }
+/**
+ * Properties for controlling overflow behavior when content exceeds container bounds.
+ */
 export interface OverflowProps {
   /**
-   * Sets the overflow behavior of the element.
+   * Controls how the container handles content that exceeds its dimensions:
+   * - `'visible'`: Content extends beyond the container's boundaries without clipping or scrolling. Overflow content is fully visible and may overlap other elements. This is the default behavior and works well for containers that should expand to fit their content naturally.
+   * - `'hidden'`: Content that exceeds the container is clipped and hidden from view—users can't see or access the overflow content. No scrollbars appear. Use this for intentionally limiting visible content, creating masked effects, or preventing content from breaking layouts. Be cautious with accessibility—hidden content may include important information users can't access.
+   * - `'auto'`: Adds scrollbars automatically when content exceeds the container, allowing users to scroll to view overflow content. Scrollbars only appear when needed. Use for scrollable regions, content lists, or any container where users should access all content but space is limited.
    *
-   * - `hidden`: clips the content when it is larger than the element’s container.
-   * The element will not be scrollable and the users will not be able
-   * to access the clipped content by dragging or using a scroll wheel on a mouse.
-   * - `visible`: the content that extends beyond the element’s container is visible.
+   * Setting overflow establishes a new block formatting context, which affects layout behaviors like margin collapsing and positioning.
    *
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
 }
+/**
+ * Base properties for box-like container elements.
+ */
 export interface BaseBoxProps
   extends AccessibilityVisibilityProps,
     BackgroundProps,
@@ -1240,400 +1228,395 @@ export interface BaseBoxProps
     BorderProps,
     OverflowProps {
   /**
-   * The content of the Box.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * A label that describes the purpose or contents of the element.
-   * When set, it will be announced to users using assistive technologies and will provide them with more context.
-   *
-   * Only use this when the element's content is not enough context for users using assistive technologies.
+   * A label that describes the purpose or contents of the element. Announced to users with assistive technologies such as screen readers to provide context.
    */
   accessibilityLabel?: string;
 }
+/**
+ * Base properties for box-like container elements with semantic role support.
+ */
 export interface BaseBoxPropsWithRole
   extends BaseBoxProps,
     AccessibilityRoleProps {}
+/**
+ * Properties for button-like interactive elements with form-related behavior.
+ */
 export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
   /**
-   * The behavior of the Button.
-   *
-   * - `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.
-   * - `button`: Used to indicate the component acts as a button, meaning it has no default action.
-   * - `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).
-   *
-   * This property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.
+   * The semantic meaning of the button action within a form context:
+   * - `'button'`: A standard button with no default form behavior
+   * - `'submit'`: Submits the containing form when activated
+   * - `'reset'`: Resets the containing form to its initial values when activated
    *
    * @default 'button'
    */
   type?: 'submit' | 'button' | 'reset';
   /**
-   * Callback when the Button is activated.
-   * This will be called before the action indicated by `type`.
+   * A callback function executed when the element is clicked or activated.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event
+   * Learn more about [click events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
    */
   onClick?: (event: Event) => void;
   /**
-   * Disables the Button meaning it cannot be clicked or receive focus.
+   * Whether the field is disabled, preventing any user interaction.
    *
    * @default false
    */
   disabled?: boolean;
   /**
-   * Replaces content with a loading indicator while a background action is being performed.
-   *
-   * This also disables the Button.
+   * Indicates whether the button action is currently in progress. When `true`, displays a loading spinner or progress indicator and prevents additional clicks to avoid duplicate submissions. The button remains visually enabled but unresponsive to interaction. Set to `true` when starting an async operation (for example, API call, navigation) and back to `false` when the operation completes or fails. This provides user feedback during long-running operations and prevents race conditions from multiple rapid clicks.
    *
    * @default false
    */
   loading?: boolean;
 }
+/**
+ * Properties for link-like interactive elements with navigation behavior.
+ */
 export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
   /**
-   * The URL to link to.
-   *
-   * - If set, it will navigate to the location specified by `href` after executing the `click` event.
-   * - If a `commandFor` is set, the `command` will be executed instead of the navigation.
+   * The URL to navigate to when the element is clicked or activated. Supports absolute URLs (for example, `https://shopify.com`), relative URLs (for example, `/products`), and anchor links (for example, `#section-id`). Navigation is triggered after the `onClick` event completes, allowing you to cancel navigation by preventing the default event action. The actual navigation behavior depends on the `target` property—same page, new tab, or external navigation. For security, browsers may block navigation to certain protocols or untrusted origins. Use this to create navigational links, external resource links, or in-app routing.
    */
   href?: string;
   /**
-   * Specifies where to display the linked URL.
+   * Specifies where to display the linked URL:
+   * - `'auto'`: The target is automatically determined based on the origin of the URL (typically behaves as `'_self'` but surfaces may handle cross-origin URLs differently).
+   * - `'_blank'`: Opens the URL in a new tab or window.
+   * - `'_self'`: Opens the URL in the same browsing context.
+   * - `'_parent'`: Opens the URL in the parent browsing context.
+   * - `'_top'`: Opens the URL in the topmost browsing context.
+   * - Custom string: Any other valid target name.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target
-   *
-   * 'auto': The target is automatically determined based on the origin of the URL.
+   * Learn more about the [`target` attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target).
    *
    * @implementation Surfaces can set specific rules on how they handle each URL.
-   * @implementation It’s expected that the behavior of `auto` is as `_self` except in specific cases.
+   * @implementation It's expected that the behavior of `auto` is as `_self` except in specific cases.
    * @implementation For example, a surface could decide to open cross-origin URLs in a new window (as `_blank`).
    *
    * @default 'auto'
    */
   target?: 'auto' | '_blank' | '_self' | '_parent' | '_top' | AnyString;
   /**
-   * Causes the browser to treat the linked URL as a download with the string being the file name.
-   * Download only works for same-origin URLs or the `blob:` and `data:` schemes.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download
+   * Treats the link as a file download instead of navigation. When set, clicking the link downloads the resource at the `href` URL rather than navigating to it. The value becomes the suggested filename shown in the download dialog or used by the browser's default save behavior (for example, `download="receipt.pdf"` saves as "receipt.pdf"). If the value is an empty string, the browser determines the filename from the URL or server headers. This only works for same-origin URLs (your app's domain) or `blob:` and `data:` URLs for security reasons—cross-origin URLs will navigate normally. Learn more about the [`download` attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).
    */
   download?: string;
   /**
-   * Callback when the link is activated.
-   * This will be called before navigating to the location specified by `href`.
+   * A callback function executed when the element is clicked or activated.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event
+   * Learn more about [click events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
    */
   onClick?: (event: Event) => void;
 }
+/**
+ * Properties for controlling interactions between elements using commands.
+ */
 export interface InteractionProps {
   /**
-   * ID of a component that should respond to activations (e.g. clicks) on this component.
-   *
-   * See `command` for how to control the behavior of the target.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor
+   * The ID of the target element that should respond when this element is clicked or activated. This creates a relationship where clicking this control (button, clickable) triggers an action on another element in the DOM. The target element must have a matching `id` attribute. Use with the `command` property to specify what action should occur (show, hide, toggle). This enables declarative element control without writing custom click handlers, improving accessibility and reducing JavaScript. Common use cases include: opening modals from buttons, toggling content visibility, showing/hiding sidebars, or controlling overlay states. If both `commandFor` and `onClick` are present, both will execute—the command action occurs first, then the click handler.
+   * Learn more about [`commandfor` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor).
    */
   commandFor?: string;
   /**
-   * Sets the action the `commandFor` should take when this clickable is activated.
+   * The action to perform on the target element specified by `commandFor`:
+   * - `'--auto'`: Execute the target element's default action (typically show for overlays, or the element's primary interaction).
+   * - `'--show'`: Make the target element visible by calling its `showOverlay()` method or setting appropriate visibility properties.
+   * - `'--hide'`: Hide the target element by calling its `hideOverlay()` method or setting appropriate visibility properties.
+   * - `'--toggle'`: Switch the target element's visibility state—if visible, hide it; if hidden, show it.
+   * - `'--copy'`: Copy content to the clipboard (requires the target to be a compatible element with copy functionality).
    *
-   * See the documentation of particular components for the actions they support.
-   *
-   * - `--auto`: a default action for the target component.
-   * - `--show`: shows the target component.
-   * - `--hide`: hides the target component.
-   * - `--toggle`: toggles the target component.
-   * - `--copy`: copies the target ClipboardItem.
+   * The command executes when this element is clicked, before any `onClick` handlers fire. If the target element doesn't support the specified command, the action may fail silently.
+   * Learn more about [button commands on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
    *
    * @default '--auto'
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command
    */
   command?: '--auto' | '--show' | '--hide' | '--toggle' | '--copy';
   /**
-   * ID of a component that should respond to interest (e.g. hover and focus) on this component.
+   * The ID of a target element that should respond to hover and focus events on this element, creating an "interest" relationship. When the user hovers over or focuses this element, the target element receives corresponding interest events, allowing it to preview or prepare content. This is useful for implementing tooltip-like previews, image zoom on hover, showing additional details before clicking, or loading content speculatively when the user shows interest. The target element must have a matching `id` and listen for interest events. Unlike `commandFor` which responds to clicks, this responds to hover and focus, providing earlier user intent signals.
    */
   interestFor?: string;
 }
+/**
+ * Combined properties for elements that can behave as both buttons and links.
+ */
 export interface BaseClickableProps
   extends ButtonBehaviorProps,
     LinkBehaviorProps {}
 export interface ButtonProps extends GlobalProps, BaseClickableProps {
   /**
-   * A label that describes the purpose or contents of the Button. It will be read to users using assistive technologies such as screen readers.
-   *
-   * Use this when using only an icon or the Button text is not enough context
-   * for users using assistive technologies.
+   * A label that describes the purpose or contents of the element. Announced to users with assistive technologies such as screen readers to provide context.
    */
   accessibilityLabel?: string;
   /**
-   * The content of the Button.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * The type of icon to be displayed in the Button.
+   * The icon identifier specifying which icon to display. Accepts any valid icon name from the icon set.
    *
    * @default ''
    */
   icon?: IconType | AnyString;
   /**
-   * The displayed inline width of the Button.
-   *
-   * - `auto`: the size of the button depends on the surface and context.
-   * - `fill`: the button will takes up 100% of the available inline size.
-   * - `fit-content`: the button will take up the minimum inline-size required to fit its content.
+   * Controls how the element's width adapts to its container and content.
    *
    * @default 'auto'
    */
   inlineSize?: 'auto' | 'fill' | 'fit-content';
   /**
-   * Changes the visual appearance of the Button.
+   * Changes the visual appearance and prominence of the button:
+   * - `'auto'`: The variant is automatically determined by context
+   * - `'primary'`: Creates a prominent call-to-action button with high visual emphasis for the most important action on a screen
+   * - `'secondary'`: Provides a less prominent button appearance for supporting actions and secondary interactions
+   * - `'tertiary'`: Provides the least prominent button appearance for tertiary or optional actions
    *
-   * @default 'auto' - the variant is automatically determined by the Button's context
+   * @default 'auto'
    */
   variant?: 'auto' | 'primary' | 'secondary' | 'tertiary';
   /**
-   * Sets the tone of the Button based on the intention of the information being conveyed.
+   * Sets the tone of the button, based on the intention of the action being performed:
+   * - `'auto'`: Automatically determines the appropriate tone based on context
+   * - `'neutral'`: The standard tone for general actions and interactions
+   * - `'caution'`: Indicates actions that require careful consideration
+   * - `'warning'`: Alerts users to potential issues or important information
+   * - `'critical'`: Used for destructive actions like deleting or removing content
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
-   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
-   * [Reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label)
+   * Indicates the language of the text content. Useful when text is in a different language than the rest of the page, allowing assistive technologies to invoke correct pronunciation. [Reference of language subtag values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
    */
   lang?: string;
 }
+/**
+ * Base properties for all form input elements.
+ */
 export interface BaseInputProps {
   /**
-   * An identifier for the field that is unique within the nearest containing form.
+   * An identifier for the field that is unique within the nearest containing form. This name is used as the key when the form data is submitted. If omitted, the field's value won't be included in form submissions. Use meaningful names that describe the data being collected (for example, `"email"`, `"quantity"`, `"customer-note"`).
    */
   name?: string;
   /**
-   * Disables the field, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction. When `true`, the field can't receive focus, be edited, or be interacted with. Disabled fields are visually dimmed, excluded from form submission, and announced as disabled to screen readers. Use when a field is temporarily unavailable due to application state, permissions, or dependencies on other fields.
    *
    * @default false
    */
   disabled?: boolean;
 }
+/**
+ * Properties for controlled form input elements with value and change callbacks.
+ */
 export interface InputProps extends BaseInputProps {
   /**
-   * Callback when the user has **finished editing** a field, e.g. once they have blurred the field.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
+   * A callback function executed when the user has committed a value change, typically triggered when the field loses focus (blur) after the value has been modified. Unlike `onInput`, this fires only once after editing is complete, not during typing. The event contains the finalized value. Use this for validation, saving data, or triggering actions that should occur after the user finishes editing rather than during typing. For controlled components, update the `value` prop in this callback. This is ideal for expensive operations like API calls that shouldn't happen on every keystroke.
+   * Learn more about [change events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
    */
   onChange?: (event: Event) => void;
   /**
-   * Callback when the user makes any changes in the field.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
+   * A callback function executed immediately when the user makes any change to the field value. Fires on every keystroke, paste, or other input modification before the field loses focus. The event contains the current field value. Use this for real-time validation, character counting, formatting input as users type, or implementing autocomplete/search-as-you-type features. For controlled components, update the `value` prop in this callback to keep state in sync. Be cautious with expensive operations here as this fires frequently during typing.
+   * Learn more about [input events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
    */
   onInput?: (event: Event) => void;
   /**
-   * The current value for the field. If omitted, the field will be empty.
+   * The current value of the field. When provided, this creates a controlled component where this value must be updated in response to user input using `onChange` or `onInput` callbacks. The format and valid values depend on the specific field type. If both `value` and `defaultValue` are provided, `value` takes precedence.
    */
   value?: string;
   /**
-   * The default value for the field.
+   * The default value used when the field is first rendered. Only applies if no `value` prop is provided, creating an uncontrolled component where the browser manages the field state internally. After initial render, the component handles its own state and you can read the current value from the DOM. Use this for forms where you don't need to control every state change but want to set initial values. For controlled components with full state management, use `value` instead.
    *
    * @implementation `defaultValue` reflects to the `value` attribute.
    */
   defaultValue?: string;
 }
+/**
+ * Properties for form inputs that support multiple selections.
+ */
 export interface MultipleInputProps extends BaseInputProps {
   /**
-   * Callback when the user has selected option(s).
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Learn more about [change events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
    */
   onChange?: (event: Event) => void;
   /**
-   * Callback when the user has selected option(s).
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Learn more about [input events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
    */
   onInput?: (event: Event) => void;
   /**
-   * An array of the `value`s of the selected options.
-   *
-   * This is a convenience prop for setting the `selected` prop on child options.
+   * An array containing the values of currently selected options in a multi-select choice list. When provided, this creates a controlled component where this array must be updated in response to user selections using the `onChange` callback. The array should contain the `value` properties of selected child `Choice` components. For single-select lists (`multiple={false}`), this array should contain zero or one items. For multi-select lists, it can contain multiple items. This is a convenience property that automatically sets the `selected` state on matching child choices based on their `value` properties. When a choice's value appears in this array, it's automatically marked as selected. Update this array immutably in callbacks (create new arrays rather than mutating).
    */
   values?: string[];
 }
+/**
+ * Properties for displaying field validation errors.
+ */
 export interface FieldErrorProps {
   /**
-   * Indicate an error to the user. The field will be given a specific stylistic treatment
-   * to communicate problems that have to be resolved immediately.
+   * An error message to display when the field contains invalid data or fails validation. When set, the field receives error styling (typically a red border and error icon) and the message appears below the field to guide users toward fixing the issue. The error is announced to screen readers for accessibility. Clear the error by setting this to an empty string or `undefined`. Display errors after validation fails, typically on blur or form submission.
    */
   error?: string;
 }
+/**
+ * Basic properties for form fields including labels, validation requirements, and error states.
+ */
 export interface BasicFieldProps
   extends FieldErrorProps,
     LabelAccessibilityVisibilityProps {
   /**
-   * Whether the field needs a value. This requirement adds semantic value
-   * to the field, but it will not cause an error to appear automatically.
-   * If you want to present an error when this field is empty, you can do
-   * so with the `error` property.
+   * Whether the field must have a value before form submission. When `true`, the field is marked as required (typically with an asterisk), announced as required to screen readers, and triggers browser validation on form submit. This property adds semantic meaning but doesn't prevent submission on its own - validation logic must be implemented and the `error` property to display validation messages.
    *
    * @default false
    */
   required?: boolean;
   /**
-   * Content to use as the field label.
+   * The text label that describes what information the field is requesting from the user. Labels are always visible (unlike placeholders which disappear on input) and are announced by screen readers, making them critical for accessibility. Labels typically appear above or beside the field and remain visible while the user interacts with the field. Use clear, concise labels that describe the expected input (for example, "Email address", "Quantity", "Customer note"). Required fields should be indicated in the label or use the `required` property for semantic marking.
    */
   label?: string;
 }
+/**
+ * Properties for adding supplementary help text to form fields.
+ */
 export interface FieldDetailsProps {
   /**
-   * Additional text to provide context or guidance for the field.
-   * This text is displayed along with the field and its label
-   * to offer more information or instructions to the user.
-   *
-   * This will also be exposed to screen reader users.
+   * Supplementary help text that provides additional context, instructions, or constraints for the field. This text typically appears below the label in a smaller, subdued style and remains visible at all times (unlike placeholders). Screen readers announce this text along with the label to provide complete field context. Use for format requirements (for example, "Use YYYY-MM-DD format"), character limits (for example, "Maximum 500 characters"), helpful hints (for example, "This will be shown on the receipt"), or clarifying instructions (for example, "Leave blank to use default shipping address"). Avoid duplicating information already in the label or placeholder.
    */
   details?: string;
 }
+/**
+ * Complete properties for standard form fields including value, label, placeholder, validation, and callbacks.
+ */
 export interface FieldProps
   extends BasicFieldProps,
     InputProps,
     FocusEventProps,
     FieldDetailsProps {
   /**
-   * A short hint that describes the expected value of the field.
+   * A short hint that provides guidance about the expected value or format of the field. Displayed when the field is empty and disappears once the user starts typing. Placeholders should supplement the label, not replace it - always provide a `label` as well since placeholders may not be accessible to all screen readers. Use for format examples (for example, "YYYY-MM-DD"), helpful hints (for example, "Leave blank for default"), or clarifying expected input (for example, "Enter SKU or product name").
    */
   placeholder?: string;
 }
+/**
+ * Base properties for text-based input fields including placeholder and read-only state.
+ */
 export interface BaseTextFieldProps extends FieldProps {
   /**
-   * The field cannot be edited by the user. It is focusable will be announced by screen readers.
+   * Indicates whether the field can be edited. When `true`, the field is focusable and announced by screen readers but can't be modified by the user. Unlike `disabled`, read-only fields can still receive focus, be copied, and participate in form submission. Use read-only for data that users need to see and interact with but shouldn't change, such as calculated values or reference information.
    *
    * @default false
    */
   readOnly?: boolean;
 }
+/**
+ * Properties for adding decorative elements like icons, prefixes, suffixes, and accessories to form fields.
+ */
 export interface FieldDecorationProps {
   /**
-   * A value to be displayed immediately after the editable portion of the field.
-   *
-   * This is useful for displaying an implied part of the value, such as "@shopify.com", or "%".
-   *
-   * This cannot be edited by the user, and it isn't included in the value of the field.
-   *
-   * It may not be displayed until the user has interacted with the input.
-   * For example, an inline label may take the place of the suffix until the user focuses the input.
+   * Static text displayed immediately after the editable portion of the field, typically inside the field border. This text is non-interactive and purely decorative—users can't edit it and it's not included in the field's value when submitted. The suffix remains visible at all times, even when the field is empty. Common uses include domain suffixes (for example, "@shopify.com" for email fields), units of measurement (for example, "kg", "%", "USD"), or clarifying context (for example, "/month" for subscription pricing). Choose between suffix and prefix based on natural reading order for your use case.
    *
    * @default ''
    */
   suffix?: string;
   /**
-   * A value to be displayed immediately before the editable portion of the field.
-   *
-   * This is useful for displaying an implied part of the value, such as "https://" or "+353".
-   *
-   * This cannot be edited by the user, and it isn't included in the value of the field.
-   *
-   * It may not be displayed until the user has interacted with the input.
-   * For example, an inline label may take the place of the prefix until the user focuses the input.
+   * Static text displayed immediately before the editable portion of the field, typically inside the field border. This text is non-interactive and purely decorative—users can't edit it and it's not included in the field's value when submitted. The prefix remains visible at all times, even when the field is empty. Common uses include currency symbols (for example, "$", "€", "£"), protocol indicators (for example, "https://"), measurement prefixes (for example, "#", "@"), or fixed identifiers. The prefix helps users understand the expected format without consuming characters from maxLength limits.
    *
    * @default ''
    */
   prefix?: string;
   /**
-   * The type of icon to be displayed in the field.
+   * The icon identifier specifying which icon to display in the field, typically positioned at the start of the field before the input area. The icon is decorative and helps users quickly identify the field's purpose through visual recognition. The icon is announced to screen readers along with the field's accessible name. Use icons that clearly communicate the field's purpose (for example, search icon for search fields, calendar icon for date fields, lock icon for password fields). The icon doesn't affect the field's functionality but improves visual recognition and scannability in forms. Avoid using both icon and prefix simultaneously as this can create visual clutter.
    *
    * @default ''
    */
   icon?: IconType | AnyString;
   /**
-   * Additional content to be displayed in the field.
-   * Commonly used to display an icon that activates a tooltip providing more information.
+   * Additional interactive content displayed within the field, typically positioned at the end of the field after the input area. Only text-only `Button` and `Clickable` components are supported—no icons or complex content. Use the `slot="accessory"` attribute to place elements here. Common uses include action buttons (for example, "Copy" button, "Generate" button, "Clear" button), toggle visibility controls (for example, "Show password" button), or quick actions related to the field (for example, "Paste from clipboard"). The accessory must not interfere with the field's primary input functionality. Ensure sufficient contrast and touch target sizes for mobile usability.
    */
   accessory?: ComponentChildren;
 }
+/**
+ * Properties for defining numeric value constraints and controls.
+ */
 export interface NumberConstraintsProps {
   /**
-   * The highest decimal or integer to be accepted for the field.
-   * When used with `step` the value will round down to the max number.
-   *
-   * Note: a user will still be able to use the keyboard to input a number higher than
-   * the max. It is up to the developer to add appropriate validation.
+   * The highest decimal or integer value that the field accepts. When used with `stepper` controls, the increment button becomes disabled at this value and attempting to increment rounds down to max. When users type values using keyboard, they can enter numbers above max—browser validation will flag these as invalid but won't prevent entry, so implement your own validation in `onChange` or before form submission. Use this to enforce business rules like maximum quantities, price caps, or valid ranges. Set to `Infinity` (default) for no upper limit.
    *
    * @default Infinity
    */
   max?: number;
   /**
-   * The lowest decimal or integer to be accepted for the field.
-   * When used with `step` the value will round up to the min number.
-   *
-   * Note: a user will still be able to use the keyboard to input a number lower than
-   * the min. It is up to the developer to add appropriate validation.
+   * The lowest decimal or integer value that the field accepts. When used with `stepper` controls, the decrement button becomes disabled at this value and attempting to decrement rounds up to min. When users type values using keyboard, they can enter numbers below min—browser validation will flag these as invalid but won't prevent entry, so implement your own validation in `onChange` or before form submission. Use this to enforce business rules like minimum quantities, preventing negative values, or valid ranges. Set to `-Infinity` (default) for no lower limit.
    *
    * @default -Infinity
    */
   min?: number;
   /**
-   * The amount the value can increase or decrease by. This can be an integer or decimal.
-   * If a `max` or `min` is specified with `step` when increasing/decreasing the value
-   * via the buttons, the final value will always round to the `max` or `min`
-   * rather than the closest valid amount.
+   * The increment/decrement amount for adjusting the numeric value. Determines how much the value changes when users click stepper buttons or press keyboard arrow keys (up/down). For example, `step="0.01"` allows currency precision, `step="5"` for quantities in increments of 5, or `step="0.25"` for quarter-hour time intervals. The browser may also use this for validation, flagging values that aren't valid steps from the `min` value. Decimals are supported unless using `stepper` controls which only accept integers.
    *
    * @default 1
    */
   step?: number;
   /**
-   * Sets the type of controls displayed in the field.
-   *
-   * - `stepper`: displays buttons to increase or decrease the value of the field by the stepping interval defined in the `step` property.
-   * Appropriate mouse and [keyboard interactions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role#keyboard_interactions) to control the value of the field are enabled.
-   * - `none`: no controls are displayed and users must input the value manually. Arrow keys and scroll wheels can’t be used either to avoid accidental changes.
-   * - `auto`: the presence of the controls depends on the surface and context.
+   * The type of controls displayed for the field:
+   * - `'auto'`: An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
+   * - `'stepper'`: Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
+   * - `'none'`: A control type with no visible controls where users must input the value manually using the keyboard.
    *
    * @default 'auto'
    */
   controls?: 'auto' | 'stepper' | 'none';
 }
+/**
+ * Properties for defining minimum and maximum character length constraints on text inputs.
+ */
 export interface MinMaxLengthProps {
   /**
-   * Specifies the maximum number of characters allowed.
+   * The maximum number of characters allowed in the text field. The browser prevents users from typing or pasting beyond this limit—additional characters are automatically truncated. The character count includes all characters (letters, numbers, spaces, special characters). This provides immediate feedback by blocking input rather than showing validation errors. Use this for enforcing hard limits like database column sizes, API constraints, or UX requirements. Commonly combined with character counter displays to show remaining space (for example, "45/100 characters").
    *
    * @default Infinity
    */
   maxLength?: number;
   /**
-   * Specifies the min number of characters allowed.
+   * The minimum number of characters required for the field value to be considered valid. Unlike `maxLength`, this doesn't prevent users from entering fewer characters—instead, browser validation marks the field as invalid if the value is too short. Validation typically occurs on form submission or blur. The field can be empty unless also marked `required`. Use this for ensuring sufficient input quality, like minimum password lengths, meaningful descriptions, or codes with fixed lengths. Combine with the `error` property to display user-friendly validation messages.
    *
    * @default 0
    */
   minLength?: number;
 }
+/**
+ * Base properties for selectable options including value, disabled state, and accessibility labels.
+ */
 export interface BaseSelectableProps {
   /**
-   * A label used for users using assistive technologies like screen readers. When set, any children or `label` supplied will not be announced.
-   * This can also be used to display a control without a visual label, while still providing context to users using screen readers.
+   * A label that describes the purpose or contents of the element. Announced to users with assistive technologies such as screen readers to provide context.
    */
   accessibilityLabel?: string;
   /**
-   * Disables the control, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction.
    *
    * @default false
    */
   disabled?: boolean;
   /**
-   * The value used in form data when the control is checked.
+   * The unique value associated with this selectable option. This value is what gets submitted with forms when the option is selected, and is used to identify which options are selected in the parent `ChoiceList`'s `values` array. The value should be unique among siblings within the same choice list to avoid selection ambiguity. When a choice is selected, this value appears in form data and in the parent's `values` array. Use meaningful, stable values that identify the choice semantically (for example, `"small"`, `"express-shipping"`, `"agree-to-terms"`) rather than display text which may change or be localized. The value isn't displayed to users—use the choice's `children` or label for visible text.
    */
   value?: string;
 }
+/**
+ * Properties for individual options within choice lists, including selection state management.
+ */
 export interface BaseOptionProps extends BaseSelectableProps {
   /**
-   * Whether the control is active.
+   * Whether the choice control is currently active or selected. This creates a controlled component - this value must be updated in response to user interactions using `onChange` handlers. When `true`, the choice appears selected with appropriate visual styling and is included in form submissions. Use this for controlled selection state where you manage the selected state in your application. If both `selected` and `defaultSelected` are provided, `selected` takes precedence.
    *
    * @default false
    */
   selected?: boolean;
   /**
-   * Whether the control is active by default.
+   * Indicates whether the control is selected by default when first rendered. This creates an uncontrolled component where the browser manages selection state internally. Use this when you want initial selection state but don't need to control every state change. The component will handle selection internally after the initial render. Prefer `selected` for controlled components where you need full control over selection state.
    *
    * @implementation `defaultSelected` reflects to the `selected` attribute.
    *
@@ -1641,9 +1624,12 @@ export interface BaseOptionProps extends BaseSelectableProps {
    */
   defaultSelected?: boolean;
 }
+/**
+ * Properties for a single choice option including label, details, selection state, and additional content.
+ */
 export interface ChoiceProps extends GlobalProps, BaseOptionProps {
   /**
-   * Content to use as the choice label.
+   * The label content for the choice option.
    *
    * @implementation (StringChildren) The label is produced by extracting and
    * concatenating the text nodes from the provided content; any markup or
@@ -1655,64 +1641,57 @@ export interface ChoiceProps extends GlobalProps, BaseOptionProps {
    */
   children?: ComponentChildren | StringChildren;
   /**
-   * Additional text to provide context or guidance for the input.
-   *
-   * This text is displayed along with the input and its label
-   * to offer more information or instructions to the user.
+   * Additional text or content that provides context or guidance for the choice option. Displayed alongside the option label to offer more information or instructions to the user. Also exposed to screen reader users.
    *
    * @implementation this content should be linked to the input with an `aria-describedby` attribute.
    */
   details?: ComponentChildren;
   /**
-   * Set to `true` to associate a choice with the error passed to `ChoiceList`
+   * An error state indicator for the choice option. When `true`, the option will be given specific stylistic treatment to communicate validation issues.
    *
    * @default false
    */
   error?: boolean;
   /**
-   * Secondary content for a choice.
+   * The additional content displayed alongside the primary choice label. Useful for providing supplementary information or context.
    */
   secondaryContent?: ComponentChildren;
   /**
-   * Content to display when the option is selected.
-   *
-   * This can be used to provide additional information or options related to the choice.
+   * The content displayed only when the option is selected. Useful for showing additional details or confirmation information.
    */
   selectedContent?: ComponentChildren;
 }
+/**
+ * Properties for a list of choice options with support for single or multiple selection modes.
+ */
 export interface ChoiceListProps
   extends GlobalProps,
     Pick<BasicFieldProps, 'label' | 'labelAccessibilityVisibility' | 'error'>,
     MultipleInputProps,
     FieldDetailsProps {
   /**
-   * Whether multiple choices can be selected.
+   * Whether multiple choices can be selected simultaneously. When `true`, users can select multiple options and the `values` array will contain all selected values. When `false`, only one option can be selected at a time and selecting a new option automatically deselects the previous one.
    *
    * @default false
    */
   multiple?: boolean;
   /**
-   * The choices a user can select from.
-   *
-   * Accepts `Choice` components.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Disables the field, disallowing any interaction.
-   *
-   * `disabled` on any child choices is ignored when this is true.
+   * Whether the field is disabled, preventing any user interaction.
    *
    * @default false
    */
   disabled?: MultipleInputProps['disabled'];
   /**
-   * The variant of the choice grid.
-   *
-   * - `auto`: The variant is determined by the context.
-   * - `list`: The choices are displayed in a list.
-   * - `inline`: The choices are displayed on the inline axis.
-   * - `block`: The choices are displayed on the block axis.
-   * - `grid`: The choices are displayed in a grid.
+   * Controls the visual layout and presentation style of the choice options:
+   * - `'auto'`: The layout is automatically determined based on context
+   * - `'list'`: Displays choices in a vertical list format
+   * - `'inline'`: Displays choices in a horizontal inline format
+   * - `'block'`: Displays choices as block-level button-like elements
+   * - `'grid'`: Displays choices in a grid layout
    *
    * @implementation The `block`, `inline` and `grid` variants are more suitable for button looking choices, but it's at the
    * discretion of each surface.
@@ -1726,49 +1705,28 @@ export interface ClickableProps
     BaseBoxProps,
     BaseClickableProps {
   /**
-   * Disables the clickable, and indicates to assistive technology that the loading is in progress.
-   *
-   * This also disables the clickable.
+   * Indicates whether the action is currently in progress. When `true`, typically displays a loading indicator and may disable interaction.
    */
   loading?: BaseClickableProps['loading'];
   /**
-   * Disables the clickable, meaning it cannot be clicked or receive focus.
-   *
-   * In this state, onClick will not fire.
-   * If the click event originates from a child element, the event will immediately stop propagating from this element.
-   *
-   * However, items within the clickable can still receive focus and be interacted with.
-   *
-   * This has no impact on the visual state by default,
-   * but developers are encouraged to style the clickable accordingly.
+   * Whether the element is disabled, preventing any user interaction.
    */
   disabled?: BaseClickableProps['disabled'];
   /**
-   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
-   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
-   * [Reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label)
+   * Specifies the language of text content using an [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) language tag (for example, `"en"` for English, `"fr"` for French, `"es-MX"` for Mexican Spanish, `"zh-Hans"` for Simplified Chinese). This enables assistive technologies to use correct pronunciation and language-specific text rendering.
    *
    * @default ''
    */
   lang?: string;
 }
+/**
+ * Properties for enabling browser autocomplete functionality on form fields.
+ */
 export interface AutocompleteProps<
   AutocompleteField extends AnyAutocompleteField,
 > {
   /**
-   * A hint as to the intended content of the field.
-   *
-   * When set to `on` (the default), this property indicates that the field should support
-   * autofill, but you do not have any more semantic information on the intended
-   * contents.
-   *
-   * When set to `off`, you are indicating that this field contains sensitive
-   * information, or contents that are never saved, like one-time codes.
-   *
-   * Alternatively, you can provide value which describes the
-   * specific data you would like to be entered into this field during autofill.
-   *
-   * @see Learn more about the set of {@link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens|autocomplete values} supported in browsers.
+   * Specifies the type of data expected in the field to enable browser autocomplete functionality. When set to a specific field type (for example, `'email'`, `'name'`, `'address-line1'`), browsers offer suggestions from previously entered or saved information, improving data entry speed and accuracy. Set to `'on'` to enable generic autocomplete without specifying data type. Set to `'off'` to disable autocomplete entirely for sensitive fields (for example, one-time codes, PINs, credit card security codes). The browser respects user preferences and privacy settings, so autocomplete suggestions may not always appear even when enabled. Prefix field types with section identifiers (`section-shipping`) or groups (`billing`, `shipping`) to disambiguate when multiple similar fields exist on the same page. Accepts standard [HTML autocomplete tokens per the WHATWG specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens).
    *
    * @default 'tel' for PhoneField
    * @default 'email' for EmailField
@@ -1784,19 +1742,18 @@ export interface AutocompleteProps<
     | 'off';
 }
 /**
- * The “section” scopes the autocomplete data that should be inserted
- * to a specific area of the page.
+ * A section prefix that scopes the autocomplete data to a specific area of the page.
  *
  * Commonly used when there are multiple fields with the same autocomplete needs
  * in the same page. For example: 2 shipping address forms in the same page.
  */
 export type AutocompleteSection = `section-${string}`;
 /**
- * The contact information group the autocomplete data should be sourced from.
+ * The contact information category that autocomplete data should be sourced from.
  */
 export type AutocompleteGroup = 'shipping' | 'billing';
 /**
- * The contact information subgroup the autocomplete data should be sourced from.
+ * The contact information subcategory that autocomplete data should be sourced from.
  */
 export type AutocompleteAddressGroup = 'fax' | 'home' | 'mobile' | 'pager';
 export type AnyAutocompleteField =
@@ -1864,6 +1821,9 @@ export type AnyAutocompleteField =
   | `${AutocompleteAddressGroup} tel-local-suffix`
   | `${AutocompleteAddressGroup} tel-local`
   | `${AutocompleteAddressGroup} tel-national`;
+/**
+ * Autocomplete field types applicable to text input fields.
+ */
 export type TextAutocompleteField = ExtractStrict<
   AnyAutocompleteField,
   | 'additional-name'
@@ -1897,12 +1857,15 @@ export type TextAutocompleteField = ExtractStrict<
   | 'cc-family-name'
   | 'cc-type'
 >;
+/**
+ * Properties for an interactive date picker component with single, multiple, or range selection modes.
+ */
 export interface DatePickerProps
   extends GlobalProps,
     InputProps,
     FocusEventProps {
   /**
-   * Default month to display in `YYYY-MM` format.
+   * The default month to display in `YYYY-MM` format when the picker is first shown.
    *
    * This value is used until `view` is set, either directly or as a result of user interaction.
    *
@@ -1910,74 +1873,35 @@ export interface DatePickerProps
    */
   defaultView?: string;
   /**
-   * Displayed month in `YYYY-MM` format.
-   *
-   * `onViewChange` is called when this value changes.
-   *
-   * Defaults to `defaultView`.
+   * The currently displayed month in `YYYY-MM` format. Controls which month is visible in the date picker.
    */
   view?: string;
   /**
-   * Called whenever the month to display changes.
-   *
-   * @param view The new month to display in `YYYY-MM` format.
+   * A callback function executed when the visible month displayed in the date picker changes, either through user navigation (clicking next/previous month buttons) or programmatic updates to the `view` property. The callback receives the new month as a string in `YYYY-MM` format (for example, `"2024-05"`). Use this to track which month users are viewing, load month-specific data (like availability or pricing), sync the view with external state, or implement custom navigation controls. For controlled date pickers, update the `view` property in this callback to keep the displayed month in sync with your application state. The callback fires after the month has changed but before the new month's dates are fully rendered, making it ideal for triggering data fetches.
    */
   onViewChange?: (view: string) => void;
   /**
-   * The type of selection the date picker allows.
-   *
-   * - `single` allows selecting a single date.
-   * - `multiple` allows selecting multiple non-contiguous dates.
-   * - `range` allows selecting a single range of dates.
+   * Controls the selection mode of the date picker:
+   * - `'single'`: Allows selecting one date
+   * - `'multiple'`: Allows selecting multiple individual dates
+   * - `'range'`: Allows selecting a continuous range of dates
    *
    * @default "single"
    */
   type?: 'single' | 'multiple' | 'range';
   /**
-   * Dates that can be selected.
-   *
-   * A comma-separated list of dates, date ranges. Whitespace is allowed after commas.
-   *
-   * The default `''` allows all dates.
-   *
-   * - Dates in `YYYY-MM-DD` format allow a single date.
-   * - Dates in `YYYY-MM` format allow a whole month.
-   * - Dates in `YYYY` format allow a whole year.
-   * - Ranges are expressed as `start--end`.
-   *     - Ranges are inclusive.
-   *     - If either `start` or `end` is omitted, the range is unbounded in that direction.
-   *     - If parts of the date are omitted for `start`, they are assumed to be the minimum possible value.
-   *       So `2024--` is equivalent to `2024-01-01--`.
-   *     - If parts of the date are omitted for `end`, they are assumed to be the maximum possible value.
-   *       So `--2024` is equivalent to `--2024-12-31`.
-   *     - Whitespace is allowed either side of `--`.
+   * Specifies allowed date values or ranges for selection. Uses ISO date format (YYYY-MM-DD) or partial dates (YYYY-MM, YYYY). Supports range syntax with `--` separator and comma-separated values.
    *
    * @default ""
    *
    * @example
    * `2024-02--2025` // allow any date from February 2024 to the end of 2025
-   * `2024-02--` // allow any date from February 2024 to the end of the month
+   * `2024-02--` // allow any date from February 2024 onwards
    * `2024-05-09, 2024-05-11` // allow only the 9th and 11th of May 2024
    */
   allow?: string;
   /**
-   * Dates that cannot be selected. These subtract from `allow`.
-   *
-   * A comma-separated list of dates, date ranges. Whitespace is allowed after commas.
-   *
-   * The default `''` has no effect on `allow`.
-   *
-   * - Dates in `YYYY-MM-DD` format disallow a single date.
-   * - Dates in `YYYY-MM` format disallow a whole month.
-   * - Dates in `YYYY` format disallow a whole year.
-   * - Ranges are expressed as `start--end`.
-   *     - Ranges are inclusive.
-   *     - If either `start` or `end` is omitted, the range is unbounded in that direction.
-   *     - If parts of the date are omitted for `start`, they are assumed to be the minimum possible value.
-   *       So `2024--` is equivalent to `2024-01-01--`.
-   *     - If parts of the date are omitted for `end`, they are assumed to be the maximum possible value.
-   *       So `--2024` is equivalent to `--2024-12-31`.
-   *     - Whitespace is allowed either side of `--`.
+   * Specifies disallowed date values or ranges that can't be selected. Uses ISO date format (YYYY-MM-DD) or partial dates (YYYY-MM, YYYY). Supports range syntax with `--` separator and comma-separated values. Takes precedence over `allow`.
    *
    * @default ""
    *
@@ -1987,82 +1911,49 @@ export interface DatePickerProps
    */
   disallow?: string;
   /**
-   * Days of the week that can be selected. These intersect with the result of `allow` and `disallow`.
-   *
-   * A comma-separated list of days. Whitespace is allowed after commas.
-   *
-   * The default `''` has no effect on the result of `allow` and `disallow`.
-   *
-   * Days are `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`.
+   * Specifies which days of the week can be selected. Accepts comma-separated day names (case-insensitive). Further restricts dates within the result of `allow` and `disallow`.
    *
    * @default ""
    *
    * @example
-   * 'saturday, sunday' // allow only weekends within the result of `allow` and `disallow`.
+   * 'saturday, sunday' // allow only weekends
+   * 'monday, wednesday, friday' // allow only specific weekdays
    */
   allowDays?: string;
   /**
-   * Days of the week that cannot be selected. This subtracts from `allowDays`, and intersects with the result of `allow` and `disallow`.
-   *
-   * A comma-separated list of days. Whitespace is allowed after commas.
-   *
-   * The default `''` has no effect on `allowDays`.
-   *
-   * Days are `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`.
+   * Specifies which days of the week can't be selected. Accepts comma-separated day names (case-insensitive). Further restricts dates within the result of `allow` and `disallow`.
    *
    * @default ""
    *
    * @example
-   * 'saturday, sunday' // disallow weekends within the result of `allow` and `disallow`.
+   * 'saturday, sunday' // disallow weekends
+   * 'monday' // disallow Mondays
    */
   disallowDays?: string;
   /**
-   * Default selected value.
-   *
-   * The default means no date is selected.
-   *
-   * If the provided value is invalid, no date is selected.
-   *
-   * - If `type="single"`, this is a date in `YYYY-MM-DD` format.
-   * - If `type="multiple"`, this is a comma-separated list of dates in `YYYY-MM-DD` format.
-   * - If `type="range"`, this is a range in `YYYY-MM-DD--YYYY-MM-DD` format. The range is inclusive.
+   * The default date value used when the field is first rendered, in ISO date format (YYYY-MM-DD, for example, `"2024-05-15"`). An empty string means no default date. For date ranges, use comma-separated dates. Only applies if no `value` prop is provided.
    *
    * @default ""
    */
   defaultValue?: string;
   /**
-   * Current selected value.
-   *
-   * The default means no date is selected.
-   *
-   * If the provided value is invalid, no date is selected.
-   *
-   * Otherwise:
-   *
-   * - If `type="single"`, this is a date in `YYYY-MM-DD` format.
-   * - If `type="multiple"`, this is a comma-separated list of dates in `YYYY-MM-DD` format.
-   * - If `type="range"`, this is a range in `YYYY-MM-DD--YYYY-MM-DD` format. The range is inclusive.
+   * The currently selected date value in ISO date format (YYYY-MM-DD, for example, `"2024-05-15"`). An empty string means no date is selected. For date ranges, use comma-separated dates (for example, `"2024-05-15,2024-05-20"`).
    *
    * @default ""
    */
   value?: string;
   /**
-   * Callback when any date is selected.
-   *
-   * - If `type="single"`, fires when a date is selected and happens before `onChange`.
-   * - If `type="multiple"`, fires when a date is selected before `onChange`.
-   * - If `type="range"`, fires when a first date is selected (with the partial value formatted as `YYYY-MM-DD--`), and when the last date is selected before `onChange`.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: Event) => void;
   /**
-   * Callback when the value is committed.
-   *
-   * - If `type="single"`, fires when a date is selected after `onInput`.
-   * - If `type="multiple"`, fires when a date is selected after `onInput`.
-   * - If `type="range"`, fires when a range is completed by selecting the end date after `onInput`.
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: Event) => void;
 }
+/**
+ * Properties for a text-based date input field with validation and autocomplete support.
+ */
 export interface DateFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
@@ -2080,19 +1971,7 @@ export interface DateFieldProps
     >,
     AutocompleteProps<DateAutocompleteField> {
   /**
-   * Callback when the field has an invalid date.
-   * This callback will be called, if the date typed is invalid or disabled.
-   *
-   * Dates that don’t exist or have formatting errors are considered invalid. Some examples of invalid dates are:
-   * - 2021-02-31: February doesn’t have 31 days
-   * - 2021-02-00: The day can’t be 00
-   *
-   * Disallowed dates are considered invalid.
-   *
-   * It’s important to note that this callback will be called only when the user **finishes editing** the date,
-   * and it’s called right after the `onChange` callback.
-   * The field is **not** validated on every change to the input. Once the buyer has signalled that
-   * they have finished editing the field (typically, by blurring the field), the field gets validated and the callback is run if the value is invalid.
+   * A callback function executed when the user enters an invalid value. Fires after change validation fails.
    */
   onInvalid?: (event: Event) => void;
 }
@@ -2106,6 +1985,9 @@ export type DateAutocompleteField = ExtractStrict<
   | 'cc-expiry-month'
   | 'cc-expiry-year'
 >;
+/**
+ * Properties for a spinner-style date selector with increment/decrement controls.
+ */
 export interface DateSpinnerProps
   extends GlobalProps,
     Pick<
@@ -2113,102 +1995,116 @@ export interface DateSpinnerProps
       'defaultValue' | 'value' | 'onInput' | 'onChange' | 'onBlur' | 'onFocus'
     > {
   /**
-   * Default selected value for the spinner.
-   *
-   * This uses a date in `YYYY-MM-DD` format.
+   * The default date value used when the field is first rendered, in ISO date format (YYYY-MM-DD, for example, `"2024-05-15"`). An empty string means no default date. Only applies if no `value` prop is provided.
    *
    * @default ""
    */
   defaultValue?: string;
   /**
-   * Current selected value for the spinner.
-   *
-   * This uses a date in `YYYY-MM-DD` format.
+   * The currently selected date value in ISO date format (YYYY-MM-DD, for example, `"2024-05-15"`). An empty string means no date is selected.
    *
    * @default ""
    */
   value?: string;
   /**
-   * Callback after the wheels have finished spinning and the value has
-   * settled.
-   *
-   * Fires once when inertial/momentum scrolling stops and the selection snaps
-   * into place.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: Event) => void;
   /**
-   * Callback when the selection has been confirmed by the user.
-   *
-   * Fires only when the user explicitly commits the selection (for example, by
-   * pressing a confirmation control).
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: Event) => void;
 }
+/**
+ * Properties for a visual divider line that separates content sections.
+ */
 export interface DividerProps extends GlobalProps {
   /**
-   * Specify the direction of the divider. This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
+   * The direction of the divider using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values). An inline divider runs horizontally across the content flow, while a block divider runs vertically along the content flow.
+   * 
+   * Available options:
+   * - `'inline'`: A horizontal divider that runs perpendicular to the text direction, creating separation between vertically stacked content sections.
+   * - `'block'`: A vertical divider that runs parallel to the text direction, creating separation between horizontally arranged content sections.
    *
    * @default 'inline'
    */
   direction?: 'inline' | 'block';
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the divider. Controls how prominent or subtle the divider appears.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
 }
+/**
+ * Properties for an email address input field with validation and autocomplete support.
+ */
 export interface EmailFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
     MinMaxLengthProps,
     AutocompleteProps<EmailAutocompleteField> {}
+/**
+ * Autocomplete field types applicable to email input fields.
+ */
 export type EmailAutocompleteField = ExtractStrict<
   AnyAutocompleteField,
   'email' | `${AutocompleteAddressGroup} email`
 >;
+/**
+ * A spacing size keyword including the option for no spacing.
+ */
 export type SpacingKeyword = SizeKeyword | 'none';
+/**
+ * Properties for controlling the spacing between child elements in a container.
+ */
 export interface GapProps {
   /**
-   * Adjust spacing between elements.
-   *
-   * A single value applies to both axes.
-   * A pair of values (eg `large-100 large-500`) can be used to set the inline and block axes respectively.
+   * The spacing between child elements. A single value applies to both axes. Two values (for example, `large-100 large-500`) set the block axis (first value) and inline axis (second value) respectively.
    *
    * @default 'none'
    */
   gap?: MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>;
   /**
-   * Adjust spacing between elements in the block axis.
-   *
-   * This overrides the row value of `gap`.
+   * The spacing between child elements along the block axis (typically vertical). Overrides the block axis value from `gap`.
    *
    * @default '' - meaning no override
    */
   rowGap?: MaybeResponsive<SpacingKeyword | ''>;
   /**
-   * Adjust spacing between elements in the inline axis.
-   *
-   * This overrides the column value of `gap`.
+   * The spacing between child elements along the inline axis (typically horizontal). Overrides the inline axis value from `gap`.
    *
    * @default '' - meaning no override
    */
   columnGap?: MaybeResponsive<SpacingKeyword | ''>;
 }
+/**
+ * A baseline alignment position keyword.
+ */
 export type BaselinePosition = 'baseline' | 'first baseline' | 'last baseline';
+/**
+ * A content distribution strategy keyword for spacing.
+ */
 export type ContentDistribution =
   | 'space-between'
   | 'space-around'
   | 'space-evenly'
   | 'stretch';
+/**
+ * A content position alignment keyword.
+ */
 export type ContentPosition = 'center' | 'start' | 'end';
+/**
+ * A content position with optional overflow safety modifier.
+ */
 export type OverflowPosition =
   | `unsafe ${ContentPosition}`
   | `safe ${ContentPosition}`;
 /**
- * Align items sets the align-self value on all direct children as a group.
+ * A type that defines how children are aligned along the cross axis.
+ * Sets the align-self value on all direct children as a group.
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
+ * Learn more about [`align-items` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
  */
 export type AlignItemsKeyword =
   | 'normal'
@@ -2217,9 +2113,9 @@ export type AlignItemsKeyword =
   | OverflowPosition
   | ContentPosition;
 /**
- * Justify content defines how the browser distributes space between and around content items along the main-axis of a flex container, and the inline axis of a grid container.
+ * A type that defines how the browser distributes space between and around content items along the main-axis of a flex container, and the inline axis of a grid container.
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
+ * Learn more about [`justify-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
  */
 export type JustifyContentKeyword =
   | 'normal'
@@ -2227,9 +2123,9 @@ export type JustifyContentKeyword =
   | OverflowPosition
   | ContentPosition;
 /**
- *Align content sets the distribution of space between and around content items along a flexbox's cross axis, or a grid or block-level element's block axis.
+ * A type that defines the distribution of space between and around content items along a flexbox's cross axis, or a grid or block-level element's block axis.
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
+ * Learn more about [`align-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
  */
 export type AlignContentKeyword =
   | 'normal'
@@ -2237,276 +2133,265 @@ export type AlignContentKeyword =
   | ContentDistribution
   | OverflowPosition
   | ContentPosition;
+/**
+ * Base properties for text styling and appearance.
+ */
 export interface BaseTypographyProps {
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the text. Controls how prominent or subtle the text appears within the interface.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
   /**
-   * Sets the tone of the component, based on the intention of the information being conveyed.
+   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Set the numeric properties of the font.
+   * Controls how numbers are displayed in the text:
+   * - `'auto'`: Inherits the setting from the parent element.
+   * - `'normal'`: Uses the default number rendering for the font.
+   * - `'tabular-nums'`: Uses fixed-width numbers for better alignment in tables and lists.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric
+   * Learn more about [`font-variant-numeric` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
    *
-   * @default 'auto' - inherit from the parent element
+   * @default 'auto'
    */
   fontVariantNumeric?: 'auto' | 'normal' | 'tabular-nums';
   /**
-   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
-   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
-   * [Reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label)
-   *
-   * It is recommended to combine it with the `dir` attribute to ensure the text is rendered correctly if the surrounding content’s direction is different.
+   * Specifies the language of text content using an [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) language tag (for example, `"en"` for English, `"fr"` for French, `"es-MX"` for Mexican Spanish, `"zh-Hans"` for Simplified Chinese). This enables assistive technologies to use correct pronunciation and language-specific text rendering.
    *
    * @default ''
    */
   lang?: string;
   /**
-   * Indicates the directionality of the element’s text.
+   * Indicates the directionality of the element's text:
+   * - `ltr`: languages written from left to right (for example, English).
+   * - `rtl`: languages written from right to left (for example, Arabic).
+   * - `auto`: the user agent determines the direction based on the content.
+   * - `''`: direction is inherited from parent elements (equivalent to not setting the attribute).
    *
-   * - `ltr`: languages written from left to right (e.g. English)
-   * - `rtl`: languages written from right to left (e.g. Arabic)
-   * - `auto`: the user agent determines the direction based on the content
-   * - `''`: direction is inherited from parent elements (equivalent to not setting the attribute)
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir
+   * Learn more about the [`dir` attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir).
    *
    * @default ''
    */
   dir?: 'ltr' | 'rtl' | 'auto' | '';
 }
+/**
+ * Properties for controlling multi-line text behavior and truncation.
+ */
 export interface BlockTypographyProps {
   /**
-   * Truncates the text content to the specified number of lines.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
+   * Limits the text content to a specified number of visible lines. When text exceeds this limit, it's truncated and an ellipsis (`…`) appears at the end of the last visible line to indicate more content exists. The truncation happens automatically based on the container's width, font size, and line height—narrow containers or large fonts will show fewer words per line. For example, `lineClamp={3}` allows maximum three lines of text regardless of total content length. Users can't access the hidden text unless an expansion mechanism (like a "Read more" button) or tooltip is provided. Commonly applied to maintain consistent layout heights in cards, lists, or grids where varying text lengths would disrupt visual alignment. Common values include 1-2 for titles/labels, 2-3 for descriptions, and 4-6 for preview text. The actual text content remains in the DOM and is accessible to screen readers (full text is announced), search engines, and selection—only the visual display is truncated. Learn more about [`line-clamp` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).
    *
    * @default Infinity - no truncation is applied
    */
   lineClamp?: number;
 }
+/**
+ * Properties for heading text elements with semantic structure and line clamping.
+ */
 export interface HeadingProps
   extends GlobalProps,
     AccessibilityVisibilityProps,
     BlockTypographyProps {
   /**
-   * The content of the Heading.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help users
-   * navigate the page.
-   *
-   * - `heading`: defines the element as a heading to a page or section.
-   * - `presentation`: the heading level will be stripped,
-   * and will prevent the element’s implicit ARIA semantics from
-   * being exposed to the accessibility tree.
-   * - `none`: a synonym for the `presentation` role.
+   * Sets the semantic role for assistive technologies. Helps screen reader users navigate and understand page structure.
    *
    * @default 'heading'
    *
    * @implementation The `heading` role doesn't need to be applied if
    * the host applies it for you; for example, an HTML host rendering
-   * an `<h2>` element should not apply the `heading` role.
+   * an `<h2>` element shouldn't apply the `heading` role.
    */
   accessibilityRole?:
     | 'heading'
     | ExtractStrict<AccessibilityRole, 'presentation' | 'none'>;
 }
+/**
+ * Properties for icon elements including type, size, color, and tone.
+ */
 export interface IconProps
   extends GlobalProps,
     Pick<InteractionProps, 'interestFor'> {
   /**
-   * Sets the tone of the icon, based on the intention of the information being conveyed.
+   * The semantic tone of the icon, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the icon. Controls how prominent or subtle the icon appears within the interface.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
   /**
-   * Adjusts the size of the icon.
+   * Adjusts the size of the icon. Available sizes range from `'small-500'` (smallest) through `'base'` (default) to `'large-500'` (largest), allowing you to match icon size to your interface hierarchy.
    *
    * @default 'base'
    */
   size?: SizeKeyword;
+  /**
+   * The icon identifier specifying which icon to display. Accepts any valid icon name from the icon set.
+   */
   type?: IconType | AnyString;
 }
+/**
+ * Base properties for image elements including source URLs and alternative text.
+ */
 export interface BaseImageProps {
   /**
-   * An alternative text description that describe the image for the reader to
-   * understand what it is about. It is extremely useful for both users using
-   * assistive technology and sighted users. A well written description
-   * provides people with visual impairments the ability to participate in
-   * consuming non-text content. When a screen readers encounters an `s-image`,
-   * the description is read and announced aloud. If an image fails to load,
-   * potentially due to a poor connection, the `alt` is displayed on
-   * screen instead. This has the benefit of letting a sighted buyer know an
-   * image was meant to load here, but as an alternative, they’re still able to
-   * consume the text content. Read
-   * [considerations when writing alternative text](https://www.shopify.com/ca/blog/image-alt-text#4)
-   * to learn more.
+   * Alternative text that describes the image content for users who can't see the image. This text is announced by screen readers, displayed when images fail to load or are blocked, and used by search engines for image indexing. Write concise, descriptive alt text that conveys the image's purpose and content (for example, "Product photo of blue running shoes" not "image" or "photo"). For decorative images that don't convey information, use an empty string (`alt=""`) to hide them from screen readers. For images containing text, include that text in the alt description. For complex images like charts or diagrams, consider providing a longer description elsewhere and summarizing in alt text. Alt text is required for accessibility compliance and should describe what users would miss if they couldn't see the image.
    *
    * @default `''`
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt
+   * Learn more about [`alt` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).
    */
   alt?: string;
   /**
-   * A set of media conditions and their corresponding sizes.
+   * Defines the image sizes for different viewport widths to help the browser select the optimal image from `srcSet`. This is a comma-separated list of media conditions and corresponding sizes (for example, `"(max-width: 600px) 480px, 800px"`). The browser uses this with `srcSet` to determine which image variant to download based on the device's screen size and pixel density, improving performance by loading appropriately-sized images. For example, mobile devices receive smaller images while desktops get larger, higher-resolution versions. When `srcSet` provides multiple image sizes, `sizes` tells the browser the rendered size at different viewport widths. If omitted, the browser assumes `100vw` (full viewport width). This only affects which image is selected, not how it's displayed—use CSS or `inlineSize` for display sizing.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes
+   * Learn more about [`sizes` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes).
    */
   sizes?: string;
   /**
-   * The image source (either a remote URL or a local file resource).
-   *
-   * When the image is loading or no `src` is provided, a placeholder will be rendered.
+   * The primary image source URL. Accepts absolute URLs (`https://example.com/image.jpg`), relative paths (`/images/product.jpg`), or data URLs (`data:image/png;base64,...`). When the image is loading or if `src` is omitted/invalid, a placeholder is displayed while reserving the image's space to prevent layout shifts. The URL must be accessible (proper [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) headers for cross-origin images), use appropriate protocols ([HTTPS](https://en.wikipedia.org/wiki/HTTPS) for security), and point to valid image formats (JPEG, PNG, GIF, WebP, SVG). Failed loads trigger the `onError` callback if provided. For responsive images serving different sizes/resolutions, `srcSet` can be used in addition to `src` (which then serves as the fallback). Images are loaded asynchronously—the `loading` property controls when loading begins.
    *
    * @implementation Surfaces may choose the style of the placeholder, but the space the image occupies should be
-   * reserved, except in cases where the image area does not have a contextual inline or block size, which should be rare.
+   * reserved, except in cases where the image area doesn't have a contextual inline or block size, which should be rare.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src
+   * Learn more about [img src on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
    */
   src?: string;
   /**
-   * A set of image sources and their width or pixel density descriptors.
+   * A set of image source URLs with descriptors for responsive image selection. Provides multiple image variants at different widths or pixel densities, allowing browsers to choose the most appropriate image for the user's device and screen. Format: comma-separated list of `URL descriptor` pairs where descriptors are either width (`w`) or pixel density (`x`). For example: `"small.jpg 480w, medium.jpg 800w, large.jpg 1200w"` for different widths, or `"standard.jpg 1x, retina.jpg 2x"` for different pixel densities. The browser considers the device's screen size, resolution, network speed, and user preferences when selecting which image to download. This improves performance (smaller images on mobile) and quality (high-DPI images on retina displays). When used with `sizes`, enables fully responsive images. The `src` property serves as fallback for browsers that don't support `srcSet`.
    *
-   * This overrides the `src` property.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset
+   * Learn more about [`src` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).set
    */
   srcSet?: string;
 }
+/**
+ * Properties for image elements including size, aspect ratio, loading behavior, and border styling.
+ */
 export interface ImageProps extends GlobalProps, BaseImageProps, BorderProps {
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help users
-   * navigate the page.
+   * Sets the semantic role for assistive technologies. Helps screen reader users navigate and understand page structure.
    *
    * @default 'img'
    *
    * @implementation The `img` role doesn't need to be applied if
    * the host applies it for you; for example, an HTML host rendering
-   * an `<img>` element should not apply the `img` role.
+   * an `<img>` element shouldn't apply the `img` role.
    */
   accessibilityRole?:
     | 'img'
     | ExtractStrict<AccessibilityRole, 'presentation' | 'none'>;
   /**
-   * The displayed inline width of the image.
-   *
-   * - `fill`: the image will takes up 100% of the available inline size.
-   * - `auto`: the image will be displayed at its natural size.
+   * Controls the displayed width of the image. Choose based on your layout requirements. For mobile interfaces, consider using `'fill'` with defined container dimensions to ensure consistent image display, as dynamic container heights can cause layout inconsistencies in scrollable views.
+   * - `'auto'`: Displays the image at its natural size. The image won't render until it has loaded, and the aspect ratio will be ignored. Use for images where maintaining original dimensions is important.
+   * - `'fill'`: Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Use for responsive layouts and flexible image containers.
    *
    * @default 'fill'
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width
+   * Learn more about [`width` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
    */
   inlineSize?: 'fill' | 'auto';
   /**
-   * The aspect ratio of the image.
+   * The aspect ratio of the image, expressed as width divided by height.
    *
    * The rendering of the image will depend on the `inlineSize` value:
    *
-   * - `inlineSize="fill"`: the aspect ratio will be respected and the image will take the necessary space.
-   * - `inlineSize="auto"`: the image will not render until it has loaded and the aspect ratio will be ignored.
+   * - `inlineSize="fill"`: The aspect ratio will be respected and the image will take the necessary space.
+   * - `inlineSize="auto"`: The image won't render until it has loaded and the aspect ratio will be ignored.
    *
    * For example, if the value is set as `50 / 100`, the getter returns `50 / 100`.
    * If the value is set as `0.5`, the getter returns `0.5 / 1`.
    *
    * @default '1/1'
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio
+   * Learn more about [`aspect-ratio` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).
    */
   aspectRatio?:
     | `${number}${optionalSpace}/${optionalSpace}${number}`
     | `${number}`;
   /**
-   * Determines how the content of the image is resized to fit its container.
-   * The image is positioned in the center of the container.
+   * Controls how the image content is resized within its container:
+   * - `'contain'`: Scales the image to fit within the container while maintaining aspect ratio. The entire image will be visible, but there may be empty space. Use when showing the complete image is important.
+   * - `'cover'`: Scales the image to fill the entire container while maintaining aspect ratio. Parts of the image may be cropped. Use when filling the container completely is more important than showing the entire image.
    *
    * @default 'contain'
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
+   * Learn more about [`object-fit` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).
    */
   objectFit?: 'contain' | 'cover';
   /**
-   * Determines the loading behavior of the image:
-   * - `eager`: Immediately loads the image, irrespective of its position within the visible viewport.
-   * - `lazy`: Delays loading the image until it approaches a specified distance from the viewport.
+   * Controls when the browser should begin loading the image resource:
+   * - `'eager'`: Loads the image immediately when the page loads, regardless of whether it's visible in the viewport. The image downloads in parallel with other page resources. Use for above-the-fold images, critical product photos, or images that will definitely be viewed. This ensures images are ready when needed but increases initial page load bandwidth.
+   * - `'lazy'`: Defers image loading until the image is approaching the viewport (typically a few hundred pixels before becoming visible). The browser only downloads the image when the user is likely to see it soon. Use for below-the-fold images, gallery images, or images in scrollable lists. This improves initial page load performance and saves bandwidth for images users may never scroll to. The browser maintains a buffer distance so images load before users reach them, preventing visible loading delays.
+   *
+   * Lazy loading is most effective for pages with many images, long scrollable content, or mobile users on limited bandwidth. Modern browsers support native lazy loading—older browsers ignore this and load eagerly.
    *
    * @default 'eager'
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading
+   * Learn more about [`loading` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading).
    */
   loading?: 'eager' | 'lazy';
   /**
-   * Invoked when load completes successfully.
+   * A callback function executed when the image finishes loading successfully and is ready to display. This fires after the browser has downloaded the image data and decoded it, but may fire before the image is actually painted to the screen. Use this for hiding loading indicators, triggering dependent actions that require the image (like image processing), tracking image load metrics, or executing layout operations that depend on image dimensions. For performance tracking, compare timestamps between navigation start and this callback. Note that cached images may trigger this callback synchronously (immediately), so handle both async and sync invocation in your code. This won't fire if the image fails to load—listen to `onError` for failures.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload
+   * Learn more about [`onload` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload).
    */
   onLoad?: (event: Event) => void;
   /**
-   * Invoked on load error.
+   * A callback function executed when the image fails to load due to network errors, invalid URLs, unsupported formats, [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) issues, or server errors (for example, 404, 500). The event contains limited error details for security reasons—the browser console provides specific failure reasons. Common operations include displaying fallback images (`event.target.src = 'fallback.jpg'`), showing error messages to users, logging failures for monitoring, hiding broken image icons, or providing alternative content when images are unavailable. A common pattern involves attempting to load a fallback image, and if that fails too, hiding the image container entirely. For critical images like product photos, a placeholder SVG or icon may be shown instead of a broken image indicator. This callback doesn't fire for images that are blocked by browser content policies or ad blockers.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
+   * Learn more about [`onerror` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror).
    */
   onError?: (event: Event) => void;
 }
+/**
+ * Properties for modal overlay dialogs including size, padding, actions, and lifecycle callbacks.
+ */
 export interface ModalProps
   extends GlobalProps,
     BaseOverlayProps,
     BaseOverlayMethods,
     ActionSlots {
   /**
-   * A label that describes the purpose of the modal. When set,
-   * it will be announced to users using assistive technologies and will
-   * provide them with more context.
-   *
-   * This overrides the `heading` prop for screen readers.
+   * A label that describes the purpose or contents of the element. Announced to users with assistive technologies such as screen readers to provide context.
    */
   accessibilityLabel?: string;
   /**
-   * A title that describes the content of the Modal.
-   *
+   * The title text displayed in the modal header. If omitted and no actions are provided, the modal will be rendered without a header.
    */
   heading?: string;
   /**
-   * Adjust the padding around the Modal content.
-   *
-   * `base`: applies padding that is appropriate for the element.
-   *
-   * `none`: removes all padding from the element. This can be useful when elements inside the Modal need to span
-   * to the edge of the Modal. For example, a full-width image. In this case, rely on `Box` with a padding of 'base'
-   * to bring back the desired padding for the rest of the content.
+   * The padding applied to all edges of the modal content.
    *
    * @default 'base'
    */
   padding?: 'base' | 'none';
   /**
-   * Adjust the size of the Modal.
-   *
-   * `max`: expands the Modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
+   * Controls the display size of the modal:
+   * - Size keywords (for example, `'small'`, `'base'`, `'large'`): Fixed size options.
+   * - `'max'`: Modal expands to fill the maximum available space.
    *
    * @default 'base'
    */
   size?: SizeKeyword | 'max';
   /**
-   * The content of the Modal.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
+/**
+ * Properties for numeric input fields with validation, constraints, and optional stepper controls.
+ */
 export interface NumberFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
@@ -2514,64 +2399,73 @@ export interface NumberFieldProps
     NumberConstraintsProps,
     FieldDecorationProps {
   /**
-   * Sets the virtual keyboard.
+   * The virtual keyboard layout displayed for numeric input on touch-enabled devices like tablets and smartphones. This property has no effect on desktop devices with physical keyboards. Not supported when using `stepper` controls.
+   * - `'decimal'`: Shows a numeric keyboard with a decimal point/comma key. Best for monetary amounts (for example, "$19.99"), measurements with precision (for example, "2.5 kg"), percentages (for example, "15.5%"), or any fractional values. The decimal separator adapts to the user's locale (period in US, comma in Europe).
+   * - `'numeric'`: Shows a numeric keyboard without decimal point, displaying only digits 0-9 and sometimes +/- symbols. Best for quantities (for example, "5 items"), whole number identifiers (for example, "Order #12345"), phone numbers, or any integer-only input. Prevents accidental decimal entry which can confuse users for whole number fields.
+   * 
+   * On mobile POS devices, choosing the correct inputMode significantly improves data entry speed and reduces errors by showing the most relevant keyboard. Users can still switch keyboards manually if needed.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
+   * Learn more about [`inputmode` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
    * @default 'decimal'
    */
   inputMode?: 'decimal' | 'numeric';
 }
+/**
+ * Autocomplete field types applicable to number input fields.
+ */
 export type NumberAutocompleteField = ExtractStrict<
   AnyAutocompleteField,
   'one-time-code' | 'cc-number' | 'cc-csc'
 >;
+/**
+ * Properties for page-level layouts including header, breadcrumbs, actions, and sidebar content.
+ */
 export interface PageProps extends GlobalProps, ActionSlots {
   /**
-   * The content of the Page.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * The main page heading
+   * The title text displayed in the page header. If omitted and no actions are provided, the page will be rendered without a header.
    */
   heading?: string;
   /**
-   * The text to be used as subtitle.
+   * A secondary page heading displayed under the main heading in the action bar.
    */
   subheading?: string;
   /**
-   * Additional contextual information about the page.
+   * The additional content displayed in the header area. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChildren;
   /**
-   * The breadcrumb actions to perform, provided as link elements.
+   * The navigation breadcrumb links displayed in the page header as link elements. These show the hierarchical path to the current page.
    */
   breadcrumbActions?: ComponentChildren;
   /**
-   * The aside element is section of a page that contains content that is tangentially related to the content around the aside element, and which could be considered separate from that content.
-   * Such sections are often represented as sidebars in printed typography.
+   * The content to display in the page's sidebar. This area is for content that is tangentially related to the main content, such as navigation or contextual information. Use the `slot="aside"` attribute to place content in this area.
+   *
    * @implementation surfaces built ontop of the web platform should implement this using the <aside> element https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside
    */
   aside?: ComponentChildren;
   /**
-   * The inline size of the page
-   * - `base` corresponds to a set default inline size
-   * - `large` full width with whitespace
+   * Controls the maximum width of the page content.
    *
    * @default 'base'
    */
   inlineSize?: SizeKeyword;
 }
+/**
+ * Properties for POS-specific content blocks with optional heading and secondary actions.
+ */
 export interface POSBlockProps
   extends GlobalProps,
     Pick<ActionSlots, 'secondaryActions'> {
   /**
-   * The heading to display within the POSBlock.
-   *
-   * If not provided, the description of the extension will be used when a heading is appropriate.
+   * The title text displayed in the block header. If omitted and no secondary actions are provided, the block will be rendered without a header.
    */
   heading?: string;
   /**
-   * The content to display within the POSBlock.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
@@ -2579,158 +2473,150 @@ export interface POSBlockProps
    */
   secondaryActions?: ComponentChildren;
 }
+/**
+ * Properties for QR code elements including content, size, border, and optional logo.
+ */
 export interface QRCodeProps extends GlobalProps {
   /**
-   * Set the border of the QR code.
-   *
-   * `base`: applies border that is appropriate for the element.
-   * `none`: removes the border from the element.
+   * Controls whether a border is displayed around the QR code.
    *
    * @default 'base'
    */
   border?: 'base' | 'none';
   /**
-   * The content to be encoded in the QR code, which can be any string such as a URL, email address, plain text, etc.
-   * Specific string formatting can trigger actions on the user's device when scanned, like opening geolocation
-   * coordinates on a map, opening a preferred app or app store entry, preparing an email, text message, and more.
+   * The content to be encoded in the QR code. This can be any string such as a URL, email address, plain text, or other data. Specific string formatting can trigger actions on the user's device when scanned, like opening geolocation coordinates on a map, opening a preferred app or app store entry, preparing an email, text message, and more.
    */
   content?: string;
   /**
-   * The displayed size of the QR code.
-   *
-   * `fill`: the QR code will takes up 100% of the available inline-size and maintain a 1:1 aspect ratio.
-   * `base`: the QR code will be displayed at its default size.
+   * Controls the display size of the QR code:
+   * - `'base'`: Fixed size QR code
+   * - `'fill'`: QR code expands to fill available space
    *
    * @default 'base'
    */
   size?: 'base' | 'fill';
   /**
-   * A label that describes the purpose or contents of the QR code. When set,
-   * it will be announced to users using assistive technologies and will
-   * provide more context about what the QR code may do when scanned.
+   * A label that describes the purpose or contents of the element. Announced to users with assistive technologies such as screen readers to provide context.
    *
    * @default 'QR code' (translated to the user's locale)
    */
   accessibilityLabel?: string;
   /**
-   * Invoked when the conversion of `content` to a QR code fails.
-   * If an error occurs, the QR code and its child elements will not be displayed.
+   * A callback function executed when the resource fails to load.
    */
   onError?: (event: Event) => void;
   /**
-   * URL of an image to be displayed in the center of the QR code.
+   * The URL of an image to be displayed in the center of the QR code.
    * This is useful for branding or to indicate to the user what scanning the QR code will do.
    * By default, no image is displayed.
    */
   logo?: string;
 }
+/**
+ * Properties for scroll-related event callbacks and edge detection.
+ */
 export interface ScrollEventProps {
   /**
-   * Callback when the scroll position reaches any edge.
+   * A callback function executed when scrolling reaches or moves away from any edge of the scrollable container.
    *
-   * Provides information about which edges have been reached:
-   * - `inline: 'start'` - reached the inline-start edge
-   * - `inline: 'end'` - reached the inline-end edge
-   * - `block: 'start'` - reached the block-start edge
-   * - `block: 'end'` - reached the block-end edge
+   * Provides information about which edges are currently reached:
+   * - `inline: 'start'` - at the inline-start edge (typically left in LTR)
+   * - `inline: 'end'` - at the inline-end edge (typically right in LTR)
+   * - `block: 'start'` - at the block-start edge (typically top)
+   * - `block: 'end'` - at the block-end edge (typically bottom)
    * - `null` - not at that edge
-   *
-   * Uses the flow‑relative axes.
    */
   onScrollToEdge?: (
     inline: 'start' | 'end' | null,
     block: 'start' | 'end' | null,
   ) => void;
   /**
-   * Distance from the edge at which `onScrollToEdge` fires.
-   * Percentage values are relative to the scrollable content's size in that axis.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported.
-   *
-   * The order is:
+   * The threshold distance from each edge at which `onScrollToEdge` triggers. Percentage values are relative to the scrollable content's size in that axis. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) in the order:
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
+   * - 1 value: applies to all edges
    *
    * For example:
-   * - `48px` means the distance from the edge at which `onScrollToEdge` fires from block-start, inline-end, block-end and inline-start is `48px`.
-   * - `48px 0` means the distance from the edge at which `onScrollToEdge` fires from block-start and block-end is `48px`, and for inline-start and inline-end is `0`.
-   * - `48 0 48` means the distance from the edge at which `onScrollToEdge` fires from block-start is `48px`, for inline-end is `0`, for block-end is `48px` and for inline-start is `0`.
-   * - `48px 0 48px 10%` means the distance from the edge at which `onScrollToEdge` fires from block-start is `48px`, for inline-end is `0`, for block-end is `48px` and for inline-start is `10%`.
+   * - `48px` - triggers 48px from all edges
+   * - `48px 0` - triggers 48px from block edges, 0px from inline edges
+   * - `48px 0 48px 10%` - custom distance for each edge
    *
    * @default '0'
-   * Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/scrollMargin) for more details.
+   * Learn more about [`scrollMargin` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/scrollMargin).
    */
   scrollMargin?: MaybeAllValuesShorthandProperty<SizeUnits>;
 }
+/**
+ * An overflow behavior keyword.
+ */
 export type OverflowKeyword = 'auto' | 'hidden';
+/**
+ * Properties for scrollable container elements with overflow control and scroll event detection.
+ */
 export interface ScrollBoxProps
   extends GlobalProps,
     ScrollEventProps,
     Omit<BaseBoxPropsWithRole, 'overflow'> {
   /**
-   * Sets the overflow behavior of the element.
-   *
-   * - `hidden`: clips the content when it is larger than the element’s container and the element will not be scrollable in that axis.
-   * - `auto`: clips the content when it is larger than the element’s container and make it scrollable in that axis.
-   *
-   * 1-to-2-value syntax is supported but note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
-   * - 2 values: `block inline`
+   * Sets overflow behavior when content exceeds container dimensions. Use `'auto'` for scrolling or `'hidden'` to clip content.
    *
    * @default 'auto'
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/overflow
+   * Learn more about [CSS overflow on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow).
    */
   overflow?: OverflowKeyword | `${OverflowKeyword} ${OverflowKeyword}`;
 }
+/**
+ * Properties for search input fields with text validation and autocomplete support.
+ */
 export interface SearchFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
     MinMaxLengthProps,
     AutocompleteProps<SearchAutocompleteField> {}
+/**
+ * Autocomplete field types applicable to search input fields (same as text fields).
+ */
 export type SearchAutocompleteField = TextAutocompleteField;
+/**
+ * Properties for content sections with optional heading and actions.
+ */
 export interface SectionProps extends GlobalProps, ActionSlots {
   /**
-   * The content of the Section.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * A label used to describe the section that will be announced by assistive technologies.
-   *
-   * When no `heading` property is provided or included as a children of the Section, you **must** provide an
-   * `accessibilityLabel` to describe the Section. This is important as it allows assistive technologies to provide
-   * the right context to users.
+   * A label that describes the purpose or contents of the element. Announced to users with assistive technologies such as screen readers to provide context.
    */
   accessibilityLabel?: string;
   /**
-   * A title that describes the content of the section.
+   * A title that describes the content of the section. If omitted and no secondary actions are provided, the section will be rendered without a header.
    */
   heading?: string;
   /**
-   * Adjust the padding of all edges.
-   *
-   * - `base`: applies padding that is appropriate for the element. Note that it may result in no padding if
-   * this is the right design decision in a particular context.
-   * - `none`: removes all padding from the element. This can be useful when elements inside the Section need to span
-   * to the edge of the Section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base'
-   * to bring back the desired padding for the rest of the content.
+   * The padding applied to all edges of the section content.
    *
    * @default 'base'
    */
   padding?: 'base' | 'none';
 }
+/**
+ * Properties for flexible layout containers with directional flow and alignment control.
+ */
 export interface StackProps
   extends GlobalProps,
     BaseBoxPropsWithRole,
     GapProps {
   /**
-   * The content of the Stack.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Sets how the children are placed within the Stack. This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
+   * The direction in which children are laid out using logical properties:
+   * - `'block'`: Vertical arrangement along the block axis (typically top to bottom) without wrapping
+   * - `'inline'`: Horizontal arrangement along the inline axis (typically left to right) with automatic wrapping when space is insufficient
    *
    * @default 'block'
    *
@@ -2738,27 +2624,30 @@ export interface StackProps
    */
   direction?: MaybeResponsive<'block' | 'inline'>;
   /**
-   * Aligns the Stack along the main axis.
+   * Controls the distribution and alignment of children along the main axis (the axis defined by the `direction` property).
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
+   * Learn more about [`justify-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
    * @default 'normal'
    */
   justifyContent?: MaybeResponsive<JustifyContentKeyword>;
   /**
-   * Aligns the Stack's children along the cross axis.
+   * Controls the alignment of individual children along the cross axis (perpendicular to the main axis).
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
+   * Learn more about [`align-items` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
    * @default 'normal'
    */
   alignItems?: MaybeResponsive<AlignItemsKeyword>;
   /**
-   * Aligns the Stack along the cross axis.
+   * Controls the distribution of space between and around lines of wrapped content along the cross axis.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
+   * Learn more about [`align-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
    * @default 'normal'
    */
   alignContent?: MaybeResponsive<AlignContentKeyword>;
 }
+/**
+ * Properties for inline text elements with semantic meaning and styling options.
+ */
 export interface TextProps
   extends GlobalProps,
     AccessibilityVisibilityProps,
@@ -2766,13 +2655,11 @@ export interface TextProps
     DisplayProps,
     Pick<InteractionProps, 'interestFor'> {
   /**
-   * The content of the Text.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Provide semantic meaning and default styling to the text.
-   *
-   * Other presentation properties on Text override the default styling.
+   * The semantic meaning of the text, which may affect its default styling and how screen readers announce it. Other presentation properties can override the default styling.
    *
    * @default 'generic'
    */
@@ -2780,7 +2667,7 @@ export interface TextProps
 }
 export type TextType =
   /**
-   * Indicate the text is contact information. Typically used for addresses.
+   * Indicates that the text is contact information. Typically used for addresses.
    *
    * This must have `inline` layout (despite the default being `block` in HTML hosts).
    *
@@ -2790,215 +2677,180 @@ export type TextType =
    *
    * @implementation vertical alignment should be `baseline` (`vertical-align: baseline`)
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
+   * Learn more about the [`address` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address).
    */
   | 'address'
   /**
-   * Indicate the text is no longer accurate or no longer relevant. One such use-case is discounted prices.
+   * Indicates that the text is no longer accurate or no longer relevant. One such use-case is discounted prices.
    *
    * Surfaces should apply styling to this type to suggest its content no longer applies.
    *
    * In an HTML host, the text will be rendered in a `<s>` element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
+   * Learn more about the [`s` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s).
    */
   | 'redundant'
   /**
-   * Indicate the text is marked or highlighted and relevant to the user’s current action.
+   * Indicates that the text is marked or highlighted and relevant to the user's current action.
    * One such use-case is to indicate the characters that matched a search query.
    *
    * Surfaces should apply styling to this type to draw attention to the content.
    *
    * In an HTML host, the text will be rendered in a `<mark>` element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
+   * Learn more about [mark element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark).
    */
   | 'mark'
   /**
-   * Indicate emphatic stress. Typically for words that have a stressed emphasis compared to surrounding text.
+   * Indicates emphatic stress. Typically for words that have a stressed emphasis compared to surrounding text.
    *
    * Surfaces should apply styling to this type to distinguish it from surrounding text. Italicization is a common choice, but not required.
    *
    * In an HTML host, the text will be rendered in an `<em>` element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
+   * Learn more about the [`em` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em).
    */
   | 'emphasis'
   /**
-   * Indicate an offset from the normal prose of the text. Typically used to indicate
+   * Indicates an offset from the normal prose of the text. Typically used to indicate
    * a foreign word, fictional character thoughts, or when the text refers to the definition of a word
    * instead of representing its semantic meaning.
    *
    * Surfaces should italicize this content by default.
    *
    * In an HTML host, the text will be rendered in a `<i>` tag.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
+   * Learn more about the [`i` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i).
    */
   | 'offset'
   /**
-   * Indicate strong importance, seriousness, or urgency.
+   * Indicates strong importance, seriousness, or urgency.
    *
    * Surfaces should render this content bold by default.
    *
    * In an HTML host, the text will be rendered in a `<strong>` tag.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
+   * Learn more about the [`s` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s).trong
    */
   | 'strong'
   /**
-   * Indicates the text is considered less important than the main content, but is still necessary for the reader to understand.
+   * Indicates that the text is considered less important than the main content, but is still necessary for the reader to understand.
    * It can be used for secondary content but also for disclaimers, terms and conditions, or legal information.
    *
    * Surfaces should apply a smaller font size than the default size.
    *
    * In an HTML host, the text will be rendered in a `<small>` element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
+   * Learn more about the [`s` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s).mall
    */
   | 'small'
   /**
-   * No additional semantics or styling is applied.
+   * Indicates that no additional semantics or styling is applied.
    *
    * Surfaces must not apply any default styling to this type.
    *
    * In an HTML host, the text will be rendered in a `<span>` tag.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
+   * Learn more about the [`s` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s).pan
    */
   | 'generic';
+/**
+ * Properties for multi-line text input areas with character length constraints and autocomplete support.
+ */
 export interface TextAreaProps
   extends GlobalProps,
     BaseTextFieldProps,
     MinMaxLengthProps,
     AutocompleteProps<TextAutocompleteField> {
   /**
-   * A number of visible text lines.
+   * The number of visible text lines that determines the initial height of the text area. Each row represents one line of text at the current font size. When users enter more content than fits in the specified rows, the text area becomes scrollable vertically, allowing access to overflow content. The text area doesn't auto-expand beyond this height. For example, `rows={3}` displays three lines of text at once. Use smaller values (2-3) for brief inputs like comments or notes, larger values (5-10) for substantial text entry like descriptions or feedback. This only sets initial height—users can resize the text area if the browser/surface allows it. The actual pixel height depends on font size and line height.
    *
    * @default 2
    */
   rows?: number;
 }
+/**
+ * Properties for single-line text input fields with decorations, constraints, and autocomplete support.
+ */
 export interface TextFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
     MinMaxLengthProps,
     AutocompleteProps<TextAutocompleteField>,
     FieldDecorationProps {}
+/**
+ * Properties for clickable tile elements with heading, subheading, and optional count indicator.
+ */
 export interface TileProps
   extends GlobalProps,
     Pick<BaseClickableProps, 'onClick' | 'disabled'> {
   /**
-   * A title that describes the content of the Tile.
+   * The primary text label displayed prominently in the tile.
    *
    * @default ''
    */
   heading?: string;
   /**
-   * Supporting text displayed below the heading.
+   * The secondary descriptive text displayed below the heading.
    *
    * @default ''
    */
   subheading?: string;
   /**
-   * A numeric indicator rendered within the Tile (for example, a count or a step number).
-   *
-   * - When provided, the indicator is displayed inside the tile.
-   * - Intended for small integers. It may clamp, truncate, or abbreviate larger values.
-   *
+   * A numeric value displayed as a counter or badge indicator. Used for showing quantities, notifications, or step numbers.
    */
   itemCount?: number;
   /**
-   * Sets the tone of the Tile, based on the intention of the information being conveyed.
+   * The semantic tone that affects the tile's color and styling to communicate meaning:
+   * - `'auto'`: Automatically determines the appropriate tone
+   * - `'neutral'`: Standard appearance for general content
+   * - `'accent'`: Emphasized appearance to draw attention
+   *
    * @default 'auto'
    */
   tone?: ExtractStrict<ToneKeyword, 'auto' | 'neutral' | 'accent'>;
 }
+/**
+ * Properties for an interactive time picker component with allow/disallow time ranges.
+ */
 export interface TimePickerProps
   extends GlobalProps,
     InputProps,
     FocusEventProps {
   /**
-   * Times that can be selected.
-   *
-   * A comma-separated list of allowed time ranges. Whitespace is allowed after commas.
-   *
-   * The default `''` allows all times.
-   *
-   * Each time range is in `HH:MM--HH:MM` format.
-   *
-   * The end of the range is exclusive, so `09:00--10:00` allows selecting `09:00` but not `10:00`.
-   *
-   * Either side of `--` can be omitted to create an unbounded range.
-   *
-   * Whitespace is allowed either side of `--`.
+   * Specifies allowed time values or ranges for selection. Uses 24-hour format (HH:mm or HH:mm:ss). Supports range syntax with `--` separator and comma-separated values.
    *
    * @default ''
    *
    * @example
-   * `09:00--10:00, 13:00--14:00` - assuming the step is 1 hour, this allows selecting `09:00` or `13:00`.
-   * `12:00--` - allows selecting `12:00` and all times after it.
+   * `09:00--10:00, 13:00--14:00` - allows selecting times within these ranges based on step value
+   * `12:00--` - allows selecting `12:00` and all times after it
    */
   allow?: string;
   /**
-   * Times that cannot be selected. This subtracts from `allow`.
-   *
-   * A comma-separated list of allowed time ranges. Whitespace is allowed after commas.
-   *
-   * The default `''` has no effect on `allow`.
-   *
-   * Each time range is in `HH:MM--HH:MM` format.
-   *
-   * The end of the range is exclusive, so `09:00--10:00` disallows selecting `09:00` but not `10:00`.
-   *
-   * Either side of `--` can be omitted to create an unbounded range.
-   *
-   * Whitespace is allowed either side of `--`.
+   * Specifies disallowed time values or ranges that can't be selected. Uses 24-hour format (HH:mm or HH:mm:ss). Supports range syntax with `--` separator and comma-separated values. Takes precedence over `allow`.
    *
    * @default ''
    *
    * @example
-   * `09:00--10:00, 13:00--14:00` - assuming the step is 1 hour, this disallows selecting `09:00` or `13:00`.
+   * `09:00--10:00, 13:00--14:00` - disallows selecting times within these ranges
    */
   disallow?: string;
   /**
-   * Default selected value.
-   *
-   * The default, `''`, means no time is selected.
-   *
-   * The value must be a 24-hour time in `HH:mm:ss` format, with leading zeros.
-   *
-   * Examples: `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`.
-   *
-   * This follows the HTML time input value format, which is always 24-hour with
-   * leading zeros regardless of UI presentation.
-   *
-   * See: https://developer.mozilla.org/docs/Web/HTML/Element/input/time
-   *
-   * If the provided value is invalid, '' is used as the value.
+   * The default time value used when the field is first rendered, in 24-hour format with leading zeros (HH:mm:ss format, for example, `"09:05:00"`). An empty string means no default time. Only applies if no `value` prop is provided.
    *
    * @default ''
    */
   defaultValue?: string;
   /**
-   * Current selected value.
-   *
-   * The default, `''`, means no time is selected.
-   *
-   * The value must be a 24-hour time in `HH:mm:ss` format, with leading zeros.
-   *
-   * Examples: `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`.
-   *
-   * This follows the HTML time input value format, which is always 24-hour with
-   * leading zeros regardless of UI presentation.
-   *
-   * See: https://developer.mozilla.org/docs/Web/HTML/Element/input/time
-   *
-   * If the provided value is invalid, '' is used as the value.
+   * The currently selected time value in 24-hour format with leading zeros (HH:mm:ss format, for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). An empty string means no time is selected. This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value).
    *
    * @default ''
    */
   value?: string;
   /**
-   * The step between selectable times, in seconds.
+   * The increment step between selectable time values, specified in seconds. For example, `60` for one-minute intervals or `3600` for one-hour intervals.
    *
    * @default 60
    */
   step?: number;
 }
+/**
+ * Properties for a text-based time input field with validation and time range constraints.
+ */
 export interface TimeFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
@@ -3007,49 +2859,15 @@ export interface TimeFieldProps
       'value' | 'defaultValue' | 'allow' | 'disallow' | 'step'
     > {
   /**
-   * Callback when the field has an invalid time.
-   * This callback will be called, if the time typed is invalid or disabled.
-   *
-   * Times that don’t exist or have formatting errors are considered invalid. Some examples of invalid times are:
-   * - 24:00
-   * - 12:60
-   *
-   * Disallowed times are considered invalid.
-   *
-   * It’s important to note that this callback will be called only when the user **finishes editing** the time,
-   * and it’s called right after the `onChange` callback.
-   * The field is **not** validated on every change to the input. Once the buyer has signalled that
-   * they have finished editing the field (typically, by blurring the field), the field gets validated and the callback is run if the value is invalid.
+   * A callback function executed when the user enters an invalid value. Fires after change validation fails.
    */
   onInvalid?: (event: Event) => void;
   /**
-   * Current selected value.
-   *
-   * The default, `''`, means no time is selected.
-   *
-   * The value must be a 24-hour time in `HH:mm:ss` format, with leading zeros.
-   *
-   * Examples: `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`.
-   *
-   * This follows the HTML time input value format, which is always 24-hour with
-   * leading zeros regardless of UI presentation.
-   *
-   * See: https://developer.mozilla.org/docs/Web/HTML/Element/input/time
+   * The currently selected time value in 24-hour format with leading zeros (HH:mm:ss format, for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). An empty string means no time is selected.
    */
   value?: string;
   /**
-   * Default selected value.
-   *
-   * The default, `''`, means no time is selected.
-   *
-   * The value must be a 24-hour time in `HH:mm:ss` format, with leading zeros.
-   *
-   * Examples: `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`.
-   *
-   * This follows the HTML time input value format, which is always 24-hour with
-   * leading zeros regardless of UI presentation.
-   *
-   * See: https://developer.mozilla.org/docs/Web/HTML/Element/input/time
+   * The default time value used when the field is first rendered, in 24-hour format with leading zeros (HH:mm:ss format, for example, `"09:05:00"`). An empty string means no default time. Only applies if no `value` prop is provided.
    */
   defaultValue?: string;
 }
@@ -3063,7 +2881,7 @@ export interface VNode<P = {}> {
   };
   key: Key;
   /**
-   * ref is not guaranteed by React.ReactElement, for compatibility reasons
+   * ref isn't guaranteed by React.ReactElement, for compatibility reasons
    * with popular react libs we define it as optional too
    */
   ref?: Ref<any> | null;
@@ -3159,9 +2977,9 @@ declare abstract class Component<P, S> {
   static displayName?: string;
   static defaultProps?: any;
   static contextType?: Context<any>;
-  // Static members cannot reference class type parameters. This is not
+  // Static members can't reference class type parameters. This isn't
   // supported in TypeScript. Reusing the same type arguments from `Component`
-  // will lead to an impossible state where one cannot satisfy the type
+  // will lead to an impossible state where one can't satisfy the type
   // constraint under no circumstances, see #1356.In general type arguments
   // seem to be a bit buggy and not supported well at the time of this
   // writing with TS 3.3.3333.
@@ -3213,7 +3031,7 @@ export interface Context<T> extends Provider<T> {
 
 type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * Used when an element doesn't have children.
  */
 interface BaseElementProps<TClass = HTMLElement> {
   key?: Key;
@@ -3245,25 +3063,22 @@ interface ButtonJSXProps
     'id' | 'disabled' | 'command' | 'commandFor' | 'loading'
   > {
   /**
-   * Sets the action the `commandFor` should take when this clickable is activated.
-   *
-   * See the documentation of particular components for the actions they support.
-   *
-   * - `--auto`: a default action for the target component.
-   * - `--show`: shows the target component.
-   * - `--hide`: hides the target component.
-   * - `--toggle`: toggles the target component.
+   * The action to perform on the target element specified by `commandFor`:
+   * - `'--auto'`: Execute the target's default action
+   * - `'--show'`: Display the target element
+   * - `'--hide'`: Hide the target element
+   * - `'--toggle'`: Switch the target's visibility state
    *
    * @default '--auto'
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command
+   * Learn more about [`command` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
    */
   command?: Extract<
     ButtonProps['command'],
     '--auto' | '--show' | '--hide' | '--toggle'
   >;
   /**
-   * Sets the tone of the Button, based on the intention of the information being conveyed.
+   * The semantic tone of the button, based on the intention of the action being performed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */
@@ -3272,17 +3087,19 @@ interface ButtonJSXProps
     'auto' | 'critical' | 'neutral' | 'warning' | 'caution'
   >;
   /**
-   * Changes the visual appearance of the Button.
+   * The visual appearance and prominence of the button:
+   * - `'primary'`: High visual emphasis for the most important action
+   * - `'secondary'`: Less prominent appearance for supporting actions
    *
-   * @default 'auto' - the variant is automatically determined by the Button's context
+   * @default 'auto' - the variant is automatically determined by context
    */
   variant?: Extract<ButtonProps['variant'], 'primary' | 'secondary'>;
   /**
-   * Called when the button is activated.
+   * A callback function executed when the element is clicked or activated.
    */
   onClick?: (event: CallbackEvent<typeof tagName$t>) => void;
   /**
-   * The content of the Button.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -3302,21 +3119,19 @@ declare module 'preact' {
 declare const tagName$s = 's-text';
 interface TextJSXProps extends Pick<TextProps, 'id'> {
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the text. Controls how prominent or subtle the text appears within the interface.
    *
    * @default 'base'
    */
   color?: Extract<TextProps['color'], 'base' | 'strong' | 'subdued'>;
   /**
-   * Provide semantic meaning and default styling to the text.
-   *
-   * Other presentation properties on Text override the default styling.
+   * The semantic meaning of the text, which may affect its default styling and how screen readers announce it. Other presentation properties can override the default styling.
    *
    * @default 'generic'
    */
   type?: Extract<TextProps['type'], 'generic' | 'strong' | 'small'>;
   /**
-   * Sets the tone of the component, based on the intention of the information being conveyed.
+   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */
@@ -3325,7 +3140,7 @@ interface TextJSXProps extends Pick<TextProps, 'id'> {
     'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'critical' | 'caution'
   >;
   /**
-   * The Text content. Supports nested text elements.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -3346,116 +3161,85 @@ type PaddingKeyword$2 = SizeKeyword | 'none';
 declare const tagName$r = 's-scroll-box';
 interface ScrollBoxJSXProps extends Pick<ScrollBoxProps, 'id'> {
   /**
-   * Adjust the block size.
+   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the inline size.
+   * The inline size (width in horizontal writing modes) of the element.
    *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the maximum block size.
+   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * Adjust the maximum inline size.
+   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * Adjust the minimum block size.
+   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * Adjust the minimum inline size.
+   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * Adjust the padding of all edges.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
-   *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
+   * The padding applied to all edges of the element.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword$2>;
   /**
-   * Adjust the block-padding.
-   *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
-   * This overrides the block value of `padding`.
+   * The block-axis padding for the element (typically vertical in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<PaddingKeyword$2> | '';
   /**
-   * Adjust the block-start padding.
-   *
-   * This overrides the block-start value of `paddingBlock`.
+   * The block-start padding for the element (typically top in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: PaddingKeyword$2 | '';
   /**
-   * Adjust the block-end padding.
-   *
-   * This overrides the block-end value of `paddingBlock`.
+   * The block-end padding for the element (typically bottom in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: PaddingKeyword$2 | '';
   /**
-   * Adjust the inline padding.
-   *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
-   * This overrides the inline value of `padding`.
+   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<PaddingKeyword$2> | '';
   /**
-   * Adjust the inline-start padding.
-   *
-   * This overrides the inline-start value of `paddingInline`.
+   * The inline-start padding for the element (typically left in LTR, right in RTL).
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: PaddingKeyword$2 | '';
   /**
-   * Adjust the inline-end padding.
-   *
-   * This overrides the inline-end value of `paddingInline`.
+   * The inline-end padding for the element (typically right in LTR, left in RTL).
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: PaddingKeyword$2 | '';
   /**
-   * The content of the ScrollBox.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -3479,13 +3263,13 @@ interface TileJSXProps
     'heading' | 'id' | 'itemCount' | 'tone' | 'subheading'
   > {
   /**
-   * Disables the Tile meaning it cannot be clicked or receive focus.
+   * Whether the field is disabled, preventing any user interaction.
    *
    * @default false
    */
   disabled?: TileProps['disabled'];
   /**
-   * Callback when the Tile is activated.
+   * A callback function executed when the element is clicked or activated.
    */
   onClick?: (event: CallbackEvent<typeof tagName$q>) => void;
 }
@@ -3505,13 +3289,13 @@ declare module 'preact' {
 declare const tagName$p = 's-banner';
 interface BannerJSXProps extends Pick<BannerProps, 'heading' | 'id'> {
   /**
-   * Determines whether the banner is hidden.
+   * Whether the banner is visible or hidden. When set to `true`, the banner will be hidden from view. Use this to programmatically show or hide banners based on application state.
    *
    * @default false
    */
   hidden?: BannerProps['hidden'];
   /**
-   * Sets the tone of the Banner, based on the intention of the information being conveyed.
+   * The semantic tone of the banner, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */
@@ -3520,11 +3304,11 @@ interface BannerJSXProps extends Pick<BannerProps, 'heading' | 'id'> {
     'auto' | 'success' | 'info' | 'warning' | 'critical'
   >;
   /**
-   * The action taken when the Banner is pressed.
+   * The primary action element displayed in the banner. Typically a button element.
    */
   primaryAction?: ComponentChild;
   /**
-   * The content of the Banner.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -3546,120 +3330,89 @@ declare const tagName$o = 's-box';
 type PaddingKeyword$1 = SizeKeyword | 'none';
 interface BoxJSXProps {
   /**
-   * A unique identifier for the element.
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
    */
   id?: string;
   /**
-   * Adjust the block size.
+   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the inline size.
+   * The inline size (width in horizontal writing modes) of the element.
    *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the maximum block size.
+   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * Adjust the maximum inline size.
+   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * Adjust the minimum block size.
+   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * Adjust the minimum inline size.
+   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * Adjust the padding of all edges.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
-   *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
+   * The padding applied to all edges of the element.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword$1>;
   /**
-   * Adjust the block-padding.
-   *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
-   * This overrides the block value of `padding`.
+   * The block-axis padding for the element (typically vertical in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<PaddingKeyword$1> | '';
   /**
-   * Adjust the block-start padding.
-   *
-   * This overrides the block-start value of `paddingBlock`.
+   * The block-start padding for the element (typically top in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: PaddingKeyword$1 | '';
   /**
-   * Adjust the block-end padding.
-   *
-   * This overrides the block-end value of `paddingBlock`.
+   * The block-end padding for the element (typically bottom in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: PaddingKeyword$1 | '';
   /**
-   * Adjust the inline padding.
-   *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
-   * This overrides the inline value of `padding`.
+   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<PaddingKeyword$1> | '';
   /**
-   * Adjust the inline-start padding.
-   *
-   * This overrides the inline-start value of `paddingInline`.
+   * The inline-start padding for the element (typically left in LTR, right in RTL).
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: PaddingKeyword$1 | '';
   /**
-   * Adjust the inline-end padding.
-   *
-   * This overrides the inline-end value of `paddingInline`.
+   * The inline-end padding for the element (typically right in LTR, left in RTL).
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: PaddingKeyword$1 | '';
   /**
-   * The content of the Box.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -3808,7 +3561,7 @@ type SupportedIconNames = Extract<
 interface IconJSXProps
   extends Pick<IconProps, 'id' | 'tone' | 'color' | 'size'> {
   /**
-   * The type of icon to display.
+   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type.
    *
    * @default ''
    */
@@ -3848,173 +3601,135 @@ type PickedProps = Pick<
 >;
 interface StackJSXProps extends PickedProps {
   /**
-   * Adjust the padding of all edges.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
-   *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
+   * The padding applied to all edges of the element.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the block-padding.
-   *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
-   * This overrides the block value of `padding`.
+   * The block-axis padding for the element (typically vertical in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<PaddingKeyword | ''>;
   /**
-   * Adjust the block-start padding.
-   *
-   * This overrides the block-start value of `paddingBlock`.
+   * The block-start padding for the element (typically top in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: PaddingKeyword | '';
   /**
-   * Adjust the block-end padding.
-   *
-   * This overrides the block-end value of `paddingBlock`.
+   * The block-end padding for the element (typically bottom in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: PaddingKeyword | '';
   /**
-   * Adjust the inline padding.
-   *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
-   * This overrides the inline value of `padding`.
+   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<PaddingKeyword | ''>;
   /**
-   * Adjust the inline-start padding.
-   *
-   * This overrides the inline-start value of `paddingInline`.
+   * The inline-start padding for the element (typically left in LTR, right in RTL).
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: PaddingKeyword | '';
   /**
-   * Adjust the inline-end padding.
-   *
-   * This overrides the inline-end value of `paddingInline`.
+   * The inline-end padding for the element (typically right in LTR, left in RTL).
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: PaddingKeyword | '';
   /**
-   * Adjust the block size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/block-size
+   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * Learn more about [`block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
    *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the maximum block size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size
+   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * Learn more about [`max-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * Adjust the maximum inline size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size
+   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * Learn more about [`max-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * Adjust the minimum block size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size
+   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * Learn more about [`min-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * Adjust the minimum inline size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size
+   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * Learn more about [`min-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * Aligns the Stack's children along the cross axis.
+   * Controls the alignment of individual children along the cross axis (perpendicular to the main axis).
    */
   alignItems?: AlignItemsKeyword;
   /**
-   * Aligns the Stack along the cross axis.
+   * Controls the distribution of space between and around lines of wrapped content along the cross axis.
    */
   alignContent?: AlignContentKeyword;
   /**
-   * Adjust spacing between elements.
-   * A single value applies to both axes. A pair of values (eg large-100 large-500) can be used to set the inline and block axes respectively.
+   * The spacing between elements. A single value applies to both axes. A pair of values (eg large-100 large-500) can be used to set the inline and block axes respectively.
    *
    * @default 'none'
    */
   gap?: MaybeTwoValuesShorthandProperty<SpacingKeyword>;
   /**
-   * Adjust spacing between elements in the inline axis. This overrides the column value of gap.
+   * The spacing between elements in the inline axis. This overrides the column value of gap.
    *
    * @default '' - meaning no override
    */
   columnGap?: SpacingKeyword | '';
   /**
-   * Sets how the children are placed within the Stack. This uses logical properties.
+   * The direction in which children are laid out using logical properties:
+   * - `'block'`: Vertical arrangement along the block axis (typically top to bottom) without wrapping
+   * - `'inline'`: Horizontal arrangement along the inline axis (typically left to right) with automatic wrapping when space is insufficient
    *
    * @default 'block'
    * @implementation - the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'
    */
   direction?: 'block' | 'inline';
   /**
-   * Adjust the inline size.
-   * @see — https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size
+   * The inline size (width in horizontal writing modes) of the element.
+   *
+   * Learn more about [`inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Aligns the Stack along the main axis.
-   * @see — https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
+   * Controls the distribution and alignment of children along the main axis (the axis defined by the `direction` property).
+   *
+   * Learn more about [`justify-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
    *
    * @default 'normal'
    */
   justifyContent?: JustifyContentKeyword;
   /**
-   * Adjust spacing between elements in the block axis. This overrides the row value of gap.
+   * The spacing between elements in the block axis. This overrides the row value of gap.
    *
    * @default '' - meaning no override
    */
   rowGap?: SpacingKeyword | '';
   /**
-   * The content of the Stack.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -4034,7 +3749,7 @@ declare module 'preact' {
 declare const tagName$l = 's-badge';
 interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
   /**
-   * Sets the tone of the Badge, based on the intention of the information being conveyed.
+   * The semantic tone of the badge, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */
@@ -4043,7 +3758,7 @@ interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
     'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'critical' | 'caution'
   >;
   /**
-   * The content of the Badge.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -4064,15 +3779,15 @@ declare const tagName$k = 's-choice-list';
 interface ChoiceListJSXProps
   extends Pick<ChoiceListProps, 'id' | 'values' | 'multiple'> {
   /**
-   * Callback when the user changes a choice. Fires simultaneously with onChange.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$k>) => void) | null;
   /**
-   * Callback when the user changes a choice. Fires simultaneously with onInput.
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$k>) => void) | null;
   /**
-   * The content of the ChoiceList. Should be one or more Choice elements.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -4110,15 +3825,15 @@ declare module 'preact' {
 declare const tagName$i = 's-modal';
 interface ModalJSXProps extends Pick<ModalProps, 'id' | 'heading'> {
   /**
-   * Callback when the modal is hidden.
+   * A callback function that is executed when the element begins to hide, before any hide animations.
    */
   onHide?: (event: CallbackEvent<typeof tagName$i>) => void | null;
   /**
-   * Callback when the modal is shown.
+   * A callback function that is executed when the element begins to appear, before any show animations.
    */
   onShow?: (event: CallbackEvent<typeof tagName$i>) => void | null;
   /**
-   * The primary action button displayed in the modal.
+   * The primary action button element displayed in the modal.
    *
    * The tone of the button is used to define the tone of the modal.
    *
@@ -4126,11 +3841,11 @@ interface ModalJSXProps extends Pick<ModalProps, 'id' | 'heading'> {
    */
   primaryAction?: ComponentChild;
   /**
-   * The secondary action buttons displayed in the modal.
+   * The secondary action button elements displayed in the modal.
    */
   secondaryActions?: ComponentChild;
   /**
-   * The content of the Modal.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -4163,23 +3878,23 @@ interface TextFieldJSXProps
     | 'maxLength'
   > {
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$h>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$h>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function executed when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$h>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function executed when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$h>) => void) | null;
   /**
-   * Additional content to be displayed in the field. Commonly used to display clickable text.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }
@@ -4201,19 +3916,19 @@ declare const tagName$g = 's-search-field';
 interface SearchFieldJSXProps
   extends Pick<SearchFieldProps, 'id' | 'disabled' | 'placeholder' | 'value'> {
   /**
-   * Callback when the user changes the value in the field.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$g>) => void) | null;
   /**
-   * Callback when the field loses focus after the user changes the value in the field.
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$g>) => void) | null;
   /**
-   * Callback when the field loses focus.
+   * A callback function executed when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$g>) => void) | null;
   /**
-   * Callback when the field is focused.
+   * A callback function executed when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$g>) => void) | null;
 }
@@ -4245,23 +3960,23 @@ interface EmailFieldJSXProps
     | 'details'
   > {
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$f>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$f>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function executed when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$f>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function executed when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$f>) => void) | null;
   /**
-   * Additional content to be displayed in the field. Commonly used to display clickable text.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }
@@ -4282,11 +3997,11 @@ declare module 'preact' {
 declare const tagName$e = 's-clickable';
 interface ClickableJSXProps extends Pick<ClickableProps, 'id' | 'disabled'> {
   /**
-   * Callback when the element is activated.
+   * A callback function executed when the element is clicked or activated.
    */
   onClick?: (event: CallbackEvent<typeof tagName$e>) => void;
   /**
-   * The content of the Clickable.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -4323,19 +4038,19 @@ interface TextAreaJSXProps
    */
   onInput?: ((event: CallbackEvent<typeof tagName$d>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$d>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function executed when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$d>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function executed when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$d>) => void) | null;
   /**
-   * Additional content to be displayed in the field. Commonly used to display clickable text.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }
@@ -4370,85 +4085,58 @@ interface NumberFieldJSXProps
     | 'controls'
   > {
   /**
-   * Content to use as the field label.
-   *
-   * Label is not supported when using Stepper controls
+   * The content to use as the field label that describes the time information being requested.
    */
   label?: NumberFieldProps['label'];
   /**
-   * Additional text to provide context or guidance for the field.
-   * This text is displayed along with the field and its label
-   * to offer more information or instructions to the user.
-   *
-   * This will also be exposed to screen reader users.
-   *
-   * Details are not supported when using Stepper controls
+   * The additional text to provide context or guidance for the field. This text is displayed along with the field and its label to offer more information or instructions to the user. This will also be exposed to screen reader users.
    */
   details?: NumberFieldProps['details'];
   /**
-   * Whether the field needs a value. This requirement adds semantic value
-   * to the field, but it will not cause an error to appear automatically.
-   * If you want to present an error when this field is empty, you can do
-   * so with the `error` property.
+   * Whether the field needs a value. This requirement adds semantic value to the field but doesn't cause an error to appear automatically. Use the `error` property to present validation errors.
    *
    * @default false
    *
-   * Required is not supported when using Stepper controls
+   * Required isn't supported when using Stepper controls
    */
   required?: NumberFieldProps['required'];
   /**
-   * Indicate an error to the user. The field will be given a specific stylistic treatment
-   * to communicate problems that have to be resolved immediately.
-   *
-   * Error is not supported when using Stepper controls
+   * An error message to indicate a problem to the user. The field will be given specific stylistic treatment to communicate issues that must be resolved immediately.
    */
   error?: NumberFieldProps['error'];
   /**
-   * Sets the virtual keyboard.
+   * The virtual keyboard layout that the field displays for numeric input. This property isn't supported when using `stepper` controls.
    *
-   * Input mode is not supported when using Stepper controls
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
+   * Learn more about [`inputmode` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
    * @default 'decimal'
    */
   inputMode?: NumberFieldProps['inputMode'];
   /**
-   * A short hint that describes the expected value of the field.
-   *
-   * Placeholder text is not supported when using Stepper controls due to constrained space for the number field, especially on phones.
+   * A short hint that provides guidance about the expected value of the field.
    */
   placeholder?: NumberFieldProps['placeholder'];
   /**
-   *  Additional content to be displayed in the field. Commonly used to display clickable text.
-   *
-   * > Note: Accessory is not supported when using Stepper controls
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
   /**
-   * Sets the type of controls displayed for the field.
-   *
-   * - `stepper`: displays buttons to increase or decrease the value of the field by the stepping interval defined in the `step` property. Note that in POS
-   *   adding stepper controls simplifies the behaviour of the Number Field itself. The field supports only integer values, is always-populated and automatically
-   *   validates the value to be within the min and max bounds. Validation, label, details and placeholder are not supported when using Stepper controls.
-   *
-   * - `none`: no controls are displayed and users must input the value manually.
-   * - `auto`: the presence of the controls depends on the surface and context.
+   * The type of controls displayed for the field:
    */
   controls?: NumberFieldProps['controls'];
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$c>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$c>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function executed when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$c>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function executed when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$c>) => void) | null;
 }
@@ -4473,19 +4161,19 @@ interface DateFieldJSXProps
     'id' | 'label' | 'details' | 'value' | 'disabled' | 'error'
   > {
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$b>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$b>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function executed when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$b>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function executed when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$b>) => void) | null;
 }
@@ -4506,19 +4194,19 @@ declare module 'preact' {
 declare const tagName$a = 's-date-picker';
 interface DatePickerJSXProps extends Pick<DatePickerProps, 'id' | 'value'> {
   /**
-   * Callback when the user selects a date from the picker.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: CallbackEvent<typeof tagName$a>) => void | null;
   /**
-   * Callback when the user selects a date from the picker that is different to the current value.
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: CallbackEvent<typeof tagName$a>) => void | null;
   /**
-   * Callback when the date picker is dismissed.
+   * A callback function executed when focus is removed from the element.
    */
   onBlur?: (event: CallbackEvent<typeof tagName$a>) => void | null;
   /**
-   * Callback when the date picker is revealed.
+   * A callback function executed when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: (event: CallbackEvent<typeof tagName$a>) => void | null;
 }
@@ -4538,19 +4226,19 @@ declare module 'preact' {
 declare const tagName$9 = 's-date-spinner';
 interface DateSpinnerJSXProps extends Pick<DateSpinnerProps, 'id' | 'value'> {
   /**
-   * Callback when the user makes a selection.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: CallbackEvent<typeof tagName$9>) => void | null;
   /**
-   * Callback when the value changes. Only called when a different value is selected.
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: CallbackEvent<typeof tagName$9>) => void | null;
   /**
-   * Callback when the date spinner is dismissed.
+   * A callback function executed when focus is removed from the element.
    */
   onBlur?: (event: CallbackEvent<typeof tagName$9>) => void | null;
   /**
-   * Callback when the date spinner is revealed.
+   * A callback function executed when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: (event: CallbackEvent<typeof tagName$9>) => void | null;
 }
@@ -4570,9 +4258,7 @@ declare module 'preact' {
 declare const tagName$8 = 's-section';
 interface SectionJSXProps extends Pick<SectionProps, 'id'> {
   /**
-   * A title that describes the content of the section.
-   *
-   * If omitted, and no secondaryActions are provided, the section will be rendered without a header.
+   * A title that describes the content of the section. If omitted and no secondary actions are provided, the section will be rendered without a header.
    */
   heading?: string;
   /**
@@ -4580,7 +4266,7 @@ interface SectionJSXProps extends Pick<SectionProps, 'id'> {
    */
   secondaryActions?: ComponentChild;
   /**
-   * The content of the Section.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -4601,7 +4287,7 @@ declare module 'preact' {
 declare const tagName$7 = 's-heading';
 interface HeadingJSXProps extends Pick<HeadingProps, 'id'> {
   /**
-   * The content of the Heading.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -4621,19 +4307,19 @@ declare module 'preact' {
 declare const tagName$6 = 's-time-picker';
 interface TimePickerJSXProps extends Pick<TimePickerProps, 'id' | 'value'> {
   /**
-   * Callback when the user selects a time from the picker.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: CallbackEvent<typeof tagName$6>) => void | null;
   /**
-   * Callback when the user selects a time from the picker that is different to the current value.
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: CallbackEvent<typeof tagName$6>) => void | null;
   /**
-   * Callback when the time picker is dismissed.
+   * A callback function executed when focus is removed from the element.
    */
   onBlur?: (event: CallbackEvent<typeof tagName$6>) => void | null;
   /**
-   * Callback when the time picker is revealed.
+   * A callback function executed when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: (event: CallbackEvent<typeof tagName$6>) => void | null;
 }
@@ -4653,26 +4339,17 @@ declare module 'preact' {
 declare const tagName$5 = 's-image';
 interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit'> {
   /**
-   * The displayed inline width of the image.
-   *
-   * - `fill`: the image will takes up 100% of the available inline size.
-   * - `auto`: the image will be displayed at its natural size.
-   *
-   * **Mobile surfaces:** Always wrap your image in a box with a set width and height.
-   * ScrollViews on mobile have a dynamic height, which can cause images to appear
-   * inconsistently without defined dimensions.
+   * The inline size (width in horizontal writing modes) of the element.
    *
    * @default 'fill'
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width
+   * Learn more about [`width` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
    */
   inlineSize?: ImageProps['inlineSize'];
   /**
-   * The image source, which should be a remote URL.
+   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are accessible and properly formatted.
    *
-   * When the image is loading or no `src` is provided, a placeholder will be rendered.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src
+   * Learn more about [`src` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
    */
   src?: ImageProps['src'];
 }
@@ -4692,13 +4369,13 @@ declare module 'preact' {
 declare const tagName$4 = 's-page';
 interface PageJSXProps extends Pick<PageProps, 'id'> {
   /**
-   * The main page heading, displayed in the action bar at the top of the page.
+   * A title that describes the content of the section. If omitted and no secondary actions are provided, the section will be rendered without a header.
    *
    * @default: ''
    */
   heading?: PageProps['heading'];
   /**
-   * A secondary page heading, displayed under the main heading in the action bar.
+   * A secondary page heading displayed under the main heading in the action bar.
    */
   subheading?: PageProps['subheading'];
   /**
@@ -4706,11 +4383,11 @@ interface PageJSXProps extends Pick<PageProps, 'id'> {
    */
   secondaryActions?: ComponentChild;
   /**
-   * Content to display in the page's sidebar.
+   * The content to display in the page's sidebar. This area is for content that is tangentially related to the main content, such as navigation or contextual information. Use the `slot="aside"` attribute to place content in this area.
    */
   aside?: ComponentChild;
   /**
-   * The content of the Page.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -4735,19 +4412,19 @@ interface TimeFieldJSXProps
     'id' | 'label' | 'disabled' | 'value' | 'error' | 'details'
   > {
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$3>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$3>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function executed when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$3>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function executed when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$3>) => void) | null;
 }
@@ -4771,7 +4448,7 @@ interface PosBlockJSXProps extends Pick<POSBlockProps, 'id' | 'heading'> {
    */
   secondaryActions?: ComponentChild;
   /**
-   * The content of the Block.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
@@ -4854,7 +4531,8 @@ export type {
 
 interface Badge {
   /**
-   * Sets the tone of the Badge, based on the intention of the information being conveyed.
+   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   *
    * @default 'auto'
    */
   tone?:
@@ -4865,7 +4543,9 @@ interface Badge {
     | 'caution'
     | 'warning'
     | 'critical';
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
 }
 
@@ -4876,424 +4556,470 @@ interface BannerSlots {
 
 interface Banner {
   /**
-   * Determines whether the banner is hidden.
+   * Whether the banner is visible or hidden. When set to `true`, the banner will be hidden from view. Use this to programmatically show or hide banners based on app state.
+   *
    * @default false
    */
   hidden?: boolean;
   /**
-   * Sets the tone of the Banner, based on the intention of the information being conveyed.
+   * The semantic tone of the banner, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   *
    * @default 'auto'
    */
   tone?: 'auto' | 'info' | 'success' | 'warning' | 'critical';
   /**
-   * The title of the banner.
+   * The title text displayed prominently at the top of the banner. Should be concise and clearly communicate the main message or purpose of the banner.
+   *
    * @default ''
    */
   heading?: string;
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
 }
 
 interface Box {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * Adjust the block size.
+   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the inline size.
+   * The inline size (width in horizontal writing modes) of the element.
+   *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the maximum block size.
+   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * Adjust the maximum inline size.
+   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * Adjust the minimum block size.
+   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * Adjust the minimum inline size.
+   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * Adjust the padding of all edges.
+   * The padding applied to all edges of the element.
    *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
-   *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the block-padding.
+   * The block-axis padding for the element (typically vertical in horizontal writing modes).
    *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
-   * This overrides the block value of `padding`.
    * @default '' - meaning no override
    */
   paddingBlock?: '' | MaybeTwoValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the block-start padding.
+   * The block-start padding for the element (typically top in horizontal writing modes).
    *
-   * This overrides the block-start value of `paddingBlock`.
    * @default '' - meaning no override
    */
   paddingBlockStart?: '' | PaddingKeyword;
   /**
-   * Adjust the block-end padding.
+   * The block-end padding for the element (typically bottom in horizontal writing modes).
    *
-   * This overrides the block-end value of `paddingBlock`.
    * @default '' - meaning no override
    */
   paddingBlockEnd?: '' | PaddingKeyword;
   /**
-   * Adjust the inline padding.
+   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
    *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
-   * This overrides the inline value of `padding`.
    * @default '' - meaning no override
    */
   paddingInline?: '' | MaybeTwoValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the inline-start padding.
+   * The inline-start padding for the element (typically left in LTR, right in RTL).
    *
-   * This overrides the inline-start value of `paddingInline`.
    * @default '' - meaning no override
    */
   paddingInlineStart?: '' | PaddingKeyword;
   /**
-   * Adjust the inline-end padding.
+   * The inline-end padding for the element (typically right in LTR, left in RTL).
    *
-   * This overrides the inline-end value of `paddingInline`.
    * @default '' - meaning no override
    */
   paddingInlineEnd?: '' | PaddingKeyword;
 }
 
 interface ButtonEvents {
-  /** Called when the button is activated. */
+  /**
+   * The callback when the element is activated.
+   */
   click?: (event: CallbackEvent<typeof tagName$t>) => void;
 }
 
 interface Button {
   /**
-   * Sets the action the `commandFor` should take when this clickable is activated.
+   * The action to perform on the target element specified by `commandFor`:
+   * - `'--auto'`: Execute the target's default action
+   * - `'--show'`: Display the target element
+   * - `'--hide'`: Hide the target element
+   * - `'--toggle'`: Switch the target's visibility state
    *
-   * See the documentation of particular components for the actions they support.
-   *
-   * - `--auto`: a default action for the target component.
-   * - `--show`: shows the target component.
-   * - `--hide`: hides the target component.
-   * - `--toggle`: toggles the target component.
    * @default '--auto'
-   * @see ://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command
+   * Learn more about [`command` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
    */
   command?: '--auto' | '--show' | '--hide' | '--toggle';
   /**
-   * Sets the tone of the Button, based on the intention of the information being conveyed.
+   * The semantic tone of the button, based on the intention of the action being performed. Affects color and styling to communicate meaning.
+   *
    * @default 'auto'
    */
   tone?: 'auto' | 'neutral' | 'caution' | 'warning' | 'critical';
   /**
-   * Changes the visual appearance of the Button.
-   * @default 'auto' - the variant is automatically determined by the Button's context
+   * The visual appearance and prominence of the button:
+   * - `'primary'`: High visual emphasis for the most important action
+   * - `'secondary'`: Less prominent appearance for supporting actions
+   *
+   * @default 'auto' - the variant is automatically determined by context
    */
   variant?: 'primary' | 'secondary';
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * Disables the Button meaning it cannot be clicked or receive focus.
+   * Whether the field is disabled, preventing any user interaction.
+   *
    * @default false
    */
   disabled?: boolean;
   /**
-   * ID of a component that should respond to activations (e.g. clicks) on this component.
-   *
-   * See `command` for how to control the behavior of the target.
-   * @see ://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor
+   * The ID of the target element that should respond to interactions (such as clicks) on this element. Used with `command` to control other components.
+   * Learn more about [`commandfor` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor).
    */
   commandFor?: string;
   /**
-   * Replaces content with a loading indicator while a background action is being performed.
+   * Indicates whether the button action is currently in progress. When `true`, typically displays a loading indicator and may disable interaction.
    *
-   * This also disables the Button.
    * @default false
    */
   loading?: boolean;
 }
 
 interface Choice {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
-  /** The value used in form data when the control is checked. */
+  /**
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   */
   value?: string;
   /**
-   * Disables the control, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction.
+   *
    * @default false
    */
   disabled?: boolean;
   /**
-   * Whether the control is active.
+   * Whether the choice control is currently active or selected.
+   *
    * @default false
    */
   selected?: boolean;
 }
 
 interface ChoiceListEvents {
-  /** Callback when the user changes a choice. Fires simultaneously with onChange. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$k>) => void;
-  /** Callback when the user changes a choice. Fires simultaneously with onInput. */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$k>) => void;
 }
 
 interface ChoiceList {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * An array of the `value`s of the selected options.
-   *
-   * This is a convenience prop for setting the `selected` prop on child options.
+   * An array of the values of the selected options. This is a convenience property for setting the selected state on child choice components.
    */
   values?: string[];
   /**
-   * Whether multiple choices can be selected.
+   * Whether multiple choices can be selected simultaneously.
+   *
    * @default false
    */
   multiple?: boolean;
 }
 
 interface ClickableEvents {
-  /** Callback when the element is activated. */
+  /**
+   * The callback when the element is activated.
+   */
   click?: (event: CallbackEvent<typeof tagName$e>) => void;
 }
 
 interface Clickable {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * Disables the clickable, meaning it cannot be clicked or receive focus.
-   *
-   * In this state, onClick will not fire.
-   * If the click event originates from a child element, the event will immediately stop propagating from this element.
-   *
-   * However, items within the clickable can still receive focus and be interacted with.
-   *
-   * This has no impact on the visual state by default,
-   * but developers are encouraged to style the clickable accordingly.
+   * Whether the field is disabled, preventing any user interaction.
    */
   disabled?: boolean;
 }
 
 interface DateFieldEvents {
-  /** Callback when the user makes any changes in the field. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$b>) => void;
-  /** Callback after editing completes (typically on blur). */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$b>) => void;
-  /** Callback when the element loses focus. */
+  /**
+   * A callback function executed when the element loses focus.
+   */
   blur?: (event: CallbackEvent<typeof tagName$b>) => void;
-  /** Callback when the element receives focus. */
+  /**
+   * A callback function executed when the element receives focus.
+   */
   focus?: (event: CallbackEvent<typeof tagName$b>) => void;
 }
 
 interface DateField {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
-  /** Content to use as the field label. */
+  /**
+   * The content to use as the field label that describes the time information being requested.
+   */
   label?: string;
   /**
-   * Additional text to provide context or guidance for the field.
-   * This text is displayed along with the field and its label
-   * to offer more information or instructions to the user.
-   *
-   * This will also be exposed to screen reader users.
+   * The additional text to provide context or guidance for the field. This text is displayed along with the field and its label to offer more information or instructions to the user. This will also be exposed to screen reader users.
    */
   details?: string;
-  /** The current value for the field. If omitted, the field will be empty. */
+  /**
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   */
   value?: string;
   /**
-   * Disables the field, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction.
+   *
    * @default false
    */
   disabled?: boolean;
   /**
-   * Indicate an error to the user. The field will be given a specific stylistic treatment
-   * to communicate problems that have to be resolved immediately.
+   * An error message to indicate a problem to the user. The field will be given specific stylistic treatment to communicate issues that must be resolved immediately.
    */
   error?: string;
 }
 
 interface DatePickerEvents {
-  /** Callback when the user selects a date from the picker. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$a>) => void | null;
-  /** Callback when the user selects a date from the picker that is different to the current value. */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$a>) => void | null;
-  /** Callback when the date picker is dismissed. */
+  /**
+   * A callback function executed when the element loses focus.
+   */
   blur?: (event: CallbackEvent<typeof tagName$a>) => void | null;
-  /** Callback when the date picker is revealed. */
+  /**
+   * A callback function executed when the element receives focus.
+   */
   focus?: (event: CallbackEvent<typeof tagName$a>) => void | null;
 }
 
 interface DatePicker {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * Current selected value.
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
    *
-   * The default means no date is selected.
-   *
-   * If the provided value is invalid, no date is selected.
-   *
-   * Otherwise:
-   *
-   * - If `type="single"`, this is a date in `YYYY-MM-DD` format.
-   * - If `type="multiple"`, this is a comma-separated list of dates in `YYYY-MM-DD` format.
-   * - If `type="range"`, this is a range in `YYYY-MM-DD--YYYY-MM-DD` format. The range is inclusive.
    * @default ""
    */
   value?: string;
 }
 
 interface DateSpinnerEvents {
-  /** Callback when the user makes a selection. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$9>) => void | null;
-  /** Callback when the value changes. Only called when a different value is selected. */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$9>) => void | null;
-  /** Callback when the date spinner is dismissed. */
+  /**
+   * A callback function executed when the element loses focus.
+   */
   blur?: (event: CallbackEvent<typeof tagName$9>) => void | null;
-  /** Callback when the date spinner is revealed. */
+  /**
+   * A callback function executed when the element receives focus.
+   */
   focus?: (event: CallbackEvent<typeof tagName$9>) => void | null;
 }
 
 interface DateSpinner {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * Current selected value for the spinner.
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
    *
-   * This uses a date in `YYYY-MM-DD` format.
    * @default ""
    */
   value?: string;
 }
 
 interface Divider {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * Specify the direction of the divider. This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
+   * The direction in which children are laid out using logical properties:
+   * - `'block'`: Vertical arrangement along the block axis (typically top to bottom) without wrapping
+   * - `'inline'`: Horizontal arrangement along the inline axis (typically left to right) with automatic wrapping when space is insufficient
+   *
    * @default 'inline'
    */
   direction?: 'inline' | 'block';
 }
 
 interface EmailFieldEvents {
-  /** Callback when the user makes any changes in the field. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$f>) => void;
-  /** Callback after editing completes (typically on blur). */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$f>) => void;
-  /** Callback when the element loses focus. */
+  /**
+   * A callback function executed when the element loses focus.
+   */
   blur?: (event: CallbackEvent<typeof tagName$f>) => void;
-  /** Callback when the element receives focus. */
+  /**
+   * A callback function executed when the element receives focus.
+   */
   focus?: (event: CallbackEvent<typeof tagName$f>) => void;
 }
 
 interface EmailFieldSlots {
-  /** Additional content to be displayed in the field. Commonly used to display clickable text. */
+  /**
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   */
   accessory?: HTMLElement;
 }
 
 interface EmailField {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
-  /** Content to use as the field label. */
+  /**
+   * The content to use as the field label that describes the time information being requested.
+   */
   label?: string;
-  /** The current value for the field. If omitted, the field will be empty. */
+  /**
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   */
   value?: string;
-  /** A short hint that describes the expected value of the field. */
+  /**
+   * A short hint that provides guidance about the expected value of the field.
+   */
   placeholder?: string;
   /**
-   * Disables the field, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction.
+   *
    * @default false
    */
   disabled?: boolean;
   /**
-   * Indicate an error to the user. The field will be given a specific stylistic treatment
-   * to communicate problems that have to be resolved immediately.
+   * An error message to indicate a problem to the user. The field will be given specific stylistic treatment to communicate issues that must be resolved immediately.
    */
   error?: string;
   /**
-   * Whether the field needs a value. This requirement adds semantic value
-   * to the field, but it will not cause an error to appear automatically.
-   * If you want to present an error when this field is empty, you can do
-   * so with the `error` property.
+   * Whether the field needs a value. This requirement adds semantic value to the field but doesn't cause an error to appear automatically. Use the `error` property to present validation errors.
+   *
    * @default false
    */
   required?: boolean;
   /**
-   * Specifies the maximum number of characters allowed.
+   * The maximum number of characters allowed in the text field.
+   *
    * @default Infinity
    */
   maxLength?: number;
   /**
-   * Additional text to provide context or guidance for the field.
-   * This text is displayed along with the field and its label
-   * to offer more information or instructions to the user.
-   *
-   * This will also be exposed to screen reader users.
+   * The additional text to provide context or guidance for the field. This text is displayed along with the field and its label to offer more information or instructions to the user. This will also be exposed to screen reader users.
    */
   details?: string;
 }
 
 interface Heading {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
 }
 
 interface Icon {
   /**
-   * The type of icon to display.
+   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type.
+   *
    * @default ''
    */
   type?: SupportedIconNames;
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * Sets the tone of the icon, based on the intention of the information being conveyed.
+   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the text. Controls how prominent or subtle the text appears within the interface.
+   *
    * @default 'base'
    */
   color?: ColorKeyword;
   /**
-   * Adjusts the size of the icon.
+   * Adjusts the size of the icon. Available sizes range from `'small-500'` (smallest) through `'base'` (default) to `'large-500'` (largest), allowing you to match icon size to your interface hierarchy.
+   *
    * @default 'base'
    */
   size?: SizeKeyword;
@@ -5301,40 +5027,39 @@ interface Icon {
 
 interface Image {
   /**
-   * The displayed inline width of the image.
+   * The inline size (width in horizontal writing modes) of the element.
    *
-   * - `fill`: the image will takes up 100% of the available inline size.
-   * - `auto`: the image will be displayed at its natural size.
-   *
-   * **Mobile surfaces:** Always wrap your image in a box with a set width and height.
-   * ScrollViews on mobile have a dynamic height, which can cause images to appear
-   * inconsistently without defined dimensions.
    * @default 'fill'
-   * @see ://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width
+   * Learn more about [`width` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
    */
   inlineSize?: 'fill' | 'auto';
   /**
-   * The image source, which should be a remote URL.
+   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are accessible and properly formatted.
    *
-   * When the image is loading or no `src` is provided, a placeholder will be rendered.
-   * @see ://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src
+   * Learn more about [`src` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
    */
   src?: string;
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * Determines how the content of the image is resized to fit its container.
-   * The image is positioned in the center of the container.
+   * Controls how the image content is resized within its container.
+   *
    * @default 'contain'
-   * @see ://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
+   * Learn more about [`object-fit` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).
    */
   objectFit?: 'contain' | 'cover';
 }
 
 interface ModalEvents {
-  /** Callback when the modal is hidden. */
+  /**
+   * The callback when the modal is hidden. Use this event to perform cleanup tasks, update application state, or trigger other actions when the modal is dismissed or closed.
+   */
   hide?: (event: CallbackEvent<typeof tagName$i>) => void | null;
-  /** Callback when the modal is shown. */
+  /**
+   * The callback when the modal is shown. Use this event to initialize modal content, focus specific elements, or perform setup tasks when the modal becomes visible.
+   */
   show?: (event: CallbackEvent<typeof tagName$i>) => void | null;
 }
 
@@ -5352,115 +5077,101 @@ interface ModalSlots {
 }
 
 interface Modal {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
-  /** A title that describes the content of the Modal. */
+  /**
+   * A title that describes the content of the section. If omitted and no secondary actions are provided, the section will be rendered without a header.
+   */
   heading?: string;
 }
 
 interface NumberFieldEvents {
-  /** Callback when the user makes any changes in the field. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$c>) => void;
-  /** Callback after editing completes (typically on blur). */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$c>) => void;
-  /** Callback when the element loses focus. */
+  /**
+   * A callback function executed when the element loses focus.
+   */
   blur?: (event: CallbackEvent<typeof tagName$c>) => void;
-  /** Callback when the element receives focus. */
+  /**
+   * A callback function executed when the element receives focus.
+   */
   focus?: (event: CallbackEvent<typeof tagName$c>) => void;
 }
 
 interface NumberFieldSlots {
   /**
-   * Additional content to be displayed in the field. Commonly used to display clickable text.
-   *
-   * > Note: Accessory is not supported when using Stepper controls
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: HTMLElement;
 }
 
 interface NumberField {
   /**
-   * Content to use as the field label.
-   *
-   * Label is not supported when using Stepper controls
+   * The content to use as the field label that describes the time information being requested.
    */
   label?: string;
   /**
-   * Additional text to provide context or guidance for the field.
-   * This text is displayed along with the field and its label
-   * to offer more information or instructions to the user.
-   *
-   * This will also be exposed to screen reader users.
-   *
-   * Details are not supported when using Stepper controls
+   * The additional text to provide context or guidance for the field. This text is displayed along with the field and its label to offer more information or instructions to the user. This will also be exposed to screen reader users.
    */
   details?: string;
   /**
-   * Whether the field needs a value. This requirement adds semantic value
-   * to the field, but it will not cause an error to appear automatically.
-   * If you want to present an error when this field is empty, you can do
-   * so with the `error` property.
+   * Whether the field needs a value. This requirement adds semantic value to the field but doesn't cause an error to appear automatically. Use the `error` property to present validation errors.
+   *
    * @default false
    *
-   * Required is not supported when using Stepper controls
+   * Required isn't supported when using Stepper controls
    */
   required?: boolean;
   /**
-   * Indicate an error to the user. The field will be given a specific stylistic treatment
-   * to communicate problems that have to be resolved immediately.
-   *
-   * Error is not supported when using Stepper controls
+   * An error message to indicate a problem to the user. The field will be given specific stylistic treatment to communicate issues that must be resolved immediately.
    */
   error?: string;
   /**
-   * Sets the virtual keyboard.
+   * The virtual keyboard layout that the field displays for numeric input. This property isn't supported when using `stepper` controls.
    *
-   * Input mode is not supported when using Stepper controls
-   * @see ://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
+   * Learn more about [`inputmode` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
    * @default 'decimal'
    */
   inputMode?: 'decimal' | 'numeric';
   /**
-   * A short hint that describes the expected value of the field.
-   *
-   * Placeholder text is not supported when using Stepper controls due to constrained space for the number field, especially on phones.
+   * A short hint that provides guidance about the expected value of the field.
    */
   placeholder?: string;
   /**
-   * Sets the type of controls displayed for the field.
-   *
-   * - `stepper`: displays buttons to increase or decrease the value of the field by the stepping interval defined in the `step` property. Note that in POS
-   *   adding stepper controls simplifies the behaviour of the Number Field itself. The field supports only integer values, is always-populated and automatically
-   *   validates the value to be within the min and max bounds. Validation, label, details and placeholder are not supported when using Stepper controls.
-   *
-   * - `none`: no controls are displayed and users must input the value manually.
-   * - `auto`: the presence of the controls depends on the surface and context.
+   * The type of controls displayed for the field:
    */
   controls?: 'auto' | 'stepper' | 'none';
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
-  /** The current value for the field. If omitted, the field will be empty. */
+  /**
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   */
   value?: string;
   /**
-   * Disables the field, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction.
+   *
    * @default false
    */
   disabled?: boolean;
   /**
-   * The highest decimal or integer to be accepted for the field.
-   * When used with `step` the value will round down to the max number.
+   * The highest decimal or integer value that the field accepts. When used with `stepper` controls, the value rounds down to the max number. Users can still input higher numbers by keyboard—validation should be implemented.
    *
-   * Note: a user will still be able to use the keyboard to input a number higher than
-   * the max. It is up to the developer to add appropriate validation.
    * @default Infinity
    */
   max?: number;
   /**
-   * The lowest decimal or integer to be accepted for the field.
-   * When used with `step` the value will round up to the min number.
+   * The lowest decimal or integer value that the field accepts. When used with `stepper` controls, the value rounds up to the min number. Users can still input lower numbers by keyboard—validation should be implemented.
    *
-   * Note: a user will still be able to use the keyboard to input a number lower than
-   * the min. It is up to the developer to add appropriate validation.
    * @default -Infinity
    */
   min?: number;
@@ -5469,19 +5180,26 @@ interface NumberField {
 interface PageSlots {
   /** Button element to display in the action bar. Only a single button is supported. */
   'secondary-actions'?: HTMLElement;
-  /** Content to display in the page's sidebar. */
+  /**
+   * The content to display in the page's sidebar. This area is for content that is tangentially related to the main content, such as navigation or contextual information. Use the `slot="aside"` attribute to place content in this area.
+   */
   aside?: HTMLElement;
 }
 
 interface Page {
   /**
-   * The main page heading, displayed in the action bar at the top of the page.
+   * A title that describes the content of the section. If omitted and no secondary actions are provided, the section will be rendered without a header.
+   *
    * @default : ''
    */
   heading?: string;
-  /** A secondary page heading, displayed under the main heading in the action bar. */
+  /**
+   * A secondary page heading displayed under the main heading in the action bar.
+   */
   subheading?: string;
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
 }
 
@@ -5491,150 +5209,149 @@ interface PosBlockSlots {
 }
 
 interface PosBlock {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * The heading to display within the POSBlock.
-   *
-   * If not provided, the description of the extension will be used when a heading is appropriate.
+   * A title that describes the content of the section. If omitted and no secondary actions are provided, the section will be rendered without a header.
    */
   heading?: string;
 }
 
 interface QrCode {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * The content to be encoded in the QR code, which can be any string such as a URL, email address, plain text, etc.
-   * Specific string formatting can trigger actions on the user's device when scanned, like opening geolocation
-   * coordinates on a map, opening a preferred app or app store entry, preparing an email, text message, and more.
+   * The content to be encoded in the QR code. This can be any string such as a URL, email address, plain text, or other data. Specific string formatting can trigger actions on the user's device when scanned, like opening geolocation coordinates on a map, opening a preferred app or app store entry, preparing an email, text message, and more.
    */
   content?: string;
 }
 
 interface ScrollBox {
   /**
-   * Adjust the block size.
+   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the inline size.
+   * The inline size (width in horizontal writing modes) of the element.
+   *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the maximum block size.
+   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * Adjust the maximum inline size.
+   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * Adjust the minimum block size.
+   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * Adjust the minimum inline size.
+   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * Adjust the padding of all edges.
+   * The padding applied to all edges of the element.
    *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
-   *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the block-padding.
+   * The block-axis padding for the element (typically vertical in horizontal writing modes).
    *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
-   * This overrides the block value of `padding`.
    * @default '' - meaning no override
    */
   paddingBlock?: '' | MaybeTwoValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the block-start padding.
+   * The block-start padding for the element (typically top in horizontal writing modes).
    *
-   * This overrides the block-start value of `paddingBlock`.
    * @default '' - meaning no override
    */
   paddingBlockStart?: '' | PaddingKeyword;
   /**
-   * Adjust the block-end padding.
+   * The block-end padding for the element (typically bottom in horizontal writing modes).
    *
-   * This overrides the block-end value of `paddingBlock`.
    * @default '' - meaning no override
    */
   paddingBlockEnd?: '' | PaddingKeyword;
   /**
-   * Adjust the inline padding.
+   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
    *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
-   * This overrides the inline value of `padding`.
    * @default '' - meaning no override
    */
   paddingInline?: '' | MaybeTwoValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the inline-start padding.
+   * The inline-start padding for the element (typically left in LTR, right in RTL).
    *
-   * This overrides the inline-start value of `paddingInline`.
    * @default '' - meaning no override
    */
   paddingInlineStart?: '' | PaddingKeyword;
   /**
-   * Adjust the inline-end padding.
+   * The inline-end padding for the element (typically right in LTR, left in RTL).
    *
-   * This overrides the inline-end value of `paddingInline`.
    * @default '' - meaning no override
    */
   paddingInlineEnd?: '' | PaddingKeyword;
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
 }
 
 interface SearchFieldEvents {
-  /** Callback when the user changes the value in the field. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$g>) => void;
-  /** Callback when the field loses focus after the user changes the value in the field. */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$g>) => void;
-  /** Callback when the field loses focus. */
+  /**
+   * A callback function executed when the element loses focus.
+   */
   blur?: (event: CallbackEvent<typeof tagName$g>) => void;
-  /** Callback when the field is focused. */
+  /**
+   * A callback function executed when the element receives focus.
+   */
   focus?: (event: CallbackEvent<typeof tagName$g>) => void;
 }
 
 interface SearchField {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * Disables the field, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction.
+   *
    * @default false
    */
   disabled?: boolean;
-  /** A short hint that describes the expected value of the field. */
+  /**
+   * A short hint that provides guidance about the expected value of the field.
+   */
   placeholder?: string;
-  /** The current value for the field. If omitted, the field will be empty. */
+  /**
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   */
   value?: string;
 }
 
@@ -5645,174 +5362,164 @@ interface SectionSlots {
 
 interface Section {
   /**
-   * A title that describes the content of the section.
-   *
-   * If omitted, and no secondaryActions are provided, the section will be rendered without a header.
+   * A title that describes the content of the section. If omitted and no secondary actions are provided, the section will be rendered without a header.
    */
   heading?: string;
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
 }
 
 interface Stack {
   /**
-   * Adjust the padding of all edges.
+   * The padding applied to all edges of the element.
    *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
-   *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the block-padding.
+   * The block-axis padding for the element (typically vertical in horizontal writing modes).
    *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
-   * This overrides the block value of `padding`.
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<'' | PaddingKeyword>;
   /**
-   * Adjust the block-start padding.
+   * The block-start padding for the element (typically top in horizontal writing modes).
    *
-   * This overrides the block-start value of `paddingBlock`.
    * @default '' - meaning no override
    */
   paddingBlockStart?: '' | PaddingKeyword;
   /**
-   * Adjust the block-end padding.
+   * The block-end padding for the element (typically bottom in horizontal writing modes).
    *
-   * This overrides the block-end value of `paddingBlock`.
    * @default '' - meaning no override
    */
   paddingBlockEnd?: '' | PaddingKeyword;
   /**
-   * Adjust the inline padding.
+   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
    *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
-   * This overrides the inline value of `padding`.
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<'' | PaddingKeyword>;
   /**
-   * Adjust the inline-start padding.
+   * The inline-start padding for the element (typically left in LTR, right in RTL).
    *
-   * This overrides the inline-start value of `paddingInline`.
    * @default '' - meaning no override
    */
   paddingInlineStart?: '' | PaddingKeyword;
   /**
-   * Adjust the inline-end padding.
+   * The inline-end padding for the element (typically right in LTR, left in RTL).
    *
-   * This overrides the inline-end value of `paddingInline`.
    * @default '' - meaning no override
    */
   paddingInlineEnd?: '' | PaddingKeyword;
   /**
-   * Adjust the block size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
-   * @see ://developer.mozilla.org/en-US/docs/Web/CSS/block-size
+   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
+   * Learn more about [`block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the maximum block size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
-   * @see ://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size
+   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
+   * Learn more about [`max-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * Adjust the maximum inline size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
-   * @see ://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size
+   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
+   * Learn more about [`max-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * Adjust the minimum block size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
-   * @see ://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size
+   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
+   * Learn more about [min-block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * Adjust the minimum inline size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
-   * @see ://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size
+   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   *
+   * Learn more about [min-inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    * @default '0'
    */
   minInlineSize?: SizeUnits;
-  /** Aligns the Stack's children along the cross axis. */
+  /**
+   * Controls the alignment of individual children along the cross axis (perpendicular to the main axis).
+   */
   alignItems?: AlignItemsKeyword;
-  /** Aligns the Stack along the cross axis. */
+  /**
+   * Controls the distribution of space between and around lines of wrapped content along the cross axis.
+   */
   alignContent?: AlignContentKeyword;
   /**
-   * Adjust spacing between elements.
-   * A single value applies to both axes. A pair of values (eg large-100 large-500) can be used to set the inline and block axes respectively.
+   * The spacing between elements. A single value applies to both axes. A pair of values (eg large-100 large-500) can be used to set the inline and block axes respectively.
+   *
    * @default 'none'
    */
   gap?: MaybeTwoValuesShorthandProperty<SpacingKeyword>;
   /**
-   * Adjust spacing between elements in the inline axis. This overrides the column value of gap.
+   * The spacing between elements in the inline axis. This overrides the column value of gap.
+   *
    * @default '' - meaning no override
    */
   columnGap?: '' | SpacingKeyword;
   /**
-   * Sets how the children are placed within the Stack. This uses logical properties.
+   * The direction in which children are laid out using logical properties:
+   * - `'block'`: Vertical arrangement along the block axis (typically top to bottom) without wrapping
+   * - `'inline'`: Horizontal arrangement along the inline axis (typically left to right) with automatic wrapping when space is insufficient
+   *
    * @default 'block'
    * @implementation - the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'
    */
   direction?: 'block' | 'inline';
   /**
-   * Adjust the inline size.
-   * @see — https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size
+   * The inline size (width in horizontal writing modes) of the element.
+   *
+   * Learn more about [`inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Aligns the Stack along the main axis.
-   * @see — https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
+   * Controls the distribution and alignment of children along the main axis (the axis defined by the `direction` property).
+   *
+   * Learn more about [`justify-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
    * @default 'normal'
    */
   justifyContent?: JustifyContentKeyword;
   /**
-   * Adjust spacing between elements in the block axis. This overrides the row value of gap.
+   * The spacing between elements in the block axis. This overrides the row value of gap.
+   *
    * @default '' - meaning no override
    */
   rowGap?: '' | SpacingKeyword;
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
 }
 
 interface Text {
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the text. Controls how prominent or subtle the text appears within the interface.
+   *
    * @default 'base'
    */
   color?: ColorKeyword;
   /**
-   * Provide semantic meaning and default styling to the text.
+   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type.
    *
-   * Other presentation properties on Text override the default styling.
    * @default 'generic'
    */
   type?: 'strong' | 'small' | 'generic';
   /**
-   * Sets the tone of the component, based on the intention of the information being conveyed.
+   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   *
    * @default 'auto'
    */
   tone?:
@@ -5823,248 +5530,277 @@ interface Text {
     | 'caution'
     | 'warning'
     | 'critical';
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
 }
 
 interface TextAreaEvents {
-  /** Callback when the user makes any changes in the field. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$d>) => void;
-  /** Callback after editing completes (typically on blur). */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$d>) => void;
-  /** Callback when the element loses focus. */
+  /**
+   * A callback function executed when the element loses focus.
+   */
   blur?: (event: CallbackEvent<typeof tagName$d>) => void;
-  /** Callback when the element receives focus. */
+  /**
+   * A callback function executed when the element receives focus.
+   */
   focus?: (event: CallbackEvent<typeof tagName$d>) => void;
 }
 
 interface TextAreaSlots {
-  /** Additional content to be displayed in the field. Commonly used to display clickable text. */
+  /**
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   */
   accessory?: HTMLElement;
 }
 
 interface TextArea {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
-  /** Content to use as the field label. */
+  /**
+   * The content to use as the field label that describes the time information being requested.
+   */
   label?: string;
   /**
-   * Additional text to provide context or guidance for the field.
-   * This text is displayed along with the field and its label
-   * to offer more information or instructions to the user.
-   *
-   * This will also be exposed to screen reader users.
+   * The additional text to provide context or guidance for the field. This text is displayed along with the field and its label to offer more information or instructions to the user. This will also be exposed to screen reader users.
    */
   details?: string;
-  /** The current value for the field. If omitted, the field will be empty. */
+  /**
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   */
   value?: string;
-  /** A short hint that describes the expected value of the field. */
+  /**
+   * A short hint that provides guidance about the expected value of the field.
+   */
   placeholder?: string;
   /**
-   * Disables the field, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction.
+   *
    * @default false
    */
   disabled?: boolean;
   /**
-   * Indicate an error to the user. The field will be given a specific stylistic treatment
-   * to communicate problems that have to be resolved immediately.
+   * An error message to indicate a problem to the user. The field will be given specific stylistic treatment to communicate issues that must be resolved immediately.
    */
   error?: string;
   /**
-   * Whether the field needs a value. This requirement adds semantic value
-   * to the field, but it will not cause an error to appear automatically.
-   * If you want to present an error when this field is empty, you can do
-   * so with the `error` property.
+   * Whether the field needs a value. This requirement adds semantic value to the field but doesn't cause an error to appear automatically. Use the `error` property to present validation errors.
+   *
    * @default false
    */
   required?: boolean;
   /**
-   * Specifies the maximum number of characters allowed.
+   * The maximum number of characters allowed in the text field.
+   *
    * @default Infinity
    */
   maxLength?: number;
   /**
-   * A number of visible text lines.
+   * The number of visible text lines that determines the initial height of the text area.
+   *
    * @default 2
    */
   rows?: number;
 }
 
 interface TextFieldEvents {
-  /** Callback when the user makes any changes in the field. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$h>) => void;
-  /** Callback after editing completes (typically on blur). */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$h>) => void;
-  /** Callback when the element loses focus. */
+  /**
+   * A callback function executed when the element loses focus.
+   */
   blur?: (event: CallbackEvent<typeof tagName$h>) => void;
-  /** Callback when the element receives focus. */
+  /**
+   * A callback function executed when the element receives focus.
+   */
   focus?: (event: CallbackEvent<typeof tagName$h>) => void;
 }
 
 interface TextFieldSlots {
-  /** Additional content to be displayed in the field. Commonly used to display clickable text. */
+  /**
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   */
   accessory?: HTMLElement;
 }
 
 interface TextField {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
-  /** Content to use as the field label. */
+  /**
+   * The content to use as the field label that describes the time information being requested.
+   */
   label?: string;
   /**
-   * Additional text to provide context or guidance for the field.
-   * This text is displayed along with the field and its label
-   * to offer more information or instructions to the user.
-   *
-   * This will also be exposed to screen reader users.
+   * The additional text to provide context or guidance for the field. This text is displayed along with the field and its label to offer more information or instructions to the user. This will also be exposed to screen reader users.
    */
   details?: string;
-  /** The current value for the field. If omitted, the field will be empty. */
+  /**
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   */
   value?: string;
-  /** A short hint that describes the expected value of the field. */
+  /**
+   * A short hint that provides guidance about the expected value of the field.
+   */
   placeholder?: string;
   /**
-   * Disables the field, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction.
+   *
    * @default false
    */
   disabled?: boolean;
   /**
-   * Indicate an error to the user. The field will be given a specific stylistic treatment
-   * to communicate problems that have to be resolved immediately.
+   * An error message to indicate a problem to the user. The field will be given specific stylistic treatment to communicate issues that must be resolved immediately.
    */
   error?: string;
   /**
-   * Whether the field needs a value. This requirement adds semantic value
-   * to the field, but it will not cause an error to appear automatically.
-   * If you want to present an error when this field is empty, you can do
-   * so with the `error` property.
+   * Whether the field needs a value. This requirement adds semantic value to the field but doesn't cause an error to appear automatically. Use the `error` property to present validation errors.
+   *
    * @default false
    */
   required?: boolean;
   /**
-   * Specifies the maximum number of characters allowed.
+   * The maximum number of characters allowed in the text field.
+   *
    * @default Infinity
    */
   maxLength?: number;
 }
 
 interface TileEvents {
-  /** Callback when the Tile is activated. */
+  /**
+   * The callback when the element is activated.
+   */
   click?: (event: CallbackEvent<typeof tagName$q>) => void;
 }
 
 interface Tile {
   /**
-   * Disables the Tile meaning it cannot be clicked or receive focus.
+   * Whether the field is disabled, preventing any user interaction.
+   *
    * @default false
    */
   disabled?: boolean;
   /**
-   * A title that describes the content of the Tile.
+   * A title that describes the content of the section. If omitted and no secondary actions are provided, the section will be rendered without a header.
+   *
    * @default ''
    */
   heading?: string;
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * A numeric indicator rendered within the Tile (for example, a count or a step number).
-   *
-   * - When provided, the indicator is displayed inside the tile.
-   * - Intended for small integers. It may clamp, truncate, or abbreviate larger values.
+   * A numeric value displayed as a counter or badge. Used for showing quantities, notifications, or step numbers.
    */
   itemCount?: number;
   /**
-   * Sets the tone of the Tile, based on the intention of the information being conveyed.
+   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   *
    * @default 'auto'
    */
   tone?: ExtractStrict<ToneKeyword, 'auto' | 'neutral' | 'accent'>;
   /**
-   * Supporting text displayed below the heading.
+   * A secondary page heading displayed under the main heading in the action bar.
+   *
    * @default ''
    */
   subheading?: string;
 }
 
 interface TimeFieldEvents {
-  /** Callback when the user makes any changes in the field. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$3>) => void;
-  /** Callback after editing completes (typically on blur). */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$3>) => void;
-  /** Callback when the element loses focus. */
+  /**
+   * A callback function executed when the element loses focus.
+   */
   blur?: (event: CallbackEvent<typeof tagName$3>) => void;
-  /** Callback when the element receives focus. */
+  /**
+   * A callback function executed when the element receives focus.
+   */
   focus?: (event: CallbackEvent<typeof tagName$3>) => void;
 }
 
 interface TimeField {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
-  /** Content to use as the field label. */
+  /**
+   * The content to use as the field label that describes the time information being requested.
+   */
   label?: string;
   /**
-   * Disables the field, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction.
+   *
    * @default false
    */
   disabled?: boolean;
   /**
-   * Current selected value.
-   *
-   * The default, `''`, means no time is selected.
-   *
-   * The value must be a 24-hour time in `HH:mm:ss` format, with leading zeros.
-   *
-   * Examples: `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`.
-   *
-   * This follows the HTML time input value format, which is always 24-hour with
-   * leading zeros regardless of UI presentation.
-   *
-   * See: https://developer.mozilla.org/docs/Web/HTML/Element/input/time
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
    */
   value?: string;
   /**
-   * Indicate an error to the user. The field will be given a specific stylistic treatment
-   * to communicate problems that have to be resolved immediately.
+   * An error message to indicate a problem to the user. The field will be given specific stylistic treatment to communicate issues that must be resolved immediately.
    */
   error?: string;
   /**
-   * Additional text to provide context or guidance for the field.
-   * This text is displayed along with the field and its label
-   * to offer more information or instructions to the user.
-   *
-   * This will also be exposed to screen reader users.
+   * The additional text to provide context or guidance for the field. This text is displayed along with the field and its label to offer more information or instructions to the user. This will also be exposed to screen reader users.
    */
   details?: string;
 }
 
 interface TimePickerEvents {
-  /** Callback when the user selects a time from the picker. */
+  /**
+   * A callback function executed when the user makes any changes in the field.
+   */
   input?: (event: CallbackEvent<typeof tagName$6>) => void | null;
-  /** Callback when the user selects a time from the picker that is different to the current value. */
+  /**
+   * A callback function executed after editing completes, typically on blur.
+   */
   change?: (event: CallbackEvent<typeof tagName$6>) => void | null;
-  /** Callback when the time picker is dismissed. */
+  /**
+   * A callback function executed when the element loses focus.
+   */
   blur?: (event: CallbackEvent<typeof tagName$6>) => void | null;
-  /** Callback when the time picker is revealed. */
+  /**
+   * A callback function executed when the element receives focus.
+   */
   focus?: (event: CallbackEvent<typeof tagName$6>) => void | null;
 }
 
 interface TimePicker {
-  /** A unique identifier for the element. */
+  /**
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   */
   id?: string;
   /**
-   * Current selected value.
+   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
    *
-   * The default, `''`, means no time is selected.
-   *
-   * The value must be a 24-hour time in `HH:mm:ss` format, with leading zeros.
-   *
-   * Examples: `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`.
-   *
-   * This follows the HTML time input value format, which is always 24-hour with
-   * leading zeros regardless of UI presentation.
-   *
-   * See: https://developer.mozilla.org/docs/Web/HTML/Element/input/time
-   *
-   * If the provided value is invalid, '' is used as the value.
    * @default ''
    */
   value?: string;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
@@ -105,7 +105,7 @@ export interface FocusEventProps {
   onFocus?: (event: FocusEvent) => void;
 }
 /**
- * A size scale keyword ranging from smallest (`'small-500'`) to largest (`'large-500'`).
+ * Defines the available size options for icons using a semantic scale. Provides granular control over icon dimensions from compact inline sizes to prominent display sizes.
  */
 export type SizeKeyword =
   | 'small-500'
@@ -122,7 +122,7 @@ export type SizeKeyword =
   | 'large-400'
   | 'large-500';
 /**
- * A color intensity keyword from subtle (`'subdued'`) to prominent (`'strong'`).
+ * Defines the available color intensity options for icons. Controls the visual prominence and contrast of icon elements within the interface.
  */
 export type ColorKeyword = 'subdued' | 'base' | 'strong';
 /**
@@ -141,12 +141,7 @@ export interface BackgroundProps {
   background?: BackgroundColorKeyword;
 }
 /**
- * A property for defining the color treatment and semantic meaning of a component.
- *
- * A tone can apply a grouping of colors to a component. For example,
- * critical may have a specific text color and background color.
- *
- * In some cases, like for Banner, the tone may also affect the semantic and accessibility treatment of the component.
+ * Defines the semantic tone options for icons. Controls the color and visual emphasis based on the information type and importance being communicated.
  *
  * @default 'auto'
  */
@@ -718,7 +713,7 @@ export type IconType = (typeof privateIconArray)[number];
  */
 export type ExtractStrict<T, U extends T> = Extract<T, U>;
 /**
- * A utility type for properties that support 1-to-4-value shorthand syntax.
+ * A utility type for properties that support [1-to-4-value shorthand syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box).
  */
 export type MaybeAllValuesShorthandProperty<T extends string> =
   | T
@@ -726,7 +721,7 @@ export type MaybeAllValuesShorthandProperty<T extends string> =
   | `${T} ${T} ${T}`
   | `${T} ${T} ${T} ${T}`;
 /**
- * A utility type for properties that support 1-to-2-value shorthand syntax.
+ * Defines a shorthand property that accepts either a single value or two space-separated values for directional properties like padding and spacing.
  */
 export type MaybeTwoValuesShorthandProperty<T extends string> = T | `${T} ${T}`;
 /**
@@ -854,7 +849,7 @@ export interface DisplayProps {
 /**
  * Properties for defining the semantic role of an element for assistive technologies.
  */
-export interface AccessibilityRoleProps{
+export interface AccessibilityRoleProps {
   /**
    * Sets the semantic role for assistive technologies. Helps screen reader users navigate and understand page structure.
    *
@@ -1011,7 +1006,7 @@ export interface LabelAccessibilityVisibilityProps {
   >;
 }
 /**
- * A padding size keyword including the option for no padding.
+ * Defines the available padding size options using a semantic scale. Provides consistent spacing values that align with the POS design system.
  */
 export type PaddingKeyword = SizeKeyword | 'none';
 /**
@@ -1019,17 +1014,18 @@ export type PaddingKeyword = SizeKeyword | 'none';
  */
 export interface PaddingProps {
   /**
-   * The padding applied to all edges of the element. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   * The padding applied to all edges of the container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
-   * - 1 value: all edges
    *
    * For example:
-   * - `large` applies `large` padding to all edges.
-   * - `large none` applies `large` to block edges and `none` to inline edges.
-   * - `large none large` applies `large` to block-start, `none` to inline edges, `large` to block-end.
-   * - `large none large small` applies different padding to each edge in order.
+   *
+   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
+   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
+   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
+   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
    *
    * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
@@ -1037,7 +1033,7 @@ export interface PaddingProps {
    */
   padding?: MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>;
   /**
-   * The block-axis padding for the element (typically vertical in horizontal writing modes). Supports two-value syntax where `large none` sets block-start to `large` and block-end to `none`. Overrides the block axis values from the `padding` property.
+   * The block-axis padding for the container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
@@ -1045,19 +1041,19 @@ export interface PaddingProps {
     MaybeTwoValuesShorthandProperty<PaddingKeyword> | ''
   >;
   /**
-   * The block-start padding for the element (typically top in horizontal writing modes). Overrides the block-start value from the `paddingBlock` property.
+   * The block-start padding for the container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * The block-end padding for the element (typically bottom in horizontal writing modes). Overrides the block-end value from the `paddingBlock` property.
+   * The block-end padding for the container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * The inline-axis padding for the element (typically horizontal in horizontal writing modes). Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline axis values from the `padding` property.
+   * The inline-axis padding for the container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
@@ -1065,28 +1061,28 @@ export interface PaddingProps {
     MaybeTwoValuesShorthandProperty<PaddingKeyword> | ''
   >;
   /**
-   * The inline-start padding for the element (typically left in LTR, right in RTL). Overrides the inline-start value from the `paddingInline` property.
+   * The inline-start padding for the container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * The inline-end padding for the element (typically right in LTR, left in RTL). Overrides the inline-end value from the `paddingInline` property.
+   * The inline-end padding for the container. Overrides the inline-end value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: MaybeResponsive<PaddingKeyword | ''>;
 }
 /**
- * A size value in pixels, percentage, or zero.
+ * Defines exact size measurements without automatic or unconstrained options. Limited to specific pixel values, percentages, or zero.
  */
 export type SizeUnits = `${number}px` | `${number}%` | `0`;
 /**
- * A size value with automatic sizing option.
+ * Defines size values that can be specified as exact measurements or automatic sizing. Supports pixel values, percentages, zero, or automatic sizing based on content.
  */
 export type SizeUnitsOrAuto = SizeUnits | 'auto';
 /**
- * A size value with no constraint option.
+ * Defines size values that can be specified as exact measurements or no constraint. Supports pixel values, percentages, zero, or no maximum limit.
  */
 export type SizeUnitsOrNone = SizeUnits | 'none';
 /**
@@ -1094,43 +1090,37 @@ export type SizeUnitsOrNone = SizeUnits | 'none';
  */
 export interface SizingProps {
   /**
-   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
-   * Learn more about [`block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
+   * The block size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   blockSize?: MaybeResponsive<SizeUnitsOrAuto>;
   /**
-   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
-   * Learn more about [`min-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
+   * The minimum block size constraint for the container.
    *
    * @default '0'
    */
   minBlockSize?: MaybeResponsive<SizeUnits>;
   /**
-   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
-   * Learn more about [`max-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
+   * The maximum block size constraint for the container.
    *
    * @default 'none'
    */
   maxBlockSize?: MaybeResponsive<SizeUnitsOrNone>;
   /**
-   * The inline size (width in horizontal writing modes) of the element.
-   * Learn more about [`inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
+   * The inline size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   inlineSize?: MaybeResponsive<SizeUnitsOrAuto>;
   /**
-   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
-   * Learn more about [`min-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
+   * The minimum inline size constraint for the container.
    *
    * @default '0'
    */
   minInlineSize?: MaybeResponsive<SizeUnits>;
   /**
-   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
-   * Learn more about [`max-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
+   * The maximum inline size constraint for the container.
    *
    * @default 'none'
    */
@@ -1561,9 +1551,10 @@ export interface NumberConstraintsProps {
   step?: number;
   /**
    * The type of controls displayed for the field:
-   * - `'auto'`: An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
-   * - `'stepper'`: Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
-   * - `'none'`: A control type with no visible controls where users must input the value manually using the keyboard.
+   *
+   * - `'auto'` - An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
+   * - `'stepper'` - Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
+   * - `'none'` - A control type with no visible controls where users must input the value manually using the keyboard.
    *
    * @default 'auto'
    */
@@ -2021,7 +2012,7 @@ export interface DateSpinnerProps
 export interface DividerProps extends GlobalProps {
   /**
    * The direction of the divider using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values). An inline divider runs horizontally across the content flow, while a block divider runs vertically along the content flow.
-   * 
+   *
    * Available options:
    * - `'inline'`: A horizontal divider that runs perpendicular to the text direction, creating separation between vertically stacked content sections.
    * - `'block'`: A vertical divider that runs parallel to the text direction, creating separation between horizontally arranged content sections.
@@ -2221,13 +2212,13 @@ export interface IconProps
   extends GlobalProps,
     Pick<InteractionProps, 'interestFor'> {
   /**
-   * The semantic tone of the icon, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Sets the tone of the icon, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * The color intensity of the icon. Controls how prominent or subtle the icon appears within the interface.
+   * Modify the color to be more or less intense. Use `'subdued'` for secondary icons, `'base'` for standard visibility, or `'strong'` for emphasized icons that need to stand out.
    *
    * @default 'base'
    */
@@ -2239,7 +2230,7 @@ export interface IconProps
    */
   size?: SizeKeyword;
   /**
-   * The icon identifier specifying which icon to display. Accepts any valid icon name from the icon set.
+   * The type of icon to display.
    */
   type?: IconType | AnyString;
 }
@@ -2261,12 +2252,7 @@ export interface BaseImageProps {
    */
   sizes?: string;
   /**
-   * The primary image source URL. Accepts absolute URLs (`https://example.com/image.jpg`), relative paths (`/images/product.jpg`), or data URLs (`data:image/png;base64,...`). When the image is loading or if `src` is omitted/invalid, a placeholder is displayed while reserving the image's space to prevent layout shifts. The URL must be accessible (proper [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) headers for cross-origin images), use appropriate protocols ([HTTPS](https://en.wikipedia.org/wiki/HTTPS) for security), and point to valid image formats (JPEG, PNG, GIF, WebP, SVG). Failed loads trigger the `onError` callback if provided. For responsive images serving different sizes/resolutions, `srcSet` can be used in addition to `src` (which then serves as the fallback). Images are loaded asynchronously—the `loading` property controls when loading begins.
-   *
-   * @implementation Surfaces may choose the style of the placeholder, but the space the image occupies should be
-   * reserved, except in cases where the image area doesn't have a contextual inline or block size, which should be rare.
-   *
-   * Learn more about [img src on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
+   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are properly formatted and properly formatted.
    */
   src?: string;
   /**
@@ -2294,12 +2280,11 @@ export interface ImageProps extends GlobalProps, BaseImageProps, BorderProps {
     | ExtractStrict<AccessibilityRole, 'presentation' | 'none'>;
   /**
    * Controls the displayed width of the image. Choose based on your layout requirements. For mobile interfaces, consider using `'fill'` with defined container dimensions to ensure consistent image display, as dynamic container heights can cause layout inconsistencies in scrollable views.
-   * - `'auto'`: Displays the image at its natural size. The image won't render until it has loaded, and the aspect ratio will be ignored. Use for images where maintaining original dimensions is important.
-   * - `'fill'`: Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Use for responsive layouts and flexible image containers.
+   *
+   * - `'auto'` - Displays the image at its natural size. The image will not render until it has loaded, and the aspect ratio will be ignored. Use for images where maintaining original dimensions is important.
+   * - `'fill'` - Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Use for responsive layouts and flexible image containers.
    *
    * @default 'fill'
-   *
-   * Learn more about [`width` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
    */
   inlineSize?: 'fill' | 'auto';
   /**
@@ -2314,20 +2299,17 @@ export interface ImageProps extends GlobalProps, BaseImageProps, BorderProps {
    * If the value is set as `0.5`, the getter returns `0.5 / 1`.
    *
    * @default '1/1'
-   *
-   * Learn more about [`aspect-ratio` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).
    */
   aspectRatio?:
     | `${number}${optionalSpace}/${optionalSpace}${number}`
     | `${number}`;
   /**
-   * Controls how the image content is resized within its container:
-   * - `'contain'`: Scales the image to fit within the container while maintaining aspect ratio. The entire image will be visible, but there may be empty space. Use when showing the complete image is important.
-   * - `'cover'`: Scales the image to fill the entire container while maintaining aspect ratio. Parts of the image may be cropped. Use when filling the container completely is more important than showing the entire image.
+   * Controls how the image content is resized within its container.
+   *
+   * - `'contain'` - Scales the image to fit within the container while maintaining aspect ratio. The entire image will be visible, but there may be empty space. Use when showing the complete image is important.
+   * - `'cover'` - Scales the image to fill the entire container while maintaining aspect ratio. Parts of the image may be cropped. Use when filling the container completely is more important than showing the entire image.
    *
    * @default 'contain'
-   *
-   * Learn more about [`object-fit` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).
    */
   objectFit?: 'contain' | 'cover';
   /**
@@ -2399,13 +2381,11 @@ export interface NumberFieldProps
     NumberConstraintsProps,
     FieldDecorationProps {
   /**
-   * The virtual keyboard layout displayed for numeric input on touch-enabled devices like tablets and smartphones. This property has no effect on desktop devices with physical keyboards. Not supported when using `stepper` controls.
-   * - `'decimal'`: Shows a numeric keyboard with a decimal point/comma key. Best for monetary amounts (for example, "$19.99"), measurements with precision (for example, "2.5 kg"), percentages (for example, "15.5%"), or any fractional values. The decimal separator adapts to the user's locale (period in US, comma in Europe).
-   * - `'numeric'`: Shows a numeric keyboard without decimal point, displaying only digits 0-9 and sometimes +/- symbols. Best for quantities (for example, "5 items"), whole number identifiers (for example, "Order #12345"), phone numbers, or any integer-only input. Prevents accidental decimal entry which can confuse users for whole number fields.
-   * 
-   * On mobile POS devices, choosing the correct inputMode significantly improves data entry speed and reduces errors by showing the most relevant keyboard. Users can still switch keyboards manually if needed.
+   * The virtual keyboard layout that the field displays for numeric input. This property isn't supported when using `stepper` controls.
    *
-   * Learn more about [`inputmode` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
+   * - `'decimal'` - A keyboard layout that includes decimal point support for entering fractional numbers, prices, or measurements with decimal precision.
+   * - `'numeric'` - A keyboard layout optimized for integer-only entry without decimal point support, ideal for quantities, counts, or whole number values.
+   *
    * @default 'decimal'
    */
   inputMode?: 'decimal' | 'numeric';
@@ -2794,10 +2774,7 @@ export interface TileProps
    */
   itemCount?: number;
   /**
-   * The semantic tone that affects the tile's color and styling to communicate meaning:
-   * - `'auto'`: Automatically determines the appropriate tone
-   * - `'neutral'`: Standard appearance for general content
-   * - `'accent'`: Emphasized appearance to draw attention
+   * Sets the visual tone of the tile based on the intention of the information being conveyed. Use `'accent'` to highlight important or primary actions, `'neutral'` for standard actions, or `'auto'` (default) to let the system determine the appropriate tone based on context.
    *
    * @default 'auto'
    */
@@ -3046,13 +3023,37 @@ interface BaseElementPropsWithChildren<TClass = HTMLElement>
   children?: ComponentChildren;
 }
 type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * Additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -3069,16 +3070,23 @@ interface ButtonJSXProps
    * - `'--hide'`: Hide the target element
    * - `'--toggle'`: Switch the target's visibility state
    *
+   * Learn more about [`command` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
+   *
    * @default '--auto'
    *
-   * Learn more about [`command` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
    */
   command?: Extract<
     ButtonProps['command'],
     '--auto' | '--show' | '--hide' | '--toggle'
   >;
   /**
-   * The semantic tone of the button, based on the intention of the action being performed. Affects color and styling to communicate meaning.
+   * Sets the tone of the button, based on the intention of the information being conveyed.
+   *
+   * - `'auto'` - Automatically determines the appropriate tone based on context.
+   * - `'neutral'` - The standard tone for general actions and interactions.
+   * - `'caution'` - Indicates actions that require careful consideration.
+   * - `'warning'` - Alerts users to potential issues or important information.
+   * - `'critical'` - Used for destructive actions like deleting or removing content.
    *
    * @default 'auto'
    */
@@ -3125,13 +3133,25 @@ interface TextJSXProps extends Pick<TextProps, 'id'> {
    */
   color?: Extract<TextProps['color'], 'base' | 'strong' | 'subdued'>;
   /**
-   * The semantic meaning of the text, which may affect its default styling and how screen readers announce it. Other presentation properties can override the default styling.
+   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type. Available options:
+   *
+   * - `'generic'` - The default text type for general content without specific semantic meaning or emphasis.
+   * - `'strong'` - A text type that provides emphasis and importance, typically rendered with increased font weight or visual prominence.
+   * - `'small'` - A text type for secondary or supplementary content, typically rendered with reduced size for captions, fine print, or less important information.
    *
    * @default 'generic'
    */
   type?: Extract<TextProps['type'], 'generic' | 'strong' | 'small'>;
   /**
-   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Determines the visual appearance and semantic meaning of the text. Available options:
+   *
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context. Use when you want the system to determine the most appropriate styling.
+   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis. Use for general status updates and standard information.
+   * - `'info'` - Blue styling for informational content and neutral updates. Use for informational content that provides helpful context.
+   * - `'success'` - Green styling for positive states, completed actions, and successful operations. Use for positive outcomes and successful processes.
+   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent. Use for potential issues that require awareness.
+   * - `'warning'` - Orange styling for important notices that require merchant awareness. Use for situations that need attention but aren't critical.
+   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action. Use for urgent issues that need immediate merchant attention.
    *
    * @default 'auto'
    */
@@ -3161,79 +3181,92 @@ type PaddingKeyword$2 = SizeKeyword | 'none';
 declare const tagName$r = 's-scroll-box';
 interface ScrollBoxJSXProps extends Pick<ScrollBoxProps, 'id'> {
   /**
-   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The block size of the scrollable container. Auto automatically sizes based on the container's content and available space.
    *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * The inline size (width in horizontal writing modes) of the element.
+   * The inline size of the scrollable container. Auto automatically sizes based on the container's content and available space.
    *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum block size constraint for the scrollable container.
    *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum inline size constraint for the scrollable container.
    *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum block size constraint for the scrollable container.
    *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum inline size constraint for the scrollable container.
    *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * The padding applied to all edges of the element.
+   * The padding applied to all edges of the scrollable container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
+   * - 4 values: `block-start inline-end block-end inline-start`
+   * - 3 values: `block-start inline block-end`
+   * - 2 values: `block inline`
+   *
+   * For example:
+   *
+   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
+   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
+   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
+   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   *
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword$2>;
   /**
-   * The block-axis padding for the element (typically vertical in horizontal writing modes).
+   * The block-axis padding for the scrollable container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<PaddingKeyword$2> | '';
   /**
-   * The block-start padding for the element (typically top in horizontal writing modes).
+   * The block-start padding for the scrollable container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: PaddingKeyword$2 | '';
   /**
-   * The block-end padding for the element (typically bottom in horizontal writing modes).
+   * The block-end padding for the scrollable container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: PaddingKeyword$2 | '';
   /**
-   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
+   * The inline-axis padding for the scrollable container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<PaddingKeyword$2> | '';
   /**
-   * The inline-start padding for the element (typically left in LTR, right in RTL).
+   * The inline-start padding for the scrollable container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: PaddingKeyword$2 | '';
   /**
-   * The inline-end padding for the element (typically right in LTR, left in RTL).
+   * The inline-end padding for the scrollable container. Overrides the inline-end value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
@@ -3295,7 +3328,13 @@ interface BannerJSXProps extends Pick<BannerProps, 'heading' | 'id'> {
    */
   hidden?: BannerProps['hidden'];
   /**
-   * The semantic tone of the banner, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Sets the visual appearance of the banner. The tone determines the color scheme. Available options:
+   *
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
+   * - `'success'` - Green styling for positive outcomes and successful operations.
+   * - `'info'` - Blue styling for general information and neutral updates.
+   * - `'warning'` - Orange styling for important notices that require attention.
+   * - `'critical'` - Red styling for errors and urgent issues requiring immediate action.
    *
    * @default 'auto'
    */
@@ -3334,79 +3373,92 @@ interface BoxJSXProps {
    */
   id?: string;
   /**
-   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The block size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * The inline size (width in horizontal writing modes) of the element.
+   * The inline size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum block size constraint for the container.
    *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum inline size constraint for the container.
    *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum block size constraint for the container.
    *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum inline size constraint for the container.
    *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * The padding applied to all edges of the element.
+   * The padding applied to all edges of the container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
+   * - 4 values: `block-start inline-end block-end inline-start`
+   * - 3 values: `block-start inline block-end`
+   * - 2 values: `block inline`
+   *
+   * For example:
+   *
+   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
+   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
+   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
+   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   *
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword$1>;
   /**
-   * The block-axis padding for the element (typically vertical in horizontal writing modes).
+   * The block-axis padding for the container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<PaddingKeyword$1> | '';
   /**
-   * The block-start padding for the element (typically top in horizontal writing modes).
+   * The block-start padding for the container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: PaddingKeyword$1 | '';
   /**
-   * The block-end padding for the element (typically bottom in horizontal writing modes).
+   * The block-end padding for the container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: PaddingKeyword$1 | '';
   /**
-   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
+   * The inline-axis padding for the container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<PaddingKeyword$1> | '';
   /**
-   * The inline-start padding for the element (typically left in LTR, right in RTL).
+   * The inline-start padding for the container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: PaddingKeyword$1 | '';
   /**
-   * The inline-end padding for the element (typically right in LTR, left in RTL).
+   * The inline-end padding for the container. Overrides the inline-end value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
@@ -3430,6 +3482,9 @@ declare module 'preact' {
 }
 
 declare const tagName$n = 's-icon';
+/**
+ * Lists all currently supported icon names available for use in the POS interface. Reference this list when selecting icons to ensure compatibility and availability.
+ */
 type SupportedIconNames = Extract<
   IconProps['type'],
   | 'alert-circle'
@@ -3561,7 +3616,7 @@ type SupportedIconNames = Extract<
 interface IconJSXProps
   extends Pick<IconProps, 'id' | 'tone' | 'color' | 'size'> {
   /**
-   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type.
+   * The type of icon to display.
    *
    * @default ''
    */
@@ -3601,78 +3656,86 @@ type PickedProps = Pick<
 >;
 interface StackJSXProps extends PickedProps {
   /**
-   * The padding applied to all edges of the element.
+   * The padding applied to all edges of the container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
+   * - 4 values: `block-start inline-end block-end inline-start`
+   * - 3 values: `block-start inline block-end`
+   * - 2 values: `block inline`
+   *
+   * For example:
+   *
+   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
+   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
+   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
+   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   *
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * The block-axis padding for the element (typically vertical in horizontal writing modes).
+   * The block-axis padding for the container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<PaddingKeyword | ''>;
   /**
-   * The block-start padding for the element (typically top in horizontal writing modes).
+   * The block-start padding for the container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: PaddingKeyword | '';
   /**
-   * The block-end padding for the element (typically bottom in horizontal writing modes).
+   * The block-end padding for the container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: PaddingKeyword | '';
   /**
-   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
+   * The inline-axis padding for the container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<PaddingKeyword | ''>;
   /**
-   * The inline-start padding for the element (typically left in LTR, right in RTL).
+   * The inline-start padding for the container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: PaddingKeyword | '';
   /**
-   * The inline-end padding for the element (typically right in LTR, left in RTL).
+   * The inline-end padding for the container. Overrides the inline-end value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: PaddingKeyword | '';
   /**
-   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
-   * Learn more about [`block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
+   * The block size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
-   * Learn more about [`max-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
+   * The maximum block size constraint for the container.
    *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
-   * Learn more about [`max-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
+   * The maximum inline size constraint for the container.
    *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
-   * Learn more about [`min-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
+   * The minimum block size constraint for the container.
    *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
-   * Learn more about [`min-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
+   * The minimum inline size constraint for the container.
    *
    * @default '0'
    */
@@ -3749,7 +3812,15 @@ declare module 'preact' {
 declare const tagName$l = 's-badge';
 interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
   /**
-   * The semantic tone of the badge, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Determines the visual appearance and semantic meaning of the badge. Available options:
+   *
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context. Use when you want the system to determine the most appropriate styling.
+   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis. Use for general status updates and standard information.
+   * - `'info'` - Blue styling for informational content and neutral updates. Use for informational content that provides helpful context.
+   * - `'success'` - Green styling for positive states, completed actions, and successful operations. Use for positive outcomes and successful processes.
+   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent. Use for potential issues that require awareness.
+   * - `'warning'` - Orange styling for important notices that require merchant awareness. Use for situations that need attention but aren't critical.
+   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action. Use for urgent issues that need immediate merchant attention.
    *
    * @default 'auto'
    */
@@ -4107,7 +4178,9 @@ interface NumberFieldJSXProps
   /**
    * The virtual keyboard layout that the field displays for numeric input. This property isn't supported when using `stepper` controls.
    *
-   * Learn more about [`inputmode` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
+   * - `'decimal'` - A keyboard layout that includes decimal point support for entering fractional numbers, prices, or measurements with decimal precision.
+   * - `'numeric'` - A keyboard layout optimized for integer-only entry without decimal point support, ideal for quantities, counts, or whole number values.
+   *
    * @default 'decimal'
    */
   inputMode?: NumberFieldProps['inputMode'];
@@ -4121,6 +4194,12 @@ interface NumberFieldJSXProps
   accessory?: ComponentChild;
   /**
    * The type of controls displayed for the field:
+   *
+   * - `'auto'` - An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
+   * - `'stepper'` - Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
+   * - `'none'` - A control type with no visible controls where users must input the value manually using the keyboard.
+   *
+   * @default 'auto'
    */
   controls?: NumberFieldProps['controls'];
   /**
@@ -4339,17 +4418,16 @@ declare module 'preact' {
 declare const tagName$5 = 's-image';
 interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit'> {
   /**
-   * The inline size (width in horizontal writing modes) of the element.
+   * Controls the displayed width of the image. Choose based on your layout requirements. For mobile interfaces, consider using `'fill'` with defined container dimensions to ensure consistent image display, as dynamic container heights can cause layout inconsistencies in scrollable views.
+   *
+   * - `'auto'` - Displays the image at its natural size. The image will not render until it has loaded, and the aspect ratio will be ignored. Use for images where maintaining original dimensions is important.
+   * - `'fill'` - Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Use for responsive layouts and flexible image containers.
    *
    * @default 'fill'
-   *
-   * Learn more about [`width` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
    */
   inlineSize?: ImageProps['inlineSize'];
   /**
-   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are accessible and properly formatted.
-   *
-   * Learn more about [`src` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
+   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are properly formatted and properly formatted.
    */
   src?: ImageProps['src'];
 }
@@ -4531,7 +4609,15 @@ export type {
 
 interface Badge {
   /**
-   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Determines the visual appearance and semantic meaning of the badge. Available options:
+   *
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context. Use when you want the system to determine the most appropriate styling.
+   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis. Use for general status updates and standard information.
+   * - `'info'` - Blue styling for informational content and neutral updates. Use for informational content that provides helpful context.
+   * - `'success'` - Green styling for positive states, completed actions, and successful operations. Use for positive outcomes and successful processes.
+   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent. Use for potential issues that require awareness.
+   * - `'warning'` - Orange styling for important notices that require merchant awareness. Use for situations that need attention but aren't critical.
+   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action. Use for urgent issues that need immediate merchant attention.
    *
    * @default 'auto'
    */
@@ -4549,8 +4635,13 @@ interface Badge {
   id?: string;
 }
 
+/**
+ * The `Banner` component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ */
 interface BannerSlots {
-  /** The action taken when the Banner is pressed. */
+  /**
+   * The primary action element displayed within the banner, typically a button. Use this slot to provide interactive elements that allow users to respond to the banner's message, such as "Dismiss," "Learn More," or "Retry" buttons.
+   */
   'primary-action'?: HTMLElement;
 }
 
@@ -4562,7 +4653,13 @@ interface Banner {
    */
   hidden?: boolean;
   /**
-   * The semantic tone of the banner, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Sets the visual appearance of the banner. The tone determines the color scheme. Available options:
+   *
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
+   * - `'success'` - Green styling for positive outcomes and successful operations.
+   * - `'info'` - Blue styling for general information and neutral updates.
+   * - `'warning'` - Orange styling for important notices that require attention.
+   * - `'critical'` - Red styling for errors and urgent issues requiring immediate action.
    *
    * @default 'auto'
    */
@@ -4581,89 +4678,105 @@ interface Banner {
 
 interface Box {
   /**
-   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   * A unique identifier for the element used for targeting with CSS or JavaScript.
    */
   id?: string;
   /**
-   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The block size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * The inline size (width in horizontal writing modes) of the element.
+   * The inline size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum block size constraint for the container.
    *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum inline size constraint for the container.
    *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum block size constraint for the container.
    *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum inline size constraint for the container.
    *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * The padding applied to all edges of the element.
+   * The padding applied to all edges of the container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
+   * - 4 values: `block-start inline-end block-end inline-start`
+   * - 3 values: `block-start inline block-end`
+   * - 2 values: `block inline`
+   *
+   * For example:
+   *
+   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
+   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
+   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
+   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   *
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * The block-axis padding for the element (typically vertical in horizontal writing modes).
+   * The block-axis padding for the container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingBlock?: '' | MaybeTwoValuesShorthandProperty<PaddingKeyword>;
   /**
-   * The block-start padding for the element (typically top in horizontal writing modes).
+   * The block-start padding for the container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: '' | PaddingKeyword;
   /**
-   * The block-end padding for the element (typically bottom in horizontal writing modes).
+   * The block-end padding for the container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: '' | PaddingKeyword;
   /**
-   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
+   * The inline-axis padding for the container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingInline?: '' | MaybeTwoValuesShorthandProperty<PaddingKeyword>;
   /**
-   * The inline-start padding for the element (typically left in LTR, right in RTL).
+   * The inline-start padding for the container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: '' | PaddingKeyword;
   /**
-   * The inline-end padding for the element (typically right in LTR, left in RTL).
+   * The inline-end padding for the container. Overrides the inline-end value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: '' | PaddingKeyword;
 }
 
+/**
+ * The `Button` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface ButtonEvents {
   /**
    * The callback when the element is activated.
@@ -4679,12 +4792,20 @@ interface Button {
    * - `'--hide'`: Hide the target element
    * - `'--toggle'`: Switch the target's visibility state
    *
-   * @default '--auto'
    * Learn more about [`command` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
+   *
+   * @default '--auto'
+   *
    */
   command?: '--auto' | '--show' | '--hide' | '--toggle';
   /**
-   * The semantic tone of the button, based on the intention of the action being performed. Affects color and styling to communicate meaning.
+   * Sets the tone of the button, based on the intention of the information being conveyed.
+   *
+   * - `'auto'` - Automatically determines the appropriate tone based on context.
+   * - `'neutral'` - The standard tone for general actions and interactions.
+   * - `'caution'` - Indicates actions that require careful consideration.
+   * - `'warning'` - Alerts users to potential issues or important information.
+   * - `'critical'` - Used for destructive actions like deleting or removing content.
    *
    * @default 'auto'
    */
@@ -4743,6 +4864,9 @@ interface Choice {
   selected?: boolean;
 }
 
+/**
+ * The `ChoiceList` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface ChoiceListEvents {
   /**
    * A callback function executed when the user makes any changes in the field.
@@ -4771,6 +4895,9 @@ interface ChoiceList {
   multiple?: boolean;
 }
 
+/**
+ * The `Clickable` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface ClickableEvents {
   /**
    * The callback when the element is activated.
@@ -4789,6 +4916,9 @@ interface Clickable {
   disabled?: boolean;
 }
 
+/**
+ * The `DateField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface DateFieldEvents {
   /**
    * A callback function executed when the user makes any changes in the field.
@@ -4837,6 +4967,9 @@ interface DateField {
   error?: string;
 }
 
+/**
+ * The `DatePicker` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface DatePickerEvents {
   /**
    * A callback function executed when the user makes any changes in the field.
@@ -4869,6 +5002,9 @@ interface DatePicker {
   value?: string;
 }
 
+/**
+ * The `DateSpinner` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface DateSpinnerEvents {
   /**
    * A callback function executed when the user makes any changes in the field.
@@ -4916,6 +5052,9 @@ interface Divider {
   direction?: 'inline' | 'block';
 }
 
+/**
+ * The `EmailField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface EmailFieldEvents {
   /**
    * A callback function executed when the user makes any changes in the field.
@@ -4935,6 +5074,9 @@ interface EmailFieldEvents {
   focus?: (event: CallbackEvent<typeof tagName$f>) => void;
 }
 
+/**
+ * The `EmailField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ */
 interface EmailFieldSlots {
   /**
    * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
@@ -4996,23 +5138,23 @@ interface Heading {
 
 interface Icon {
   /**
-   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type.
+   * The type of icon to display.
    *
    * @default ''
    */
   type?: SupportedIconNames;
   /**
-   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
+   * A unique identifier for the element. Use this to reference the icon in JavaScript or CSS.
    */
   id?: string;
   /**
-   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Sets the tone of the icon, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * The color intensity of the text. Controls how prominent or subtle the text appears within the interface.
+   * Modify the color to be more or less intense. Use `'subdued'` for secondary icons, `'base'` for standard visibility, or `'strong'` for emphasized icons that need to stand out.
    *
    * @default 'base'
    */
@@ -5027,16 +5169,19 @@ interface Icon {
 
 interface Image {
   /**
-   * The inline size (width in horizontal writing modes) of the element.
+   * Controls the displayed width of the image. Choose based on your layout requirements. For mobile interfaces, consider using `'fill'` with defined container dimensions to ensure consistent image display, as dynamic container heights can cause layout inconsistencies in scrollable views.
+   *
+   * - `'auto'` - Displays the image at its natural size. The image will not render until it has loaded, and the aspect ratio will be ignored. Use for images where maintaining original dimensions is important.
+   * - `'fill'` - Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Use for responsive layouts and flexible image containers.
    *
    * @default 'fill'
-   * Learn more about [`width` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
    */
   inlineSize?: 'fill' | 'auto';
   /**
-   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are accessible and properly formatted.
+   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are properly formatted and properly formatted.
    *
-   * Learn more about [`src` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
+   * @implementation Surfaces may choose the style of the placeholder, but the space the image occupies should be
+   * reserved, except in cases where the image area doesn't have a contextual inline or block size, which should be rare.
    */
   src?: string;
   /**
@@ -5046,12 +5191,17 @@ interface Image {
   /**
    * Controls how the image content is resized within its container.
    *
+   * - `'contain'` - Scales the image to fit within the container while maintaining aspect ratio. The entire image will be visible, but there may be empty space. Use when showing the complete image is important.
+   * - `'cover'` - Scales the image to fill the entire container while maintaining aspect ratio. Parts of the image may be cropped. Use when filling the container completely is more important than showing the entire image.
+   *
    * @default 'contain'
-   * Learn more about [`object-fit` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).
    */
   objectFit?: 'contain' | 'cover';
 }
 
+/**
+ * The `Modal` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface ModalEvents {
   /**
    * The callback when the modal is hidden. Use this event to perform cleanup tasks, update application state, or trigger other actions when the modal is dismissed or closed.
@@ -5063,16 +5213,17 @@ interface ModalEvents {
   show?: (event: CallbackEvent<typeof tagName$i>) => void | null;
 }
 
+/**
+ * The `Modal` component supports slots for additional content placement within the modal. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ */
 interface ModalSlots {
   /**
-   * The primary action button displayed in the modal.
-   *
-   * The tone of the button is used to define the tone of the modal.
-   *
-   * If omitted, the modal will default to an 'info' tone, and show an 'OK' button, translated according to the user's locale.
+   * The primary action button displayed in the modal. The tone of the button is used to define the tone of the modal. If omitted, the modal will default to an `'info'` tone, and show an OK button, translated according to the user's locale.
    */
   'primary-action'?: HTMLElement;
-  /** The secondary action buttons displayed in the modal. */
+  /**
+   * The secondary action buttons displayed in the modal. Use this slot to provide alternative actions or cancel options that give users flexibility in how they respond to the modal.
+   */
   'secondary-actions'?: HTMLElement;
 }
 
@@ -5087,6 +5238,9 @@ interface Modal {
   heading?: string;
 }
 
+/**
+ * The `NumberField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface NumberFieldEvents {
   /**
    * A callback function executed when the user makes any changes in the field.
@@ -5106,6 +5260,9 @@ interface NumberFieldEvents {
   focus?: (event: CallbackEvent<typeof tagName$c>) => void;
 }
 
+/**
+ * The `NumberField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ */
 interface NumberFieldSlots {
   /**
    * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
@@ -5137,7 +5294,9 @@ interface NumberField {
   /**
    * The virtual keyboard layout that the field displays for numeric input. This property isn't supported when using `stepper` controls.
    *
-   * Learn more about [`inputmode` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
+   * - `'decimal'` - A keyboard layout that includes decimal point support for entering fractional numbers, prices, or measurements with decimal precision.
+   * - `'numeric'` - A keyboard layout optimized for integer-only entry without decimal point support, ideal for quantities, counts, or whole number values.
+   *
    * @default 'decimal'
    */
   inputMode?: 'decimal' | 'numeric';
@@ -5147,6 +5306,12 @@ interface NumberField {
   placeholder?: string;
   /**
    * The type of controls displayed for the field:
+   *
+   * - `'auto'` - An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
+   * - `'stepper'` - Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
+   * - `'none'` - A control type with no visible controls where users must input the value manually using the keyboard.
+   *
+   * @default 'auto'
    */
   controls?: 'auto' | 'stepper' | 'none';
   /**
@@ -5177,8 +5342,13 @@ interface NumberField {
   min?: number;
 }
 
+/**
+ * The `Page` component supports slots for additional content placement within the page. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ */
 interface PageSlots {
-  /** Button element to display in the action bar. Only a single button is supported. */
+  /**
+   * A button element to display in the action bar. Only a single button is supported. Use the `slot="secondary-actions"` attribute to place content in this area.
+   */
   'secondary-actions'?: HTMLElement;
   /**
    * The content to display in the page's sidebar. This area is for content that is tangentially related to the main content, such as navigation or contextual information. Use the `slot="aside"` attribute to place content in this area.
@@ -5203,8 +5373,13 @@ interface Page {
   id?: string;
 }
 
+/**
+ * The `PosBlock` component supports slots for additional content placement within the block. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ */
 interface PosBlockSlots {
-  /** The secondary actions to perform, provided as button or link type elements. */
+  /**
+   * The secondary actions to perform, provided as button or link type elements. Use the `slot="secondary-actions"` attribute to place interactive elements that allow users to take actions related to the block's content.
+   */
   'secondary-actions'?: HTMLElement;
 }
 
@@ -5232,79 +5407,92 @@ interface QrCode {
 
 interface ScrollBox {
   /**
-   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The block size of the scrollable container. Auto automatically sizes based on the container's content and available space.
    *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * The inline size (width in horizontal writing modes) of the element.
+   * The inline size of the scrollable container. Auto automatically sizes based on the container's content and available space.
    *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum block size constraint for the scrollable container.
    *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum inline size constraint for the scrollable container.
    *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum block size constraint for the scrollable container.
    *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum inline size constraint for the scrollable container.
    *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * The padding applied to all edges of the element.
+   * The padding applied to all edges of the scrollable container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
+   * - 4 values: `block-start inline-end block-end inline-start`
+   * - 3 values: `block-start inline block-end`
+   * - 2 values: `block inline`
+   *
+   * For example:
+   *
+   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
+   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
+   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
+   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   *
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * The block-axis padding for the element (typically vertical in horizontal writing modes).
+   * The block-axis padding for the scrollable container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingBlock?: '' | MaybeTwoValuesShorthandProperty<PaddingKeyword>;
   /**
-   * The block-start padding for the element (typically top in horizontal writing modes).
+   * The block-start padding for the scrollable container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: '' | PaddingKeyword;
   /**
-   * The block-end padding for the element (typically bottom in horizontal writing modes).
+   * The block-end padding for the scrollable container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: '' | PaddingKeyword;
   /**
-   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
+   * The inline-axis padding for the scrollable container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingInline?: '' | MaybeTwoValuesShorthandProperty<PaddingKeyword>;
   /**
-   * The inline-start padding for the element (typically left in LTR, right in RTL).
+   * The inline-start padding for the scrollable container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: '' | PaddingKeyword;
   /**
-   * The inline-end padding for the element (typically right in LTR, left in RTL).
+   * The inline-end padding for the scrollable container. Overrides the inline-end value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
@@ -5315,6 +5503,9 @@ interface ScrollBox {
   id?: string;
 }
 
+/**
+ * The `SearchField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface SearchFieldEvents {
   /**
    * A callback function executed when the user makes any changes in the field.
@@ -5355,8 +5546,13 @@ interface SearchField {
   value?: string;
 }
 
+/**
+ * The `Section` component supports slots for additional content placement within the section. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ */
 interface SectionSlots {
-  /** Button element to display in the section heading. A single button is supported. */
+  /**
+   * A button element to display in the section heading. Only a single button is supported. Use the `slot="secondary-actions"` attribute to place action elements that relate to the entire section's content.
+   */
   'secondary-actions'?: HTMLElement;
 }
 
@@ -5373,79 +5569,87 @@ interface Section {
 
 interface Stack {
   /**
-   * The padding applied to all edges of the element.
+   * The padding applied to all edges of the container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
+   * - 4 values: `block-start inline-end block-end inline-start`
+   * - 3 values: `block-start inline block-end`
+   * - 2 values: `block inline`
+   *
+   * For example:
+   *
+   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
+   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
+   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
+   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   *
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * The block-axis padding for the element (typically vertical in horizontal writing modes).
+   * The block-axis padding for the container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<'' | PaddingKeyword>;
   /**
-   * The block-start padding for the element (typically top in horizontal writing modes).
+   * The block-start padding for the container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: '' | PaddingKeyword;
   /**
-   * The block-end padding for the element (typically bottom in horizontal writing modes).
+   * The block-end padding for the container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: '' | PaddingKeyword;
   /**
-   * The inline-axis padding for the element (typically horizontal in horizontal writing modes).
+   * The inline-axis padding for the container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<'' | PaddingKeyword>;
   /**
-   * The inline-start padding for the element (typically left in LTR, right in RTL).
+   * The inline-start padding for the container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: '' | PaddingKeyword;
   /**
-   * The inline-end padding for the element (typically right in LTR, left in RTL).
+   * The inline-end padding for the container. Overrides the inline-end value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: '' | PaddingKeyword;
   /**
-   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The block size of the container. Auto automatically sizes based on the container's children.
    *
-   * Learn more about [`block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum block size constraint for the container.
    *
-   * Learn more about [`max-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum inline size constraint for the container.
    *
-   * Learn more about [`max-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum block size constraint for the container.
    *
-   * Learn more about [min-block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum inline size constraint for the container.
    *
-   * Learn more about [min-inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    * @default '0'
    */
   minInlineSize?: SizeUnits;
@@ -5512,13 +5716,25 @@ interface Text {
    */
   color?: ColorKeyword;
   /**
-   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type.
+   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type. Available options:
+   *
+   * - `'generic'` - The default text type for general content without specific semantic meaning or emphasis.
+   * - `'strong'` - A text type that provides emphasis and importance, typically rendered with increased font weight or visual prominence.
+   * - `'small'` - A text type for secondary or supplementary content, typically rendered with reduced size for captions, fine print, or less important information.
    *
    * @default 'generic'
    */
   type?: 'strong' | 'small' | 'generic';
   /**
-   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Determines the visual appearance and semantic meaning of the text. Available options:
+   *
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context. Use when you want the system to determine the most appropriate styling.
+   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis. Use for general status updates and standard information.
+   * - `'info'` - Blue styling for informational content and neutral updates. Use for informational content that provides helpful context.
+   * - `'success'` - Green styling for positive states, completed actions, and successful operations. Use for positive outcomes and successful processes.
+   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent. Use for potential issues that require awareness.
+   * - `'warning'` - Orange styling for important notices that require merchant awareness. Use for situations that need attention but aren't critical.
+   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action. Use for urgent issues that need immediate merchant attention.
    *
    * @default 'auto'
    */
@@ -5536,6 +5752,9 @@ interface Text {
   id?: string;
 }
 
+/**
+ * The `TextArea` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface TextAreaEvents {
   /**
    * A callback function executed when the user makes any changes in the field.
@@ -5555,6 +5774,9 @@ interface TextAreaEvents {
   focus?: (event: CallbackEvent<typeof tagName$d>) => void;
 }
 
+/**
+ * The `TextArea` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ */
 interface TextAreaSlots {
   /**
    * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
@@ -5613,6 +5835,9 @@ interface TextArea {
   rows?: number;
 }
 
+/**
+ * The `TextField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface TextFieldEvents {
   /**
    * A callback function executed when the user makes any changes in the field.
@@ -5632,6 +5857,9 @@ interface TextFieldEvents {
   focus?: (event: CallbackEvent<typeof tagName$h>) => void;
 }
 
+/**
+ * The `TextField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ */
 interface TextFieldSlots {
   /**
    * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
@@ -5713,7 +5941,7 @@ interface Tile {
    */
   itemCount?: number;
   /**
-   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Sets the visual tone of the tile based on the intention of the information being conveyed. Use `'accent'` to highlight important or primary actions, `'neutral'` for standard actions, or `'auto'` (default) to let the system determine the appropriate tone based on context.
    *
    * @default 'auto'
    */
@@ -5726,6 +5954,9 @@ interface Tile {
   subheading?: string;
 }
 
+/**
+ * The `TimeField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface TimeFieldEvents {
   /**
    * A callback function executed when the user makes any changes in the field.
@@ -5774,6 +6005,9 @@ interface TimeField {
   details?: string;
 }
 
+/**
+ * The `TimePicker` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ */
 interface TimePickerEvents {
   /**
    * A callback function executed when the user makes any changes in the field.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge.d.ts
@@ -12,18 +12,30 @@ import type {BadgeProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
@@ -31,7 +43,14 @@ export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 declare const tagName = 's-badge';
 export interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
   /**
-   * Sets the tone of the Badge, based on the intention of the information being conveyed.
+   * Determines the visual appearance and semantic meaning of the badge. Available options:
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context. Typically applied when you want the system to determine the most appropriate styling.
+   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis. Commonly used for general status updates and standard information.
+   * - `'info'` - Blue styling for informational content and neutral updates. Commonly used for informational content that provides helpful context.
+   * - `'success'` - Green styling for positive states, completed actions, and successful operations. Commonly used for positive outcomes and successful processes.
+   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent. Commonly used for potential issues that require awareness.
+   * - `'warning'` - Orange styling for important notices that require merchant awareness. Commonly used for situations that need attention but aren't critical.
+   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action. Commonly used for urgent issues that need immediate merchant attention.
    *
    * @default 'auto'
    */
@@ -40,7 +59,7 @@ export interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
     'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'critical' | 'caution'
   >;
   /**
-   * The content of the Badge.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -17,7 +17,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Titles and text',
+  subCategory: 'Feedback and status indicators',
   defaultExample: {
     image: 'badge-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -35,28 +35,22 @@ const data: ReferenceEntityTemplateSchema = {
   subSections: [
     {
       type: 'Generic',
-      anchorLink: 'guidelines',
-      title: 'Guidelines',
-      sectionContent: `
-- Badges should be positioned as close as possible to the item they’re related to.
-`,
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Apply appropriate tones:** Use `success` for positive states, `critical` for urgent issues, `warning` for attention-needed states, `info` for neutral information.\n' +
+        '- **Keep text brief:** Use single words or short phrases. Avoid lengthy descriptions that don\'t fit the compact design.\n' +
+        '- **Position near related content:** Place badges next to the items they describe for clear associations.\n' +
+        '- **Use for status, not actions:** Badges display information only. For interactive elements, use buttons or clickable components.',
     },
     {
       type: 'Generic',
-      anchorLink: 'content-guidelines',
-      title: 'Content guidelines',
-      sectionContent: `
-- Be concise. Use a single word to describe the status of an item.
-- Only use two or three words if you need to describe a complex state, for example "partially fulfilled".
-
-✅ fulfilled
-❌ order fulfilled
-
-Statuses should ideally be written as adjectives:
-
-✅ unpaid
-❌ payment not received
-      `,
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Badges aren\'t interactive elements—they display information but don\'t respond to user interactions like clicks or taps.\n' +
+        '- The component relies on the tone system for semantic meaning, so custom styling may not convey the same semantic benefits.\n' +
+        '- Very long text content may be truncated or cause layout issues depending on the container and screen size.',
     },
   ],
   related: [],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -20,8 +20,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Titles and text',
   defaultExample: {
     image: 'badge-default.png',
+    description:
+      'Display status information using a `Badge` component with customizable tone and content. This example shows a basic badge with a tone property to indicate status through color.',
     codeblock: {
-      title: 'Code',
+      title: 'Display status information with a badge',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -3,14 +3,16 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Badge',
   description:
-    'Use color and text to communicate the state of orders, products, customers, and other business data.',
+    'The `Badge` component uses color and text to communicate status information for orders, products, customers, and other business data. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes within your POS interface.' +
+    '\n\nThe component automatically adjusts its appearance based on the specified `tone` property, ensuring consistent visual communication across the POS interface. Badges support different sizes and can display text, numbers, or status indicators, making them versatile for representing everything from order counts to inventory alerts in a compact, scannable format.',
   thumbnail: 'badge-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Badge` component.',
       type: 'Badge',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -39,7 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Apply appropriate tones:** Use `success` for positive states, `critical` for urgent issues, `warning` for attention-needed states, `info` for neutral information.\n' +
-        '- **Keep text brief:** Use single words or short phrases. Avoid lengthy descriptions that don\'t fit the compact design.\n' +
+        "- **Keep text brief:** Use single words or short phrases. Avoid lengthy descriptions that don't fit the compact design.\n" +
         '- **Position near related content:** Place badges next to the items they describe for clear associations.\n' +
         '- **Use for status, not actions:** Badges display information only. For interactive elements, use buttons or clickable components.',
     },
@@ -48,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Badges aren\'t interactive elements—they display information but don\'t respond to user interactions like clicks or taps.\n' +
+        "- Badges aren't interactive elements—they display information but don't respond to user interactions like clicks or taps.\n" +
         '- The component relies on the tone system for semantic meaning, so custom styling may not convey the same semantic benefits.\n' +
         '- Very long text content may be truncated or cause layout issues depending on the container and screen size.',
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Badge',
   description:
-    'Informs merchants about the status of an object or indicates that an action has been completed. Badges display text with visual styling to communicate status information.',
+    'Use color and text to communicate the state of orders, products, customers, and other business data.',
   thumbnail: 'badge-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner.d.ts
@@ -17,18 +17,30 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
@@ -36,13 +48,18 @@ export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 declare const tagName = 's-banner';
 export interface BannerJSXProps extends Pick<BannerProps, 'heading' | 'id'> {
   /**
-   * Determines whether the banner is hidden.
+   * Controls whether the banner is visible or hidden. When set to `true`, the banner will be hidden from view. Use this to programmatically show or hide banners based on application state. Default is `false`.
    *
    * @default false
    */
   hidden?: BannerProps['hidden'];
   /**
-   * Sets the tone of the Banner, based on the intention of the information being conveyed.
+   * Sets the visual appearance and accessibility behavior of the banner. The tone determines both the color scheme and how screen readers announce the banner. Available options:
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context
+   * - `'success'` - Green styling for positive outcomes and successful operations. Creates an informative live region for screen readers
+   * - `'info'` - Blue styling for general information and neutral updates. Creates an informative live region for screen readers
+   * - `'warning'` - Orange styling for important notices that require attention. Creates an informative live region for screen readers
+   * - `'critical'` - Red styling for errors and urgent issues requiring immediate action. Creates an assertive live region that is announced immediately by screen readers
    *
    * @default 'auto'
    */
@@ -51,11 +68,11 @@ export interface BannerJSXProps extends Pick<BannerProps, 'heading' | 'id'> {
     'auto' | 'success' | 'info' | 'warning' | 'critical'
   >;
   /**
-   * The action taken when the Banner is pressed.
+   * The primary action element displayed within the banner, typically a button. Use this slot to provide interactive elements that allow users to respond to the banner's message, such as "Dismiss," "Learn More," or "Retry" buttons.
    */
   primaryAction?: ComponentChild;
   /**
-   * The content of the Banner.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner.d.ts
@@ -54,12 +54,13 @@ export interface BannerJSXProps extends Pick<BannerProps, 'heading' | 'id'> {
    */
   hidden?: BannerProps['hidden'];
   /**
-   * Sets the visual appearance and accessibility behavior of the banner. The tone determines both the color scheme and how screen readers announce the banner. Available options:
-   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context
-   * - `'success'` - Green styling for positive outcomes and successful operations. Creates an informative live region for screen readers
-   * - `'info'` - Blue styling for general information and neutral updates. Creates an informative live region for screen readers
-   * - `'warning'` - Orange styling for important notices that require attention. Creates an informative live region for screen readers
-   * - `'critical'` - Red styling for errors and urgent issues requiring immediate action. Creates an assertive live region that is announced immediately by screen readers
+   * Sets the visual appearance of the banner. The tone determines the color scheme. Available options:
+   *
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
+   * - `'success'` - Green styling for positive outcomes and successful operations.
+   * - `'info'` - Blue styling for general information and neutral updates.
+   * - `'warning'` - Orange styling for important notices that require attention.
+   * - `'critical'` - Red styling for errors and urgent issues requiring immediate action.
    *
    * @default 'auto'
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Banner',
   description:
-    'Highlights important information or required actions prominently within the interface. Use to communicate critical updates, warnings, information or success messages in a prominent way.',
+    'Highlight important information or required actions prominently within the POS interface.',
   thumbnail: 'banner-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -56,7 +56,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- The `Banner` component only accepts a `heading` property for text content and doesn\'t support body content. You can\'t place `<s-text>` or other text elements inside the banner as children.',
+        "- The `Banner` component only accepts a `heading` property for text content and doesn't support body content. You can't place `<s-text>` or other text elements inside the banner as children.",
     },
   ],
   related: [],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -41,12 +41,22 @@ const data: ReferenceEntityTemplateSchema = {
   subSections: [
     {
       type: 'Generic',
-      anchorLink: 'guidelines',
-      title: 'Guidelines',
-      sectionContent: `
-- Use when needing to communicate to merchants in a way that is persistent but non-interruptive.
-- Only one banner should be visible at a time.
-`,
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Apply appropriate tones:** Use `critical` for errors requiring immediate action, `warning` for important notices, `success` for confirmations, `info` for general information.\n' +
+        '- **Keep headings concise:** Write brief headings that clearly communicate the message. Use the collapsible feature for additional detail.\n' +
+        '- **Show one banner at a time:** Display only one banner to avoid overwhelming the interface. Prioritize by importance.\n' +
+        '- **Make non-critical banners dismissible:** Allow dismissal for non-critical information. Keep critical alerts non-dismissible until resolved.\n' +
+        '- **Include clear actions:** If action is needed, use the primaryAction slot to provide clear next steps.\n' +
+        '- **Use for persistent messages:** Use banners for messages that need to persist. For temporary notifications, consider toast notifications.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- The `Banner` component only accepts a `heading` property for text content and doesn\'t support body content. You can\'t place `<s-text>` or other text elements inside the banner as children.',
     },
   ],
   related: [],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -26,8 +26,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Feedback',
   defaultExample: {
     image: 'banner-default.png',
+    description:
+      'Display important messages using a `Banner` component with automatic color coding based on message severity. This example shows a basic banner with a heading and descriptive text.',
     codeblock: {
-      title: 'Code',
+      title: 'Display important messages with a banner',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -3,19 +3,22 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Banner',
   description:
-    'Highlight important information or required actions prominently within the POS interface.',
+    'The `Banner` component highlights important information or required actions prominently within the POS interface. Use banners to communicate critical updates, warnings, informational messages, or success notifications that require merchant attention in a persistent but non-interruptive way.' +
+    '\n\nThe component provides persistent visibility for important messages while remaining non-intrusive to the main workflow, with support for dismissible and non-dismissible states. It includes automatic color coding based on message severity and integrates with the POS design system to maintain visual consistency across different alert types and use cases.',
   thumbnail: 'banner-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Banner` component.',
       type: 'Banner',
     },
     {
       title: 'Slots',
-      description: '',
+      description:
+        'The `Banner` component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'BannerSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -23,7 +23,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Feedback',
+  subCategory: 'Feedback and status indicators',
   defaultExample: {
     image: 'banner-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box.d.ts
@@ -50,6 +50,9 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 
 declare const tagName = 's-box';
+/**
+ * Defines the available padding size options using a semantic scale. Provides consistent spacing values that align with the POS design system.
+ */
 export type PaddingKeyword = SizeKeyword | 'none';
 export interface BoxJSXProps {
   /**
@@ -93,15 +96,19 @@ export interface BoxJSXProps {
    */
   minInlineSize?: SizeUnits;
   /**
-   * The padding applied to all edges of the container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   * The padding applied to all edges of the container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
+   *
    * For example:
+   *
    * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
    * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
    * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
    * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   *
    * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box.d.ts
@@ -21,18 +21,30 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
@@ -41,120 +53,98 @@ declare const tagName = 's-box';
 export type PaddingKeyword = SizeKeyword | 'none';
 export interface BoxJSXProps {
   /**
-   * A unique identifier for the element.
+   * A unique identifier for the element used for targeting with CSS, JavaScript, or accessibility features.
    */
   id?: string;
   /**
-   * Adjust the block size.
+   * The block size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the inline size.
+   * The inline size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the maximum block size.
+   * The maximum block size constraint for the container.
    *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * Adjust the maximum inline size.
+   * The maximum inline size constraint for the container.
    *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * Adjust the minimum block size.
+   * The minimum block size constraint for the container.
    *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * Adjust the minimum inline size.
+   * The minimum inline size constraint for the container.
    *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * Adjust the padding of all edges.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
+   * The padding applied to all edges of the container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
-   *
    * For example:
    * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
    * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
    * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
    * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the block-padding.
-   *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
-   * This overrides the block value of `padding`.
+   * The block-axis padding for the container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<PaddingKeyword> | '';
   /**
-   * Adjust the block-start padding.
-   *
-   * This overrides the block-start value of `paddingBlock`.
+   * The block-start padding for the container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: PaddingKeyword | '';
   /**
-   * Adjust the block-end padding.
-   *
-   * This overrides the block-end value of `paddingBlock`.
+   * The block-end padding for the container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: PaddingKeyword | '';
   /**
-   * Adjust the inline padding.
-   *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
-   * This overrides the inline value of `padding`.
+   * The inline-axis padding for the container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<PaddingKeyword> | '';
   /**
-   * Adjust the inline-start padding.
-   *
-   * This overrides the inline-start value of `paddingInline`.
+   * The inline-start padding for the container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: PaddingKeyword | '';
   /**
-   * Adjust the inline-end padding.
-   *
-   * This overrides the inline-end value of `paddingInline`.
+   * The inline-end padding for the container. Overrides the inline-end value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: PaddingKeyword | '';
   /**
-   * The content of the Box.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
-    'A generic container that provides flexible layout with consistent spacing and styling. Use it to apply padding, to nest and group other components, or as the foundation for building structured layouts.',
+    'Display a generic container with consistent spacing and styling.',
   thumbnail: 'box-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -18,6 +18,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Structure',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use semantic sizing:** Choose `auto` to adapt to content, percentages for responsive layouts, pixels only for exact dimensions.\n' +
+        '- **Use design system padding:** Use predefined padding keywords (`small`, `base`, `large`) for consistency.\n' +
+        '- **Use directional padding for asymmetry:** Use `paddingInline` and `paddingBlock` when different spacing is needed on different sides.\n' +
+        '- **Understand block vs inline:** `block` refers to content flow direction (usually vertical), `inline` to text direction (usually horizontal).',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Box is a layout container and doesn\'t provide interactive functionality—use it in combination with interactive components like `Button` or `Clickable` for user interactions.\n' +
+        '- Padding values are limited to the predefined design system scale—custom pixel values for padding aren\'t supported to maintain design consistency.\n' +
+        '- Box doesn\'t provide scrolling capabilities for overflow content—use ScrollBox when content might exceed container dimensions.',
+    },
+  ],
   defaultExample: {
     image: 'box-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -3,14 +3,16 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
-    'Display a generic container with consistent spacing and styling.',
+    'The `Box` component displays a generic container with consistent spacing and styling. Use it to apply padding, to nest and group other components, or as the foundation for building structured layouts.' +
+    '\n\nThe component provides granular control over spacing through padding properties and sizing through width/height properties, serving as a building block for precise layouts. It simplifies the creation of containers with consistent spacing by using design system tokens, ensuring visual consistency and reducing the need for custom CSS in most layout scenarios.' +
+    '\n\n`Box` components provide shorthand properties for common padding patterns like equal padding on all sides or symmetric horizontal/vertical padding, reducing verbose property specifications for simpler layouts.',
   thumbnail: 'box-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description: 'Configure the following properties on the `Box` component.',
       type: 'Box',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -17,7 +17,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Structure',
+  subCategory: 'Layout and structure',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -34,9 +34,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Box is a layout container and doesn\'t provide interactive functionality—use it in combination with interactive components like `Button` or `Clickable` for user interactions.\n' +
-        '- Padding values are limited to the predefined design system scale—custom pixel values for padding aren\'t supported to maintain design consistency.\n' +
-        '- Box doesn\'t provide scrolling capabilities for overflow content—use ScrollBox when content might exceed container dimensions.',
+        "- Box is a layout container and doesn't provide interactive functionality—use it in combination with interactive components like `Button` or `Clickable` for user interactions.\n" +
+        "- Padding values are limited to the predefined design system scale—custom pixel values for padding aren't supported to maintain design consistency.\n" +
+        "- Box doesn't provide scrolling capabilities for overflow content—use ScrollBox when content might exceed container dimensions.",
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -20,8 +20,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Structure',
   defaultExample: {
     image: 'box-default.png',
+    description:
+      'Create flexible layouts using the `Box` component with configurable spacing, borders, and background colors. This example demonstrates a basic box container with padding and styling.',
     codeblock: {
-      title: 'Code',
+      title: 'Create a container with a box',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button.d.ts
@@ -12,28 +12,64 @@ import type {ButtonProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * Additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -44,25 +80,26 @@ export interface ButtonJSXProps
     'id' | 'disabled' | 'command' | 'commandFor' | 'loading'
   > {
   /**
-   * Sets the action the `commandFor` should take when this clickable is activated.
-   *
-   * See the documentation of particular components for the actions they support.
-   *
-   * - `--auto`: a default action for the target component.
-   * - `--show`: shows the target component.
-   * - `--hide`: hides the target component.
-   * - `--toggle`: toggles the target component.
+   * Sets the action the `commandFor` should take when this clickable is activated:
+   * - `--auto`: A default action for the target component
+   * - `--show`: Shows the target component
+   * - `--hide`: Hides the target component
+   * - `--toggle`: Toggles the target component
    *
    * @default '--auto'
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command
+   * Learn more about [button command on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
    */
   command?: Extract<
     ButtonProps['command'],
     '--auto' | '--show' | '--hide' | '--toggle'
   >;
   /**
-   * Sets the tone of the Button, based on the intention of the information being conveyed.
+   * Sets the tone of the button, based on the intention of the information being conveyed.
+   * - `auto`: Automatically determines the appropriate tone based on context.
+   * - `neutral`: The standard tone for general actions and interactions.
+   * - `caution`: Indicates actions that require careful consideration.
+   * - `warning`: Alerts users to potential issues or important information.
+   * - `critical`: Used for destructive actions like deleting or removing content.
    *
    * @default 'auto'
    */
@@ -71,17 +108,19 @@ export interface ButtonJSXProps
     'auto' | 'critical' | 'neutral' | 'warning' | 'caution'
   >;
   /**
-   * Changes the visual appearance of the Button.
+   * Changes the visual appearance of the button.
+   * - `primary`: Creates a prominent call-to-action button with high visual emphasis for the most important action on a screen.
+   * - `secondary`: Provides a less prominent button appearance for supporting actions and secondary interactions.
    *
    * @default 'auto' - the variant is automatically determined by the Button's context
    */
   variant?: Extract<ButtonProps['variant'], 'primary' | 'secondary'>;
   /**
-   * Called when the button is activated.
+   * An event that's called when the button is activated.
    */
   onClick?: (event: CallbackEvent<typeof tagName>) => void;
   /**
-   * The content of the Button.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button.d.ts
@@ -95,11 +95,12 @@ export interface ButtonJSXProps
   >;
   /**
    * Sets the tone of the button, based on the intention of the information being conveyed.
-   * - `auto`: Automatically determines the appropriate tone based on context.
-   * - `neutral`: The standard tone for general actions and interactions.
-   * - `caution`: Indicates actions that require careful consideration.
-   * - `warning`: Alerts users to potential issues or important information.
-   * - `critical`: Used for destructive actions like deleting or removing content.
+   *
+   * - `'auto'` - Automatically determines the appropriate tone based on context.
+   * - `'neutral'` - The standard tone for general actions and interactions.
+   * - `'caution'` - Indicates actions that require careful consideration.
+   * - `'warning'` - Alerts users to potential issues or important information.
+   * - `'critical'` - Used for destructive actions like deleting or removing content.
    *
    * @default 'auto'
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -26,8 +26,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Actions',
   defaultExample: {
     image: 'button-default.png',
+    description:
+      'Trigger actions using a `Button` component with customizable visual styles and tones. This example shows a basic button with text content.',
     codeblock: {
-      title: 'Code',
+      title: 'Trigger actions with a button',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -41,9 +41,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Button content must be plain text. If you nest components inside a button, the button extracts and displays only the text content from those components. For example, placing an `s-icon` inside a button won\'t display the icon—only any text content will be rendered. HTML, markdown, or rich text formatting isn\'t supported.\n' +
-        '- Loading states replace all button content with a spinner. Custom loading indicators or partial content updates aren\'t supported.\n' +
-        '- Complex button layouts or nested interactive components within buttons aren\'t supported.',
+        "- Button content must be plain text. If you nest components inside a button, the button extracts and displays only the text content from those components. For example, placing an `s-icon` inside a button won't display the icon—only any text content will be rendered. HTML, markdown, or rich text formatting isn't supported.\n" +
+        "- Loading states replace all button content with a spinner. Custom loading indicators or partial content updates aren't supported.\n" +
+        "- Complex button layouts or nested interactive components within buttons aren't supported.",
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
-    'Triggers actions or events, such as opening dialogs or navigating to other pages. Use Button to let merchants perform specific tasks or initiate interactions throughout the interface.',
+    'Trigger actions or events, such as opening dialogs or navigating to other pages.',
   thumbnail: 'button-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -24,6 +24,28 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Actions',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Write action-oriented text:** Use specific, actionable language like "Save customer" or "Process payment" rather than generic terms like "OK" or "Submit."\n' +
+        '- **Choose appropriate variants and tones:** Use `primary` for the main action and `secondary` for supporting actions. Use `critical` for destructive actions, `caution` or `warning` for actions requiring attention.\n' +
+        '- **Show loading states:** Set `loading` to `true` during async operations to prevent duplicate submissions.\n' +
+        '- **Use command system for component control:** Use `commandFor` and `command` to control modals and overlays declaratively.\n' +
+        '- **Structure hierarchies clearly:** Group related actions together. Separate destructive actions to prevent accidental activation.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Button content must be plain text. If you nest components inside a button, the button extracts and displays only the text content from those components. For example, placing an `s-icon` inside a button won\'t display the icon—only any text content will be rendered. HTML, markdown, or rich text formatting isn\'t supported.\n' +
+        '- Loading states replace all button content with a spinner. Custom loading indicators or partial content updates aren\'t supported.\n' +
+        '- Complex button layouts or nested interactive components within buttons aren\'t supported.',
+    },
+  ],
   defaultExample: {
     image: 'button-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -3,19 +3,22 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
-    'Trigger actions or events, such as opening dialogs or navigating to other pages.',
+    'The `Button` component triggers actions or events, such as opening dialogs or navigating to other pages. Use `Button` to let merchants perform specific tasks or initiate interactions throughout the POS interface.' +
+    '\n\nButtons provide clear calls-to-action that guide merchants through workflows, enable form submissions, and trigger important operations. They support various visual styles, tones, and interaction patterns to communicate intent and hierarchy within the interface.',
   thumbnail: 'button-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Button` component.',
       type: 'Button',
     },
     {
       title: 'Events',
-      description: '',
+      description:
+        'The `Button` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ButtonEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Choice.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Choice.d.ts
@@ -12,18 +12,30 @@ import type {ChoiceProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList.d.ts
@@ -12,28 +12,64 @@ import type {ChoiceListProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * Additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -41,15 +77,15 @@ declare const tagName = 's-choice-list';
 export interface ChoiceListJSXProps
   extends Pick<ChoiceListProps, 'id' | 'values' | 'multiple'> {
   /**
-   * Callback when the user changes a choice. Fires simultaneously with onChange.
+   * A callback function executed when the user changes a choice. Fires simultaneously with `onChange`.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the user changes a choice. Fires simultaneously with onInput.
+   * A callback function executed when the user changes a choice. Fires simultaneously with `onInput`.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * The content of the ChoiceList. Should be one or more Choice elements.
+   * The child elements to render within this component. Should be one or more Choice elements.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -45,8 +45,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- `ChoiceList` requires choice components as children—other component types can\'t be used as options within the choice list.\n' +
-        '- The component provides the selection interface but doesn\'t automatically filter or update content based on selections—you must implement the logic to respond to selection changes.\n' +
+        "- `ChoiceList` requires choice components as children—other component types can't be used as options within the choice list.\n" +
+        "- The component provides the selection interface but doesn't automatically filter or update content based on selections—you must implement the logic to respond to selection changes.\n" +
         '- Visual variants have different presentations across devices and contexts—the actual appearance may vary based on the POS platform and screen size.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -33,8 +33,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'choicelist-default.png',
+    description:
+      'Present multiple options for single or multiple selections using a `ChoiceList` component. This example shows a basic choice list with radio button semantics for single selection.',
     codeblock: {
-      title: 'Code',
+      title: 'Create a choice list for selections',
       tabs: [
         {
           code: './examples/default.html',
@@ -45,27 +47,30 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'ChoiceList usage patterns',
+    description:
+      'Learn how to handle selection events and enable multiple selection modes.',
     examples: [
       {
-        description: 'Enable multiple selection mode with controlled values',
+        description:
+          'Subscribe to `onChange` and `onInput` events to respond when merchants select options. This example shows how to handle selection changes and capture user input in real time, enabling dynamic behavior and form validation based on merchant choices.',
         codeblock: {
-          title: 'Multiple selection',
+          title: 'Handle selection events',
           tabs: [
             {
-              code: './examples/multiple-selection.jsx',
+              code: './examples/event-handling.jsx',
               language: 'jsx',
             },
           ],
         },
       },
       {
-        description: 'Handle onChange and onInput events.',
+        description:
+          'Enable multiple selection mode to allow merchants to select multiple options from the list. This example demonstrates using controlled values with the `multiple` property, perfect for filtering interfaces or collecting multiple preferences in forms.',
         codeblock: {
-          title: 'Event handling',
+          title: 'Enable multiple selection mode',
           tabs: [
             {
-              code: './examples/event-handling.jsx',
+              code: './examples/multiple-selection.jsx',
               language: 'jsx',
             },
           ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -48,21 +48,8 @@ const data: ReferenceEntityTemplateSchema = {
   related: [],
   examples: {
     description:
-      'Learn how to handle selection events and enable multiple selection modes.',
+      'Learn how to enable multiple selection modes and handle selection events.',
     examples: [
-      {
-        description:
-          'Subscribe to `onChange` and `onInput` events to respond when merchants select options. This example shows how to handle selection changes and capture user input in real time, enabling dynamic behavior and form validation based on merchant choices.',
-        codeblock: {
-          title: 'Handle selection events',
-          tabs: [
-            {
-              code: './examples/event-handling.jsx',
-              language: 'jsx',
-            },
-          ],
-        },
-      },
       {
         description:
           'Enable multiple selection mode to allow merchants to select multiple options from the list. This example demonstrates using controlled values with the `multiple` property, perfect for filtering interfaces or collecting multiple preferences in forms.',
@@ -71,6 +58,19 @@ const data: ReferenceEntityTemplateSchema = {
           tabs: [
             {
               code: './examples/multiple-selection.jsx',
+              language: 'jsx',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Subscribe to `onChange` and `onInput` events to respond when merchants select options. This example shows how to handle selection changes and capture user input in real time, enabling dynamic behavior and form validation based on merchant choices.',
+        codeblock: {
+          title: 'Handle selection events',
+          tabs: [
+            {
+              code: './examples/event-handling.jsx',
               language: 'jsx',
             },
           ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -31,6 +31,25 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Choose appropriate selection modes:** Use single selection for mutually exclusive options. Enable `multiple` when merchants can select more than one.\n' +
+        '- **Write clear, concise choice labels:** Keep labels short but descriptive enough that merchants understand each option without additional explanation.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `ChoiceList` requires choice components as children—other component types can\'t be used as options within the choice list.\n' +
+        '- The component provides the selection interface but doesn\'t automatically filter or update content based on selections—you must implement the logic to respond to selection changes.\n' +
+        '- Visual variants have different presentations across devices and contexts—the actual appearance may vary based on the POS platform and screen size.',
+    },
+  ],
   defaultExample: {
     image: 'choicelist-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -2,8 +2,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ChoiceList',
-  description:
-    'Presents multiple options for single or multiple selections. Use when merchants need to choose from a defined set of options in forms or filtering interfaces.',
+  description: 'Present multiple options for single or multiple selections.',
   thumbnail: 'choicelist-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -2,26 +2,30 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'ChoiceList',
-  description: 'Present multiple options for single or multiple selections.',
+  description:
+    'The `ChoiceList` component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options in forms or filtering interfaces.' +
+    '\n\nThe component supports both single and multiple selection modes with clear visual indicators for selected states and proper checkbox or radio button semantics. It includes features like select all/none functionality for multiple selection across various configuration and filtering scenarios.' +
+    '\n\n`ChoiceList` components maintain selection state across navigation and form resets, with proper visual indication of indeterminate states when some but not all options in a group are selected.',
   thumbnail: 'choicelist-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `ChoiceList` component.',
       type: 'ChoiceList',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `ChoiceList` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ChoiceListEvents',
     },
     {
       title: 'Choice',
       description:
-        'Creates options that let merchants select one or multiple items from a list of choices.',
+        'The `Choice` component creates options that let merchants select one or multiple items from a list of choices.',
       type: 'Choice',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable.d.ts
@@ -12,28 +12,64 @@ import type {ClickableProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * Additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow. Returns a number indicating which phase the event is in: 1 (capturing phase), 2 (at target), or 3 (bubbling phase). This helps determine how the event is propagating through the DOM hierarchy.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -41,11 +77,11 @@ declare const tagName = 's-clickable';
 export interface ClickableJSXProps
   extends Pick<ClickableProps, 'id' | 'disabled'> {
   /**
-   * Callback when the element is activated.
+   * The callback when the element is activated.
    */
   onClick?: (event: CallbackEvent<typeof tagName>) => void;
   /**
-   * The content of the Clickable.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
-    'A generic interactive container component that makes any content interactive and accessible via taps.',
+    'Make any content interactive and accessible to user interactions.',
   thumbnail: 'clickable-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Ensure sufficient hit area:** Provide enough space around clickable elements for easy tap targets, especially on touch devices.\n' +
-        '- **Use for custom interactive elements:** Reserve `Clickable` for scenarios where `Button` styling isn\'t appropriate.\n' +
+        "- **Use for custom interactive elements:** Reserve `Clickable` for scenarios where `Button` styling isn't appropriate.\n" +
         '- **Provide visual feedback:** Ensure wrapped content shows clear visual feedback on interaction through styling or state changes.\n' +
         '- **Use command system when appropriate:** Use `commandFor` and `command` to control modals and overlays declaratively rather than through manual state management.',
     },
@@ -40,8 +40,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- `Clickable` doesn\'t provide built-in visual styling—you must design and implement all visual feedback and states for wrapped content.\n' +
-        '- The component doesn\'t automatically handle keyboard navigation for complex interactive patterns—implement additional keyboard handlers if needed.\n' +
+        "- `Clickable` doesn't provide built-in visual styling—you must design and implement all visual feedback and states for wrapped content.\n" +
+        "- The component doesn't automatically handle keyboard navigation for complex interactive patterns—implement additional keyboard handlers if needed.\n" +
         '- Nested clickable elements can create confusing interactions—avoid placing clickable content inside other clickable containers.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -3,19 +3,22 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
-    'Make any content interactive and accessible to user interactions.',
+    'The `Clickable` component makes any content interactive to user interactions. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.' +
+    "\n\nThis component provides a flexible way to wrap any content and make it respond to user interactions. Unlike buttons, it doesn't impose visual styling, allowing you to create custom interactive elements that match your design requirements while ensuring proper event handling.",
   thumbnail: 'clickable-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Clickable` component.',
       type: 'Clickable',
     },
     {
       title: 'Events',
-      description: '',
+      description:
+        'The `Clickable` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ClickableEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -24,6 +24,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Actions',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Ensure sufficient hit area:** Provide enough space around clickable elements for easy tap targets, especially on touch devices.\n' +
+        '- **Use for custom interactive elements:** Reserve `Clickable` for scenarios where `Button` styling isn\'t appropriate.\n' +
+        '- **Provide visual feedback:** Ensure wrapped content shows clear visual feedback on interaction through styling or state changes.\n' +
+        '- **Use command system when appropriate:** Use `commandFor` and `command` to control modals and overlays declaratively rather than through manual state management.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `Clickable` doesn\'t provide built-in visual styling—you must design and implement all visual feedback and states for wrapped content.\n' +
+        '- The component doesn\'t automatically handle keyboard navigation for complex interactive patterns—implement additional keyboard handlers if needed.\n' +
+        '- Nested clickable elements can create confusing interactions—avoid placing clickable content inside other clickable containers.',
+    },
+  ],
   defaultExample: {
     image: 'clickable-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -26,8 +26,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Actions',
   defaultExample: {
     image: 'clickable-default.png',
+    description:
+      'Make any content interactive using a `Clickable` component wrapper without imposing visual styling. This example shows how to create custom interactive elements while maintaining full control over appearance.',
     codeblock: {
-      title: 'Code',
+      title: 'Make content clickable',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField.d.ts
@@ -12,28 +12,64 @@ import type {DateFieldProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * Additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -44,19 +80,19 @@ export interface DateFieldJSXProps
     'id' | 'label' | 'details' | 'value' | 'disabled' | 'error'
   > {
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function executed when the user makes any changes in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function executed after editing completes, typically on blur.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function executed when the element loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function executed when the element receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -3,20 +3,23 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DateField',
   description:
-    'Capture date input with a consistent interface for date selection and proper validation.',
+    'The `DateField` component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
+    '\n\n`DateField` components support both manual text entry and picker selection, giving merchants flexibility to choose their preferred input method based on personal preference and specific date entry scenarios.' +
+    '\n\nFor visual calendar-based selection, consider `DatePicker`. For space-constrained layouts with scrolling date selection, use `DateSpinner`.',
   thumbnail: 'date-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `DateField` component.',
       type: 'DateField',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `DateField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DateFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -27,8 +27,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'date-field-default.png',
+    description:
+      'Capture date input using a `DateField` component with built-in validation and picker integration. This example shows a basic date field with label and placeholder text.',
     codeblock: {
-      title: 'Code',
+      title: 'Capture date input with a date field',
       tabs: [
         {
           code: './examples/default.html',
@@ -39,12 +41,14 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'DateField usage patterns',
+    description:
+      'Learn how to handle date selection events and validate date input.',
     examples: [
       {
-        description: 'Handle date input events',
+        description:
+          'Subscribe to date input events to respond when merchants select or enter dates. This example shows how to handle `onChange` events to capture date selections, enabling real-time validation, date range checks, or dynamic scheduling behavior based on merchant input.',
         codeblock: {
-          title: 'Event handling',
+          title: 'Handle date selection events',
           tabs: [
             {
               code: './examples/event-handling.jsx',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -25,6 +25,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Choose for direct text input:** Use `DateField` when users know the exact date and can type it efficiently. Use `DatePicker` for calendar selection or `DateSpinner` for space-constrained layouts.\n' +
+        '- **Explain date constraints:** Use `details` to clarify requirements like "Select a date within the next 30 days" or "Must be a future date."\n' +
+        '- **Write actionable error messages:** Provide clear validation messages for invalid dates that help users correct their input.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `DateField` accepts date values in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601) (`YYYY-MM-DD`)—other date formats require conversion before setting the value property.\n' +
+        '- Validation occurs when the user finishes editing rather than on every keystroke—invalid dates are only flagged after blur, which may delay error feedback.\n' +
+        '- The component provides text-based date input—for calendar-style date selection, use the `DatePicker` component which offers visual date selection interface.',
+    },
+  ],
   defaultExample: {
     image: 'date-field-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DateField',
   description:
-    'Captures date input from merchants. Provides a consistent interface for date selection, with proper validation.',
+    'Capture date input with a consistent interface for date selection and proper validation.',
   thumbnail: 'date-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker.d.ts
@@ -12,28 +12,64 @@ import type {DatePickerProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * Additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -41,19 +77,19 @@ declare const tagName = 's-date-picker';
 export interface DatePickerJSXProps
   extends Pick<DatePickerProps, 'id' | 'value'> {
   /**
-   * Callback when the user selects a date from the picker.
+   * A callback function executed when the user selects a date from the picker.
    */
   onInput?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * Callback when the user selects a date from the picker that is different to the current value.
+   * A callback function executed when the user selects a date from the picker that is different from the current value.
    */
   onChange?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * Callback when the date picker is dismissed.
+   * A callback function executed when the date picker is dismissed or closed.
    */
   onBlur?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * Callback when the date picker is revealed.
+   * A callback function executed when the date picker is revealed or opened.
    */
   onFocus?: (event: CallbackEvent<typeof tagName>) => void | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -26,8 +26,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'date-picker-default.png',
+    description:
+      'Enable visual date selection using a `DatePicker` component with a calendar interface. This example shows a basic date picker with month view and date selection.',
     codeblock: {
-      title: 'Code',
+      title: 'Select dates with a calendar picker',
       tabs: [
         {
           code: './examples/default.html',
@@ -38,12 +40,14 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'DatePicker usage patterns',
+    description:
+      'Learn how to control picker visibility and handle date selection events.',
     examples: [
       {
-        description: 'Show and hide DatePicker using button commands',
+        description:
+          'Control `DatePicker` visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the calendar picker, enabling custom trigger patterns for date selection workflows.',
         codeblock: {
-          title: 'Command system',
+          title: 'Control picker visibility',
           tabs: [
             {
               code: './examples/command-system.jsx',
@@ -53,9 +57,10 @@ const data: ReferenceEntityTemplateSchema = {
         },
       },
       {
-        description: 'Handle date selection events',
+        description:
+          'Subscribe to date selection events to respond when merchants pick a date from the calendar. This example shows how to handle `onChange` events to capture selected dates, enabling validation, scheduling logic, or dynamic updates based on the chosen date.',
         codeblock: {
-          title: 'Event handling',
+          title: 'Handle date selection events',
           tabs: [
             {
               code: './examples/event-handling.jsx',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -40,7 +40,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- `DatePicker` provides the calendar interface but requires external state management for the selected value—you must update the `value` property in response to change events.\n' +
         '- The component supports single dates, multiple dates, and date ranges through value format alone—the selection mode is inferred from the `value` property format rather than an explicit property.\n' +
-        '- Invalid date values result in no date being selected—the component doesn\'t provide specific error feedback, so you must validate date formats before setting the `value` property.',
+        "- Invalid date values result in no date being selected—the component doesn't provide specific error feedback, so you must validate date formats before setting the `value` property.",
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -3,20 +3,22 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DatePicker',
   description:
-    'Allow merchants to select a specific date using a calendar-like picker interface.',
+    'The `DatePicker` component allows merchants to select a specific date using a calendar-like picker interface. Use it to provide visual date selection with an intuitive calendar view for improved user experience.' +
+    '\n\n`DatePicker` offers a calendar-based alternative to spinner-style pickers when visual calendar context is beneficial. The calendar interface allows merchants to see dates in context of the full month, making it easier to select dates relative to specific days of the week or to visualize date ranges within a month view.',
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `DatePicker` component.',
       type: 'DatePicker',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `DatePicker` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DatePickerEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -24,6 +24,25 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Choose for calendar-based selection:** Use `DatePicker` when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use `DateSpinner` for tight spaces or `DateField` when users know the exact date.\n' +
+        '- **Provide adequate space:** Ensure sufficient spacing around the picker to avoid interfering with on-screen keyboards or other interactive elements.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `DatePicker` provides the calendar interface but requires external state management for the selected value—you must update the `value` property in response to change events.\n' +
+        '- The component supports single dates, multiple dates, and date ranges through value format alone—the selection mode is inferred from the `value` property format rather than an explicit property.\n' +
+        '- Invalid date values result in no date being selected—the component doesn\'t provide specific error feedback, so you must validate date formats before setting the `value` property.',
+    },
+  ],
   defaultExample: {
     image: 'date-picker-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DatePicker',
   description:
-    'Allows merchants to select a specific date, using a calendar-like picker interface.',
+    'Allow merchants to select a specific date using a calendar-like picker interface.',
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner.d.ts
@@ -12,28 +12,64 @@ import type {DateSpinnerProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * Additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -41,19 +77,19 @@ declare const tagName = 's-date-spinner';
 export interface DateSpinnerJSXProps
   extends Pick<DateSpinnerProps, 'id' | 'value'> {
   /**
-   * Callback when the user makes a selection.
+   * A callback function executed when the user makes a selection in the spinner.
    */
   onInput?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * Callback when the value changes. Only called when a different value is selected.
+   * A callback function executed when the value changes. Only called when a different value is selected.
    */
   onChange?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * Callback when the date spinner is dismissed.
+   * A callback function executed when the date spinner is dismissed or closed.
    */
   onBlur?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * Callback when the date spinner is revealed.
+   * A callback function executed when the date spinner is revealed or opened.
    */
   onFocus?: (event: CallbackEvent<typeof tagName>) => void | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DateSpinner',
   description:
-    'Allows merchants to select a specific date, using a spinner interface.',
+    'Enable merchants to select a specific date using a spinner interface with scrollable columns for month, day, and year.',
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -3,20 +3,22 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DateSpinner',
   description:
-    'Enable merchants to select a specific date using a spinner interface with scrollable columns for month, day, and year.',
+    'The `DateSpinner` component enables merchants to select a specific date using a spinner interface with scrollable columns for month, day, and year. Use it to provide compact date selection in constrained spaces.' +
+    '\n\n`DateSpinner` offers an alternative to calendar-style pickers when space is limited or when users prefer scrolling through date values. The spinner interface allows merchants to select dates by scrolling through separate columns for month, day, and year, providing a compact and intuitive way to select dates in constrained layouts.',
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `DateSpinner` component.',
       type: 'DateSpinner',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `DateSpinner` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DateSpinnerEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -26,8 +26,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'date-spinner-default.png',
+    description:
+      'Enable compact date selection using a `DateSpinner` component with scrollable columns for month, day, and year. This example shows a basic date spinner for space-constrained layouts.',
     codeblock: {
-      title: 'Code',
+      title: 'Select dates with a spinner',
       tabs: [
         {
           code: './examples/default.html',
@@ -38,12 +40,14 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'DateSpinner usage patterns',
+    description:
+      'Learn how to control spinner visibility and handle date selection events.',
     examples: [
       {
-        description: 'Show and hide DateSpinner using button commands',
+        description:
+          'Control `DateSpinner` visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the spinner picker, enabling custom trigger patterns for date selection in constrained layouts.',
         codeblock: {
-          title: 'Command system',
+          title: 'Control spinner visibility',
           tabs: [
             {
               code: './examples/command-system.jsx',
@@ -53,9 +57,10 @@ const data: ReferenceEntityTemplateSchema = {
         },
       },
       {
-        description: 'Handle date selection events',
+        description:
+          'Subscribe to date selection events to respond when merchants pick a date from the spinner columns. This example shows how to handle `onChange` events to capture selected dates, enabling validation, scheduling logic, or dynamic updates based on the chosen date.',
         codeblock: {
-          title: 'Event handling',
+          title: 'Handle date selection events',
           tabs: [
             {
               code: './examples/event-handling.jsx',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -24,6 +24,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use for space-constrained layouts:** Choose `DateSpinner` for narrow layouts or split-screen interfaces where a calendar view would be impractical.\n' +
+        '- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, `DatePicker` provides faster navigation.\n' +
+        '- **Provide interaction cues:** Consider labels or instructions to help first-time users understand the scrollable column interface.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `DateSpinner` uses [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date format (`YYYY-MM-DD`) only—other date formats require conversion before setting the value property.\n' +
+        '- The component provides spinner-based date selection exclusively—for calendar-style visual selection with month context, use the `DatePicker` component instead.\n' +
+        '- `DateSpinner` doesn\'t include field labels, help text, or error messaging—combine with other UI elements or text components to provide complete form field experiences.',
+    },
+  ],
   defaultExample: {
     image: 'date-spinner-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -41,7 +41,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- `DateSpinner` uses [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date format (`YYYY-MM-DD`) only—other date formats require conversion before setting the value property.\n' +
         '- The component provides spinner-based date selection exclusively—for calendar-style visual selection with month context, use the `DatePicker` component instead.\n' +
-        '- `DateSpinner` doesn\'t include field labels, help text, or error messaging—combine with other UI elements or text components to provide complete form field experiences.',
+        "- `DateSpinner` doesn't include field labels, help text, or error messaging—combine with other UI elements or text components to provide complete form field experiences.",
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider.d.ts
@@ -12,18 +12,30 @@ import type {DividerProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -33,9 +33,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- `Divider` is a purely visual component and doesn\'t provide interactive functionality—it serves only to create visual separation between content areas.\n' +
-        '- The component doesn\'t support custom styling beyond the available direction property—color, thickness, and other visual properties are controlled by the POS design system.\n' +
-        '- Dividers don\'t automatically adjust spacing around themselves—you must manage appropriate margins and padding in surrounding content to achieve proper visual separation.',
+        "- `Divider` is a purely visual component and doesn't provide interactive functionality—it serves only to create visual separation between content areas.\n" +
+        "- The component doesn't support custom styling beyond the available direction property—color, thickness, and other visual properties are controlled by the POS design system.\n" +
+        "- Dividers don't automatically adjust spacing around themselves—you must manage appropriate margins and padding in surrounding content to achieve proper visual separation.",
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -2,14 +2,18 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Divider',
-  description: 'Create visual separation between content sections.',
+  description:
+    'The `Divider` component creates a visual separation between content sections. Use dividers to organize information and improve content hierarchy by providing clear section boundaries.' +
+    '\n\nThe component renders a subtle horizontal line that follows design system specifications for color and thickness, maintaining visual consistency across the interface. It provides a clean way to separate content groups without adding significant visual weight, helping merchants scan and understand interface structure through strategic content segmentation.' +
+    '\n\n`Divider` components support both full-width and inset dividers with configurable margins, allowing precise control over visual separation without adding custom CSS for common divider placement patterns.',
   thumbnail: 'divider-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Divider` component.',
       type: 'Divider',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -19,6 +19,25 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Structure',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Choose appropriate direction:** Use `inline` (horizontal) for most content separation. Use `block` (vertical) for columns or sidebar boundaries.\n' +
+        '- **Avoid overuse:** Use dividers strategically. In dense interfaces, consider whitespace or typography hierarchy instead.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `Divider` is a purely visual component and doesn\'t provide interactive functionality—it serves only to create visual separation between content areas.\n' +
+        '- The component doesn\'t support custom styling beyond the available direction property—color, thickness, and other visual properties are controlled by the POS design system.\n' +
+        '- Dividers don\'t automatically adjust spacing around themselves—you must manage appropriate margins and padding in surrounding content to achieve proper visual separation.',
+    },
+  ],
   defaultExample: {
     image: 'divider-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Structure',
+  subCategory: 'Layout and structure',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -21,8 +21,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Structure',
   defaultExample: {
     image: 'divider-default.png',
+    description:
+      'Create visual separation between content sections using a `Divider` component. This example shows a horizontal divider that provides clear section boundaries.',
     codeblock: {
-      title: 'Code',
+      title: 'Separate content sections with a divider',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -2,8 +2,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Divider',
-  description:
-    'Creates a visual separation between content sections. Dividers help organize information and improve content hierarchy by providing clear section boundaries.',
+  description: 'Create visual separation between content sections.',
   thumbnail: 'divider-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField.d.ts
@@ -17,28 +17,64 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * Additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -57,23 +93,23 @@ export interface EmailFieldJSXProps
     | 'details'
   > {
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function executed when the user makes any changes in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function executed after editing completes, typically on blur.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function executed when the element loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function executed when the element receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Additional content to be displayed in the field. Commonly used to display clickable text.
+   * Additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -3,26 +3,29 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'EmailField',
   description:
-    'Capture email address input from customers with built-in validation.',
+    'The `EmailField` component captures email address input from customers with built-in validation. Use it to collect email information in forms, customer profiles, or contact workflows.' +
+    '\n\nThe component includes built-in email format validation using standard email patterns to ensure data quality. It provides real-time feedback on invalid entries and supports features like autocomplete and keyboard optimization for email input, helping merchants quickly capture valid customer contact information during checkout or registration workflows.' +
+    '\n\n`EmailField` components integrate with browser autocomplete features to speed up email entry by suggesting previously used addresses, significantly reducing typing time during customer registration workflows.',
   thumbnail: 'email-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `EmailField` component.',
       type: 'EmailField',
     },
     {
       title: 'Slots',
       description:
-        'Learn more about using [slots](/docs/api/pos-ui-extensions/using-polaris-components#slots)',
+        'The `EmailField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'EmailFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `EmailField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'EmailFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -46,9 +46,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- `EmailField` provides the input interface but doesn\'t perform automatic email validation—you must implement validation logic and use the `error` property to display validation results.\n' +
-        '- The `required` property adds semantic meaning only—it doesn\'t trigger automatic error display, so you must manually check for empty values and set errors accordingly.\n' +
-        '- The `accessory` slot supports only `Button` and `Clickable` components—other component types can\'t be used in the accessory slot.',
+        "- `EmailField` provides the input interface but doesn't perform automatic email validation—you must implement validation logic and use the `error` property to display validation results.\n" +
+        "- The `required` property adds semantic meaning only—it doesn't trigger automatic error display, so you must manually check for empty values and set errors accordingly.\n" +
+        "- The `accessory` slot supports only `Button` and `Clickable` components—other component types can't be used in the accessory slot.",
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -31,6 +31,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Write descriptive labels:** Use specific labels like "Customer Email" or "Receipt Email Address" rather than generic "Email."\n' +
+        '- **Provide context in details:** Use `details` for additional context like "Required for digital receipts" or "We\'ll send order updates to this address."\n' +
+        '- **Write actionable error messages:** Provide clear validation messages like "Please enter a valid email address" that help users correct their input.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `EmailField` provides the input interface but doesn\'t perform automatic email validation—you must implement validation logic and use the `error` property to display validation results.\n' +
+        '- The `required` property adds semantic meaning only—it doesn\'t trigger automatic error display, so you must manually check for empty values and set errors accordingly.\n' +
+        '- The `accessory` slot supports only `Button` and `Clickable` components—other component types can\'t be used in the accessory slot.',
+    },
+  ],
   defaultExample: {
     image: 'email-field-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -33,8 +33,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'email-field-default.png',
+    description:
+      'Capture email address input using an `EmailField` component with built-in email validation. This example shows a basic email field with label and automatic format validation.',
     codeblock: {
-      title: 'Code',
+      title: 'Capture email addresses with an email field',
       tabs: [
         {
           code: './examples/default.html',
@@ -45,15 +47,17 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'EmailField usage patterns',
+    description:
+      'Learn how to add accessory buttons and handle email input events.',
     examples: [
       {
-        description: 'Handle email input events',
+        description:
+          'Add action buttons to the email field using the accessory slot for quick actions like clearing input or verifying email addresses. This example shows how to use `s-button` and `s-clickable` components in the accessory slot, providing inline functionality within the email input context.',
         codeblock: {
-          title: 'Event handling',
+          title: 'Add accessory buttons',
           tabs: [
             {
-              code: './examples/event-handling.jsx',
+              code: './examples/accessory-slot.jsx',
               language: 'jsx',
             },
           ],
@@ -61,12 +65,12 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Add action buttons using the accessory slot. Only s-button and s-clickable are supported',
+          'Subscribe to email input events to respond when merchants enter email addresses. This example demonstrates handling `onChange`, `onInput`, `onFocus`, and `onBlur` events for real-time email validation, duplicate checking, or autosave functionality.',
         codeblock: {
-          title: 'Accessory slot',
+          title: 'Handle email input events',
           tabs: [
             {
-              code: './examples/accessory-slot.jsx',
+              code: './examples/event-handling.jsx',
               language: 'jsx',
             },
           ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'EmailField',
   description:
-    'Captures email address input from merchants. Provides built-in email validation and appropriate keyboard layout.',
+    'Capture email address input from customers with built-in validation.',
   thumbnail: 'email-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading.d.ts
@@ -12,18 +12,30 @@ import type {HeadingProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The content of the heading, typically text that describes the section or page it introduces.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
@@ -31,7 +43,7 @@ export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 declare const tagName = 's-heading';
 export interface HeadingJSXProps extends Pick<HeadingProps, 'id'> {
   /**
-   * The content of the Heading.
+   * The content of the heading, typically text that describes the section or page it introduces.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
-    'Renders hierarchical titles to communicate the structure and organization of page content. Heading levels adjust automatically based on nesting within parent Section components, ensuring a meaningful and accessible page outline.',
+    'Render hierarchical titles to communicate the structure and organization of page content.',
   thumbnail: 'heading-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -3,11 +3,20 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
-    'Render hierarchical titles to communicate the structure and organization of page content.',
+    'The `Heading` component renders hierarchical titles to communicate the structure and organization of page content. Heading levels adjust automatically based on nesting within parent Section components, ensuring a meaningful page outline.' +
+    '\n\nUse headings to create clear information hierarchy and help users navigate complex interfaces efficiently.' +
+    '\n\n`Heading` components provide consistent typographic scaling that maintains visual hierarchy while ensuring headings remain readable at all levels, even when deeply nested within multiple `Section` components.',
   thumbnail: 'heading-thumbnail.png',
   isVisualComponent: true,
   type: '',
-  definitions: [],
+  definitions: [
+    {
+      title: 'Properties',
+      description:
+        'Configure the following properties on the `Heading` component.',
+      type: 'Heading',
+    },
+  ],
   category: 'Polaris web components',
   subCategory: 'Titles and text',
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Titles and text',
+  subCategory: 'Layout and structure',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -19,6 +19,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Titles and text',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Create logical hierarchy:** Start with higher-level headings for main sections, nested headings for subsections. Nested sections automatically adjust heading levels.\n' +
+        '- **Write specific headings:** Avoid generic terms like "Details." Use specific descriptions like "Customer Contact Information" or "Transaction Summary."\n' +
+        '- **Keep text concise:** Headings don\'t truncate, so keep them brief enough to display across different screen sizes.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Heading levels are automatically determined by nesting within `Section` components—manual heading level control is not available to ensure consistent document structure.\n' +
+        '- The component doesn\'t support rich text formatting within the heading content—use plain text or simple inline elements for heading content.\n' +
+        '- Visual styling is controlled by the POS design system and heading level—custom typography styles beyond the available properties aren\'t supported.',
+    },
+  ],
   defaultExample: {
     image: 'heading-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- **Create logical hierarchy:** Start with higher-level headings for main sections, nested headings for subsections. Nested sections automatically adjust heading levels.\n' +
         '- **Write specific headings:** Avoid generic terms like "Details." Use specific descriptions like "Customer Contact Information" or "Transaction Summary."\n' +
-        '- **Keep text concise:** Headings don\'t truncate, so keep them brief enough to display across different screen sizes.',
+        "- **Keep text concise:** Headings don't truncate, so keep them brief enough to display across different screen sizes.",
     },
     {
       type: 'Generic',
@@ -35,8 +35,8 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent:
         '- Heading levels are automatically determined by nesting within `Section` components—manual heading level control is not available to ensure consistent document structure.\n' +
-        '- The component doesn\'t support rich text formatting within the heading content—use plain text or simple inline elements for heading content.\n' +
-        '- Visual styling is controlled by the POS design system and heading level—custom typography styles beyond the available properties aren\'t supported.',
+        "- The component doesn't support rich text formatting within the heading content—use plain text or simple inline elements for heading content.\n" +
+        "- Visual styling is controlled by the POS design system and heading level—custom typography styles beyond the available properties aren't supported.",
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -21,8 +21,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Titles and text',
   defaultExample: {
     image: 'heading-default.png',
+    description:
+      'Create hierarchical titles using a `Heading` component that adjusts levels automatically based on nesting. This example shows a basic heading with automatic level management.',
     codeblock: {
-      title: 'Code',
+      title: 'Display hierarchical headings',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon.d.ts
@@ -12,23 +12,164 @@ import type {IconProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 
 declare const tagName = 's-icon';
+/**
+ * The available icon types for the `Icon` component. Each icon represents a specific action, status, or category:
+ *
+ * - `'alert-circle'` - An alert or warning indicator with circular background. Commonly used for system alerts, validation errors, or important notifications that require attention.
+ * - `'apps'` - An application grid or app launcher symbol. Commonly used for accessing installed apps, extensions, or additional software features.
+ * - `'arrow-down'` - A downward pointing arrow. Commonly used for dropdown menus, collapsing content, downloading actions, or indicating downward movement.
+ * - `'arrow-left'` - A leftward pointing arrow. Commonly used for back navigation, previous actions, or indicating leftward movement in interfaces.
+ * - `'arrow-right'` - A rightward pointing arrow. Commonly used for forward navigation, next actions, or indicating rightward movement and progression.
+ * - `'arrow-up'` - An upward pointing arrow. Commonly used for expanding content, uploading actions, or indicating upward movement and elevation.
+ * - `'backspace'` - A backspace or delete key symbol. Commonly used for removing characters, undoing input, or clearing entered data.
+ * - `'barcode'` - A barcode scanning symbol. Commonly used for product scanning, inventory management, or barcode-related functionality.
+ * - `'battery-low'` - A low battery indicator. Commonly used for device status, power warnings, or battery-related notifications.
+ * - `'bolt-filled'` - A lightning bolt symbol with fill. Commonly used for power, energy, fast actions, or high-priority features.
+ * - `'bullet'` - A bullet point or dot symbol. Commonly used for list items, status indicators, or simple visual markers.
+ * - `'camera-flip'` - A camera rotation or flip symbol. Commonly used for switching camera views, rotating images, or camera-related controls.
+ * - `'caret-down'` - A small downward caret. Commonly used for dropdown indicators, collapsible sections, or subtle directional cues.
+ * - `'caret-up'` - A small upward caret. Commonly used for expandable sections, sort indicators, or subtle upward directional cues.
+ * - `'cart'` - A shopping cart outline. Commonly used for shopping functionality, adding items to cart, or e-commerce actions.
+ * - `'cart-down'` - A shopping cart with downward arrow. Commonly used for removing items from cart or decreasing quantities.
+ * - `'cart-filled'` - A filled shopping cart. Commonly used to indicate items in cart, active shopping session, or cart with contents.
+ * - `'cart-send'` - A cart with send arrow. Commonly used for sharing cart contents, sending cart to another device, or cart transfer actions.
+ * - `'cart-up'` - A shopping cart with upward arrow. Commonly used for adding items to cart or increasing quantities.
+ * - `'chart-line'` - A line chart or graph symbol. Commonly used for analytics, sales reports, performance metrics, or data visualization.
+ * - `'chart-vertical'` - A vertical bar chart symbol. Commonly used for sales data, inventory levels, comparative analytics, or statistical displays.
+ * - `'check'` - A checkmark symbol. Commonly used for confirmation, completion, success states, or selection indicators.
+ * - `'check-circle-filled'` - A checkmark in filled circle. Commonly used for completed tasks, successful operations, or positive confirmation states.
+ * - `'chevron-down'` - A downward chevron. Commonly used for dropdown menus, expandable content, or indicating downward navigation.
+ * - `'chevron-left'` - A leftward chevron. Commonly used for back navigation, previous items, or leftward movement in carousels and lists.
+ * - `'chevron-right'` - A rightward chevron. Commonly used for forward navigation, next items, or rightward movement and progression.
+ * - `'chevron-up'` - An upward chevron. Commonly used for collapsible content, scroll to top, or indicating upward navigation.
+ * - `'circle'` - A simple circle outline. Commonly used for radio buttons, status indicators, or basic geometric markers.
+ * - `'clipboard-checklist'` - A clipboard with checklist. Commonly used for tasks, order fulfillment, inventory checks, or process completion.
+ * - `'clock'` - A clock or time symbol. Commonly used for scheduling, time tracking, business hours, or temporal information.
+ * - `'collection'` - A product collection or group symbol. Commonly used for product categories, grouped items, or collection management.
+ * - `'credit-card'` - A credit card symbol. Commonly used for payment methods, card transactions, or financial operations.
+ * - `'credit-card-reader'` - A card reader device symbol. Commonly used for payment processing, card scanning, or POS hardware functions.
+ * - `'delete'` - A delete or trash symbol. Commonly used for removing items, deleting records, or destructive actions.
+ * - `'delivery'` - A delivery truck or shipping symbol. Commonly used for order fulfillment, shipping options, or delivery tracking.
+ * - `'desktop'` - A desktop computer symbol. Commonly used for device types, platform indicators, or desktop-specific features.
+ * - `'disabled'` - A disabled or inactive state symbol. Commonly used for unavailable features, inactive items, or disabled functionality.
+ * - `'disabled-filled'` - A filled disabled state symbol. Commonly used for prominently indicating unavailable or inactive elements.
+ * - `'discount'` - A discount or sale symbol. Commonly used for promotions, price reductions, or special offers.
+ * - `'discount-add'` - An add discount symbol. Commonly used for applying discounts, creating promotions, or adding price reductions.
+ * - `'discount-automatic'` - An automatic discount symbol. Commonly used for system-applied discounts, automatic promotions, or rule-based reductions.
+ * - `'discount-code'` - A discount code symbol. Commonly used for coupon codes, promotional codes, or manual discount entry.
+ * - `'discount-remove'` - A remove discount symbol. Commonly used for removing applied discounts, canceling promotions, or undoing price reductions.
+ * - `'drag-handle'` - A drag handle or grip symbol. Commonly used for reorderable lists, draggable elements, or sortable interfaces.
+ * - `'drawer'` - A cash drawer symbol. Commonly used for cash register operations, drawer opening, or cash management.
+ * - `'duplicate'` - A duplicate or copy symbol. Commonly used for copying items, duplicating records, or replication actions.
+ * - `'edit'` - An edit or pencil symbol. Commonly used for editing content, modifying records, or entering edit mode.
+ * - `'email'` - An email or message symbol. Commonly used for email functionality, messaging, or communication features.
+ * - `'exchange'` - An exchange or swap symbol. Commonly used for product exchanges, return processing, or item swapping.
+ * - `'external'` - An external link symbol. Commonly used for links that open in new windows, external resources, or outside navigation.
+ * - `'flag'` - A flag or marker symbol. Commonly used for flagging items, marking important content, or status indicators.
+ * - `'gift-card'` - A gift card symbol. Commonly used for gift card sales, redemption, or gift card management features.
+ * - `'graduation-hat'` - A graduation cap symbol. Commonly used for training, education, tutorials, or learning features.
+ * - `'grid'` - A grid view symbol. Commonly used for switching to grid layout, organizing content, or grid-based displays.
+ * - `'hide-filled'` - A hide or visibility off symbol with fill. Commonly used for hiding content, privacy controls, or visibility toggles.
+ * - `'home'` - A home outline symbol. Commonly used for home navigation, main dashboard, or returning to start screen.
+ * - `'home-filled'` - A filled home symbol. Commonly used for active home state, main navigation, or primary dashboard indicator.
+ * - `'image'` - A single image symbol. Commonly used for image upload, photo features, or visual content indicators.
+ * - `'images'` - A multiple images symbol. Commonly used for image galleries, bulk photo operations, or media collections.
+ * - `'info'` - An information symbol. Commonly used for help content, additional details, or informational messages.
+ * - `'inventory'` - An inventory or stock symbol. Commonly used for inventory management, stock levels, or product tracking.
+ * - `'inventory-edit'` - An edit inventory symbol. Commonly used for modifying stock levels, updating inventory, or inventory adjustments.
+ * - `'inventory-list'` - An inventory list symbol. Commonly used for viewing stock lists, inventory reports, or product catalogs.
+ * - `'inventory-transfer'` - An inventory transfer symbol. Commonly used for moving stock between locations, transfers, or redistribution.
+ * - `'keyboard-hide'` - A hide keyboard symbol. Commonly used for dismissing on-screen keyboards or input controls.
+ * - `'keypad'` - A numeric keypad symbol. Commonly used for number entry, PIN input, or calculator functions.
+ * - `'link'` - A link or chain symbol. Commonly used for hyperlinks, connections, or linking functionality.
+ * - `'list-bulleted'` - A bulleted list outline symbol. Commonly used for list views, itemized content, or list formatting.
+ * - `'list-bulleted-filled'` - A filled bulleted list symbol. Commonly used for active list views or selected list formatting.
+ * - `'live'` - A live or active status symbol. Commonly used for real-time features, live updates, or active connections.
+ * - `'live-critical'` - A critical live status symbol. Commonly used for urgent live alerts, critical real-time issues, or emergency states.
+ * - `'live-none'` - A no live status symbol. Commonly used for offline states, inactive connections, or unavailable live features.
+ * - `'location'` - A location or map pin symbol. Commonly used for store locations, addresses, or geographic features.
+ * - `'lock'` - A lock or security symbol. Commonly used for secure features, locked content, or security settings.
+ * - `'maximize'` - A maximize or expand symbol. Commonly used for fullscreen mode, expanding windows, or enlarging content.
+ * - `'menu'` - A menu outline symbol. Commonly used for navigation menus, options lists, or menu toggles.
+ * - `'menu-filled'` - A filled menu symbol. Commonly used for active menu states or prominent menu indicators.
+ * - `'menu-horizontal'` - A horizontal menu symbol. Commonly used for horizontal navigation, action menus, or more options.
+ * - `'minimize'` - A minimize or collapse symbol. Commonly used for reducing windows, collapsing content, or minimizing interfaces.
+ * - `'minus'` - A minus or subtract symbol. Commonly used for decreasing quantities, removing items, or subtraction operations.
+ * - `'mobile'` - A mobile phone symbol. Commonly used for mobile features, device types, or mobile-specific functionality.
+ * - `'money'` - A money or currency symbol. Commonly used for financial features, pricing, or monetary transactions.
+ * - `'money-split'` - A split payment symbol. Commonly used for divided payments, partial payments, or payment splitting features.
+ * - `'note'` - A note or document symbol. Commonly used for notes, documentation, or text content features.
+ * - `'order'` - An order outline symbol. Commonly used for order management, order history, or order-related functions.
+ * - `'order-draft'` - A draft order symbol. Commonly used for incomplete orders, order drafts, or pending order creation.
+ * - `'order-filled'` - A filled order symbol. Commonly used for completed orders, active order states, or order fulfillment.
+ * - `'package'` - A package or shipping box symbol. Commonly used for shipping, packaging, or fulfillment operations.
+ * - `'package-cancel'` - A cancel package symbol. Commonly used for canceling shipments, stopping fulfillment, or package cancellation.
+ * - `'package-reassign'` - A reassign package symbol. Commonly used for changing fulfillment locations, reassigning orders, or package redirection.
+ * - `'payment'` - A payment symbol. Commonly used for payment processing, transaction features, or financial operations.
+ * - `'person'` - A person outline symbol. Commonly used for user accounts, customer profiles, or people-related features.
+ * - `'person-add'` - An add person symbol. Commonly used for creating accounts, adding customers, or user registration.
+ * - `'person-filled'` - A filled person symbol. Commonly used for active user states, logged-in users, or selected profiles.
+ * - `'phablet'` - A phablet device symbol. Commonly used for large mobile devices, tablet phones, or device-specific features.
+ * - `'phone-out'` - An outgoing phone call symbol. Commonly used for making calls, phone features, or communication functions.
+ * - `'play-circle'` - A play button in circle. Commonly used for starting processes, playing media, or initiating actions.
+ * - `'plus'` - A plus or add symbol. Commonly used for adding items, creating new content, or addition operations.
+ * - `'point-of-sale'` - A point of sale system symbol. Commonly used for POS features, retail operations, or sales terminals.
+ * - `'point-of-sale-register'` - A cash register symbol. Commonly used for register operations, cash handling, or traditional POS functions.
+ * - `'print'` - A print symbol. Commonly used for printing receipts, documents, or print-related functionality.
+ * - `'product'` - A product outline symbol. Commonly used for product management, catalog features, or product-related functions.
+ * - `'product-filled'` - A filled product symbol. Commonly used for active products, selected items, or product highlights.
+ * - `'profile'` - A user profile symbol. Commonly used for profile management, account settings, or personal information.
+ * - `'question-circle-filled'` - A question mark in filled circle. Commonly used for help features, support, or informational assistance.
+ * - `'receipt'` - A receipt symbol. Commonly used for transaction receipts, purchase confirmations, or receipt management.
+ * - `'refresh'` - A refresh or reload symbol. Commonly used for updating content, refreshing data, or reload operations.
+ * - `'return'` - A return symbol. Commonly used for product returns, refund processing, or return management.
+ * - `'scan-qr-code'` - A QR code scanning symbol. Commonly used for QR code features, digital scanning, or code-based interactions.
+ * - `'search'` - A search or magnifying glass symbol. Commonly used for search functionality, finding content, or lookup features.
+ * - `'send'` - A send or submit symbol. Commonly used for sending messages, submitting forms, or transmission actions.
+ * - `'settings'` - A settings or gear symbol. Commonly used for configuration, preferences, or system settings.
+ * - `'shipping-label-cancel'` - A cancel shipping label symbol. Commonly used for voiding labels, canceling shipments, or shipping corrections.
+ * - `'sort'` - A sort or arrange symbol. Commonly used for sorting lists, organizing content, or arrangement controls.
+ * - `'star-circle'` - A star in circle symbol. Commonly used for ratings, favorites, or featured content indicators.
+ * - `'star-filled'` - A filled star symbol. Commonly used for ratings, favorites, or highlighting important content.
+ * - `'store'` - A store or shop symbol. Commonly used for store information, retail locations, or shop-related features.
+ * - `'tablet'` - A tablet device symbol. Commonly used for tablet features, device types, or tablet-specific functionality.
+ * - `'transaction-fee-add'` - An add transaction fee symbol. Commonly used for applying fees, additional charges, or fee management.
+ * - `'unlock'` - An unlock symbol. Commonly used for unlocking features, accessing content, or security controls.
+ * - `'variant'` - A product variant symbol. Commonly used for product variations, different options, or variant management.
+ * - `'view'` - A view or eye symbol. Commonly used for viewing content, visibility controls, or display options.
+ * - `'wallet'` - A wallet symbol. Commonly used for digital wallets, payment methods, or financial account features.
+ * - `'x'` - An X or close symbol. Commonly used for closing dialogs, canceling actions, or dismissing content.
+ * - `'x-circle'` - An X in circle symbol. Commonly used for error states, cancellation, or removing items with emphasis.
+ */
 export type SupportedIconNames = Extract<
   IconProps['type'],
   | 'alert-circle'
@@ -160,7 +301,7 @@ export type SupportedIconNames = Extract<
 export interface IconJSXProps
   extends Pick<IconProps, 'id' | 'tone' | 'color' | 'size'> {
   /**
-   * The type of icon to display.
+   * The type of icon to display. Choose from a comprehensive set of POS-specific icons including navigation arrows, commerce symbols, device indicators, and action icons like `'cart'`, `'search'`, `'settings'`, and `'payment'`.
    *
    * @default ''
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon.d.ts
@@ -42,133 +42,7 @@ export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 
 declare const tagName = 's-icon';
 /**
- * The available icon types for the `Icon` component. Each icon represents a specific action, status, or category:
- *
- * - `'alert-circle'` - An alert or warning indicator with circular background. Commonly used for system alerts, validation errors, or important notifications that require attention.
- * - `'apps'` - An application grid or app launcher symbol. Commonly used for accessing installed apps, extensions, or additional software features.
- * - `'arrow-down'` - A downward pointing arrow. Commonly used for dropdown menus, collapsing content, downloading actions, or indicating downward movement.
- * - `'arrow-left'` - A leftward pointing arrow. Commonly used for back navigation, previous actions, or indicating leftward movement in interfaces.
- * - `'arrow-right'` - A rightward pointing arrow. Commonly used for forward navigation, next actions, or indicating rightward movement and progression.
- * - `'arrow-up'` - An upward pointing arrow. Commonly used for expanding content, uploading actions, or indicating upward movement and elevation.
- * - `'backspace'` - A backspace or delete key symbol. Commonly used for removing characters, undoing input, or clearing entered data.
- * - `'barcode'` - A barcode scanning symbol. Commonly used for product scanning, inventory management, or barcode-related functionality.
- * - `'battery-low'` - A low battery indicator. Commonly used for device status, power warnings, or battery-related notifications.
- * - `'bolt-filled'` - A lightning bolt symbol with fill. Commonly used for power, energy, fast actions, or high-priority features.
- * - `'bullet'` - A bullet point or dot symbol. Commonly used for list items, status indicators, or simple visual markers.
- * - `'camera-flip'` - A camera rotation or flip symbol. Commonly used for switching camera views, rotating images, or camera-related controls.
- * - `'caret-down'` - A small downward caret. Commonly used for dropdown indicators, collapsible sections, or subtle directional cues.
- * - `'caret-up'` - A small upward caret. Commonly used for expandable sections, sort indicators, or subtle upward directional cues.
- * - `'cart'` - A shopping cart outline. Commonly used for shopping functionality, adding items to cart, or e-commerce actions.
- * - `'cart-down'` - A shopping cart with downward arrow. Commonly used for removing items from cart or decreasing quantities.
- * - `'cart-filled'` - A filled shopping cart. Commonly used to indicate items in cart, active shopping session, or cart with contents.
- * - `'cart-send'` - A cart with send arrow. Commonly used for sharing cart contents, sending cart to another device, or cart transfer actions.
- * - `'cart-up'` - A shopping cart with upward arrow. Commonly used for adding items to cart or increasing quantities.
- * - `'chart-line'` - A line chart or graph symbol. Commonly used for analytics, sales reports, performance metrics, or data visualization.
- * - `'chart-vertical'` - A vertical bar chart symbol. Commonly used for sales data, inventory levels, comparative analytics, or statistical displays.
- * - `'check'` - A checkmark symbol. Commonly used for confirmation, completion, success states, or selection indicators.
- * - `'check-circle-filled'` - A checkmark in filled circle. Commonly used for completed tasks, successful operations, or positive confirmation states.
- * - `'chevron-down'` - A downward chevron. Commonly used for dropdown menus, expandable content, or indicating downward navigation.
- * - `'chevron-left'` - A leftward chevron. Commonly used for back navigation, previous items, or leftward movement in carousels and lists.
- * - `'chevron-right'` - A rightward chevron. Commonly used for forward navigation, next items, or rightward movement and progression.
- * - `'chevron-up'` - An upward chevron. Commonly used for collapsible content, scroll to top, or indicating upward navigation.
- * - `'circle'` - A simple circle outline. Commonly used for radio buttons, status indicators, or basic geometric markers.
- * - `'clipboard-checklist'` - A clipboard with checklist. Commonly used for tasks, order fulfillment, inventory checks, or process completion.
- * - `'clock'` - A clock or time symbol. Commonly used for scheduling, time tracking, business hours, or temporal information.
- * - `'collection'` - A product collection or group symbol. Commonly used for product categories, grouped items, or collection management.
- * - `'credit-card'` - A credit card symbol. Commonly used for payment methods, card transactions, or financial operations.
- * - `'credit-card-reader'` - A card reader device symbol. Commonly used for payment processing, card scanning, or POS hardware functions.
- * - `'delete'` - A delete or trash symbol. Commonly used for removing items, deleting records, or destructive actions.
- * - `'delivery'` - A delivery truck or shipping symbol. Commonly used for order fulfillment, shipping options, or delivery tracking.
- * - `'desktop'` - A desktop computer symbol. Commonly used for device types, platform indicators, or desktop-specific features.
- * - `'disabled'` - A disabled or inactive state symbol. Commonly used for unavailable features, inactive items, or disabled functionality.
- * - `'disabled-filled'` - A filled disabled state symbol. Commonly used for prominently indicating unavailable or inactive elements.
- * - `'discount'` - A discount or sale symbol. Commonly used for promotions, price reductions, or special offers.
- * - `'discount-add'` - An add discount symbol. Commonly used for applying discounts, creating promotions, or adding price reductions.
- * - `'discount-automatic'` - An automatic discount symbol. Commonly used for system-applied discounts, automatic promotions, or rule-based reductions.
- * - `'discount-code'` - A discount code symbol. Commonly used for coupon codes, promotional codes, or manual discount entry.
- * - `'discount-remove'` - A remove discount symbol. Commonly used for removing applied discounts, canceling promotions, or undoing price reductions.
- * - `'drag-handle'` - A drag handle or grip symbol. Commonly used for reorderable lists, draggable elements, or sortable interfaces.
- * - `'drawer'` - A cash drawer symbol. Commonly used for cash register operations, drawer opening, or cash management.
- * - `'duplicate'` - A duplicate or copy symbol. Commonly used for copying items, duplicating records, or replication actions.
- * - `'edit'` - An edit or pencil symbol. Commonly used for editing content, modifying records, or entering edit mode.
- * - `'email'` - An email or message symbol. Commonly used for email functionality, messaging, or communication features.
- * - `'exchange'` - An exchange or swap symbol. Commonly used for product exchanges, return processing, or item swapping.
- * - `'external'` - An external link symbol. Commonly used for links that open in new windows, external resources, or outside navigation.
- * - `'flag'` - A flag or marker symbol. Commonly used for flagging items, marking important content, or status indicators.
- * - `'gift-card'` - A gift card symbol. Commonly used for gift card sales, redemption, or gift card management features.
- * - `'graduation-hat'` - A graduation cap symbol. Commonly used for training, education, tutorials, or learning features.
- * - `'grid'` - A grid view symbol. Commonly used for switching to grid layout, organizing content, or grid-based displays.
- * - `'hide-filled'` - A hide or visibility off symbol with fill. Commonly used for hiding content, privacy controls, or visibility toggles.
- * - `'home'` - A home outline symbol. Commonly used for home navigation, main dashboard, or returning to start screen.
- * - `'home-filled'` - A filled home symbol. Commonly used for active home state, main navigation, or primary dashboard indicator.
- * - `'image'` - A single image symbol. Commonly used for image upload, photo features, or visual content indicators.
- * - `'images'` - A multiple images symbol. Commonly used for image galleries, bulk photo operations, or media collections.
- * - `'info'` - An information symbol. Commonly used for help content, additional details, or informational messages.
- * - `'inventory'` - An inventory or stock symbol. Commonly used for inventory management, stock levels, or product tracking.
- * - `'inventory-edit'` - An edit inventory symbol. Commonly used for modifying stock levels, updating inventory, or inventory adjustments.
- * - `'inventory-list'` - An inventory list symbol. Commonly used for viewing stock lists, inventory reports, or product catalogs.
- * - `'inventory-transfer'` - An inventory transfer symbol. Commonly used for moving stock between locations, transfers, or redistribution.
- * - `'keyboard-hide'` - A hide keyboard symbol. Commonly used for dismissing on-screen keyboards or input controls.
- * - `'keypad'` - A numeric keypad symbol. Commonly used for number entry, PIN input, or calculator functions.
- * - `'link'` - A link or chain symbol. Commonly used for hyperlinks, connections, or linking functionality.
- * - `'list-bulleted'` - A bulleted list outline symbol. Commonly used for list views, itemized content, or list formatting.
- * - `'list-bulleted-filled'` - A filled bulleted list symbol. Commonly used for active list views or selected list formatting.
- * - `'live'` - A live or active status symbol. Commonly used for real-time features, live updates, or active connections.
- * - `'live-critical'` - A critical live status symbol. Commonly used for urgent live alerts, critical real-time issues, or emergency states.
- * - `'live-none'` - A no live status symbol. Commonly used for offline states, inactive connections, or unavailable live features.
- * - `'location'` - A location or map pin symbol. Commonly used for store locations, addresses, or geographic features.
- * - `'lock'` - A lock or security symbol. Commonly used for secure features, locked content, or security settings.
- * - `'maximize'` - A maximize or expand symbol. Commonly used for fullscreen mode, expanding windows, or enlarging content.
- * - `'menu'` - A menu outline symbol. Commonly used for navigation menus, options lists, or menu toggles.
- * - `'menu-filled'` - A filled menu symbol. Commonly used for active menu states or prominent menu indicators.
- * - `'menu-horizontal'` - A horizontal menu symbol. Commonly used for horizontal navigation, action menus, or more options.
- * - `'minimize'` - A minimize or collapse symbol. Commonly used for reducing windows, collapsing content, or minimizing interfaces.
- * - `'minus'` - A minus or subtract symbol. Commonly used for decreasing quantities, removing items, or subtraction operations.
- * - `'mobile'` - A mobile phone symbol. Commonly used for mobile features, device types, or mobile-specific functionality.
- * - `'money'` - A money or currency symbol. Commonly used for financial features, pricing, or monetary transactions.
- * - `'money-split'` - A split payment symbol. Commonly used for divided payments, partial payments, or payment splitting features.
- * - `'note'` - A note or document symbol. Commonly used for notes, documentation, or text content features.
- * - `'order'` - An order outline symbol. Commonly used for order management, order history, or order-related functions.
- * - `'order-draft'` - A draft order symbol. Commonly used for incomplete orders, order drafts, or pending order creation.
- * - `'order-filled'` - A filled order symbol. Commonly used for completed orders, active order states, or order fulfillment.
- * - `'package'` - A package or shipping box symbol. Commonly used for shipping, packaging, or fulfillment operations.
- * - `'package-cancel'` - A cancel package symbol. Commonly used for canceling shipments, stopping fulfillment, or package cancellation.
- * - `'package-reassign'` - A reassign package symbol. Commonly used for changing fulfillment locations, reassigning orders, or package redirection.
- * - `'payment'` - A payment symbol. Commonly used for payment processing, transaction features, or financial operations.
- * - `'person'` - A person outline symbol. Commonly used for user accounts, customer profiles, or people-related features.
- * - `'person-add'` - An add person symbol. Commonly used for creating accounts, adding customers, or user registration.
- * - `'person-filled'` - A filled person symbol. Commonly used for active user states, logged-in users, or selected profiles.
- * - `'phablet'` - A phablet device symbol. Commonly used for large mobile devices, tablet phones, or device-specific features.
- * - `'phone-out'` - An outgoing phone call symbol. Commonly used for making calls, phone features, or communication functions.
- * - `'play-circle'` - A play button in circle. Commonly used for starting processes, playing media, or initiating actions.
- * - `'plus'` - A plus or add symbol. Commonly used for adding items, creating new content, or addition operations.
- * - `'point-of-sale'` - A point of sale system symbol. Commonly used for POS features, retail operations, or sales terminals.
- * - `'point-of-sale-register'` - A cash register symbol. Commonly used for register operations, cash handling, or traditional POS functions.
- * - `'print'` - A print symbol. Commonly used for printing receipts, documents, or print-related functionality.
- * - `'product'` - A product outline symbol. Commonly used for product management, catalog features, or product-related functions.
- * - `'product-filled'` - A filled product symbol. Commonly used for active products, selected items, or product highlights.
- * - `'profile'` - A user profile symbol. Commonly used for profile management, account settings, or personal information.
- * - `'question-circle-filled'` - A question mark in filled circle. Commonly used for help features, support, or informational assistance.
- * - `'receipt'` - A receipt symbol. Commonly used for transaction receipts, purchase confirmations, or receipt management.
- * - `'refresh'` - A refresh or reload symbol. Commonly used for updating content, refreshing data, or reload operations.
- * - `'return'` - A return symbol. Commonly used for product returns, refund processing, or return management.
- * - `'scan-qr-code'` - A QR code scanning symbol. Commonly used for QR code features, digital scanning, or code-based interactions.
- * - `'search'` - A search or magnifying glass symbol. Commonly used for search functionality, finding content, or lookup features.
- * - `'send'` - A send or submit symbol. Commonly used for sending messages, submitting forms, or transmission actions.
- * - `'settings'` - A settings or gear symbol. Commonly used for configuration, preferences, or system settings.
- * - `'shipping-label-cancel'` - A cancel shipping label symbol. Commonly used for voiding labels, canceling shipments, or shipping corrections.
- * - `'sort'` - A sort or arrange symbol. Commonly used for sorting lists, organizing content, or arrangement controls.
- * - `'star-circle'` - A star in circle symbol. Commonly used for ratings, favorites, or featured content indicators.
- * - `'star-filled'` - A filled star symbol. Commonly used for ratings, favorites, or highlighting important content.
- * - `'store'` - A store or shop symbol. Commonly used for store information, retail locations, or shop-related features.
- * - `'tablet'` - A tablet device symbol. Commonly used for tablet features, device types, or tablet-specific functionality.
- * - `'transaction-fee-add'` - An add transaction fee symbol. Commonly used for applying fees, additional charges, or fee management.
- * - `'unlock'` - An unlock symbol. Commonly used for unlocking features, accessing content, or security controls.
- * - `'variant'` - A product variant symbol. Commonly used for product variations, different options, or variant management.
- * - `'view'` - A view or eye symbol. Commonly used for viewing content, visibility controls, or display options.
- * - `'wallet'` - A wallet symbol. Commonly used for digital wallets, payment methods, or financial account features.
- * - `'x'` - An X or close symbol. Commonly used for closing dialogs, canceling actions, or dismissing content.
- * - `'x-circle'` - An X in circle symbol. Commonly used for error states, cancellation, or removing items with emphasis.
+ * Lists all currently supported icon names available for use in the POS interface. Reference this list when selecting icons to ensure compatibility and availability.
  */
 export type SupportedIconNames = Extract<
   IconProps['type'],
@@ -301,7 +175,7 @@ export type SupportedIconNames = Extract<
 export interface IconJSXProps
   extends Pick<IconProps, 'id' | 'tone' | 'color' | 'size'> {
   /**
-   * The type of icon to display. Choose from a comprehensive set of POS-specific icons including navigation arrows, commerce symbols, device indicators, and action icons like `'cart'`, `'search'`, `'settings'`, and `'payment'`.
+   * The type of icon to display.
    *
    * @default ''
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -18,6 +18,28 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Media',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Choose recognizable icons:** Use universally recognized symbols like `search`, `cart`, or `settings`. Avoid ambiguous icons.\n' +
+        '- **Match size to context:** Use smaller sizes for inline text or secondary actions, `base` for standard elements, larger sizes for primary actions.\n' +
+        '- **Apply tones for meaning:** Use `critical` for destructive actions, `warning` for cautions, `success` for confirmations, `auto` or `neutral` for general elements.\n' +
+        '- **Pair with text for clarity:** Consider adding text labels, especially for complex or uncommon actions.\n' +
+        '- **Use color for hierarchy:** Use `subdued` for secondary elements, `base` for standard visibility, `strong` for emphasis.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Icons are purely decorative and don\'t support click events or interactive behaviors—wrap them in `Clickable` components for interactive functionality.\n' +
+        '- The available icon set is predefined and limited to POS-specific symbols—custom icons or external icon libraries aren\'t supported.\n' +
+        '- Icon appearance and styling are controlled by the POS design system—custom colors, styles, or modifications beyond the provided properties are not available.',
+    },
+  ],
   defaultExample: {
     image: 'icon-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -17,7 +17,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Media',
+  subCategory: 'Media and visuals',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
-    'Displays graphic symbols to communicate meaning and functionality. Use to enhance navigation, indicate actions, or provide visual context alongside text.',
+    'Display standardized visual symbols from the POS catalog to represent actions, statuses, or categories consistently.',
   thumbnail: 'icon-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -35,8 +35,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Icons are purely decorative and don\'t support click events or interactive behaviors—wrap them in `Clickable` components for interactive functionality.\n' +
-        '- The available icon set is predefined and limited to POS-specific symbols—custom icons or external icon libraries aren\'t supported.\n' +
+        "- Icons are purely decorative and don't support click events or interactive behaviors—wrap them in `Clickable` components for interactive functionality.\n" +
+        "- The available icon set is predefined and limited to POS-specific symbols—custom icons or external icon libraries aren't supported.\n" +
         '- Icon appearance and styling are controlled by the POS design system—custom colors, styles, or modifications beyond the provided properties are not available.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -20,8 +20,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Media',
   defaultExample: {
     image: 'icon-default.png',
+    description:
+      'Display standardized visual symbols using an `Icon` component from the POS icon catalog. This example shows a basic icon with proper sizing and accessibility.',
     codeblock: {
-      title: 'Code',
+      title: 'Display icons from the POS catalog',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -3,14 +3,16 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
-    'Display standardized visual symbols from the POS catalog to represent actions, statuses, or categories consistently.',
+    'The `Icon` component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories consistently. Use icons to enhance navigation or provide visual context alongside text in POS interfaces.' +
+    '\n\nIcons help merchants quickly understand interface elements and actions without relying solely on text labels. Icons are optimized for readability at standard sizes and automatically scale to maintain visual consistency across different screen densities and device types.',
   thumbnail: 'icon-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Icon` component.',
       type: 'Icon',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
@@ -12,18 +12,30 @@ import type {ImageProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
@@ -31,26 +43,18 @@ export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 declare const tagName = 's-image';
 export interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit'> {
   /**
-   * The displayed inline width of the image.
-   *
-   * - `fill`: the image will takes up 100% of the available inline size.
-   * - `auto`: the image will be displayed at its natural size.
-   *
-   * **Mobile surfaces:** Always wrap your image in a box with a set width and height.
-   * ScrollViews on mobile have a dynamic height, which can cause images to appear
-   * inconsistently without defined dimensions.
+   * Controls the displayed width of the image. Choose based on your layout requirements. For mobile interfaces, consider using `'fill'` with defined container dimensions to ensure consistent image display, as dynamic container heights can cause layout inconsistencies in scrollable views.
+   * - `'auto'` - Displays the image at its natural size. The image won't render until it has loaded, and the aspect ratio will be ignored. Commonly used for images where maintaining original dimensions is important.
+   * - `'fill'` - Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Commonly used for responsive layouts and flexible image containers.
    *
    * @default 'fill'
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width
+   * Learn more about [img width on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
    */
   inlineSize?: ImageProps['inlineSize'];
   /**
-   * The image source, which should be a remote URL.
+   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are accessible and properly formatted.
    *
-   * When the image is loading or no `src` is provided, a placeholder will be rendered.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src
+   * Learn more about [img src on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
    */
   src?: ImageProps['src'];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
@@ -44,17 +44,15 @@ declare const tagName = 's-image';
 export interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit'> {
   /**
    * Controls the displayed width of the image. Choose based on your layout requirements. For mobile interfaces, consider using `'fill'` with defined container dimensions to ensure consistent image display, as dynamic container heights can cause layout inconsistencies in scrollable views.
-   * - `'auto'` - Displays the image at its natural size. The image won't render until it has loaded, and the aspect ratio will be ignored. Commonly used for images where maintaining original dimensions is important.
-   * - `'fill'` - Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Commonly used for responsive layouts and flexible image containers.
+   *
+   * - `'auto'` - Displays the image at its natural size. The image will not render until it has loaded, and the aspect ratio will be ignored. Use for images where maintaining original dimensions is important.
+   * - `'fill'` - Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Use for responsive layouts and flexible image containers.
    *
    * @default 'fill'
-   * Learn more about [img width on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
    */
   inlineSize?: ImageProps['inlineSize'];
   /**
-   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are accessible and properly formatted.
-   *
-   * Learn more about [img src on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
+   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are properly formatted and properly formatted.
    */
   src?: ImageProps['src'];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -21,8 +21,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Media',
   defaultExample: {
     image: 'image-default.png',
+    description:
+      'Display visual content using an `Image` component with automatic loading optimization and error handling. This example shows a basic image with source URL and alt text for accessibility.',
     codeblock: {
-      title: 'Code',
+      title: 'Display an image',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -3,14 +3,17 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
-    'Add visual content to the POS interface and customize the presentation of visuals.',
+    'The `Image` component adds visual content to the POS interface and allows you to customize the presentation of visuals. Use images to showcase products, illustrate concepts, provide visual context, or support user tasks and interactions in POS workflows.' +
+    '\n\nImages enhance the user experience by providing immediate visual recognition and reducing cognitive load.' +
+    '\n\n`Image` components handle loading errors gracefully with fallback options and provides placeholder states to maintain layout stability during image loading on slower network connections. The component implements lazy loading for images outside the viewport, improving initial page load performance while ensuring smooth scrolling as merchants navigate through product catalogs or image-heavy interfaces.',
   thumbnail: 'image-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Image` component.',
       type: 'Image',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Media',
+  subCategory: 'Media and visuals',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
-    'Embeds an image within the interface and controls its presentation. Use to visually illustrate concepts, showcase products, or support user tasks and interactions.',
+    'Add visual content to the POS interface and customize the presentation of visuals.',
   thumbnail: 'image-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -19,6 +19,25 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Media',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Choose appropriate sizing:** Use `inlineSize="fill"` for responsive layouts. Use `inlineSize="auto"` to maintain natural dimensions.\n' +
+        '- **Select object fit behavior:** Use `objectFit="contain"` to show the complete image. Use `objectFit="cover"` to fill the container, accepting cropping.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Images are display-only components and don\'t support click events or interactive behaviors—wrap them in `Clickable` components for interactive functionality.\n' +
+        '- Image loading and caching behavior depends on the browser and network conditions—implement proper error handling and loading states for better user experience.\n' +
+        '- Large images can impact performance—ensure proper optimization and compression for better loading times.',
+    },
+  ],
   defaultExample: {
     image: 'image-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Images are display-only components and don\'t support click events or interactive behaviors—wrap them in `Clickable` components for interactive functionality.\n' +
+        "- Images are display-only components and don't support click events or interactive behaviors—wrap them in `Clickable` components for interactive functionality.\n" +
         '- Image loading and caching behavior depends on the browser and network conditions—implement proper error handling and loading states for better user experience.\n' +
         '- Large images can impact performance—ensure proper optimization and compression for better loading times.',
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal.d.ts
@@ -17,55 +17,87 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * Additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
 declare const tagName = 's-modal';
 export interface ModalJSXProps extends Pick<ModalProps, 'id' | 'heading'> {
   /**
-   * Callback when the modal is hidden.
+   * The callback when the modal is hidden. Use this event to perform cleanup tasks, update application state, or trigger other actions when the modal is dismissed or closed.
    */
   onHide?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * Callback when the modal is shown.
+   * The callback when the modal is shown. Use this event to initialize modal content, focus specific elements, or perform setup tasks when the modal becomes visible.
    */
   onShow?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * The primary action button displayed in the modal.
-   *
-   * The tone of the button is used to define the tone of the modal.
-   *
-   * If omitted, the modal will default to an 'info' tone, and show an 'OK' button, translated according to the user's locale.
+   * The primary action button displayed in the modal. The tone of the button is used to define the tone of the modal. If omitted, the modal will default to an `'info'` tone, and show an OK button, translated according to the user's locale.
    */
   primaryAction?: ComponentChild;
   /**
-   * The secondary action buttons displayed in the modal.
+   * The secondary action buttons displayed in the modal. Use this slot to provide alternative actions or cancel options that give users flexibility in how they respond to the modal.
    */
   secondaryActions?: ComponentChild;
   /**
-   * The content of the Modal.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -32,8 +32,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Structure',
   defaultExample: {
     image: 'modal-default.png',
+    description:
+      'Display focused content in an overlay using a `Modal` component that requires merchant attention. This example shows a basic modal with header, content area, and action buttons.',
     codeblock: {
-      title: 'Code',
+      title: 'Display content in a modal overlay',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Modal',
   description:
-    'Displays content in an overlay that requires merchant attention. Use to present critical information, confirmations, or focused tasks without losing page context.',
+    'Display content in an overlay that requires merchant attention.',
   thumbnail: 'modal-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -29,7 +29,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Structure',
+  subCategory: 'Feedback and status indicators',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -3,24 +3,28 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Modal',
   description:
-    'Display content in an overlay that requires merchant attention.',
+    'The `Modal` component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.' +
+    '\n\nModals block interaction with the underlying interface until the merchant resolves the modal content. The component maintains focus within the modal boundary and returns focus to the trigger element on close, ensuring keyboard navigation remains predictable throughout the modal lifecycle.',
   thumbnail: 'modal-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Modal` component.',
       type: 'Modal',
     },
     {
       title: 'Slots',
-      description: '',
+      description:
+        'The `Modal` component supports slots for additional content placement within the modal. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ModalSlots',
     },
     {
       title: 'Events',
-      description: '',
+      description:
+        'The `Modal` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ModalEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -30,6 +30,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Structure',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use for focused interactions:** Reserve modals for confirmations, critical information, or tasks requiring immediate attention.\n' +
+        '- **Write clear headings:** Use concise titles that communicate the purpose or action.\n' +
+        "- **Choose appropriate button tones:** The `primary-action` button's `tone` determines the modal's overall tone. Use `critical` for destructive actions, `success` for confirmations.\n" +
+        '- **Include secondary actions:** Provide options like "Cancel" or "Go Back" to give merchants flexibility.\n' +
+        '- **Keep content focused:** Limit to essential information and actions. For complex workflows, break into multiple steps.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        "- Multiple modals can't be displayed simultaneously—showing a new modal while another is visible may cause unexpected behavior or poor user experience.\n" +
+        "- Modal visibility and lifecycle must be managed programmatically through events and commands—they don't automatically handle state management or persistence.",
+    },
+  ],
   defaultExample: {
     image: 'modal-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField.d.ts
@@ -17,28 +17,64 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * The additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -59,85 +95,61 @@ export interface NumberFieldJSXProps
     | 'controls'
   > {
   /**
-   * Content to use as the field label.
-   *
-   * Label is not supported when using Stepper controls
+   * The text content that displays as the field label, describing the numeric information being requested. This property isn't supported when using `stepper` controls.
    */
   label?: NumberFieldProps['label'];
   /**
-   * Additional text to provide context or guidance for the field.
-   * This text is displayed along with the field and its label
-   * to offer more information or instructions to the user.
-   *
-   * This will also be exposed to screen reader users.
-   *
-   * Details are not supported when using Stepper controls
+   * The additional text to provide context or guidance for the field. This text is displayed along with the field and its label to offer more information or instructions to the user. This will also be exposed to screen reader users. This property isn't supported when using `stepper` controls.
    */
   details?: NumberFieldProps['details'];
   /**
-   * Whether the field needs a value. This requirement adds semantic value
-   * to the field, but it will not cause an error to appear automatically.
-   * If you want to present an error when this field is empty, you can do
-   * so with the `error` property.
+   * Whether the field needs a value. This requirement adds semantic value to the field but doesn't cause an error to appear automatically. Use the `error` property to present validation errors. This property isn't supported when using `stepper` controls.
    *
    * @default false
-   *
-   * Required is not supported when using Stepper controls
    */
   required?: NumberFieldProps['required'];
   /**
-   * Indicate an error to the user. The field will be given a specific stylistic treatment
-   * to communicate problems that have to be resolved immediately.
-   *
-   * Error is not supported when using Stepper controls
+   * An error message that indicates a problem to the user. The field receives specific stylistic treatment to communicate issues that must be resolved immediately. This property isn't supported when using `stepper` controls.
    */
   error?: NumberFieldProps['error'];
   /**
-   * Sets the virtual keyboard.
+   * The virtual keyboard layout that the field displays for numeric input. This property isn't supported when using `stepper` controls.
+   * - `decimal`: A keyboard layout that includes decimal point support for entering fractional numbers, prices, or measurements with decimal precision.
+   * - `numeric`: A keyboard layout optimized for integer-only entry without decimal point support, ideal for quantities, counts, or whole number values.
    *
-   * Input mode is not supported when using Stepper controls
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
+   * Learn more about [inputmode on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
    * @default 'decimal'
    */
   inputMode?: NumberFieldProps['inputMode'];
   /**
-   * A short hint that describes the expected value of the field.
-   *
-   * Placeholder text is not supported when using Stepper controls due to constrained space for the number field, especially on phones.
+   * A short hint that provides guidance about the expected value of the field. This property isn't supported when using `stepper` controls due to constrained space, especially on phones.
    */
   placeholder?: NumberFieldProps['placeholder'];
   /**
-   *  Additional content to be displayed in the field. Commonly used to display clickable text.
-   *
-   * > Note: Accessory is not supported when using Stepper controls
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Use the `slot="accessory"` attribute to place elements in this area. This slot isn't supported when using `stepper` controls.
    */
   accessory?: ComponentChild;
   /**
-   * Sets the type of controls displayed for the field.
-   *
-   * - `stepper`: displays buttons to increase or decrease the value of the field by the stepping interval defined in the `step` property. Note that in POS
-   *   adding stepper controls simplifies the behaviour of the Number Field itself. The field supports only integer values, is always-populated and automatically
-   *   validates the value to be within the min and max bounds. Validation, label, details and placeholder are not supported when using Stepper controls.
-   *
-   * - `none`: no controls are displayed and users must input the value manually.
-   * - `auto`: the presence of the controls depends on the surface and context.
+   * The type of controls displayed for the field:
+   * - `auto`: An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
+   * - `stepper`: Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
+   * - `none`: A control type with no visible controls where users must input the value manually using the keyboard.
    */
   controls?: NumberFieldProps['controls'];
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function that executes when the user makes any changes in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function that executes after editing completes, typically on blur.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function that executes when the element loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function that executes when the element receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField.d.ts
@@ -114,10 +114,10 @@ export interface NumberFieldJSXProps
   error?: NumberFieldProps['error'];
   /**
    * The virtual keyboard layout that the field displays for numeric input. This property isn't supported when using `stepper` controls.
-   * - `decimal`: A keyboard layout that includes decimal point support for entering fractional numbers, prices, or measurements with decimal precision.
-   * - `numeric`: A keyboard layout optimized for integer-only entry without decimal point support, ideal for quantities, counts, or whole number values.
    *
-   * Learn more about [inputmode on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
+   * - `'decimal'` - A keyboard layout that includes decimal point support for entering fractional numbers, prices, or measurements with decimal precision.
+   * - `'numeric'` - A keyboard layout optimized for integer-only entry without decimal point support, ideal for quantities, counts, or whole number values.
+   *
    * @default 'decimal'
    */
   inputMode?: NumberFieldProps['inputMode'];
@@ -131,9 +131,12 @@ export interface NumberFieldJSXProps
   accessory?: ComponentChild;
   /**
    * The type of controls displayed for the field:
-   * - `auto`: An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
-   * - `stepper`: Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
-   * - `none`: A control type with no visible controls where users must input the value manually using the keyboard.
+   *
+   * - `'auto'` - An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
+   * - `'stepper'` - Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
+   * - `'none'` - A control type with no visible controls where users must input the value manually using the keyboard.
+   *
+   * @default 'auto'
    */
   controls?: NumberFieldProps['controls'];
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -2,8 +2,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'NumberField',
-  description:
-    'Captures numeric input from merchants. Provides built-in number validation and appropriate keyboard layout for numeric entry.',
+  description: 'Capture numeric input with built-in validation.',
   thumbnail: 'number-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -2,26 +2,29 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'NumberField',
-  description: 'Capture numeric input with built-in validation.',
+  description:
+    'The `NumberField` component captures numeric input with built-in validation. Use it to collect quantity, price, or other numeric information with optional `stepper` controls.' +
+    '\n\nThe component includes built-in number validation, optional min/max constraints, and step increments to ensure accurate numeric data entry. It supports various number formats including integers and decimals, with validation feedback to prevent entry errors during high-volume retail operations.',
   thumbnail: 'number-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `NumberField` component.',
       type: 'NumberField',
     },
     {
       title: 'Slots',
       description:
-        'Learn more about using [slots](/docs/api/pos-ui-extensions/using-polaris-components#slots)',
+        'The `NumberField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'NumberFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `NumberField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'NumberFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -45,7 +45,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- `NumberField` provides numeric input but doesn\'t enforce `min`/`max` constraints for keyboard input—you must implement validation logic to enforce bounds and display appropriate errors.\n' +
+        "- `NumberField` provides numeric input but doesn't enforce `min`/`max` constraints for keyboard input—you must implement validation logic to enforce bounds and display appropriate errors.\n" +
         '- The component handles numeric input and basic format validation, but specialized number formatting like currency symbols or thousand separators requires additional formatting logic.\n' +
         '- Stepper controls work best for small ranges and adjustments—they may not be practical for large numeric ranges or precise decimal entry.',
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -32,8 +32,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'number-field-default.png',
+    description:
+      'Capture numeric input using a `NumberField` component with built-in validation and optional stepper controls. This example shows a basic number field with label and numeric validation.',
     codeblock: {
-      title: 'Code',
+      title: 'Capture numeric input with a number field',
       tabs: [
         {
           code: './examples/default.html',
@@ -44,13 +46,14 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'NumberField usage patterns',
+    description:
+      'Learn how to add stepper controls, set constraints, and configure keyboard layouts.',
     examples: [
       {
         description:
-          'Use controls for increment/decrement buttons and set min/max constraints',
+          'Enable stepper controls with increment and decrement buttons and set min/max constraints to limit valid input ranges. This example demonstrates using the `controls` property with `min` and `max` values to create bounded numeric inputs with visual stepper controls, ideal for quantity selection or limited-range numeric entry.',
         codeblock: {
-          title: 'Controls and constraints',
+          title: 'Add stepper controls and constraints',
           tabs: [
             {
               code: './examples/controls-constraints.jsx',
@@ -61,9 +64,9 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Specify inputMode for decimal or numeric keyboard layouts',
+          'Configure the keyboard layout by specifying `inputMode` for decimal or numeric entry. This example shows how to use the `inputMode` property to display appropriate mobile keyboards—numeric for integers or decimal for numbers with fractional parts—improving data entry speed and accuracy.',
         codeblock: {
-          title: 'Input modes',
+          title: 'Configure keyboard input modes',
           tabs: [
             {
               code: './examples/input-mode.jsx',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -30,6 +30,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Choose appropriate controls:** Use `stepper` for quantities or small adjustments. Use `none` for prices or large values where steppers are impractical.\n' +
+        '- **Select the right input mode:** Use `decimal` for prices and measurements. Use `numeric` for quantities and counts.\n' +
+        '- **Explain constraints in details:** Use `details` to clarify valid ranges or formatting, like "Enter a quantity between 1 and 999."',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `NumberField` provides numeric input but doesn\'t enforce `min`/`max` constraints for keyboard input—you must implement validation logic to enforce bounds and display appropriate errors.\n' +
+        '- The component handles numeric input and basic format validation, but specialized number formatting like currency symbols or thousand separators requires additional formatting logic.\n' +
+        '- Stepper controls work best for small ranges and adjustments—they may not be practical for large numeric ranges or precise decimal entry.',
+    },
+  ],
   defaultExample: {
     image: 'number-field-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page.d.ts
@@ -17,18 +17,30 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
@@ -36,25 +48,25 @@ export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 declare const tagName = 's-page';
 export interface PageJSXProps extends Pick<PageProps, 'id'> {
   /**
-   * The main page heading, displayed in the action bar at the top of the page.
+   * The main page heading displayed in the action bar at the top of the page.
    *
    * @default: ''
    */
   heading?: PageProps['heading'];
   /**
-   * A secondary page heading, displayed under the main heading in the action bar.
+   * A secondary page heading displayed under the main heading in the action bar.
    */
   subheading?: PageProps['subheading'];
   /**
-   * Button element to display in the action bar. Only a single button is supported.
+   * A button element to display in the action bar. Only a single button is supported. Use the `slot="secondary-actions"` attribute to place content in this area.
    */
   secondaryActions?: ComponentChild;
   /**
-   * Content to display in the page's sidebar.
+   * The content to display in the page's sidebar. This area is for content that is tangentially related to the main content, such as navigation or contextual information. Use the `slot="aside"` attribute to place content in this area.
    */
   aside?: ComponentChild;
   /**
-   * The content of the Page.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -27,8 +27,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Structure',
   defaultExample: {
     image: 'page-default.png',
+    description:
+      'Structure full-screen views using a `Page` component with built-in header and content layouts. This example shows a basic page with title and main content area.',
     codeblock: {
-      title: 'Code',
+      title: 'Structure a page layout',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -3,19 +3,23 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Page',
   description:
-    'Provide the main container for app content with preset layouts and heading controls.',
+    'The `Page` component serves as the main container for app content with preset layouts and heading controls. Use it to structure full-screen views with consistent navigation and content organization.' +
+    '\n\nThe component provides a complete page structure with built-in header, sidebar, and action bar layouts that follow POS design patterns. It manages heading hierarchy, spacing, and responsive behavior automatically, allowing you to focus on content rather than layout mechanics while ensuring consistent page structures across extensions.' +
+    '\n\n`Page` components handle safe area insets automatically for devices with notches or rounded corners, ensuring content remains visible and interactive without manual padding adjustments for different device shapes.',
   thumbnail: 'page-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Page` component.',
       type: 'Page',
     },
     {
       title: 'Slots',
-      description: '',
+      description:
+        'The `Page` component supports slots for additional content placement within the page. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'PageSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -24,7 +24,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Structure',
+  subCategory: 'Layout and structure',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -25,6 +25,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Structure',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        "- **Write descriptive headings:** Use heading and subheading to describe the page's purpose and provide context about the current workflow step.\n" +
+        "- **Place one primary action in action bar:** Use the `secondary-actions` slot for the page's most important action.\n" +
+        '- **Use aside for supplementary content:** Reserve the aside slot for navigation, contextual help, or supporting information.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        "- The `secondary-actions` slot supports only a single button element—multiple actions in the action bar aren't supported and should be handled within the main content area.\n" +
+        '- Page layout and styling are controlled by the POS design system—custom page-level styling beyond the provided slots and properties is not available.\n' +
+        "- The component is designed for full-screen modal interfaces—it's not suitable for inline content or partial page layouts within existing POS screens.",
+    },
+  ],
   defaultExample: {
     image: 'page-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Page',
   description:
-    'Serves as the main container for app content with preset layouts and heading controls. Use to structure full-screen views with consistent navigation and content organization.',
+    'Provide the main container for app content with preset layouts and heading controls.',
   thumbnail: 'page-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock.d.ts
@@ -17,18 +17,30 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
@@ -37,11 +49,11 @@ declare const tagName = 's-pos-block';
 export interface PosBlockJSXProps
   extends Pick<POSBlockProps, 'id' | 'heading'> {
   /**
-   * The secondary actions to perform, provided as button or link type elements.
+   * The secondary actions to perform, provided as button or link type elements. Use the `slot="secondary-actions"` attribute to place interactive elements that allow users to take actions related to the block's content.
    */
   secondaryActions?: ComponentChild;
   /**
-   * The content of the Block.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -31,6 +31,25 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Structure',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Provide descriptive headings:** If you don\'t specify a heading, the system uses your extension\'s description, so ensure it\'s meaningful and concise.\n' +
+        '- **Place important actions in secondary-actions slot:** Include only the most relevant actions directly related to your block\'s content.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `PosBlock` is designed specifically for block targets—it can\'t be used in modal or action (menu item) targets.\n' +
+        '- The component\'s visual styling is controlled by the POS design system—custom styling beyond content organization isn\'t supported.\n' +
+        '- Only one secondary action element is recommended to maintain clean, focused interfaces that don\'t overwhelm the existing POS workflow.',
+    },
+  ],
   defaultExample: {
     image: 'pos-block-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -2,8 +2,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'PosBlock',
-  description:
-    'Creates a surface on the specified block extension target, serving as a container to place content with an action button.',
+  description: 'Create a container to place content with an action button.',
   thumbnail: 'pos-block-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -37,17 +37,17 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Provide descriptive headings:** If you don\'t specify a heading, the system uses your extension\'s description, so ensure it\'s meaningful and concise.\n' +
-        '- **Place important actions in secondary-actions slot:** Include only the most relevant actions directly related to your block\'s content.',
+        "- **Provide descriptive headings:** If you don't specify a heading, the system uses your extension's description, so ensure it's meaningful and concise.\n" +
+        "- **Place important actions in secondary-actions slot:** Include only the most relevant actions directly related to your block's content.",
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- `PosBlock` is designed specifically for block targets—it can\'t be used in modal or action (menu item) targets.\n' +
-        '- The component\'s visual styling is controlled by the POS design system—custom styling beyond content organization isn\'t supported.\n' +
-        '- Only one secondary action element is recommended to maintain clean, focused interfaces that don\'t overwhelm the existing POS workflow.',
+        "- `PosBlock` is designed specifically for block targets—it can't be used in modal or action (menu item) targets.\n" +
+        "- The component's visual styling is controlled by the POS design system—custom styling beyond content organization isn't supported.\n" +
+        "- Only one secondary action element is recommended to maintain clean, focused interfaces that don't overwhelm the existing POS workflow.",
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -30,7 +30,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Structure',
+  subCategory: 'Layout and structure',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -2,25 +2,30 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'PosBlock',
-  description: 'Create a container to place content with an action button.',
+  description:
+    'The `PosBlock` component creates a container to place content with an action button. Use it to display structured content within POS block targets.' +
+    '\n\nThe component provides a standardized layout specifically designed for content blocks within POS detail views, with consistent padding, spacing, and optional action buttons. It integrates with the native POS design language, ensuring extension content feels cohesive with the core POS interface while maintaining clear content boundaries.' +
+    '\n\n`PosBlock` components provide consistent interaction patterns for action buttons across different block types, ensuring merchants can predict button behavior and location regardless of the specific POS context.',
   thumbnail: 'pos-block-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `PosBlock` component.',
       type: 'PosBlock',
     },
     {
       title: 'QR Code',
       description:
-        'Renders a QR code when the block is used within a Receipt target.',
+        'The `PosBlock` component renders a QR code when the block is used within a receipt target.',
       type: 'QrCode',
     },
     {
       title: 'Slots',
-      description: '',
+      description:
+        'The `PosBlock` component supports slots for additional content placement within the block. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'PosBlockSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -33,8 +33,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Structure',
   defaultExample: {
     image: 'pos-block-default.png',
+    description:
+      'Create structured content blocks using a `PosBlock` component with optional action buttons. This example shows a basic block with content and an action button.',
     codeblock: {
-      title: 'Code',
+      title: 'Create a content block with an action button',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/QrCode.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/QrCode.d.ts
@@ -12,18 +12,30 @@ import type {QRCodeProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox.d.ts
@@ -22,18 +22,30 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
@@ -42,116 +54,94 @@ export type PaddingKeyword = SizeKeyword | 'none';
 declare const tagName = 's-scroll-box';
 export interface ScrollBoxJSXProps extends Pick<ScrollBoxProps, 'id'> {
   /**
-   * Adjust the block size.
+   * The block size of the scrollable container. Auto automatically sizes based on the container's content and available space.
    *
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the inline size.
+   * The inline size of the scrollable container. Auto automatically sizes based on the container's content and available space.
    *
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the maximum block size.
+   * The maximum block size constraint for the scrollable container.
    *
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * Adjust the maximum inline size.
+   * The maximum inline size constraint for the scrollable container.
    *
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * Adjust the minimum block size.
+   * The minimum block size constraint for the scrollable container.
    *
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * Adjust the minimum inline size.
+   * The minimum inline size constraint for the scrollable container.
    *
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * Adjust the padding of all edges.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
+   * The padding applied to all edges of the scrollable container. Supports 1-to-4-value syntax using flow-relative values in the order:
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
-   *
    * For example:
    * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
    * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
    * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
    * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the block-padding.
-   *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
-   * This overrides the block value of `padding`.
+   * The block-axis padding for the scrollable container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<PaddingKeyword> | '';
   /**
-   * Adjust the block-start padding.
-   *
-   * This overrides the block-start value of `paddingBlock`.
+   * The block-start padding for the scrollable container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: PaddingKeyword | '';
   /**
-   * Adjust the block-end padding.
-   *
-   * This overrides the block-end value of `paddingBlock`.
+   * The block-end padding for the scrollable container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: PaddingKeyword | '';
   /**
-   * Adjust the inline padding.
-   *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
-   * This overrides the inline value of `padding`.
+   * The inline-axis padding for the scrollable container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<PaddingKeyword> | '';
   /**
-   * Adjust the inline-start padding.
-   *
-   * This overrides the inline-start value of `paddingInline`.
+   * The inline-start padding for the scrollable container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: PaddingKeyword | '';
   /**
-   * Adjust the inline-end padding.
-   *
-   * This overrides the inline-end value of `paddingInline`.
+   * The inline-end padding for the scrollable container. Overrides the inline-end value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: PaddingKeyword | '';
   /**
-   * The content of the ScrollBox.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox.d.ts
@@ -50,6 +50,9 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 
+/**
+ * Defines the available padding size options using a semantic scale. Provides consistent spacing values that align with the POS design system.
+ */
 export type PaddingKeyword = SizeKeyword | 'none';
 declare const tagName = 's-scroll-box';
 export interface ScrollBoxJSXProps extends Pick<ScrollBoxProps, 'id'> {
@@ -90,15 +93,19 @@ export interface ScrollBoxJSXProps extends Pick<ScrollBoxProps, 'id'> {
    */
   minInlineSize?: SizeUnits;
   /**
-   * The padding applied to all edges of the scrollable container. Supports 1-to-4-value syntax using flow-relative values in the order:
+   * The padding applied to all edges of the scrollable container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
+   *
    * For example:
+   *
    * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
    * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
    * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
    * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   *
    * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -3,14 +3,17 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'ScrollBox',
   description:
-    'Create a scrollable area for content that exceeds container bounds.',
+    'The `ScrollBox` component creates a scrollable area for content that exceeds container bounds. Use it to display large amounts of content within constrained spaces while maintaining usability.' +
+    '\n\nThe component creates a defined scrollable area with customizable dimensions and scroll behavior, essential for constraining content height in modal dialogs and constrained layouts. It provides touch-optimized scrolling for POS devices with visual scroll indicators.' +
+    '\n\n`ScrollBox` components provide scrollbar styling that matches the design system while ensuring sufficient contrast for visibility, with automatic thickness adjustments for touch-based scrolling versus mouse-based scrolling.',
   thumbnail: 'scrollbox-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `ScrollBox` component.',
       type: 'ScrollBox',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Structure',
+  subCategory: 'Layout and structure',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -19,6 +19,25 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Structure',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Set clear dimensions:** Use percentage values for responsive layouts or pixels for exact dimensions.\n' +
+        '- **Use for appropriate content:** Reserve `ScrollBox` for long lists or dynamic content that genuinely needs scrolling, not short content that fits within available space.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `ScrollBox` automatically manage overflow behavior—manual overflow control beyond the component\'s built-in scrolling isn\'t available.\n' +
+        '- Scroll behavior and styling are controlled by the POS design system—custom scroll bar styling or scroll physics modifications aren\'t supported.\n' +
+        '- The component is optimized for touch-based scrolling in POS environments—complex scroll interactions or nested scrolling scenarios may not perform optimally.',
+    },
+  ],
   defaultExample: {
     image: 'scrollbox-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -21,8 +21,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Structure',
   defaultExample: {
     image: 'scrollbox-default.png',
+    description:
+      'Create scrollable content areas using a `ScrollBox` component for content that exceeds container bounds. This example shows a basic scrollable area with customizable dimensions.',
     codeblock: {
-      title: 'Code',
+      title: 'Create a scrollable content area',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -33,8 +33,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- `ScrollBox` automatically manage overflow behavior—manual overflow control beyond the component\'s built-in scrolling isn\'t available.\n' +
-        '- Scroll behavior and styling are controlled by the POS design system—custom scroll bar styling or scroll physics modifications aren\'t supported.\n' +
+        "- `ScrollBox` automatically manage overflow behavior—manual overflow control beyond the component's built-in scrolling isn't available.\n" +
+        "- Scroll behavior and styling are controlled by the POS design system—custom scroll bar styling or scroll physics modifications aren't supported.\n" +
         '- The component is optimized for touch-based scrolling in POS environments—complex scroll interactions or nested scrolling scenarios may not perform optimally.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'ScrollBox',
   description:
-    'Creates a scrollable area for content that exceeds container bounds.',
+    'Create a scrollable area for content that exceeds container bounds.',
   thumbnail: 'scrollbox-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField.d.ts
@@ -12,28 +12,64 @@ import type {SearchFieldProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * The additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -41,19 +77,19 @@ declare const tagName = 's-search-field';
 export interface SearchFieldJSXProps
   extends Pick<SearchFieldProps, 'id' | 'disabled' | 'placeholder' | 'value'> {
   /**
-   * Callback when the user changes the value in the field.
+   * A callback function executed when the user changes the value in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the field loses focus after the user changes the value in the field.
+   * A callback function executed when the field loses focus after the user changes the value in the field.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the field loses focus.
+   * A callback function executed when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the field is focused.
+   * A callback function executed when the field is focused.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -25,6 +25,27 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use for inline search and filtering:** Choose `SearchField` for filtering within specific sections or lists, not for global navigation or complex multi-step searches.\n' +
+        '- **Follow placeholder pattern:** Use "Search {items}" format like "Search products" or "Search customers" to clarify scope.\n' +
+        '- **Choose the right event:** Use `input` for real-time filtering as users type. Use `change` for expensive operations that should wait until typing completes.\n' +
+        '- **Handle empty values:** When the field is cleared, reset filters or show all items appropriately.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `SearchField` provides a search input field with visual styling and clear functionality—additional search features like filters, sorting, search history, or search buttons require custom implementation.\n' +
+        '- The component handles text input and basic interaction events—complex search workflows with multiple steps or advanced state management require additional components or custom logic.\n' +
+        '- `SearchField` is optimized for inline search and filtering—displaying search results requires using other components like `Stack`, `Section`, or custom layout components to present filtered content.',
+    },
+  ],
   defaultExample: {
     image: 'search-field-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -2,8 +2,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'SearchField',
-  description:
-    'Captures search terms from merchants using a single-line input field. Includes visual styling to indicate search functionality, and an accessory to quickly clear the input.',
+  description: 'Capture search terms using a single-line input field.',
   thumbnail: 'search-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -2,20 +2,24 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'SearchField',
-  description: 'Capture search terms using a single-line input field.',
+  description:
+    'The `SearchField` component captures search terms using a single-line input field. Use it to enable search and filtering within POS interfaces.' +
+    '\n\nThe component includes built-in debouncing to optimize performance during real-time search operations and supports features like autocomplete suggestions and search history. It provides clear visual feedback for search states including loading, results found, and no results, helping merchants quickly locate products, customers, or orders in large catalogs.' +
+    '\n\n`SearchField` components clear search queries with a single tap on the clear button while maintaining search history for quick access to recent searches, balancing convenience with data management.',
   thumbnail: 'search-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `SearchField` component.',
       type: 'SearchField',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `SearchField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'SearchFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -27,8 +27,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'search-field-default.png',
+    description:
+      'Enable search functionality using a `SearchField` component with built-in debouncing. This example shows a basic search field with placeholder text.',
     codeblock: {
-      title: 'Code',
+      title: 'Enable search with a search field',
       tabs: [
         {
           code: './examples/default.html',
@@ -39,12 +41,14 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'SearchField usage patterns',
+    description:
+      'Learn how to handle search input and implement real-time filtering.',
     examples: [
       {
-        description: 'Handle search input events',
+        description:
+          'Subscribe to search input events to respond when merchants enter search terms. This example demonstrates handling `onChange` and `onInput` events for real-time search functionality, debounced filtering, or triggering search API calls as merchants type their queries.',
         codeblock: {
-          title: 'Event handling',
+          title: 'Handle search input events',
           tabs: [
             {
               code: './examples/event-handling.jsx',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section.d.ts
@@ -17,18 +17,30 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
@@ -36,17 +48,15 @@ export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 declare const tagName = 's-section';
 export interface SectionJSXProps extends Pick<SectionProps, 'id'> {
   /**
-   * A title that describes the content of the section.
-   *
-   * If omitted, and no secondaryActions are provided, the section will be rendered without a header.
+   * A title that describes the content of the section. If omitted and no secondary actions are provided, the section will be rendered without a header.
    */
   heading?: string;
   /**
-   * Button element to display in the section heading. A single button is supported.
+   * A button element to display in the section heading. Only a single button is supported. Use the `slot="secondary-actions"` attribute to place action elements that relate to the entire section's content.
    */
   secondaryActions?: ComponentChild;
   /**
-   * The content of the Section.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -26,8 +26,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Structure',
   defaultExample: {
     image: 'section-default.png',
+    description:
+      'Group related content using a `Section` component with automatic heading level management. This example shows a basic section with a heading and content area.',
     codeblock: {
-      title: 'Code',
+      title: 'Group related content into sections',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -2,8 +2,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Section',
-  description:
-    'Groups related content into clearly-defined thematic areas. Sections have contextual heading levels to maintain a meaningful and accessible page structure.',
+  description: 'Group related content into clearly-defined thematic areas.',
   thumbnail: 'section-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -24,6 +24,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Structure',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        "- **Write descriptive headings:** Provide clear heading text that represents the section's content.\n" +
+        '- **Let heading levels adjust automatically:** Nested sections automatically adjust heading levels for proper semantic structure.\n' +
+        '- **Place relevant secondary actions:** Use the `secondary-actions` slot for actions that apply to the entire section, like "Edit Settings" or "Add Item."',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Section heading levels are automatically determined by nesting depth—manual heading level control is not available to ensure consistent document structure.\n' +
+        "- Only one secondary action button is supported per section to maintain clean, focused interfaces that don't overwhelm users.\n" +
+        "- The component's visual styling and spacing are controlled by the POS design system—custom section styling beyond content organization is not supported.",
+    },
+  ],
   defaultExample: {
     image: 'section-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -23,7 +23,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Structure',
+  subCategory: 'Layout and structure',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -2,19 +2,23 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Section',
-  description: 'Group related content into clearly-defined thematic areas.',
+  description:
+    'The `Section` component groups related content into clearly-defined thematic areas. Sections have contextual heading levels to maintain a meaningful page structure.' +
+    '\n\nUse sections to organize content logically and provide clear navigation landmarks. The component manages heading levels to ensure nested sections maintain proper semantic structure.',
   thumbnail: 'section-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Section` component.',
       type: 'Section',
     },
     {
       title: 'Slots',
-      description: '',
+      description:
+        'The `Section` component supports slots for additional content placement within the section. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'SectionSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack.d.ts
@@ -78,60 +78,56 @@ export type PickedProps = Pick<
 >;
 export interface StackJSXProps extends PickedProps {
   /**
-   * The padding applied to all edges of the `Stack` component.
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties#edges_of_a_box) is supported. Contrary to the CSS, it uses flow-relative values and the order is:
+   * The padding applied to all edges of the container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
+   *
    * For example:
+   *
    * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
    * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
    * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
    * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
+   *
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * The block-axis padding for the `Stack` component.
-   * `large none` means block-start padding is `large`, block-end padding is `none`.
-   * This overrides the block value of `padding`.
+   * The block-axis padding for the container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<PaddingKeyword | ''>;
   /**
-   * The block-start padding for the `Stack` component.
-   * This overrides the block-start value of `paddingBlock`.
+   * The block-start padding for the container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: PaddingKeyword | '';
   /**
-   * The block-end padding for the `Stack` component.
-   * This overrides the block-end value of `paddingBlock`.
+   * The block-end padding for the container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: PaddingKeyword | '';
   /**
-   * The inline-axis padding for the `Stack` component.
-   * `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   * This overrides the inline value of `padding`.
+   * The inline-axis padding for the container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<PaddingKeyword | ''>;
   /**
-   * The inline-start padding for the `Stack` component.
-   * This overrides the inline-start value of `paddingInline`.
+   * The inline-start padding for the container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: PaddingKeyword | '';
   /**
-   * The inline-end padding for the `Stack` component.
+   * The inline-end padding for the container.
    * This overrides the inline-end value of `paddingInline`.
    *
    * @default '' - meaning no override

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack.d.ts
@@ -26,23 +26,38 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 
 declare const tagName = 's-stack';
+/**
+ * Defines the available padding size options using a semantic scale. Provides consistent spacing values that align with the POS design system.
+ */
 export type PaddingKeyword = SizeKeyword | 'none';
 export type PickedProps = Pick<
   StackProps,
@@ -63,173 +78,148 @@ export type PickedProps = Pick<
 >;
 export interface StackJSXProps extends PickedProps {
   /**
-   * Adjust the padding of all edges.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
+   * The padding applied to all edges of the `Stack` component.
+   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties#edges_of_a_box) is supported. Contrary to the CSS, it uses flow-relative values and the order is:
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
-   *
    * For example:
    * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
    * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
    * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
    * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
    * @default 'none'
    */
   padding?: MaybeAllValuesShorthandProperty<PaddingKeyword>;
   /**
-   * Adjust the block-padding.
-   *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
+   * The block-axis padding for the `Stack` component.
+   * `large none` means block-start padding is `large`, block-end padding is `none`.
    * This overrides the block value of `padding`.
    *
    * @default '' - meaning no override
    */
   paddingBlock?: MaybeTwoValuesShorthandProperty<PaddingKeyword | ''>;
   /**
-   * Adjust the block-start padding.
-   *
+   * The block-start padding for the `Stack` component.
    * This overrides the block-start value of `paddingBlock`.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: PaddingKeyword | '';
   /**
-   * Adjust the block-end padding.
-   *
+   * The block-end padding for the `Stack` component.
    * This overrides the block-end value of `paddingBlock`.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: PaddingKeyword | '';
   /**
-   * Adjust the inline padding.
-   *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
+   * The inline-axis padding for the `Stack` component.
+   * `large none` means inline-start padding is `large`, inline-end padding is `none`.
    * This overrides the inline value of `padding`.
    *
    * @default '' - meaning no override
    */
   paddingInline?: MaybeTwoValuesShorthandProperty<PaddingKeyword | ''>;
   /**
-   * Adjust the inline-start padding.
-   *
+   * The inline-start padding for the `Stack` component.
    * This overrides the inline-start value of `paddingInline`.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: PaddingKeyword | '';
   /**
-   * Adjust the inline-end padding.
-   *
+   * The inline-end padding for the `Stack` component.
    * This overrides the inline-end value of `paddingInline`.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: PaddingKeyword | '';
   /**
-   * Adjust the block size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
+   * The block size of the `Stack` component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/block-size
-   *
+   * Learn more about [block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * Adjust the maximum block size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
+   * The maximum block size constraint for the `Stack` component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size
-   *
+   * Learn more about [max-block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * Adjust the maximum inline size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
+   * The maximum inline size constraint for the `Stack` component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size
-   *
+   * Learn more about [max-inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * Adjust the minimum block size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
+   * The minimum block size constraint for the `Stack` component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size
-   *
+   * Learn more about [min-block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * Adjust the minimum inline size.
-   * **Mobile surfaces:** Avoid using percentage-based sizes. They do not behave as expected when placed within a scrollable container.
+   * The minimum inline size constraint for the `Stack` component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size
-   *
+   * Learn more about [min-inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * Aligns the Stack's children along the cross axis.
+   * The alignment of the `Stack` component's children along the cross axis.
    */
   alignItems?: AlignItemsKeyword;
   /**
-   * Aligns the Stack along the cross axis.
+   * The alignment of the `Stack` component along the cross axis.
    */
   alignContent?: AlignContentKeyword;
   /**
-   * Adjust spacing between elements.
-   * A single value applies to both axes. A pair of values (eg large-100 large-500) can be used to set the inline and block axes respectively.
+   * The spacing between elements. A single value applies to both axes. A pair of values (eg large-100 large-500) can be used to set the inline and block axes respectively.
    *
    * @default 'none'
    */
   gap?: MaybeTwoValuesShorthandProperty<SpacingKeyword>;
   /**
-   * Adjust spacing between elements in the inline axis. This overrides the column value of gap.
+   * The spacing between elements in the inline axis. This overrides the column value of gap.
    *
    * @default '' - meaning no override
    */
   columnGap?: SpacingKeyword | '';
   /**
-   * Sets how the children are placed within the Stack. This uses logical properties.
+   * The direction in which children are placed within the `Stack` component using logical properties. Use `'block'` for vertical arrangement where children are placed along the block axis (typically top to bottom) without wrapping. Use `'inline'` for horizontal arrangement where children are placed along the inline axis (typically left to right) with automatic wrapping when space is insufficient.
    *
    * @default 'block'
-   * @implementation - the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'
    */
   direction?: 'block' | 'inline';
   /**
-   * Adjust the inline size.
-   * @see — https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size
+   * The inline size of the `Stack` component.
    *
+   * Learn more about [inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Aligns the Stack along the main axis.
-   * @see — https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
+   * The alignment of the `Stack` component along the main axis.
    *
+   * Learn more about [justify-content on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
    * @default 'normal'
    */
   justifyContent?: JustifyContentKeyword;
   /**
-   * Adjust spacing between elements in the block axis. This overrides the row value of gap.
+   * The spacing between elements in the block axis. This overrides the row value of gap.
    *
    * @default '' - meaning no override
    */
   rowGap?: SpacingKeyword | '';
   /**
-   * The content of the Stack.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -21,8 +21,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Structure',
   defaultExample: {
     image: 'stack-default.png',
+    description:
+      'Organize elements horizontally or vertically using a `Stack` component with automatic spacing. This example shows a basic stack with gap spacing between child elements.',
     codeblock: {
-      title: 'Code',
+      title: 'Organize elements with a stack',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -19,6 +19,28 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Structure',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Choose appropriate direction:** Use `block` for vertical arrangements like forms. Use `inline` for horizontal arrangements like button groups. Note that inline wraps while block doesn\'t.\n' +
+        '- **Use design system spacing:** Use `SpacingKeyword` values for consistency. Start with `base` and adjust as needed.\n' +
+        '- **Apply alignment properties:** Use `justifyContent` for main axis distribution, `alignItems` for cross axis positioning, `alignContent` for extra space distribution.\n' +
+        '- **Avoid percentages on mobile:** Don\'t use percentage-based sizing within scrollable containers on mobile surfaces.\n' +
+        '- **Use gap for spacing control:** Use `gap` for uniform spacing, `rowGap` for block axis, `columnGap` for inline axis.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Wrapping behavior is determined by direction—inline stacks wrap content while block stacks don\'t, which may not suit all layout requirements.\n' +
+        '- Percentage-based sizing should be avoided on mobile surfaces within scrollable containers due to unexpected behavior.\n' +
+        '- Complex grid-like layouts may require multiple nested `Stack` components or alternative layout approaches for optimal results.',
+    },
+  ],
   defaultExample: {
     image: 'stack-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
-    'Organizes elements horizontally or vertically along the block or inline axis. Use to structure layouts, group related components, or control spacing between elements.',
+    'Organize elements horizontally or vertically along the block or inline axis.',
   thumbnail: 'stack-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Structure',
+  subCategory: 'Layout and structure',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -25,10 +25,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Choose appropriate direction:** Use `block` for vertical arrangements like forms. Use `inline` for horizontal arrangements like button groups. Note that inline wraps while block doesn\'t.\n' +
+        "- **Choose appropriate direction:** Use `block` for vertical arrangements like forms. Use `inline` for horizontal arrangements like button groups. Note that inline wraps while block doesn't.\n" +
         '- **Use design system spacing:** Use `SpacingKeyword` values for consistency. Start with `base` and adjust as needed.\n' +
         '- **Apply alignment properties:** Use `justifyContent` for main axis distribution, `alignItems` for cross axis positioning, `alignContent` for extra space distribution.\n' +
-        '- **Avoid percentages on mobile:** Don\'t use percentage-based sizing within scrollable containers on mobile surfaces.\n' +
+        "- **Avoid percentages on mobile:** Don't use percentage-based sizing within scrollable containers on mobile surfaces.\n" +
         '- **Use gap for spacing control:** Use `gap` for uniform spacing, `rowGap` for block axis, `columnGap` for inline axis.',
     },
     {
@@ -36,7 +36,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Wrapping behavior is determined by direction—inline stacks wrap content while block stacks don\'t, which may not suit all layout requirements.\n' +
+        "- Wrapping behavior is determined by direction—inline stacks wrap content while block stacks don't, which may not suit all layout requirements.\n" +
         '- Percentage-based sizing should be avoided on mobile surfaces within scrollable containers due to unexpected behavior.\n' +
         '- Complex grid-like layouts may require multiple nested `Stack` components or alternative layout approaches for optimal results.',
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -3,14 +3,17 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
-    'Organize elements horizontally or vertically along the block or inline axis.',
+    'The `Stack` component organizes elements horizontally or vertically along the block or inline axis. Use it to structure layouts, group related components, or control spacing between elements with flexible alignment options.' +
+    '\n\nThe component simplifies layout creation by automatically managing spacing between child elements through gap properties, eliminating the need for manual margin management. It supports both horizontal and vertical arrangements, flexible alignment options, and wrapping behavior, making it the foundation for building consistent, responsive layouts throughout POS extensions.' +
+    '\n\n`Stack` components support responsive gap values that automatically adjust spacing based on screen size, ensuring layouts remain visually balanced and maintain proper element separation across different devices.',
   thumbnail: 'stack-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Stack` component.',
       type: 'Stack',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text.d.ts
@@ -12,18 +12,30 @@ import type {TextProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
@@ -31,21 +43,19 @@ export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 declare const tagName = 's-text';
 export interface TextJSXProps extends Pick<TextProps, 'id'> {
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the text. Controls how prominent or subtle the text appears within the interface.
    *
    * @default 'base'
    */
   color?: Extract<TextProps['color'], 'base' | 'strong' | 'subdued'>;
   /**
-   * Provide semantic meaning and default styling to the text.
-   *
-   * Other presentation properties on Text override the default styling.
+   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type.
    *
    * @default 'generic'
    */
   type?: Extract<TextProps['type'], 'generic' | 'strong' | 'small'>;
   /**
-   * Sets the tone of the component, based on the intention of the information being conveyed.
+   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text.d.ts
@@ -49,13 +49,25 @@ export interface TextJSXProps extends Pick<TextProps, 'id'> {
    */
   color?: Extract<TextProps['color'], 'base' | 'strong' | 'subdued'>;
   /**
-   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type.
+   * The semantic meaning and default styling of the text. Other presentation properties override the default styling provided by the type. Available options:
+   *
+   * - `'generic'` - The default text type for general content without specific semantic meaning or emphasis.
+   * - `'strong'` - A text type that provides emphasis and importance, typically rendered with increased font weight or visual prominence.
+   * - `'small'` - A text type for secondary or supplementary content, typically rendered with reduced size for captions, fine print, or less important information.
    *
    * @default 'generic'
    */
   type?: Extract<TextProps['type'], 'generic' | 'strong' | 'small'>;
   /**
-   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Determines the visual appearance and semantic meaning of the text. Available options:
+   *
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context. Use when you want the system to determine the most appropriate styling.
+   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis. Use for general status updates and standard information.
+   * - `'info'` - Blue styling for informational content and neutral updates. Use for informational content that provides helpful context.
+   * - `'success'` - Green styling for positive states, completed actions, and successful operations. Use for positive outcomes and successful processes.
+   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent. Use for potential issues that require awareness.
+   * - `'warning'` - Orange styling for important notices that require merchant awareness. Use for situations that need attention but aren't critical.
+   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action. Use for urgent issues that need immediate merchant attention.
    *
    * @default 'auto'
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -22,8 +22,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Titles and text',
   defaultExample: {
     image: 'text-default.png',
+    description:
+      'Display text content using a `Text` component with customizable visual styles and tones. This example shows basic text with appropriate emphasis and hierarchy.',
     codeblock: {
-      title: 'Code',
+      title: 'Display text with visual styles',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -20,6 +20,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Titles and text',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Choose semantic types:** Use `strong` for emphasis, `small` for secondary info, `generic` for standard text.\n' +
+        '- **Apply appropriate tones:** Use `success` for positive outcomes, `warning` or `critical` for alerts, `info` for helpful context, `auto` for neutral content.\n' +
+        '- **Balance color intensity:** Use `strong` for emphasis, `base` for readability, `subdued` for secondary info.\n' +
+        '- **Nest for mixed formatting:** Nest `Text` components when you need multiple styles within one text block.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Text styling is controlled by the POS design system through the provided properties—custom font families, sizes, or styling beyond the available options aren\'t supported.\n' +
+        '- Complex rich text formatting isn\'t supported—use multiple `Text` components or nested text elements for varied formatting needs.',
+    },
+  ],
   defaultExample: {
     image: 'text-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -2,8 +2,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Text',
-  description: `Displays text with specific visual styles or tones. Use to present content with appropriate emphasis, hierarchy, or tone.
-  > Note: Text on mobile surfaces is blockish, rather than inline.`,
+  description: `Display text with specific visual styles or tones.`,
   thumbnail: 'text-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -2,14 +2,19 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Text',
-  description: `Display text with specific visual styles or tones.`,
+  description:
+    'The `Text` component displays text with specific visual styles or tones. Use it to present content with appropriate emphasis, hierarchy, or tone while maintaining semantic meaning.' +
+    '\n\nText provides flexible styling options that integrate with the POS design system while ensuring proper contrast and readability across different contexts.' +
+    '\n\nThe component automatically adjusts line length for optimal readability based on container width, preventing overly long lines that reduce reading speed and comprehension in wider layouts.' +
+    '\n\nText on mobile surfaces is blockish, rather than inline.',
   thumbnail: 'text-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Text` component.',
       type: 'Text',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -19,7 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   category: 'Polaris web components',
-  subCategory: 'Titles and text',
+  subCategory: 'Layout and structure',
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -36,8 +36,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Text styling is controlled by the POS design system through the provided properties—custom font families, sizes, or styling beyond the available options aren\'t supported.\n' +
-        '- Complex rich text formatting isn\'t supported—use multiple `Text` components or nested text elements for varied formatting needs.',
+        "- Text styling is controlled by the POS design system through the provided properties—custom font families, sizes, or styling beyond the available options aren't supported.\n" +
+        "- Complex rich text formatting isn't supported—use multiple `Text` components or nested text elements for varied formatting needs.",
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea.d.ts
@@ -17,28 +17,64 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * The additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -58,23 +94,23 @@ export interface TextAreaJSXProps
     | 'rows'
   > {
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function that executes when the user makes any changes in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function that executes after editing completes, typically on blur.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function that executes when the element loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function that executes when the element receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Additional content to be displayed in the field. Commonly used to display clickable text.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -30,6 +30,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Set appropriate row count:** Use 2-3 rows for brief notes, 4-6 for descriptions, and more for extensive content.\n' +
+        '- **Show character limit feedback:** When approaching `maxLength`, display remaining characters in the `details` text.\n' +
+        '- **Write descriptive labels:** Use specific labels like "Product Description" or "Special Instructions" rather than generic terms.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        "- `TextArea` provides multi-line text input but doesn't include rich text formatting capabilities—complex formatting like bold, italic, or lists requires alternative solutions or plain text representations.\n" +
+        "- The `required` property adds semantic meaning only—it doesn't trigger automatic error display or validation, so you must implement validation logic manually.\n" +
+        "- The `accessory` slot supports only `Button` and `Clickable` components—other component types can't be used for field accessories.",
+    },
+  ],
   defaultExample: {
     image: 'text-area-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -3,26 +3,28 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextArea',
   description:
-    'Capture longer text content with a multi-line, resizable text input area.',
+    'The `TextArea` component captures longer text content with a multi-line, resizable text input area. Use it to collect descriptions, notes, comments, or other extended text input in forms and data entry workflows.' +
+    '\n\nThe component provides a multi-line text input area that accommodates longer content. It supports validation and multi-line formatting, making it ideal for capturing detailed information such as order notes, product descriptions, or customer feedback that requires more than single-line input.',
   thumbnail: 'text-area-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `TextArea` component.',
       type: 'TextArea',
     },
     {
       title: 'Slots',
       description:
-        'Learn more about using [slots](/docs/api/pos-ui-extensions/using-polaris-components#slots)',
+        'The `TextArea` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TextAreaSlots',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `TextArea` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TextAreaEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextArea',
   description:
-    'Captures longer text content from merchants with a multi-line, resizable text input area.',
+    'Capture longer text content with a multi-line, resizable text input area.',
   thumbnail: 'text-area-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -47,7 +47,7 @@ const data: ReferenceEntityTemplateSchema = {
   related: [],
   examples: {
     description:
-      'Learn how to add accessory buttons, handle events, and configure visible rows.',
+      'Learn how to add accessory buttons, configure visible rows, and handle events.',
     examples: [
       {
         description:
@@ -64,12 +64,12 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Subscribe to text area events to respond when merchants enter or modify text. This example demonstrates handling `onChange`, `onInput`, `onFocus`, and `onBlur` events for autosave functionality, character counting, or real-time validation of longer text content.',
+          'Configure the number of visible rows and character limits to control text area size and input length. This example shows how to use the `rows` property to set initial height and `maxlength` to limit content, ensuring appropriate sizing for different types of text input.',
         codeblock: {
-          title: 'Handle text input events',
+          title: 'Configure rows and character limits',
           tabs: [
             {
-              code: './examples/event-handling.jsx',
+              code: './examples/rows-configuration.jsx',
               language: 'jsx',
             },
           ],
@@ -77,12 +77,12 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Configure the number of visible rows and character limits to control text area size and input length. This example shows how to use the `rows` property to set initial height and `maxlength` to limit content, ensuring appropriate sizing for different types of text input.',
+          'Subscribe to text area events to respond when merchants enter or modify text. This example demonstrates handling `onChange`, `onInput`, `onFocus`, and `onBlur` events for autosave functionality, character counting, or real-time validation of longer text content.',
         codeblock: {
-          title: 'Configure rows and character limits',
+          title: 'Handle text input events',
           tabs: [
             {
-              code: './examples/rows-configuration.jsx',
+              code: './examples/event-handling.jsx',
               language: 'jsx',
             },
           ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -32,8 +32,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'text-area-default.png',
+    description:
+      'Capture multi-line text input using a `TextArea` component with resizable height. This example shows a basic text area with label for longer content entry.',
     codeblock: {
-      title: 'Code',
+      title: 'Capture multi-line text with a text area',
       tabs: [
         {
           code: './examples/default.html',
@@ -44,24 +46,27 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'TextArea usage patterns',
+    description:
+      'Learn how to add accessory buttons, handle events, and configure visible rows.',
     examples: [
       {
-        description: 'Configure visible rows and character limits',
+        description:
+          'Add action buttons to the text area using the accessory slot for quick actions like clearing text or formatting content. This example shows how to use `s-button` and `s-clickable` components in the accessory slot, providing inline functionality within the multi-line input context.',
         codeblock: {
-          title: 'Rows configuration',
+          title: 'Add accessory buttons',
           tabs: [
             {
-              code: './examples/rows-configuration.jsx',
+              code: './examples/accessory-slot.jsx',
               language: 'jsx',
             },
           ],
         },
       },
       {
-        description: 'Handle text area events',
+        description:
+          'Subscribe to text area events to respond when merchants enter or modify text. This example demonstrates handling `onChange`, `onInput`, `onFocus`, and `onBlur` events for autosave functionality, character counting, or real-time validation of longer text content.',
         codeblock: {
-          title: 'Event handling',
+          title: 'Handle text input events',
           tabs: [
             {
               code: './examples/event-handling.jsx',
@@ -72,12 +77,12 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Add action buttons using the accessory slot. Only s-button and s-clickable are supported',
+          'Configure the number of visible rows and character limits to control text area size and input length. This example shows how to use the `rows` property to set initial height and `maxlength` to limit content, ensuring appropriate sizing for different types of text input.',
         codeblock: {
-          title: 'Accessory slot',
+          title: 'Configure rows and character limits',
           tabs: [
             {
-              code: './examples/accessory-slot.jsx',
+              code: './examples/rows-configuration.jsx',
               language: 'jsx',
             },
           ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField.d.ts
@@ -17,28 +17,64 @@ import type {
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * The additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -57,23 +93,23 @@ export interface TextFieldJSXProps
     | 'maxLength'
   > {
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function that executes when the user makes any changes in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function that executes after editing completes, typically on blur.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function that executes when the element loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function that executes when the element receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Additional content to be displayed in the field. Commonly used to display clickable text.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -2,8 +2,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextField',
-  description:
-    'Captures single-line text input from merchants. Use to collect short, free-form information.',
+  description: 'Capture single-line text input.',
   thumbnail: 'text-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -30,6 +30,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use for single-line text input:** Choose `TextField` for short values like names, titles, or identifiers. For multi-line content, use `TextArea`.\n' +
+        '- **Show character limit feedback:** When approaching `maxLength`, display remaining characters in the `details` text.\n' +
+        '- **Write descriptive labels:** Use specific labels like "Product Name" or "Reference Code" rather than generic terms.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `TextField` provides single-line text input only—multi-line text entry requires the `TextArea` component.\n' +
+        "- The `required` property adds semantic meaning only—it doesn't trigger automatic error display or validation, so you must implement validation logic manually.\n" +
+        "- The `accessory` slot supports only `Button` and `Clickable` components with text content only—other component types or complex layouts can't be used for field accessories.",
+    },
+  ],
   defaultExample: {
     image: 'text-field-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -32,8 +32,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'text-field-default.png',
+    description:
+      'Capture single-line text input using a `TextField` component with validation support. This example shows a basic text field with label and placeholder text.',
     codeblock: {
-      title: 'Code',
+      title: 'Capture text input with a text field',
       tabs: [
         {
           code: './examples/default.html',
@@ -44,26 +46,14 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'Advanced usage patterns for TextField component',
+    description:
+      'Learn how to handle events, use accessory slots, and configure common properties for validation and user guidance.',
     examples: [
       {
         description:
-          'Handle TextField events: onInput, onFocus, onBlur, and onChange.',
+          'Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use `s-button` and `s-clickable` components with text content in the accessory slot, enabling inline actions without leaving the input context.',
         codeblock: {
-          title: 'Event handling',
-          tabs: [
-            {
-              code: './examples/event-handling.jsx',
-              language: 'jsx',
-            },
-          ],
-        },
-      },
-      {
-        description:
-          'Add action buttons using the accessory slot. Only `s-button` and `s-clickable` are supported, with text content only',
-        codeblock: {
-          title: 'Accessory slot',
+          title: 'Add accessory buttons',
           tabs: [
             {
               code: './examples/accessory-slot.jsx',
@@ -74,12 +64,25 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Common TextField props for validation, constraints, and user guidance.',
+          'Configure common `TextField` properties for validation, character limits, and user guidance. This example demonstrates using props like `maxlength`, `required`, `helperText`, and `error` to create a well-guided input experience with proper validation feedback.',
         codeblock: {
-          title: 'Common props',
+          title: 'Configure validation and guidance',
           tabs: [
             {
               code: './examples/common-props.jsx',
+              language: 'jsx',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Subscribe to `TextField` events including `onInput`, `onFocus`, `onBlur`, and `onChange` to respond to user interactions. This example shows how to handle different input events for real-time validation, autosave functionality, or dynamic form behavior.',
+        codeblock: {
+          title: 'Handle input events',
+          tabs: [
+            {
+              code: './examples/event-handling.jsx',
               language: 'jsx',
             },
           ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -2,26 +2,29 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextField',
-  description: 'Capture single-line text input.',
+  description:
+    'The `TextField` component captures single-line text input. Use it to collect short, free-form information in forms and data entry workflows.' +
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. It includes built-in support for labels, helper text, and error states to guide merchants through data entry, ensuring accurate and efficient information capture across different retail scenarios.',
   thumbnail: 'text-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `TextField` component.',
       type: 'TextField',
     },
     {
       title: 'Slots',
       description:
-        'Learn more about using [slots](/docs/api/pos-ui-extensions/using-polaris-components#slots)',
+        'The `TextField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TextFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `TextField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TextFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile.d.ts
@@ -12,28 +12,64 @@ import type {TileProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents an event triggered by user interaction with the tile. Provides information about the event and access to the tile element that triggered it.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The tile element to which the event handler is attached. This always refers to the element that the event listener was added to, unlike `target` which may refer to a child element. Commonly used to access the tile's properties or manipulate the element directly.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Indicates whether the event bubbles up through the DOM tree. When `true`, parent elements can also handle this event. Commonly used to determine if the event will propagate to parent handlers.
+   */
   bubbles?: boolean;
+  /**
+   * Indicates whether the event's default action can be prevented. When `true`, calling `preventDefault()` on the event will prevent the default behavior. Commonly used to determine if you can prevent the default action programmatically.
+   */
   cancelable?: boolean;
+  /**
+   * Indicates whether the event will propagate across shadow DOM boundaries into the standard DOM. When `true`, the event can be handled by elements outside the shadow DOM. Relevant for web component implementations.
+   */
   composed?: boolean;
+  /**
+   * The custom data associated with the event. For custom events, this can contain any additional information about the event. For standard tile click events, this is typically undefined unless custom data is provided.
+   */
   detail?: any;
+  /**
+   * Indicates the current phase of the event flow. Standard DOM event phase values: `0` (none), `1` (capturing), `2` (at target), or `3` (bubbling). Typically applied when implementing custom event handling logic that needs to differentiate between event phases.
+   */
   eventPhase: number;
+  /**
+   * The element that originally triggered the event. For tiles, this is typically the same as `currentTarget` since tiles are single interactive elements. Returns `null` if the target is no longer in the document.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -44,13 +80,13 @@ export interface TileJSXProps
     'heading' | 'id' | 'itemCount' | 'tone' | 'subheading'
   > {
   /**
-   * Disables the Tile meaning it cannot be clicked or receive focus.
+   * Controls whether the tile can be clicked or receive focus. When `true`, the tile appears dimmed and doesn't respond to user interactions or fire click events. Commonly used to prevent actions when conditions aren't met, such as insufficient cart contents or missing permissions. Defaults to `false`.
    *
    * @default false
    */
   disabled?: TileProps['disabled'];
   /**
-   * Callback when the Tile is activated.
+   * The callback function executed when the tile is activated by user interaction. Use this to launch modal workflows with `api.action.presentModal()`, update application state, or trigger other actions. The event parameter provides details about the interaction and the tile element that was clicked.
    */
   onClick?: (event: CallbackEvent<typeof tagName>) => void;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -3,19 +3,22 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Tile',
   description:
-    'Display interactive buttons for the POS smart grid that allow merchants to complete actions quickly.',
+    'The `Tile` component displays interactive buttons for the POS smart grid that allow merchants to complete actions quickly. Tiles serve as customizable shortcuts that provide contextual information and enable merchants to quickly access workflows, actions, and information from the smart grid and detail pages.' +
+    '\n\nTiles are dynamic components that can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They support tap interactions, visual feedback, and can display contextual information through titles, subtitles, and badge values.',
   thumbnail: 'tile-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `Tile` component.',
       type: 'Tile',
     },
     {
       title: 'Events',
-      description: '',
+      description:
+        'The `Tile` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TileEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Tile',
   description:
-    "Customizable buttons that allow merchants to complete actions quickly. Tiles provide contextual information and let merchants access workflows, actions, and information from the Smart Grid and the top of detail pages. They're dynamic and can change based on surrounding context, such as what's in the cart.",
+    'Display interactive buttons for the POS smart grid that allow merchants to complete actions quickly.',
   thumbnail: 'tile-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -26,8 +26,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Actions',
   defaultExample: {
     image: 'tile-default.png',
+    description:
+      'Create interactive smart grid shortcuts using a `Tile` component with customizable title, subtitle, and badge. This example shows a basic tile for the POS smart grid.',
     codeblock: {
-      title: 'Code',
+      title: 'Create a smart grid tile',
       tabs: [
         {
           code: './examples/default.html',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -41,11 +41,11 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent:
         '- Each POS UI extension can only render one `Tile` component per tile target.\n' +
-        '- The `itemCount` property only accepts numeric values—string or text badges aren\'t supported.\n' +
-        '- Custom icons, images, or visual styling beyond the built-in `tone` property aren\'t supported.\n' +
-        '- Tile size and layout are determined by the smart grid system and can\'t be customized.\n' +
-        '- The `Tile` component supports click and long press interactions only. Swipe, drag, and other gestures aren\'t supported.\n' +
-        '- The `heading` and `subheading` properties must be plain strings—HTML, markdown, or rich text formatting isn\'t supported.',
+        "- The `itemCount` property only accepts numeric values—string or text badges aren't supported.\n" +
+        "- Custom icons, images, or visual styling beyond the built-in `tone` property aren't supported.\n" +
+        "- Tile size and layout are determined by the smart grid system and can't be customized.\n" +
+        "- The `Tile` component supports click and long press interactions only. Swipe, drag, and other gestures aren't supported.\n" +
+        "- The `heading` and `subheading` properties must be plain strings—HTML, markdown, or rich text formatting isn't supported.",
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Tile',
   description:
-    'The `Tile` component displays interactive buttons for the POS smart grid that allow merchants to complete actions quickly. Tiles serve as customizable shortcuts that provide contextual information and enable merchants to quickly access workflows, actions, and information from the smart grid and detail pages.' +
+    'The `Tile` component displays interactive buttons for the POS smart grid that allow merchants to complete actions quickly. Tiles serve as customizable shortcuts that provide contextual information and enable merchants to quickly access workflows, actions, and information from the smart grid.' +
     '\n\nTiles are dynamic components that can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They support tap interactions, visual feedback, and can display contextual information through titles, subtitles, and badge values.',
   thumbnail: 'tile-thumbnail.png',
   isVisualComponent: true,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -24,6 +24,30 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Actions',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Write action-oriented headings:** Use specific language like "Apply loyalty discount" rather than generic terms like "Loyalty app."\n' +
+        '- **Provide contextual subheadings:** Show dynamic information like cart totals, eligibility requirements, or current status.\n' +
+        '- **Use meaningful item counts:** Display counts for actionable items like pending notifications or items requiring action, not just informational counts.\n' +
+        '- **Launch modals for workflows:** Use `onClick` with `shopify.action.presentModal()` rather than performing complex operations directly.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- Each POS UI extension can only render one `Tile` component per tile target.\n' +
+        '- The `itemCount` property only accepts numeric values—string or text badges aren\'t supported.\n' +
+        '- Custom icons, images, or visual styling beyond the built-in `tone` property aren\'t supported.\n' +
+        '- Tile size and layout are determined by the smart grid system and can\'t be customized.\n' +
+        '- The `Tile` component supports click and long press interactions only. Swipe, drag, and other gestures aren\'t supported.\n' +
+        '- The `heading` and `subheading` properties must be plain strings—HTML, markdown, or rich text formatting isn\'t supported.',
+    },
+  ],
   defaultExample: {
     image: 'tile-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField.d.ts
@@ -12,28 +12,64 @@ import type {TimeFieldProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * The additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -44,19 +80,19 @@ export interface TimeFieldJSXProps
     'id' | 'label' | 'disabled' | 'value' | 'error' | 'details'
   > {
   /**
-   * Callback when the user makes any changes in the field.
+   * A callback function executed when the user makes any changes in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback after editing completes (typically on blur).
+   * A callback function executed after editing completes, typically on blur.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element loses focus.
+   * A callback function executed when the element loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback when the element receives focus.
+   * A callback function executed when the element receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -27,8 +27,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'time-field-default.png',
+    description:
+      'Capture time input using a `TimeField` component with locale-aware formatting. This example shows a basic time field with label and time validation.',
     codeblock: {
-      title: 'Code',
+      title: 'Capture time input with a time field',
       tabs: [
         {
           code: './examples/default.html',
@@ -39,12 +41,14 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'TimeField usage patterns',
+    description:
+      'Learn how to handle time selection events and validate time input.',
     examples: [
       {
-        description: 'Handle time input events',
+        description:
+          'Subscribe to time input events to respond when merchants select or enter times. This example shows how to handle `onChange` events to capture time selections, enabling real-time validation, time range checks, or dynamic scheduling behavior based on merchant input.',
         codeblock: {
-          title: 'Event handling',
+          title: 'Handle time selection events',
           tabs: [
             {
               code: './examples/event-handling.jsx',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -25,6 +25,25 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Use correct format:** Always use `HH:mm:ss` format with leading zeros (like `"09:05:00"` not `"9:5:0"`).\n' +
+        '- **Explain time constraints:** Use `details` to clarify requirements like "Business hours only (09:00-17:00)" or "Must be a future time."',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `TimeField` accepts time values in 24-hour `HH:mm:ss` format only—12-hour times or other formats require conversion before setting the value property.\n' +
+        '- The component provides text-based time input—for visual time selection with clock or spinner interfaces, use the `TimePicker` component which offers interactive time selection.\n' +
+        '- Validation occurs when the user finishes editing rather than on every keystroke—invalid times are only flagged after blur, which may delay error feedback.',
+    },
+  ],
   defaultExample: {
     image: 'time-field-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -3,20 +3,23 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimeField',
   description:
-    'Capture time input with a consistent interface for time selection and validation.',
+    'The `TimeField` component captures time input with a consistent interface for time selection and validation. Use it to collect time information in scheduling, booking, or data entry workflows.' +
+    '\n\nThe component supports both 12-hour and 24-hour time formats based on locale settings, with built-in validation to ensure valid time entries. It includes features like time picker integration, keyboard shortcuts, and formatted display to streamline time entry for scheduling, appointment booking, and time-sensitive operations in retail environments.' +
+    '\n\n`TimeField` components respects merchant locale settings for default time format preferences while allowing manual override for specific use cases that require alternative formats.',
   thumbnail: 'time-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `TimeField` component.',
       type: 'TimeField',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `TimeField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TimeFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimeField',
   description:
-    'Captures time input from merchants. Provides a consistent interface for time selection, with proper validation.',
+    'Capture time input with a consistent interface for time selection and validation.',
   thumbnail: 'time-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker.d.ts
@@ -12,28 +12,64 @@ import type {TimePickerProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * Used when an element does not have children.
+ * The base props for elements without children, providing key, ref, and slot properties.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
+  /**
+   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
+   */
   key?: Key;
+  /**
+   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
+   */
   ref?: Ref<TClass>;
+  /**
+   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
+   */
   slot?: Lowercase<string>;
 }
 /**
- * Used when an element has children.
+ * The base props for elements with children, extending `BaseElementProps` with children support.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
+  /**
+   * The child elements to render within this component.
+   */
   children?: ComponentChildren;
 }
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+/**
+ * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
+ */
 export interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
+  /**
+   * The element that the event listener is attached to.
+   */
   currentTarget: HTMLElementTagNameMap[T];
+  /**
+   * Whether the event bubbles up through the DOM tree.
+   */
   bubbles?: boolean;
+  /**
+   * Whether the event can be canceled.
+   */
   cancelable?: boolean;
+  /**
+   * Whether the event will trigger listeners outside of a shadow root.
+   */
   composed?: boolean;
+  /**
+   * The additional data associated with the event.
+   */
   detail?: any;
+  /**
+   * The current phase of the event flow.
+   */
   eventPhase: number;
+  /**
+   * The element that triggered the event.
+   */
   target: HTMLElementTagNameMap[T] | null;
 }
 
@@ -41,19 +77,19 @@ declare const tagName = 's-time-picker';
 export interface TimePickerJSXProps
   extends Pick<TimePickerProps, 'id' | 'value'> {
   /**
-   * Callback when the user selects a time from the picker.
+   * A callback function executed when the user selects a time from the picker.
    */
   onInput?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * Callback when the user selects a time from the picker that is different to the current value.
+   * A callback function executed when the user selects a time from the picker that is different from the current value.
    */
   onChange?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * Callback when the time picker is dismissed.
+   * A callback function executed when the time picker is dismissed or closed.
    */
   onBlur?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * Callback when the time picker is revealed.
+   * A callback function executed when the time picker is revealed or opened.
    */
   onFocus?: (event: CallbackEvent<typeof tagName>) => void | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -26,8 +26,10 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'time-spinner-default.png',
+    description:
+      'Enable visual time selection using a `TimePicker` component with an interactive picker interface. This example shows a basic time picker for selecting hours and minutes.',
     codeblock: {
-      title: 'Code',
+      title: 'Select times with a time picker',
       tabs: [
         {
           code: './examples/default.html',
@@ -38,12 +40,14 @@ const data: ReferenceEntityTemplateSchema = {
   },
   related: [],
   examples: {
-    description: 'TimePicker usage patterns',
+    description:
+      'Learn how to control picker visibility and handle time selection events.',
     examples: [
       {
-        description: 'Show and hide TimePicker using button commands',
+        description:
+          'Control `TimePicker` visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the time picker, enabling custom trigger patterns for time selection workflows.',
         codeblock: {
-          title: 'Command system',
+          title: 'Control picker visibility',
           tabs: [
             {
               code: './examples/command-system.jsx',
@@ -53,9 +57,10 @@ const data: ReferenceEntityTemplateSchema = {
         },
       },
       {
-        description: 'Handle time selection events',
+        description:
+          'Subscribe to time selection events to respond when merchants pick a time. This example shows how to handle `onChange` events to capture selected times, enabling validation, scheduling logic, or dynamic updates based on the chosen time.',
         codeblock: {
-          title: 'Event handling',
+          title: 'Handle time selection events',
           tabs: [
             {
               code: './examples/event-handling.jsx',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -2,7 +2,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimePicker',
-  description: 'Allows merchants to select a specific time.',
+  description:
+    'Allow merchants to select a specific time using an interactive picker interface.',
   thumbnail: 'time-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -3,20 +3,22 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimePicker',
   description:
-    'Allow merchants to select a specific time using an interactive picker interface.',
+    'The `TimePicker` component allows merchants to select a specific time using an interactive picker interface. Use it to provide visual time selection for improved user experience and reduced input errors.' +
+    '\n\n`TimePicker` offers a more visual and touch-friendly alternative to text-based time input, making time selection faster and more accurate. The picker interface provides an intuitive way to select hours and minutes through an interactive interface.',
   thumbnail: 'time-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: '',
+      description:
+        'Configure the following properties on the `TimePicker` component.',
       type: 'TimePicker',
     },
     {
       title: 'Events',
       description:
-        'Learn more about registering [events](/docs/api/pos-ui-extensions/using-polaris-components#events)',
+        'The `TimePicker` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TimePickerEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -24,6 +24,26 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'Polaris web components',
   subCategory: 'Forms',
+  subSections: [
+    {
+      type: 'Generic',
+      anchorLink: 'best-practices',
+      title: 'Best practices',
+      sectionContent:
+        '- **Choose for visual time selection:** Use `TimePicker` when users benefit from a visual picker interface. Use `TimeField` when users know the exact time.\n' +
+        '- **Use correct format:** Always use `HH:mm:ss` format with leading zeros. The internal format is always 24-hour regardless of UI presentation.\n' +
+        '- **Validate before setting values:** Invalid values reset to empty string. Implement validation to show appropriate error messages.',
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'limitations',
+      title: 'Limitations',
+      sectionContent:
+        '- `TimePicker` provides the picker interface but requires external state management for the selected value—you must update the value property in response to change events.\n' +
+        '- The component uses 24-hour `HH:mm:ss` format internally—display formatting for 12-hour time or locale-specific formats requires additional formatting logic in your application.\n' +
+        '- Invalid time values result in an empty string without specific error feedback—you must validate time formats before setting the value property to provide meaningful error messages to users.',
+    },
+  ],
   defaultExample: {
     image: 'time-spinner-default.png',
     description:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
@@ -10,84 +10,99 @@
  * TODO: Update `any` type here after this is resolved
  * https://github.com/Shopify/ui-api-design/issues/139
  */
+/**
+ * Represents any valid child content that can be rendered within a component.
+ */
 export type ComponentChildren = any;
+/**
+ * Represents text-only child content.
+ */
 export type StringChildren = string;
+/**
+ * Properties that are available on all components.
+ */
 export interface GlobalProps {
   /**
-   * A unique identifier for the element.
+   * A unique identifier for the element within the document. This ID is used for multiple purposes: targeting the element from JavaScript code, creating relationships between elements (using `commandFor`, `interestFor`, ARIA attributes), linking labels to form controls, enabling fragment navigation with URL anchors (for example, `#section-id`), and applying element-specific styles. The ID must be unique across the entire page—duplicate IDs will cause unexpected behavior and accessibility issues. IDs are case-sensitive and should only contain letters, digits, hyphens, and underscores.
    */
   id?: string;
 }
+/**
+ * Provides slots for primary and secondary action elements.
+ */
 export interface ActionSlots {
   /**
-   * The primary action to perform, provided as a button or link type element.
+   * The primary action element to display, typically a `Button` or clickable link representing the most important action available in the current context. This action aligns with the user's primary goal or the main purpose of the interface (for example, "Save changes", "Checkout", "Add to cart", "Submit order"). The primary action receives visual emphasis through styling to draw user attention. Only one primary action is displayed to maintain clear focus on the main call-to-action.
    */
   primaryAction?: ComponentChildren;
   /**
-   * The secondary actions to perform, provided as button or link type elements.
+   * Secondary action elements to display, typically `Button` or clickable link elements representing alternative or supporting actions that are less important than the primary action (for example, "Cancel", "Save draft", "Skip", "Learn more"). Secondary actions receive less visual prominence than the primary action to maintain clear hierarchy. Multiple secondary actions can be provided and are displayed together, often in a different visual style or position than the primary action. The order of actions in the array may affect their display order depending on the component.
    */
   secondaryActions?: ComponentChildren;
 }
+/**
+ * Properties for overlay lifecycle callbacks.
+ */
 export interface BaseOverlayProps {
   /**
-   * Callback fired after the overlay is shown.
+   * A callback function executed when the overlay begins to appear, immediately after `showOverlay()` is called or the `hidden` property changes to `false`, but before any show animations start. The element may not be visible yet. Common operations include initializing overlay content, fetching data needed for display, setting focus on the first interactive element, or tracking analytics events. Layout calculations should be avoided here as the element may not have final dimensions yet.
    */
   onShow?: (event: Event) => void;
   /**
-   * Callback fired when the overlay is shown **after** any animations to show the overlay have finished.
+   * A callback function executed after the overlay is fully visible and all show animations have completed. At this point, the overlay is completely rendered with final dimensions and positioning. Common operations include focusing specific elements after animations complete, measuring rendered content dimensions, triggering secondary animations, or initializing interactive features that depend on final layout. This is the safest point for DOM measurements and layout-dependent operations.
    */
   onAfterShow?: (event: Event) => void;
   /**
-   * Callback fired after the overlay is hidden.
+   * A callback function executed when the overlay begins to hide, immediately after `hideOverlay()` is called or the `hidden` property changes to `true`, but before any hide animations start. The element is still visible. Common operations include cleanup tasks, saving overlay state before it disappears, canceling pending requests, or preparing for the post-hide state. This is the last opportunity to interact with the visible overlay before animations begin.
    */
   onHide?: (event: Event) => void;
   /**
-   * Callback fired when the overlay is hidden **after** any animations to hide the overlay have finished.
+   * A callback function executed after the overlay is completely hidden and all hide animations have finished. The element is no longer visible or interactive. Common operations include final cleanup, focusing the element that triggered the overlay, navigating to another view, freeing resources, or performing operations that should only occur after the overlay is completely dismissed. Post-dismissal navigation or state updates that would be jarring during animations are appropriate here.
    */
   onAfterHide?: (event: Event) => void;
 }
 /**
- * Shared interfaces for web component methods.
- *
- * Methods are required (not optional) because:
+ * Methods for controlling overlay visibility. These methods are required (not optional) because:
  * - Components implementing this interface must provide all methods
- * - Unlike props/attributes, methods are not rendered in HTML but are JavaScript APIs
+ * - Unlike props/attributes, methods aren't rendered in HTML but are JavaScript APIs
  * - Consumers expect these methods to be consistently available on all instances
  */
 export interface BaseOverlayMethods {
   /**
-   * Method to show an overlay.
+   * Programmatically displays the overlay element. When called, the overlay becomes visible and triggers any associated `onShow` and `onAfterShow` callbacks. This method opens modals, dialogs, or other overlay components in response to user actions or application state changes.
    *
    * @implementation This is a method to be called on the element and not a callback and should hence be camelCase
    */
   showOverlay: () => void;
   /**
-   * Method to hide an overlay.
+   * Programmatically hides the overlay element. When called, the overlay becomes hidden and triggers any associated `onHide` and `onAfterHide` callbacks. This method closes modals, dismisses dialogs, or hides overlay components programmatically without requiring user interaction.
    *
    * @implementation This is a method to be called on the element and not a callback and should hence be camelCase
    */
   hideOverlay: () => void;
   /**
-   * Method to toggle the visiblity of an overlay.
+   * Programmatically toggles the overlay's visibility state. If currently visible, the overlay will be hidden; if currently hidden, it will be shown. This triggers the appropriate show/hide callbacks based on the resulting state. This method enables toggle buttons or cyclic visibility controls.
    *
    * @implementation This is a method to be called on the element and not a callback and should hence be camelCase
    */
   toggleOverlay: () => void;
 }
+/**
+ * Properties for focus event callbacks.
+ */
 export interface FocusEventProps {
   /**
-   * Callback when the element loses focus.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event
+   * A callback function executed when focus is removed from the element, either by the user moving to another field (tabbing, clicking elsewhere) or programmatically using `blur()`. This event fires before `onChange` for modified fields. The event contains information about which element is receiving focus next (`relatedTarget`). Common operations include triggering validation, saving in-progress changes, hiding related UI elements like autocomplete dropdowns, or tracking field interaction analytics. A common pattern is validating and showing errors on blur to avoid disrupting users while they're still typing. Learn more about [blur events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
    */
   onBlur?: (event: FocusEvent) => void;
   /**
-   * Callback when the element receives focus.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event
+   * A callback function executed when the element receives focus through user interaction (clicking, tabbing) or programmatic methods like `focus()`. This event fires before any input occurs. The event contains information about which element previously had focus (`relatedTarget`). Common operations include showing helper text, highlighting the active field, displaying related UI like autocomplete suggestions, preselecting content, or tracking which fields users interact with. A common pattern is clearing errors on focus to provide a fresh start when users re-attempt input after validation failure. Learn more about [focus events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
    */
   onFocus?: (event: FocusEvent) => void;
 }
+/**
+ * A size scale keyword ranging from smallest (`'small-500'`) to largest (`'large-500'`).
+ */
 export type SizeKeyword =
   | 'small-500'
   | 'small-400'
@@ -102,18 +117,27 @@ export type SizeKeyword =
   | 'large-300'
   | 'large-400'
   | 'large-500';
+/**
+ * A color intensity keyword from subtle (`'subdued'`) to prominent (`'strong'`).
+ */
 export type ColorKeyword = 'subdued' | 'base' | 'strong';
+/**
+ * A background color keyword including transparent option.
+ */
 export type BackgroundColorKeyword = 'transparent' | ColorKeyword;
+/**
+ * Properties for controlling the background color of an element.
+ */
 export interface BackgroundProps {
   /**
-   * Adjust the background of the element.
+   * Sets the background color intensity of the element. Controls how the element stands out from its surroundings.
    *
    * @default 'transparent'
    */
   background?: BackgroundColorKeyword;
 }
 /**
- * Tone is a property for defining the color treatment of a component.
+ * A property for defining the color treatment and semantic meaning of a component.
  *
  * A tone can apply a grouping of colors to a component. For example,
  * critical may have a specific text color and background color.
@@ -681,17 +705,29 @@ declare const privateIconArray: readonly [
   'x-circle',
   'x-circle-filled',
 ];
+/**
+ * A valid icon identifier from the available icon set.
+ */
 export type IconType = (typeof privateIconArray)[number];
 /**
  * Like `Extract`, but ensures that the extracted type is a strict subtype of the input type.
  */
 export type ExtractStrict<T, U extends T> = Extract<T, U>;
+/**
+ * A utility type for properties that support 1-to-4-value shorthand syntax.
+ */
 export type MaybeAllValuesShorthandProperty<T extends string> =
   | T
   | `${T} ${T}`
   | `${T} ${T} ${T}`
   | `${T} ${T} ${T} ${T}`;
+/**
+ * A utility type for properties that support 1-to-2-value shorthand syntax.
+ */
 export type MaybeTwoValuesShorthandProperty<T extends string> = T | `${T} ${T}`;
+/**
+ * A utility type for values that can be responsive using container queries.
+ */
 export type MaybeResponsive<T> = T | `@container${string}`;
 /**
  * Prevents widening string literal types in a union to `string`.
@@ -703,41 +739,42 @@ export type MaybeResponsive<T> = T | `@container${string}`;
  */
 export type AnyString = string & {};
 /**
- * This is purely to give the ability
- * to have a space or not in the string literal types.
+ * A utility type that allows optional spacing in string literal values.
  *
- * For example in the `aspectRatio` property, `16/9` and `16 / 9` are both valid.
+ * For example, in the `aspectRatio` property, `16/9` and `16 / 9` are both valid.
  */
 export type optionalSpace = '' | ' ';
 export interface BadgeProps extends GlobalProps {
   /**
-   * The content of the Badge.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Sets the tone of the Badge, based on the intention of the information being conveyed.
+   * The semantic tone of the badge, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the badge. Controls how prominent or subtle the badge appears within the interface.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
   /**
-   * The type of icon to be displayed in the badge.
+   * The icon identifier specifying which icon to display within the badge. Accepts any valid icon name from the icon set.
    *
    * @default ''
    */
   icon?: IconType | AnyString;
   /**
-   * The position of the icon in relation to the text.
+   * The position of the icon relative to the badge text content:
+   * - `'start'`: Icon appears before the text
+   * - `'end'`: Icon appears after the text
    */
   iconPosition?: 'start' | 'end';
   /**
-   * Adjusts the size.
+   * Adjusts the size of the badge and its icon. Available sizes range from `'small-500'` (smallest) through `'base'` (default) to `'large-500'` (largest), allowing you to match badge size to your interface hierarchy.
    *
    * @default 'base'
    */
@@ -745,60 +782,46 @@ export interface BadgeProps extends GlobalProps {
 }
 export interface BannerProps extends GlobalProps, ActionSlots {
   /**
-   * The title of the banner.
+   * The title text displayed prominently at the top of the banner, summarizing the banner's main message in a single, scannable line. This heading is typically concise (3-8 words) and immediately communicates the banner's purpose or key information without requiring users to read the full banner content. The heading appears before the banner's child content and uses emphasized typography to catch attention. When omitted, the banner displays only its child content and actions without a title. Clear, action-oriented or informative headings tell users what they need to know at a glance (for example, "Order placed successfully", "Action required", "New feature available", "Connection lost"). The heading's visual style adapts to the banner's `tone` property for semantic consistency.
    *
    * @default ''
    */
   heading?: string;
   /**
-   * The content of the Banner.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Sets the tone of the Banner, based on the intention of the information being conveyed.
+   * Sets the visual appearance and accessibility behavior of the banner. The tone determines both the color scheme and how screen readers announce the banner. Available options:
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
+   * - `'success'` - Green styling for positive outcomes and successful operations. Creates an informative live region for screen readers.
+   * - `'info'` - Blue styling for general information and neutral updates. Creates an informative live region for screen readers.
+   * - `'warning'` - Orange styling for important notices that require attention. Creates an informative live region for screen readers.
+   * - `'critical'` - Red styling for errors and urgent issues requiring immediate action. Creates an assertive live region that is announced immediately by screen readers.
    *
-   * The banner is a live region and the type of status will be dictated by the Tone selected.
-   *
-   * - `critical` creates an [assertive live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) that is announced by screen readers immediately.
-   * - `neutral`, `info`, `success`, `warning` and `caution` creates an [informative live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) that is announced by screen readers after the current message.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
-   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
-   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role
+   * Learn more about [ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions), [alert role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role), and [status role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) on MDN.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Makes the content collapsible.
-   * A collapsible banner will conceal child elements initially, but allow the user to expand the banner to see them.
+   * Whether the banner content can be collapsed and expanded. When `true`, the banner displays a collapse/expand toggle control and child elements are initially hidden. Users can click the toggle to reveal or hide the content. Typically applied to lengthy banners or supplementary information that users can choose to view. Collapsed state persists during the component lifecycle but resets on re-render.
    *
    * @default false
    */
   collapsible?: boolean;
   /**
-   * Determines whether the close button of the banner is present.
-   *
-   * When the close button is pressed, the `dismiss` event will fire,
-   * then `hidden` will be true,
-   * any animation will complete,
-   * and the `afterhide` event will fire.
+   * Whether a close button is displayed in the banner. When `true`, a close (X) button appears allowing users to permanently dismiss the banner. Once dismissed, the banner triggers the `onDismiss` callback and remains hidden until the component is re-rendered or the `hidden` property is changed. Typically applied to non-critical notifications or messages that users can choose to dismiss after reading.
    *
    * @default false
    */
   dismissible?: boolean;
   /**
-   * Event handler when the banner is dismissed by the user.
-   *
-   * This does not fire when setting `hidden` manually.
-   *
-   * The `hidden` property will be `false` when this event fires.
+   * A callback function executed when the user dismisses the banner by clicking the close (X) button. This only fires for user-initiated dismissals through the UI close button, not when the banner is hidden programmatically using the `hidden` property. The callback fires after the user clicks but before hide animations begin. Common operations include tracking dismissal metrics, saving user preferences to avoid showing the banner again, performing cleanup when banners are dismissed, or triggering follow-up actions. The banner remains in the DOM after dismissal (just hidden) until re-rendered—complete removal requires controlling rendering at the component level based on dismissal state.
    */
   onDismiss?: (event: Event) => void;
   /**
-   * Event handler when the banner has fully hidden.
-   *
-   * The `hidden` property will be `true` when this event fires.
+   * A callback function executed after the element is fully hidden and all hide animations have completed.
    *
    * @implementation If implementations animate the hiding of the banner,
    * this event must fire after the banner has fully hidden.
@@ -806,35 +829,29 @@ export interface BannerProps extends GlobalProps, ActionSlots {
    */
   onAfterHide?: (event: Event) => void;
   /**
-   * Determines whether the banner is hidden.
-   *
-   * If this property is being set on each framework render (as in 'controlled' usage),
-   * and the banner is `dismissible`,
-   * ensure you update app state for this property when the `dismiss` event fires.
-   *
-   * If the banner is not `dismissible`, it can still be hidden by setting this property.
+   * Whether the banner is visible or hidden. When set to `true`, the banner is completely hidden from view and removed from the accessibility tree, meaning screen readers won't announce it. Changing this value triggers hide/show animations if configured. Unlike temporary dismissal with the close button, this property provides programmatic control for conditional visibility based on application state, user permissions, or other dynamic conditions.
    *
    * @default false
    */
   hidden?: boolean;
 }
+/**
+ * Properties for controlling the display behavior of an element.
+ */
 export interface DisplayProps {
   /**
-   * Sets the outer display type of the component. The outer type sets a component’s participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
+   * Sets the outer display type controlling the element's participation in flow layout. When set to `'none'`, the element is completely removed from both the visual layout and the accessibility tree—it takes up no space and screen readers ignore it entirely, as if it doesn't exist in the DOM. This is different from `hidden` which may keep some accessibility tree presence. The element's `children` and event listeners remain in memory. The value `'auto'` (default) applies normal display behavior. Learn more about the [CSS display property on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
    *
-   * - `auto`: the component’s initial value. The actual value depends on the component and context.
-   * - `none`: hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
    * @default 'auto'
    */
   display?: MaybeResponsive<'auto' | 'none'>;
 }
+/**
+ * Properties for defining the semantic role of an element for assistive technologies.
+ */
 export interface AccessibilityRoleProps {
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help users
-   * navigate the page.
+   * Sets the semantic role for assistive technologies. Helps screen reader users navigate and understand page structure.
    *
    * @implementation Although, in HTML hosts, this property changes the element used,
    * changing this property must not impact the visual styling of inside or outside of the box.
@@ -845,28 +862,28 @@ export interface AccessibilityRoleProps {
 }
 export type AccessibilityRole =
   /**
-   * Used to indicate the primary content.
+   * Used to indicate the primary content area of the page.
    *
    * In an HTML host, `main` will render a `<main>` element.
    * Learn more about the [`<main>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/main_role) in the MDN web docs.
    */
   | 'main'
   /**
-   * Used to indicate the component is a header.
+   * Used to indicate the element is a header section.
    *
    * In an HTML host `header` will render a `<header>` element.
    * Learn more about the [`<header>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/main_role) in the MDN web docs.
    */
   | 'header'
   /**
-   * Used to display information such as copyright information, navigation links, and privacy statements.
+   * Used to display footer information such as copyright information, navigation links, and privacy statements.
    *
    * In an HTML host `footer` will render a `<footer>` element.
    * Learn more about the [`<footer>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/contentinfo_role) in the MDN web docs.
    */
   | 'footer'
   /**
-   * Used to indicate a generic section.
+   * Used to indicate a thematic grouping of content.
    * Sections should always have a `Heading` or an accessible name provided in the `accessibilityLabel` property.
    *
    * In an HTML host `section` will render a `<section>` element.
@@ -875,21 +892,21 @@ export type AccessibilityRole =
    */
   | 'section'
   /**
-   * Used to designate a supporting section that relates to the main content.
+   * Used to designate a supporting section that is tangentially related to the main content.
    *
    * In an HTML host `aside` will render an `<aside>` element.
    * Learn more about the [`<aside>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/complementary_role) in the MDN web docs.
    */
   | 'aside'
   /**
-   * Used to identify major groups of links used for navigating.
+   * Used to identify navigation link groups used for navigating through the site or page.
    *
    * In an HTML host `navigation` will render a `<nav>` element.
    * Learn more about the [`<nav>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role) in the MDN web docs.
    */
   | 'navigation'
   /**
-   * Used to identify a list of ordered items.
+   * Used to identify a list where items have a meaningful order or sequence.
    *
    * In an HTML host `ordered-list` will render a `<ol>` element.
    * Learn more about the [`<ol>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/list_role) in the MDN web docs.
@@ -903,79 +920,83 @@ export type AccessibilityRole =
    */
   | 'list-item'
   /**
-   * Used to indicates the component acts as a divider that separates and distinguishes sections of content in a list of items.
+   * Used to indicate the component acts as a divider that separates and distinguishes sections of content in a list of items.
    *
    * In an HTML host `list-item-separator` will render as `<li role="separator">`.
    * Learn more about the [`<li>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li) and the [`separator` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role) in the MDN web docs.
    */
   | 'list-item-separator'
   /**
-   * Used to identify a list of unordered items.
+   * Used to identify a list where item order has no significance.
    *
    * In an HTML host `unordered-list` will render a `<ul>` element.
    * Learn more about the [`<ul>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/list_role) in the MDN web docs.
    */
   | 'unordered-list'
   /**
-   * Used to indicates the component acts as a divider that separates and distinguishes sections of content.
+   * Used to indicate the component acts as a divider that separates and distinguishes sections of content.
    *
    * In an HTML host `separator` will render as `<div role="separator">`.
    * Learn more about the [`separator` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role) in the MDN web docs.
    */
   | 'separator'
   /**
-   * Used to define a live region containing advisory information for the user that is not important enough to be an alert.
+   * Used to define a live region containing advisory information for the user that isn't important enough to be an alert.
    *
    * In an HTML host `status` will render as `<div role="status">`.
    * Learn more about the [`status` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) in the MDN web docs.
    */
   | 'status'
   /**
-   * Used for important, and usually time-sensitive, information.
+   * Used for important and usually time-sensitive information that requires immediate attention.
    *
    * In an HTML host `alert` will render as `<div role="alert">`.
    * Learn more about the [`alert` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) in the MDN web docs.
    */
   | 'alert'
   /**
-   * Used to create a nameless container element which has no semantic meaning on its own.
+   * Used to create a container element with no specific semantic meaning.
    *
    * In an HTML host `generic'` will render a `<div>` element.
    * Learn more about the [`generic` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/generic_role) in the MDN web docs.
    */
   | 'generic'
   /**
-   * Used to strip the semantic meaning of an element, but leave the visual styling intact.
+   * Used to remove semantic meaning from an element while preserving its visual styling.
    *
    * Synonym for `none`
    * Learn more about the [`presentation` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) in the MDN web docs.
    */
   | 'presentation'
   /**
-   * Used to strip the semantic meaning of an element, but leave the visual styling intact.
+   * Used to remove semantic meaning from an element while preserving its visual styling.
    *
    * Synonym for `presentation`
    * Learn more about the [`none` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/none_role) in the MDN web docs.
    */
   | 'none';
+/**
+ * Properties for controlling visibility to assistive technologies.
+ */
 export interface AccessibilityVisibilityProps {
   /**
-   * Changes the visibility of the element.
-   *
-   * - `visible`: the element is visible to all users.
-   * - `hidden`: the element is removed from the accessibility tree but remains visible.
-   * - `exclusive`: the element is visually hidden but remains in the accessibility tree.
+   * Controls visibility for assistive technologies:
+   * - `'visible'`: Announced normally by screen readers
+   * - `'hidden'`: Hidden from screen readers while remaining visually visible
+   * - `'exclusive'`: Only this element is announced to screen readers, hiding other content
    *
    * @default 'visible'
    */
   accessibilityVisibility?: 'visible' | 'hidden' | 'exclusive';
 }
+/**
+ * Properties for controlling the visibility of field labels to screen readers.
+ */
 export interface LabelAccessibilityVisibilityProps {
   /**
-   * Changes the visibility of the component's label.
-   *
-   * - `visible`: the label is visible to all users.
-   * - `exclusive`: the label is visually hidden but remains in the accessibility tree.
+   * Controls whether the label is announced to screen readers:
+   * - `'visible'`: Label is announced normally by screen readers
+   * - `'exclusive'`: Only the label is announced, hiding other related content from screen readers
    *
    * @default 'visible'
    */
@@ -984,35 +1005,34 @@ export interface LabelAccessibilityVisibilityProps {
     'visible' | 'exclusive'
   >;
 }
+/**
+ * A padding size keyword including the option for no padding.
+ */
 export type PaddingKeyword = SizeKeyword | 'none';
+/**
+ * Properties for controlling the padding (internal spacing) of an element.
+ */
 export interface PaddingProps {
   /**
-   * Adjust the padding of all edges.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
+   * The padding applied to all edges of the element. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
+   * - 1 value: all edges
    *
    * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
+   * - `large` applies `large` padding to all edges.
+   * - `large none` applies `large` to block edges and `none` to inline edges.
+   * - `large none large` applies `large` to block-start, `none` to inline edges, `large` to block-end.
+   * - `large none large small` applies different padding to each edge in order.
    *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
+   * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
    * @default 'none'
    */
   padding?: MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>;
   /**
-   * Adjust the block-padding.
-   *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
-   *
-   * This overrides the block value of `padding`.
+   * The block-axis padding for the element (typically vertical in horizontal writing modes). Supports two-value syntax where `large none` sets block-start to `large` and block-end to `none`. Overrides the block axis values from the `padding` property.
    *
    * @default '' - meaning no override
    */
@@ -1020,27 +1040,19 @@ export interface PaddingProps {
     MaybeTwoValuesShorthandProperty<PaddingKeyword> | ''
   >;
   /**
-   * Adjust the block-start padding.
-   *
-   * This overrides the block-start value of `paddingBlock`.
+   * The block-start padding for the element (typically top in horizontal writing modes). Overrides the block-start value from the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * Adjust the block-end padding.
-   *
-   * This overrides the block-end value of `paddingBlock`.
+   * The block-end padding for the element (typically bottom in horizontal writing modes). Overrides the block-end value from the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * Adjust the inline padding.
-   *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
-   *
-   * This overrides the inline value of `padding`.
+   * The inline-axis padding for the element (typically horizontal in horizontal writing modes). Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline axis values from the `padding` property.
    *
    * @default '' - meaning no override
    */
@@ -1048,82 +1060,87 @@ export interface PaddingProps {
     MaybeTwoValuesShorthandProperty<PaddingKeyword> | ''
   >;
   /**
-   * Adjust the inline-start padding.
-   *
-   * This overrides the inline-start value of `paddingInline`.
+   * The inline-start padding for the element (typically left in LTR, right in RTL). Overrides the inline-start value from the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * Adjust the inline-end padding.
-   *
-   * This overrides the inline-end value of `paddingInline`.
+   * The inline-end padding for the element (typically right in LTR, left in RTL). Overrides the inline-end value from the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: MaybeResponsive<PaddingKeyword | ''>;
 }
+/**
+ * A size value in pixels, percentage, or zero.
+ */
 export type SizeUnits = `${number}px` | `${number}%` | `0`;
+/**
+ * A size value with automatic sizing option.
+ */
 export type SizeUnitsOrAuto = SizeUnits | 'auto';
+/**
+ * A size value with no constraint option.
+ */
 export type SizeUnitsOrNone = SizeUnits | 'none';
+/**
+ * Properties for controlling the dimensions of an element.
+ */
 export interface SizingProps {
   /**
-   * Adjust the block size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/block-size
+   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container. Learn more about [`block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
    *
    * @default 'auto'
    */
   blockSize?: MaybeResponsive<SizeUnitsOrAuto>;
   /**
-   * Adjust the minimum block size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size
+   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container. Learn more about [`min-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    *
    * @default '0'
    */
   minBlockSize?: MaybeResponsive<SizeUnits>;
   /**
-   * Adjust the maximum block size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size
+   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container. Learn more about [`max-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    *
    * @default 'none'
    */
   maxBlockSize?: MaybeResponsive<SizeUnitsOrNone>;
   /**
-   * Adjust the inline size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size
+   * The inline size (width in horizontal writing modes) of the element. Learn more about [`inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    *
    * @default 'auto'
    */
   inlineSize?: MaybeResponsive<SizeUnitsOrAuto>;
   /**
-   * Adjust the minimum inline size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size
+   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container. Learn more about [`min-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    *
    * @default '0'
    */
   minInlineSize?: MaybeResponsive<SizeUnits>;
   /**
-   * Adjust the maximum inline size.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size
+   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container. Learn more about [`max-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    *
    * @default 'none'
    */
   maxInlineSize?: MaybeResponsive<SizeUnitsOrNone>;
 }
+/**
+ * A border line style keyword.
+ */
 export type BorderStyleKeyword =
   | 'none'
   | 'solid'
   | 'dashed'
   | 'dotted'
   | 'auto';
+/**
+ * A border thickness keyword.
+ */
 export type BorderSizeKeyword = SizeKeyword | 'none';
+/**
+ * A border radius keyword including maximum rounding option.
+ */
 export type BorderRadiusKeyword = SizeKeyword | 'max' | 'none';
 /**
  * Represents a shorthand for defining a border. It can be a combination of size, optionally followed by color, optionally followed by style.
@@ -1132,17 +1149,12 @@ export type BorderShorthand =
   | BorderSizeKeyword
   | `${BorderSizeKeyword} ${ColorKeyword}`
   | `${BorderSizeKeyword} ${ColorKeyword} ${BorderStyleKeyword}`;
+/**
+ * Properties for controlling the border styling of an element.
+ */
 export interface BorderProps {
   /**
-   * Set the border via the shorthand property.
-   *
-   * This can be a size, optionally followed by a color, optionally followed by a style.
-   *
-   * If the color is not specified, it will be `base`.
-   *
-   * If the style is not specified, it will be `auto`.
-   *
-   * Values can be overridden by `borderWidth`, `borderStyle`, and `borderColor`.
+   * Sets the border style, width, and color using shorthand syntax. Accepts a size keyword, optionally followed by a color keyword, optionally followed by a style keyword.
    *
    * @example
    * // The following are equivalent:
@@ -1153,82 +1165,49 @@ export interface BorderProps {
    */
   border?: BorderShorthand;
   /**
-   * Set the width of the border.
-   *
-   * If set, it takes precedence over the `border` property's width.
-   *
-   * Like CSS, up to 4 values can be specified.
-   *
-   * If one value is specified, it applies to all sides.
-   *
-   * If two values are specified, they apply to the block sides and inline sides respectively.
-   *
-   * If three values are specified, they apply to the block-start, both inline sides, and block-end respectively.
-   *
-   * If four values are specified, they apply to the block-start, block-end, inline-start, and inline-end sides respectively.
+   * Sets the thickness of the border using size keywords. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per edge.
    *
    * @default '' - meaning no override
    */
   borderWidth?: MaybeAllValuesShorthandProperty<BorderSizeKeyword> | '';
   /**
-   * Set the style of the border.
-   *
-   * If set, it takes precedence over the `border` property's style.
-   *
-   * Like CSS, up to 4 values can be specified.
-   *
-   * If one value is specified, it applies to all sides.
-   *
-   * If two values are specified, they apply to the block sides and inline sides respectively.
-   *
-   * If three values are specified, they apply to the block-start, both inline sides, and block-end respectively.
-   *
-   * If four values are specified, they apply to the block-start, block-end, inline-start, and inline-end sides respectively.
+   * Sets the line style of the border. Controls the visual pattern of the border lines (for example, solid, dashed, dotted). Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per edge.
    *
    * @default '' - meaning no override
    */
   borderStyle?: MaybeAllValuesShorthandProperty<BorderStyleKeyword> | '';
   /**
-   * Set the color of the border.
-   *
-   * If set, it takes precedence over the `border` property's color.
+   * Sets the color intensity of the border. Controls how prominent the border appears.
    *
    * @default '' - meaning no override
    */
   borderColor?: ColorKeyword | '';
   /**
-   * Set the radius of the border.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
-   * - 4 values: `start-start start-end end-end end-start`
-   * - 3 values: `start-start (start-end & end-start) start-end`
-   * - 2 values: `(start-start & end-end) (start-end & end-start)`
-   *
-   * For example:
-   * - `small-100` means start-start, start-end, end-end and end-start border radii are `small-100`.
-   * - `small-100 none` means start-start and end-end border radii are `small-100`, start-end and end-start border radii are `none`.
-   * - `small-100 none large-100` means start-start border radius is `small-100`, start-end border radius is `none`, end-end border radius is `large-100` and end-start border radius is `none`.
-   * - `small-100 none large-100 small-100` means start-start border radius is `small-100`, start-end border radius is `none`, end-end border radius is `large-100` and end-start border radius is `small-100`.
+   * Sets the corner rounding radius of the border. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner.
    *
    * @defaultValue 'none'
    */
   borderRadius?: MaybeAllValuesShorthandProperty<BorderRadiusKeyword>;
 }
+/**
+ * Properties for controlling overflow behavior when content exceeds container bounds.
+ */
 export interface OverflowProps {
   /**
-   * Sets the overflow behavior of the element.
+   * Controls how the container handles content that exceeds its dimensions:
+   * - `'visible'`: Content extends beyond the container's boundaries without clipping or scrolling. Overflow content is fully visible and may overlap other elements. This is the default behavior and works well for containers that should expand to fit their content naturally.
+   * - `'hidden'`: Content that exceeds the container is clipped and hidden from view—users can't see or access the overflow content. No scrollbars appear. Typically applied to intentionally limit visible content, create masked effects, or prevent content from breaking layouts. Hidden content may include important information users can't access.
+   * - `'auto'`: Only available in some components like `ScrollBox`. Adds scrollbars automatically when content exceeds the container, allowing users to scroll to view overflow content. Scrollbars only appear when needed. Commonly applied to scrollable regions, content lists, or containers where users should access all content but space is limited.
    *
-   * - `hidden`: clips the content when it is larger than the element’s container.
-   * The element will not be scrollable and the users will not be able
-   * to access the clipped content by dragging or using a scroll wheel on a mouse.
-   * - `visible`: the content that extends beyond the element’s container is visible.
+   * The choice depends on layout needs: `'visible'` for flexible layouts, `'hidden'` for strict boundaries, `'auto'` for user-controlled scrolling. Setting overflow establishes a new block formatting context, which affects layout behaviors like margin collapsing and positioning.
    *
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
 }
+/**
+ * Base properties for box-like container elements.
+ */
 export interface BaseBoxProps
   extends AccessibilityVisibilityProps,
     BackgroundProps,
@@ -1238,400 +1217,385 @@ export interface BaseBoxProps
     BorderProps,
     OverflowProps {
   /**
-   * The content of the Box.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * A label that describes the purpose or contents of the element.
-   * When set, it will be announced to users using assistive technologies and will provide them with more context.
-   *
-   * Only use this when the element's content is not enough context for users using assistive technologies.
+   * A text label that describes the purpose, function, or contents of the element for users of assistive technologies like screen readers. This label is announced by screen readers but isn't visually displayed. Typically applied when an element doesn't have visible text that adequately describes it, such as icon-only buttons, image carousels, or complex interactive regions. The label is concise yet descriptive (for example, "Close modal", "Product image carousel", "Shopping cart with 3 items"). If the element already has clear visible labels or headings, this property may be unnecessary. For form fields, the `label` property is both visible and accessible.
    */
   accessibilityLabel?: string;
 }
+/**
+ * Base properties for box-like container elements with semantic role support.
+ */
 export interface BaseBoxPropsWithRole
   extends BaseBoxProps,
     AccessibilityRoleProps {}
+/**
+ * Properties for button-like interactive elements with form-related behavior.
+ */
 export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
   /**
-   * The behavior of the Button.
-   *
-   * - `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.
-   * - `button`: Used to indicate the component acts as a button, meaning it has no default action.
-   * - `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).
-   *
-   * This property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.
+   * The semantic meaning of the button action within a form context:
+   * - `'button'`: A standard button with no default form behavior
+   * - `'submit'`: Submits the containing form when activated
+   * - `'reset'`: Resets the containing form to its initial values when activated
    *
    * @default 'button'
    */
   type?: 'submit' | 'button' | 'reset';
   /**
-   * Callback when the Button is activated.
-   * This will be called before the action indicated by `type`.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event
+   * A callback function executed when the element is clicked or activated. Learn more about [click events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
    */
   onClick?: (event: Event) => void;
   /**
-   * Disables the Button meaning it cannot be clicked or receive focus.
+   * Whether the field is disabled, preventing any user interaction.
    *
    * @default false
    */
   disabled?: boolean;
   /**
-   * Replaces content with a loading indicator while a background action is being performed.
-   *
-   * This also disables the Button.
+   * Indicates whether the button action is currently in progress. When `true`, displays a loading spinner or progress indicator and prevents additional clicks to avoid duplicate submissions. The button remains visually enabled but unresponsive to interaction. Set to `true` when starting an async operation (for example, API call, navigation) and back to `false` when the operation completes or fails. This provides user feedback during long-running operations and prevents race conditions from multiple rapid clicks.
    *
    * @default false
    */
   loading?: boolean;
 }
+/**
+ * Properties for link-like interactive elements with navigation behavior.
+ */
 export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
   /**
-   * The URL to link to.
-   *
-   * - If set, it will navigate to the location specified by `href` after executing the `click` event.
-   * - If a `commandFor` is set, the `command` will be executed instead of the navigation.
+   * The URL to navigate to when the element is clicked or activated. Supports absolute URLs (for example, `https://shopify.com`), relative URLs (for example, `/products`), and anchor links (for example, `#section-id`). Navigation is triggered after the `onClick` event completes, allowing navigation to be canceled by preventing the default event action. The actual navigation behavior depends on the `target` property—same page, new tab, or external navigation. For security, browsers may block navigation to certain protocols or untrusted origins. Commonly applied to create navigational links, external resource links, or in-app routing.
    */
   href?: string;
   /**
-   * Specifies where to display the linked URL.
+   * Specifies where to display the linked URL:
+   * - `'auto'`: The target is automatically determined based on the origin of the URL (typically behaves as `'_self'` but surfaces may handle cross-origin URLs differently)
+   * - `'_blank'`: Opens the URL in a new tab or window
+   * - `'_self'`: Opens the URL in the same browsing context
+   * - `'_parent'`: Opens the URL in the parent browsing context
+   * - `'_top'`: Opens the URL in the topmost browsing context
+   * - Custom string: Any other valid target name
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target
-   *
-   * 'auto': The target is automatically determined based on the origin of the URL.
+   * Learn more about the [`target` attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target).
    *
    * @implementation Surfaces can set specific rules on how they handle each URL.
-   * @implementation It’s expected that the behavior of `auto` is as `_self` except in specific cases.
+   * @implementation It's expected that the behavior of `auto` is as `_self` except in specific cases.
    * @implementation For example, a surface could decide to open cross-origin URLs in a new window (as `_blank`).
    *
    * @default 'auto'
    */
   target?: 'auto' | '_blank' | '_self' | '_parent' | '_top' | AnyString;
   /**
-   * Causes the browser to treat the linked URL as a download with the string being the file name.
-   * Download only works for same-origin URLs or the `blob:` and `data:` schemes.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download
+   * Treats the link as a file download instead of navigation. When set, clicking the link downloads the resource at the `href` URL rather than navigating to it. The value becomes the suggested filename shown in the download dialog or used by the browser's default save behavior (for example, `download="receipt.pdf"` saves as "receipt.pdf"). If the value is an empty string, the browser determines the filename from the URL or server headers. This only works for same-origin URLs (your app's domain) or `blob:` and `data:` URLs for security reasons—cross-origin URLs will navigate normally. Commonly applied to generate and download reports, receipts, CSV exports, or any file that should be saved rather than displayed. Learn more about the [`download` attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).
    */
   download?: string;
   /**
-   * Callback when the link is activated.
-   * This will be called before navigating to the location specified by `href`.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event
+   * A callback function executed when the element is clicked or activated. Learn more about [click events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
    */
   onClick?: (event: Event) => void;
 }
+/**
+ * Properties for controlling interactions between elements using commands.
+ */
 export interface InteractionProps {
   /**
-   * ID of a component that should respond to activations (e.g. clicks) on this component.
-   *
-   * See `command` for how to control the behavior of the target.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor
+   * The ID of the target element that should respond when this element is clicked or activated. This creates a relationship where clicking this control (button, clickable) triggers an action on another element in the DOM. The target element must have a matching `id` attribute. Use with the `command` property to specify what action should occur (show, hide, toggle). This enables declarative element control without writing custom click handlers, improving accessibility and reducing JavaScript. Common use cases include: opening modals from buttons, toggling content visibility, showing/hiding sidebars, or controlling overlay states. If both `commandFor` and `onClick` are present, both will execute—the command action occurs first, then the click handler. Learn more about [`commandfor` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor).
    */
   commandFor?: string;
   /**
-   * Sets the action the `commandFor` should take when this clickable is activated.
+   * The action to perform on the target element specified by `commandFor`:
+   * - `'--auto'`: Execute the target element's default action (typically show for overlays, or the element's primary interaction)
+   * - `'--show'`: Make the target element visible by calling its `showOverlay()` method or setting appropriate visibility properties
+   * - `'--hide'`: Hide the target element by calling its `hideOverlay()` method or setting appropriate visibility properties
+   * - `'--toggle'`: Switch the target element's visibility state—if visible, hide it; if hidden, show it
+   * - `'--copy'`: Copy content to the clipboard (requires the target to be a compatible element with copy functionality)
    *
-   * See the documentation of particular components for the actions they support.
-   *
-   * - `--auto`: a default action for the target component.
-   * - `--show`: shows the target component.
-   * - `--hide`: hides the target component.
-   * - `--toggle`: toggles the target component.
-   * - `--copy`: copies the target ClipboardItem.
+   * The command executes when this element is clicked, before any `onClick` handlers fire. If the target element doesn't support the specified command, the action may fail silently. Learn more about [button commands on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
    *
    * @default '--auto'
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command
    */
   command?: '--auto' | '--show' | '--hide' | '--toggle' | '--copy';
   /**
-   * ID of a component that should respond to interest (e.g. hover and focus) on this component.
+   * The ID of a target element that should respond to hover and focus events on this element, creating an "interest" relationship. When the user hovers over or focuses this element, the target element receives corresponding interest events, allowing it to preview or prepare content. This is useful for implementing tooltip-like previews, image zoom on hover, showing additional details before clicking, or loading content speculatively when the user shows interest. The target element must have a matching `id` and listen for interest events. Unlike `commandFor` which responds to clicks, this responds to hover and focus, providing earlier user intent signals.
    */
   interestFor?: string;
 }
+/**
+ * Combined properties for elements that can behave as both buttons and links.
+ */
 export interface BaseClickableProps
   extends ButtonBehaviorProps,
     LinkBehaviorProps {}
 export interface ButtonProps extends GlobalProps, BaseClickableProps {
   /**
-   * A label that describes the purpose or contents of the Button. It will be read to users using assistive technologies such as screen readers.
-   *
-   * Use this when using only an icon or the Button text is not enough context
-   * for users using assistive technologies.
+   * A label that describes the purpose or contents of the element. Announced to users with assistive technologies such as screen readers to provide context.
    */
   accessibilityLabel?: string;
   /**
-   * The content of the Button.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * The type of icon to be displayed in the Button.
+   * The icon identifier specifying which icon to display. Accepts any valid icon name from the icon set.
    *
    * @default ''
    */
   icon?: IconType | AnyString;
   /**
-   * The displayed inline width of the Button.
-   *
-   * - `auto`: the size of the button depends on the surface and context.
-   * - `fill`: the button will takes up 100% of the available inline size.
-   * - `fit-content`: the button will take up the minimum inline-size required to fit its content.
+   * Controls how the element's width adapts to its container and content.
    *
    * @default 'auto'
    */
   inlineSize?: 'auto' | 'fill' | 'fit-content';
   /**
-   * Changes the visual appearance of the Button.
+   * Changes the visual appearance and prominence of the button:
+   * - `'auto'`: The variant is automatically determined by context
+   * - `'primary'`: Creates a prominent call-to-action button with high visual emphasis for the most important action on a screen
+   * - `'secondary'`: Provides a less prominent button appearance for supporting actions and secondary interactions
+   * - `'tertiary'`: Provides the least prominent button appearance for tertiary or optional actions
    *
-   * @default 'auto' - the variant is automatically determined by the Button's context
+   * @default 'auto'
    */
   variant?: 'auto' | 'primary' | 'secondary' | 'tertiary';
   /**
-   * Sets the tone of the Button based on the intention of the information being conveyed.
+   * Sets the tone of the button, based on the intention of the action being performed:
+   * - `'auto'`: Automatically determines the appropriate tone based on context
+   * - `'neutral'`: The standard tone for general actions and interactions
+   * - `'caution'`: Indicates actions that require careful consideration
+   * - `'warning'`: Alerts users to potential issues or important information
+   * - `'critical'`: Used for destructive actions like deleting or removing content
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
-   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
-   * [Reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label)
+   * Indicates the language of the text content. Useful when text is in a different language than the rest of the page, allowing assistive technologies to invoke correct pronunciation. [Reference of language subtag values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
    */
   lang?: string;
 }
+/**
+ * Base properties for all form input elements.
+ */
 export interface BaseInputProps {
   /**
-   * An identifier for the field that is unique within the nearest containing form.
+   * An identifier for the field that is unique within the nearest containing form. This name is used as the key when the form data is submitted. If omitted, the field's value won't be included in form submissions. Meaningful names describe the data being collected (for example, `"email"`, `"quantity"`, `"customer-note"`).
    */
   name?: string;
   /**
-   * Disables the field, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction. When `true`, the field can't receive focus, be edited, or be interacted with. Disabled fields are visually dimmed, excluded from form submission, and announced as disabled to screen readers. Typically set when a field is temporarily unavailable due to application state, permissions, or dependencies on other fields.
    *
    * @default false
    */
   disabled?: boolean;
 }
+/**
+ * Properties for controlled form input elements with value and change callbacks.
+ */
 export interface InputProps extends BaseInputProps {
   /**
-   * Callback when the user has **finished editing** a field, e.g. once they have blurred the field.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
+   * A callback function executed when the user has committed a value change, typically triggered when the field loses focus (blur) after the value has been modified. Unlike `onInput`, this fires only once after editing is complete, not during typing. The event contains the finalized value. Common operations include validation, saving data, or triggering actions that should occur after the user finishes editing rather than during typing. For controlled components, the `value` prop should be updated in this callback. This is ideal for expensive operations like API calls that shouldn't happen on every keystroke. Learn more about [change events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
    */
   onChange?: (event: Event) => void;
   /**
-   * Callback when the user makes any changes in the field.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
+   * A callback function executed immediately when the user makes any change to the field value. Fires on every keystroke, paste, or other input modification before the field loses focus. The event contains the current field value. Common operations include real-time validation, character counting, formatting input as users type, or implementing autocomplete/search-as-you-type features. For controlled components, the `value` prop should be updated in this callback to keep state in sync. Expensive operations should be avoided here as this fires frequently during typing. Learn more about [input events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
    */
   onInput?: (event: Event) => void;
   /**
-   * The current value for the field. If omitted, the field will be empty.
+   * The current value of the field. When provided, this creates a controlled component where this value must be updated in response to user input using `onChange` or `onInput` callbacks. The format and valid values depend on the specific field type. If both `value` and `defaultValue` are provided, `value` takes precedence.
    */
   value?: string;
   /**
-   * The default value for the field.
+   * The default value used when the field is first rendered. Only applies if no `value` prop is provided, creating an uncontrolled component where the browser manages the field state internally. After initial render, the component handles its own state and the current value can be read from the DOM.
    *
    * @implementation `defaultValue` reflects to the `value` attribute.
    */
   defaultValue?: string;
 }
+/**
+ * Properties for form inputs that support multiple selections.
+ */
 export interface MultipleInputProps extends BaseInputProps {
   /**
-   * Callback when the user has selected option(s).
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed. Learn more about [change events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
    */
   onChange?: (event: Event) => void;
   /**
-   * Callback when the user has selected option(s).
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction. Learn more about [input events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
    */
   onInput?: (event: Event) => void;
   /**
-   * An array of the `value`s of the selected options.
-   *
-   * This is a convenience prop for setting the `selected` prop on child options.
+   * An array containing the values of currently selected options in a multi-select choice list. When provided, this creates a controlled component where this array must be updated in response to user selections using the `onChange` callback. The array contains the `value` properties of selected child `Choice` components. For single-select lists (`multiple={false}`), this array contains zero or one items. For multi-select lists, it can contain multiple items. This is a convenience property that automatically sets the `selected` state on matching child choices based on their `value` properties. When a choice's value appears in this array, it's automatically marked as selected. The array should be updated immutably in callbacks (creating new arrays rather than mutating existing ones).
    */
   values?: string[];
 }
+/**
+ * Properties for displaying field validation errors.
+ */
 export interface FieldErrorProps {
   /**
-   * Indicate an error to the user. The field will be given a specific stylistic treatment
-   * to communicate problems that have to be resolved immediately.
+   * An error message to display when the field contains invalid data or fails validation. When set, the field receives error styling (typically a red border and error icon) and the message appears below the field to guide users toward fixing the issue. The error is announced to screen readers for accessibility. The error is cleared by setting this to an empty string or `undefined`. Errors are typically displayed after validation fails, usually on blur or form submission.
    */
   error?: string;
 }
+/**
+ * Basic properties for form fields including labels, validation requirements, and error states.
+ */
 export interface BasicFieldProps
   extends FieldErrorProps,
     LabelAccessibilityVisibilityProps {
   /**
-   * Whether the field needs a value. This requirement adds semantic value
-   * to the field, but it will not cause an error to appear automatically.
-   * If you want to present an error when this field is empty, you can do
-   * so with the `error` property.
+   * Whether the field must have a value before form submission. When `true`, the field is marked as required (typically with an asterisk), announced as required to screen readers, and triggers browser validation on form submit. This property adds semantic meaning but doesn't prevent submission on its own—validation logic must be implemented and the `error` property used to display validation messages.
    *
    * @default false
    */
   required?: boolean;
   /**
-   * Content to use as the field label.
+   * The text label that describes what information the field is requesting from the user. Labels are always visible (unlike placeholders which disappear on input) and are announced by screen readers, making them critical for accessibility. Labels typically appear above or beside the field and remain visible while the user interacts with the field. Clear, concise labels describe the expected input (for example, "Email address", "Quantity", "Customer note").
    */
   label?: string;
 }
+/**
+ * Properties for adding supplementary help text to form fields.
+ */
 export interface FieldDetailsProps {
   /**
-   * Additional text to provide context or guidance for the field.
-   * This text is displayed along with the field and its label
-   * to offer more information or instructions to the user.
-   *
-   * This will also be exposed to screen reader users.
+   * Supplementary help text that provides additional context, instructions, or constraints for the field. This text typically appears below the label in a smaller, subdued style and remains visible at all times (unlike placeholders). Screen readers announce this text along with the label to provide complete field context. Common content includes format requirements (for example, "Use YYYY-MM-DD format"), character limits (for example, "Maximum 500 characters"), helpful hints (for example, "This will be shown on the receipt"), or clarifying instructions (for example, "Leave blank to use default shipping address"). Information already in the label or placeholder shouldn't be duplicated here.
    */
   details?: string;
 }
+/**
+ * Complete properties for standard form fields including value, label, placeholder, validation, and callbacks.
+ */
 export interface FieldProps
   extends BasicFieldProps,
     InputProps,
     FocusEventProps,
     FieldDetailsProps {
   /**
-   * A short hint that describes the expected value of the field.
+   * A short hint that provides guidance about the expected value or format of the field. Displayed when the field is empty and disappears once the user starts typing. Placeholders should supplement the label, not replace it—a `label` should always be provided as well since placeholders may not be accessible to all screen readers. Common placeholder content includes format examples (for example, "YYYY-MM-DD"), helpful hints (for example, "Leave blank for default"), or clarifying expected input (for example, "Enter SKU or product name").
    */
   placeholder?: string;
 }
+/**
+ * Base properties for text-based input fields including placeholder and read-only state.
+ */
 export interface BaseTextFieldProps extends FieldProps {
   /**
-   * The field cannot be edited by the user. It is focusable will be announced by screen readers.
+   * Whether the field can be edited. When `true`, the field is focusable and announced by screen readers but can't be modified by the user. Unlike `disabled`, read-only fields can still receive focus, be copied, and participate in form submission. Typically applied to calculated values, reference information, or data that users need to see and interact with but shouldn't change.
    *
    * @default false
    */
   readOnly?: boolean;
 }
+/**
+ * Properties for adding decorative elements like icons, prefixes, suffixes, and accessories to form fields.
+ */
 export interface FieldDecorationProps {
   /**
-   * A value to be displayed immediately after the editable portion of the field.
-   *
-   * This is useful for displaying an implied part of the value, such as "@shopify.com", or "%".
-   *
-   * This cannot be edited by the user, and it isn't included in the value of the field.
-   *
-   * It may not be displayed until the user has interacted with the input.
-   * For example, an inline label may take the place of the suffix until the user focuses the input.
+   * Static text displayed immediately after the editable portion of the field, typically inside the field border. This text is non-interactive and purely decorative—users can't edit it and it's not included in the field's value when submitted. The suffix remains visible at all times, even when the field is empty. Common uses include domain suffixes (for example, "@shopify.com" for email fields), units of measurement (for example, "kg", "%", "USD"), or clarifying context (for example, "/month" for subscription pricing). Choose between suffix and prefix based on natural reading order for your use case.
    *
    * @default ''
    */
   suffix?: string;
   /**
-   * A value to be displayed immediately before the editable portion of the field.
-   *
-   * This is useful for displaying an implied part of the value, such as "https://" or "+353".
-   *
-   * This cannot be edited by the user, and it isn't included in the value of the field.
-   *
-   * It may not be displayed until the user has interacted with the input.
-   * For example, an inline label may take the place of the prefix until the user focuses the input.
+   * Static text displayed immediately before the editable portion of the field, typically inside the field border. This text is non-interactive and purely decorative—users can't edit it and it's not included in the field's value when submitted. The prefix remains visible at all times, even when the field is empty. Common uses include currency symbols (for example, "$", "€", "£"), protocol indicators (for example, "https://"), measurement prefixes (for example, "#", "@"), or fixed identifiers. The prefix helps users understand the expected format without consuming characters from maxLength limits.
    *
    * @default ''
    */
   prefix?: string;
   /**
-   * The type of icon to be displayed in the field.
+   * The icon identifier specifying which icon to display in the field, typically positioned at the start of the field before the input area. The icon is decorative and helps users quickly identify the field's purpose through visual recognition. The icon is announced to screen readers along with the field's accessible name. Use icons that clearly communicate the field's purpose (for example, search icon for search fields, calendar icon for date fields, lock icon for password fields). The icon doesn't affect the field's functionality but improves visual recognition and scannability in forms. Avoid using both icon and prefix simultaneously as this can create visual clutter.
    *
    * @default ''
    */
   icon?: IconType | AnyString;
   /**
-   * Additional content to be displayed in the field.
-   * Commonly used to display an icon that activates a tooltip providing more information.
+   * Additional interactive content displayed within the field, typically positioned at the end of the field after the input area. Only text-only `Button` and `Clickable` components are supported—no icons or complex content. Use the `slot="accessory"` attribute to place elements here. Common uses include action buttons (for example, "Copy" button, "Generate" button, "Clear" button), toggle visibility controls (for example, "Show password" button), or quick actions related to the field (for example, "Paste from clipboard"). The accessory must not interfere with the field's primary input functionality. Ensure sufficient contrast and touch target sizes for mobile usability.
    */
   accessory?: ComponentChildren;
 }
+/**
+ * Properties for defining numeric value constraints and controls.
+ */
 export interface NumberConstraintsProps {
   /**
-   * The highest decimal or integer to be accepted for the field.
-   * When used with `step` the value will round down to the max number.
-   *
-   * Note: a user will still be able to use the keyboard to input a number higher than
-   * the max. It is up to the developer to add appropriate validation.
+   * The highest decimal or integer value that the field accepts. When used with `stepper` controls, the increment button becomes disabled at this value and attempting to increment rounds down to max. When users type values using keyboard, they can enter numbers above max—browser validation will flag these as invalid but won't prevent entry, so validation should be implemented in `onChange` or before form submission. Commonly applied to enforce business rules like maximum quantities, price caps, or valid ranges. Setting to `Infinity` (default) removes the upper limit.
    *
    * @default Infinity
    */
   max?: number;
   /**
-   * The lowest decimal or integer to be accepted for the field.
-   * When used with `step` the value will round up to the min number.
-   *
-   * Note: a user will still be able to use the keyboard to input a number lower than
-   * the min. It is up to the developer to add appropriate validation.
+   * The lowest decimal or integer value that the field accepts. When used with `stepper` controls, the decrement button becomes disabled at this value and attempting to decrement rounds up to min. When users type values using keyboard, they can enter numbers below min—browser validation will flag these as invalid but won't prevent entry, so validation should be implemented in `onChange` or before form submission. Commonly applied to enforce business rules like minimum quantities, prevent negative values, or define valid ranges. Setting to `-Infinity` (default) removes the lower limit.
    *
    * @default -Infinity
    */
   min?: number;
   /**
-   * The amount the value can increase or decrease by. This can be an integer or decimal.
-   * If a `max` or `min` is specified with `step` when increasing/decreasing the value
-   * via the buttons, the final value will always round to the `max` or `min`
-   * rather than the closest valid amount.
+   * The increment/decrement amount for adjusting the numeric value. Determines how much the value changes when users click stepper buttons or press keyboard arrow keys (up/down). For example, `step="0.01"` allows currency precision, `step="5"` for quantities in increments of 5, or `step="0.25"` for quarter-hour time intervals. The browser may also use this for validation, flagging values that aren't valid steps from the `min` value. Decimals are supported unless using `stepper` controls which only accept integers.
    *
    * @default 1
    */
   step?: number;
   /**
-   * Sets the type of controls displayed in the field.
-   *
-   * - `stepper`: displays buttons to increase or decrease the value of the field by the stepping interval defined in the `step` property.
-   * Appropriate mouse and [keyboard interactions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role#keyboard_interactions) to control the value of the field are enabled.
-   * - `none`: no controls are displayed and users must input the value manually. Arrow keys and scroll wheels can’t be used either to avoid accidental changes.
-   * - `auto`: the presence of the controls depends on the surface and context.
+   * The type of controls displayed for the field:
+   * - `'auto'`: An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
+   * - `'stepper'`: Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
+   * - `'none'`: A control type with no visible controls where users must input the value manually using the keyboard.
    *
    * @default 'auto'
    */
   controls?: 'auto' | 'stepper' | 'none';
 }
+/**
+ * Properties for defining minimum and maximum character length constraints on text inputs.
+ */
 export interface MinMaxLengthProps {
   /**
-   * Specifies the maximum number of characters allowed.
+   * The maximum number of characters allowed in the text field. The browser prevents users from typing or pasting beyond this limit—additional characters are automatically truncated. The character count includes all characters (letters, numbers, spaces, special characters). This provides immediate feedback by blocking input rather than showing validation errors. Commonly applied to enforce hard limits like database column sizes, API constraints, or UX requirements. Often combined with character counter displays to show remaining space (for example, "45/100 characters").
    *
    * @default Infinity
    */
   maxLength?: number;
   /**
-   * Specifies the min number of characters allowed.
+   * The minimum number of characters required for the field value to be considered valid. Unlike `maxLength`, this doesn't prevent users from entering fewer characters—instead, browser validation marks the field as invalid if the value is too short. Validation typically occurs on form submission or blur. The field can be empty unless also marked `required`. Commonly applied to ensure sufficient input quality, such as minimum password lengths, meaningful descriptions, or codes with fixed lengths. The `error` property can be combined with this to display user-friendly validation messages.
    *
    * @default 0
    */
   minLength?: number;
 }
+/**
+ * Base properties for selectable options including value, disabled state, and accessibility labels.
+ */
 export interface BaseSelectableProps {
   /**
-   * A label used for users using assistive technologies like screen readers. When set, any children or `label` supplied will not be announced.
-   * This can also be used to display a control without a visual label, while still providing context to users using screen readers.
+   * A label that describes the purpose or contents of the element. Announced to users with assistive technologies such as screen readers to provide context.
    */
   accessibilityLabel?: string;
   /**
-   * Disables the control, disallowing any interaction.
+   * Whether the field is disabled, preventing any user interaction.
    *
    * @default false
    */
   disabled?: boolean;
   /**
-   * The value used in form data when the control is checked.
+   * The unique value associated with this selectable option. This value is what gets submitted with forms when the option is selected, and is used to identify which options are selected in the parent `ChoiceList`'s `values` array. The value should be unique among siblings within the same choice list to avoid selection ambiguity. When a choice is selected, this value appears in form data and in the parent's `values` array. Use meaningful, stable values that identify the choice semantically (for example, `"small"`, `"express-shipping"`, `"agree-to-terms"`) rather than display text which may change or be localized. The value isn't displayed to users—use the choice's `children` or label for visible text.
    */
   value?: string;
 }
+/**
+ * Properties for individual options within choice lists, including selection state management.
+ */
 export interface BaseOptionProps extends BaseSelectableProps {
   /**
-   * Whether the control is active.
+   * Whether the choice control is currently active or selected. This creates a controlled component—this value must be updated in response to user interactions using `onChange` handlers. When `true`, the choice appears selected with appropriate visual styling and is included in form submissions. If both `selected` and `defaultSelected` are provided, `selected` takes precedence.
    *
    * @default false
    */
   selected?: boolean;
   /**
-   * Whether the control is active by default.
+   * Whether the control is selected by default when first rendered. This creates an uncontrolled component where the browser manages selection state internally after the initial render. The component handles selection internally without requiring updates using callbacks.
    *
    * @implementation `defaultSelected` reflects to the `selected` attribute.
    *
@@ -1639,9 +1603,12 @@ export interface BaseOptionProps extends BaseSelectableProps {
    */
   defaultSelected?: boolean;
 }
+/**
+ * Properties for a single choice option including label, details, selection state, and additional content.
+ */
 export interface ChoiceProps extends GlobalProps, BaseOptionProps {
   /**
-   * Content to use as the choice label.
+   * The label content for the choice option.
    *
    * @implementation (StringChildren) The label is produced by extracting and
    * concatenating the text nodes from the provided content; any markup or
@@ -1653,64 +1620,57 @@ export interface ChoiceProps extends GlobalProps, BaseOptionProps {
    */
   children?: ComponentChildren | StringChildren;
   /**
-   * Additional text to provide context or guidance for the input.
-   *
-   * This text is displayed along with the input and its label
-   * to offer more information or instructions to the user.
+   * Additional text or content that provides context or guidance for the choice option. Displayed alongside the option label to offer more information or instructions to the user. Also exposed to screen reader users.
    *
    * @implementation this content should be linked to the input with an `aria-describedby` attribute.
    */
   details?: ComponentChildren;
   /**
-   * Set to `true` to associate a choice with the error passed to `ChoiceList`
+   * An error state indicator for the choice option. When `true`, the option will be given specific stylistic treatment to communicate validation issues.
    *
    * @default false
    */
   error?: boolean;
   /**
-   * Secondary content for a choice.
+   * The additional content displayed alongside the primary choice label. Useful for providing supplementary information or context.
    */
   secondaryContent?: ComponentChildren;
   /**
-   * Content to display when the option is selected.
-   *
-   * This can be used to provide additional information or options related to the choice.
+   * The content displayed only when the option is selected. Useful for showing additional details or confirmation information.
    */
   selectedContent?: ComponentChildren;
 }
+/**
+ * Properties for a list of choice options with support for single or multiple selection modes.
+ */
 export interface ChoiceListProps
   extends GlobalProps,
     Pick<BasicFieldProps, 'label' | 'labelAccessibilityVisibility' | 'error'>,
     MultipleInputProps,
     FieldDetailsProps {
   /**
-   * Whether multiple choices can be selected.
+   * Whether multiple choices can be selected simultaneously. When `true`, users can select multiple options and the `values` array will contain all selected values. When `false`, only one option can be selected at a time and selecting a new option automatically deselects the previous one.
    *
    * @default false
    */
   multiple?: boolean;
   /**
-   * The choices a user can select from.
-   *
-   * Accepts `Choice` components.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Disables the field, disallowing any interaction.
-   *
-   * `disabled` on any child choices is ignored when this is true.
+   * Whether the field is disabled, preventing any user interaction.
    *
    * @default false
    */
   disabled?: MultipleInputProps['disabled'];
   /**
-   * The variant of the choice grid.
-   *
-   * - `auto`: The variant is determined by the context.
-   * - `list`: The choices are displayed in a list.
-   * - `inline`: The choices are displayed on the inline axis.
-   * - `block`: The choices are displayed on the block axis.
-   * - `grid`: The choices are displayed in a grid.
+   * Controls the visual layout and presentation style of the choice options:
+   * - `'auto'`: The layout is automatically determined based on context
+   * - `'list'`: Displays choices in a vertical list format
+   * - `'inline'`: Displays choices in a horizontal inline format
+   * - `'block'`: Displays choices as block-level button-like elements
+   * - `'grid'`: Displays choices in a grid layout
    *
    * @implementation The `block`, `inline` and `grid` variants are more suitable for button looking choices, but it's at the
    * discretion of each surface.
@@ -1724,49 +1684,28 @@ export interface ClickableProps
     BaseBoxProps,
     BaseClickableProps {
   /**
-   * Disables the clickable, and indicates to assistive technology that the loading is in progress.
-   *
-   * This also disables the clickable.
+   * Indicates whether the action is currently in progress. When `true`, typically displays a loading indicator and may disable interaction.
    */
   loading?: BaseClickableProps['loading'];
   /**
-   * Disables the clickable, meaning it cannot be clicked or receive focus.
-   *
-   * In this state, onClick will not fire.
-   * If the click event originates from a child element, the event will immediately stop propagating from this element.
-   *
-   * However, items within the clickable can still receive focus and be interacted with.
-   *
-   * This has no impact on the visual state by default,
-   * but developers are encouraged to style the clickable accordingly.
+   * Whether the element is disabled, preventing any user interaction.
    */
   disabled?: BaseClickableProps['disabled'];
   /**
-   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
-   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
-   * [Reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label)
+   * Specifies the language of text content using an [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) language tag (for example, `"en"` for English, `"fr"` for French, `"es-MX"` for Mexican Spanish, `"zh-Hans"` for Simplified Chinese). This enables assistive technologies to use correct pronunciation and language-specific text rendering.
    *
    * @default ''
    */
   lang?: string;
 }
+/**
+ * Properties for enabling browser autocomplete functionality on form fields.
+ */
 export interface AutocompleteProps<
   AutocompleteField extends AnyAutocompleteField,
 > {
   /**
-   * A hint as to the intended content of the field.
-   *
-   * When set to `on` (the default), this property indicates that the field should support
-   * autofill, but you do not have any more semantic information on the intended
-   * contents.
-   *
-   * When set to `off`, you are indicating that this field contains sensitive
-   * information, or contents that are never saved, like one-time codes.
-   *
-   * Alternatively, you can provide value which describes the
-   * specific data you would like to be entered into this field during autofill.
-   *
-   * @see Learn more about the set of {@link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens|autocomplete values} supported in browsers.
+   * Specifies the type of data expected in the field to enable browser autocomplete functionality. When set to a specific field type (for example, `'email'`, `'name'`, `'address-line1'`), browsers offer suggestions from previously entered or saved information, improving data entry speed and accuracy. Set to `'on'` to enable generic autocomplete without specifying data type. Set to `'off'` to disable autocomplete entirely for sensitive fields (for example, one-time codes, PINs, credit card security codes). The browser respects user preferences and privacy settings, so autocomplete suggestions may not always appear even when enabled. Prefix field types with section identifiers (`section-shipping`) or groups (`billing`, `shipping`) to disambiguate when multiple similar fields exist on the same page. Accepts standard [HTML autocomplete tokens per the WHATWG specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens).
    *
    * @default 'tel' for PhoneField
    * @default 'email' for EmailField
@@ -1782,19 +1721,18 @@ export interface AutocompleteProps<
     | 'off';
 }
 /**
- * The “section” scopes the autocomplete data that should be inserted
- * to a specific area of the page.
+ * A section prefix that scopes the autocomplete data to a specific area of the page.
  *
  * Commonly used when there are multiple fields with the same autocomplete needs
  * in the same page. For example: 2 shipping address forms in the same page.
  */
 export type AutocompleteSection = `section-${string}`;
 /**
- * The contact information group the autocomplete data should be sourced from.
+ * The contact information category that autocomplete data should be sourced from.
  */
 export type AutocompleteGroup = 'shipping' | 'billing';
 /**
- * The contact information subgroup the autocomplete data should be sourced from.
+ * The contact information subcategory that autocomplete data should be sourced from.
  */
 export type AutocompleteAddressGroup = 'fax' | 'home' | 'mobile' | 'pager';
 export type AnyAutocompleteField =
@@ -1862,6 +1800,9 @@ export type AnyAutocompleteField =
   | `${AutocompleteAddressGroup} tel-local-suffix`
   | `${AutocompleteAddressGroup} tel-local`
   | `${AutocompleteAddressGroup} tel-national`;
+/**
+ * Autocomplete field types applicable to text input fields.
+ */
 export type TextAutocompleteField = ExtractStrict<
   AnyAutocompleteField,
   | 'additional-name'
@@ -1895,12 +1836,15 @@ export type TextAutocompleteField = ExtractStrict<
   | 'cc-family-name'
   | 'cc-type'
 >;
+/**
+ * Properties for an interactive date picker component with single, multiple, or range selection modes.
+ */
 export interface DatePickerProps
   extends GlobalProps,
     InputProps,
     FocusEventProps {
   /**
-   * Default month to display in `YYYY-MM` format.
+   * The default month to display in `YYYY-MM` format when the picker is first shown.
    *
    * This value is used until `view` is set, either directly or as a result of user interaction.
    *
@@ -1908,74 +1852,35 @@ export interface DatePickerProps
    */
   defaultView?: string;
   /**
-   * Displayed month in `YYYY-MM` format.
-   *
-   * `onViewChange` is called when this value changes.
-   *
-   * Defaults to `defaultView`.
+   * The currently displayed month in `YYYY-MM` format. Controls which month is visible in the date picker.
    */
   view?: string;
   /**
-   * Called whenever the month to display changes.
-   *
-   * @param view The new month to display in `YYYY-MM` format.
+   * A callback function executed when the visible month displayed in the date picker changes, either through user navigation (clicking next/previous month buttons) or programmatic updates to the `view` property. The callback receives the new month as a string in `YYYY-MM` format (for example, `"2024-05"`). Common operations include tracking which month users are viewing, loading month-specific data (like availability or pricing), syncing the view with external state, or implementing custom navigation controls. For controlled date pickers, the `view` property should be updated in this callback to keep the displayed month in sync with application state. The callback fires after the month has changed but before the new month's dates are fully rendered, making it well-suited for triggering data fetches.
    */
   onViewChange?: (view: string) => void;
   /**
-   * The type of selection the date picker allows.
-   *
-   * - `single` allows selecting a single date.
-   * - `multiple` allows selecting multiple non-contiguous dates.
-   * - `range` allows selecting a single range of dates.
+   * Controls the selection mode of the date picker:
+   * - `'single'`: Allows selecting one date
+   * - `'multiple'`: Allows selecting multiple individual dates
+   * - `'range'`: Allows selecting a continuous range of dates
    *
    * @default "single"
    */
   type?: 'single' | 'multiple' | 'range';
   /**
-   * Dates that can be selected.
-   *
-   * A comma-separated list of dates, date ranges. Whitespace is allowed after commas.
-   *
-   * The default `''` allows all dates.
-   *
-   * - Dates in `YYYY-MM-DD` format allow a single date.
-   * - Dates in `YYYY-MM` format allow a whole month.
-   * - Dates in `YYYY` format allow a whole year.
-   * - Ranges are expressed as `start--end`.
-   *     - Ranges are inclusive.
-   *     - If either `start` or `end` is omitted, the range is unbounded in that direction.
-   *     - If parts of the date are omitted for `start`, they are assumed to be the minimum possible value.
-   *       So `2024--` is equivalent to `2024-01-01--`.
-   *     - If parts of the date are omitted for `end`, they are assumed to be the maximum possible value.
-   *       So `--2024` is equivalent to `--2024-12-31`.
-   *     - Whitespace is allowed either side of `--`.
+   * Specifies allowed date values or ranges for selection. Uses ISO date format (YYYY-MM-DD) or partial dates (YYYY-MM, YYYY). Supports range syntax with `--` separator and comma-separated values.
    *
    * @default ""
    *
    * @example
    * `2024-02--2025` // allow any date from February 2024 to the end of 2025
-   * `2024-02--` // allow any date from February 2024 to the end of the month
+   * `2024-02--` // allow any date from February 2024 onwards
    * `2024-05-09, 2024-05-11` // allow only the 9th and 11th of May 2024
    */
   allow?: string;
   /**
-   * Dates that cannot be selected. These subtract from `allow`.
-   *
-   * A comma-separated list of dates, date ranges. Whitespace is allowed after commas.
-   *
-   * The default `''` has no effect on `allow`.
-   *
-   * - Dates in `YYYY-MM-DD` format disallow a single date.
-   * - Dates in `YYYY-MM` format disallow a whole month.
-   * - Dates in `YYYY` format disallow a whole year.
-   * - Ranges are expressed as `start--end`.
-   *     - Ranges are inclusive.
-   *     - If either `start` or `end` is omitted, the range is unbounded in that direction.
-   *     - If parts of the date are omitted for `start`, they are assumed to be the minimum possible value.
-   *       So `2024--` is equivalent to `2024-01-01--`.
-   *     - If parts of the date are omitted for `end`, they are assumed to be the maximum possible value.
-   *       So `--2024` is equivalent to `--2024-12-31`.
-   *     - Whitespace is allowed either side of `--`.
+   * Specifies disallowed date values or ranges that can't be selected. Uses ISO date format (YYYY-MM-DD) or partial dates (YYYY-MM, YYYY). Supports range syntax with `--` separator and comma-separated values. Takes precedence over `allow`.
    *
    * @default ""
    *
@@ -1985,82 +1890,49 @@ export interface DatePickerProps
    */
   disallow?: string;
   /**
-   * Days of the week that can be selected. These intersect with the result of `allow` and `disallow`.
-   *
-   * A comma-separated list of days. Whitespace is allowed after commas.
-   *
-   * The default `''` has no effect on the result of `allow` and `disallow`.
-   *
-   * Days are `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`.
+   * Specifies which days of the week can be selected. Accepts comma-separated day names (case-insensitive). Further restricts dates within the result of `allow` and `disallow`.
    *
    * @default ""
    *
    * @example
-   * 'saturday, sunday' // allow only weekends within the result of `allow` and `disallow`.
+   * 'saturday, sunday' // allow only weekends
+   * 'monday, wednesday, friday' // allow only specific weekdays
    */
   allowDays?: string;
   /**
-   * Days of the week that cannot be selected. This subtracts from `allowDays`, and intersects with the result of `allow` and `disallow`.
-   *
-   * A comma-separated list of days. Whitespace is allowed after commas.
-   *
-   * The default `''` has no effect on `allowDays`.
-   *
-   * Days are `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`.
+   * Specifies which days of the week can't be selected. Accepts comma-separated day names (case-insensitive). Further restricts dates within the result of `allow` and `disallow`.
    *
    * @default ""
    *
    * @example
-   * 'saturday, sunday' // disallow weekends within the result of `allow` and `disallow`.
+   * 'saturday, sunday' // disallow weekends
+   * 'monday' // disallow Mondays
    */
   disallowDays?: string;
   /**
-   * Default selected value.
-   *
-   * The default means no date is selected.
-   *
-   * If the provided value is invalid, no date is selected.
-   *
-   * - If `type="single"`, this is a date in `YYYY-MM-DD` format.
-   * - If `type="multiple"`, this is a comma-separated list of dates in `YYYY-MM-DD` format.
-   * - If `type="range"`, this is a range in `YYYY-MM-DD--YYYY-MM-DD` format. The range is inclusive.
+   * The default date value used when the field is first rendered, in ISO date format (YYYY-MM-DD, for example, `"2024-05-15"`). An empty string means no default date. For date ranges, use comma-separated dates. Only applies if no `value` prop is provided.
    *
    * @default ""
    */
   defaultValue?: string;
   /**
-   * Current selected value.
-   *
-   * The default means no date is selected.
-   *
-   * If the provided value is invalid, no date is selected.
-   *
-   * Otherwise:
-   *
-   * - If `type="single"`, this is a date in `YYYY-MM-DD` format.
-   * - If `type="multiple"`, this is a comma-separated list of dates in `YYYY-MM-DD` format.
-   * - If `type="range"`, this is a range in `YYYY-MM-DD--YYYY-MM-DD` format. The range is inclusive.
+   * The currently selected date value in ISO date format (YYYY-MM-DD, for example, `"2024-05-15"`). An empty string means no date is selected. For date ranges, use comma-separated dates (for example, `"2024-05-15,2024-05-20"`).
    *
    * @default ""
    */
   value?: string;
   /**
-   * Callback when any date is selected.
-   *
-   * - If `type="single"`, fires when a date is selected and happens before `onChange`.
-   * - If `type="multiple"`, fires when a date is selected before `onChange`.
-   * - If `type="range"`, fires when a first date is selected (with the partial value formatted as `YYYY-MM-DD--`), and when the last date is selected before `onChange`.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: Event) => void;
   /**
-   * Callback when the value is committed.
-   *
-   * - If `type="single"`, fires when a date is selected after `onInput`.
-   * - If `type="multiple"`, fires when a date is selected after `onInput`.
-   * - If `type="range"`, fires when a range is completed by selecting the end date after `onInput`.
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: Event) => void;
 }
+/**
+ * Properties for a text-based date input field with validation and autocomplete support.
+ */
 export interface DateFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
@@ -2078,22 +1950,13 @@ export interface DateFieldProps
     >,
     AutocompleteProps<DateAutocompleteField> {
   /**
-   * Callback when the field has an invalid date.
-   * This callback will be called, if the date typed is invalid or disabled.
-   *
-   * Dates that don’t exist or have formatting errors are considered invalid. Some examples of invalid dates are:
-   * - 2021-02-31: February doesn’t have 31 days
-   * - 2021-02-00: The day can’t be 00
-   *
-   * Disallowed dates are considered invalid.
-   *
-   * It’s important to note that this callback will be called only when the user **finishes editing** the date,
-   * and it’s called right after the `onChange` callback.
-   * The field is **not** validated on every change to the input. Once the buyer has signalled that
-   * they have finished editing the field (typically, by blurring the field), the field gets validated and the callback is run if the value is invalid.
+   * A callback function executed when the user enters an invalid value. Fires after change validation fails.
    */
   onInvalid?: (event: Event) => void;
 }
+/**
+ * Autocomplete field types applicable to date input fields.
+ */
 export type DateAutocompleteField = ExtractStrict<
   AnyAutocompleteField,
   | 'bday'
@@ -2104,6 +1967,9 @@ export type DateAutocompleteField = ExtractStrict<
   | 'cc-expiry-month'
   | 'cc-expiry-year'
 >;
+/**
+ * Properties for a spinner-style date selector with increment/decrement controls.
+ */
 export interface DateSpinnerProps
   extends GlobalProps,
     Pick<
@@ -2111,102 +1977,114 @@ export interface DateSpinnerProps
       'defaultValue' | 'value' | 'onInput' | 'onChange' | 'onBlur' | 'onFocus'
     > {
   /**
-   * Default selected value for the spinner.
-   *
-   * This uses a date in `YYYY-MM-DD` format.
+   * The default date value used when the field is first rendered, in ISO date format (YYYY-MM-DD, for example, `"2024-05-15"`). An empty string means no default date. Only applies if no `value` prop is provided.
    *
    * @default ""
    */
   defaultValue?: string;
   /**
-   * Current selected value for the spinner.
-   *
-   * This uses a date in `YYYY-MM-DD` format.
+   * The currently selected date value in ISO date format (YYYY-MM-DD, for example, `"2024-05-15"`). An empty string means no date is selected.
    *
    * @default ""
    */
   value?: string;
   /**
-   * Callback after the wheels have finished spinning and the value has
-   * settled.
-   *
-   * Fires once when inertial/momentum scrolling stops and the selection snaps
-   * into place.
+   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: Event) => void;
   /**
-   * Callback when the selection has been confirmed by the user.
-   *
-   * Fires only when the user explicitly commits the selection (for example, by
-   * pressing a confirmation control).
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: Event) => void;
 }
+/**
+ * Properties for a visual divider line that separates content sections.
+ */
 export interface DividerProps extends GlobalProps {
   /**
-   * Specify the direction of the divider. This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
+   * The direction of the divider using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values). An inline divider runs horizontally across the content flow, while a block divider runs vertically along the content flow.
+   * 
+   * Available options:
+   * - `'inline'`: A horizontal divider that runs perpendicular to the text direction, creating separation between vertically stacked content sections.
+   * - `'block'`: A vertical divider that runs parallel to the text direction, creating separation between horizontally arranged content sections.
    *
    * @default 'inline'
    */
   direction?: 'inline' | 'block';
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the divider. Controls how prominent or subtle the divider appears.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
 }
+/**
+ * Properties for an email address input field with validation and autocomplete support.
+ */
 export interface EmailFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
     MinMaxLengthProps,
     AutocompleteProps<EmailAutocompleteField> {}
+/**
+ * Autocomplete field types applicable to email input fields.
+ */
 export type EmailAutocompleteField = ExtractStrict<
   AnyAutocompleteField,
   'email' | `${AutocompleteAddressGroup} email`
 >;
+/**
+ * A spacing size keyword including the option for no spacing.
+ */
 export type SpacingKeyword = SizeKeyword | 'none';
+/**
+ * Properties for controlling the spacing between child elements in a container.
+ */
 export interface GapProps {
   /**
-   * Adjust spacing between elements.
-   *
-   * A single value applies to both axes.
-   * A pair of values (eg `large-100 large-500`) can be used to set the inline and block axes respectively.
+   * The spacing between child elements. A single value applies to both axes. Two values (for example, `large-100 large-500`) set the block axis (first value) and inline axis (second value) respectively.
    *
    * @default 'none'
    */
   gap?: MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>;
   /**
-   * Adjust spacing between elements in the block axis.
-   *
-   * This overrides the row value of `gap`.
+   * The spacing between child elements along the block axis (typically vertical). Overrides the block axis value from `gap`.
    *
    * @default '' - meaning no override
    */
   rowGap?: MaybeResponsive<SpacingKeyword | ''>;
   /**
-   * Adjust spacing between elements in the inline axis.
-   *
-   * This overrides the column value of `gap`.
+   * The spacing between child elements along the inline axis (typically horizontal). Overrides the inline axis value from `gap`.
    *
    * @default '' - meaning no override
    */
   columnGap?: MaybeResponsive<SpacingKeyword | ''>;
 }
+/**
+ * A baseline alignment position keyword.
+ */
 export type BaselinePosition = 'baseline' | 'first baseline' | 'last baseline';
+/**
+ * A content distribution strategy keyword for spacing.
+ */
 export type ContentDistribution =
   | 'space-between'
   | 'space-around'
   | 'space-evenly'
   | 'stretch';
+/**
+ * A content position alignment keyword.
+ */
 export type ContentPosition = 'center' | 'start' | 'end';
+/**
+ * A content position with optional overflow safety modifier.
+ */
 export type OverflowPosition =
   | `unsafe ${ContentPosition}`
   | `safe ${ContentPosition}`;
 /**
- * Align items sets the align-self value on all direct children as a group.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
+ * A type that defines how children are aligned along the cross axis.
+ * Sets the align-self value on all direct children as a group. Learn more about [`align-items` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
  */
 export type AlignItemsKeyword =
   | 'normal'
@@ -2215,9 +2093,7 @@ export type AlignItemsKeyword =
   | OverflowPosition
   | ContentPosition;
 /**
- * Justify content defines how the browser distributes space between and around content items along the main-axis of a flex container, and the inline axis of a grid container.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
+ * A type that defines how the browser distributes space between and around content items along the main-axis of a flex container, and the inline axis of a grid container. Learn more about [`justify-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
  */
 export type JustifyContentKeyword =
   | 'normal'
@@ -2225,9 +2101,7 @@ export type JustifyContentKeyword =
   | OverflowPosition
   | ContentPosition;
 /**
- *Align content sets the distribution of space between and around content items along a flexbox's cross axis, or a grid or block-level element's block axis.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
+ * A type that defines the distribution of space between and around content items along a flexbox's cross axis, or a grid or block-level element's block axis. Learn more about [`align-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
  */
 export type AlignContentKeyword =
   | 'normal'
@@ -2235,276 +2109,253 @@ export type AlignContentKeyword =
   | ContentDistribution
   | OverflowPosition
   | ContentPosition;
+/**
+ * Base properties for text styling and appearance.
+ */
 export interface BaseTypographyProps {
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the text. Controls how prominent or subtle the text appears within the interface.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
   /**
-   * Sets the tone of the component, based on the intention of the information being conveyed.
+   * The semantic tone of the text, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Set the numeric properties of the font.
+   * Controls how numbers are displayed in the text:
+   * - `'auto'`: Inherits the setting from the parent element.
+   * - `'normal'`: Uses the default number rendering for the font.
+   * - `'tabular-nums'`: Uses fixed-width numbers for better alignment in tables and lists.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric
+   * Learn more about [`font-variant-numeric` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
    *
-   * @default 'auto' - inherit from the parent element
+   * @default 'auto'
    */
   fontVariantNumeric?: 'auto' | 'normal' | 'tabular-nums';
   /**
-   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
-   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
-   * [Reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label)
-   *
-   * It is recommended to combine it with the `dir` attribute to ensure the text is rendered correctly if the surrounding content’s direction is different.
+   * Specifies the language of text content using an [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) language tag (for example, `"en"` for English, `"fr"` for French, `"es-MX"` for Mexican Spanish, `"zh-Hans"` for Simplified Chinese). This enables assistive technologies to use correct pronunciation and language-specific text rendering.
    *
    * @default ''
    */
   lang?: string;
   /**
-   * Indicates the directionality of the element’s text.
+   * Indicates the directionality of the element's text:
+   * - `ltr`: languages written from left to right (for example, English).
+   * - `rtl`: languages written from right to left (for example, Arabic).
+   * - `auto`: the user agent determines the direction based on the content.
+   * - `''`: direction is inherited from parent elements (equivalent to not setting the attribute).
    *
-   * - `ltr`: languages written from left to right (e.g. English)
-   * - `rtl`: languages written from right to left (e.g. Arabic)
-   * - `auto`: the user agent determines the direction based on the content
-   * - `''`: direction is inherited from parent elements (equivalent to not setting the attribute)
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir
+   * Learn more about the [`dir` attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir).
    *
    * @default ''
    */
   dir?: 'ltr' | 'rtl' | 'auto' | '';
 }
+/**
+ * Properties for controlling multi-line text behavior and truncation.
+ */
 export interface BlockTypographyProps {
   /**
-   * Truncates the text content to the specified number of lines.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
+   * Limits the text content to a specified number of visible lines. When text exceeds this limit, it's truncated and an ellipsis (`…`) appears at the end of the last visible line to indicate more content exists. The truncation happens automatically based on the container's width, font size, and line height—narrow containers or large fonts will show fewer words per line. For example, `lineClamp={3}` allows maximum three lines of text regardless of total content length. Users can't access the hidden text unless an expansion mechanism (like a "Read more" button) or tooltip is provided. Commonly applied to maintain consistent layout heights in cards, lists, or grids where varying text lengths would disrupt visual alignment. Common values include 1-2 for titles/labels, 2-3 for descriptions, and 4-6 for preview text. The actual text content remains in the DOM and is accessible to screen readers (full text is announced), search engines, and selection—only the visual display is truncated. Learn more about [`line-clamp` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).
    *
    * @default Infinity - no truncation is applied
    */
   lineClamp?: number;
 }
+/**
+ * Properties for heading text elements with semantic structure and line clamping.
+ */
 export interface HeadingProps
   extends GlobalProps,
     AccessibilityVisibilityProps,
     BlockTypographyProps {
   /**
-   * The content of the Heading.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help users
-   * navigate the page.
-   *
-   * - `heading`: defines the element as a heading to a page or section.
-   * - `presentation`: the heading level will be stripped,
-   * and will prevent the element’s implicit ARIA semantics from
-   * being exposed to the accessibility tree.
-   * - `none`: a synonym for the `presentation` role.
+   * Sets the semantic role for assistive technologies. Helps screen reader users navigate and understand page structure.
    *
    * @default 'heading'
    *
    * @implementation The `heading` role doesn't need to be applied if
    * the host applies it for you; for example, an HTML host rendering
-   * an `<h2>` element should not apply the `heading` role.
+   * an `<h2>` element shouldn't apply the `heading` role.
    */
   accessibilityRole?:
     | 'heading'
     | ExtractStrict<AccessibilityRole, 'presentation' | 'none'>;
 }
+/**
+ * Properties for icon elements including type, size, color, and tone.
+ */
 export interface IconProps
   extends GlobalProps,
     Pick<InteractionProps, 'interestFor'> {
   /**
-   * Sets the tone of the icon, based on the intention of the information being conveyed.
+   * The semantic tone of the icon, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Modify the color to be more or less intense.
+   * The color intensity of the icon. Controls how prominent or subtle the icon appears within the interface.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
   /**
-   * Adjusts the size of the icon.
+   * Adjusts the size of the icon. Available sizes range from `'small-500'` (smallest) through `'base'` (default) to `'large-500'` (largest), allowing you to match icon size to your interface hierarchy.
    *
    * @default 'base'
    */
   size?: SizeKeyword;
+  /**
+   * The icon identifier specifying which icon to display. Accepts any valid icon name from the icon set.
+   */
   type?: IconType | AnyString;
 }
+/**
+ * Base properties for image elements including source URLs and alternative text.
+ */
 export interface BaseImageProps {
   /**
-   * An alternative text description that describe the image for the reader to
-   * understand what it is about. It is extremely useful for both users using
-   * assistive technology and sighted users. A well written description
-   * provides people with visual impairments the ability to participate in
-   * consuming non-text content. When a screen readers encounters an `s-image`,
-   * the description is read and announced aloud. If an image fails to load,
-   * potentially due to a poor connection, the `alt` is displayed on
-   * screen instead. This has the benefit of letting a sighted buyer know an
-   * image was meant to load here, but as an alternative, they’re still able to
-   * consume the text content. Read
-   * [considerations when writing alternative text](https://www.shopify.com/ca/blog/image-alt-text#4)
-   * to learn more.
+   * Alternative text that describes the image content for users who can't see the image. This text is announced by screen readers, displayed when images fail to load or are blocked, and used by search engines for image indexing. Write concise, descriptive alt text that conveys the image's purpose and content (for example, "Product photo of blue running shoes" not "image" or "photo"). For decorative images that don't convey information, use an empty string (`alt=""`) to hide them from screen readers. For images containing text, include that text in the alt description. For complex images like charts or diagrams, consider providing a longer description elsewhere and summarizing in alt text. Alt text is required for accessibility compliance and should describe what users would miss if they couldn't see the image. Learn more about [`alt` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).
    *
    * @default `''`
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt
    */
   alt?: string;
   /**
-   * A set of media conditions and their corresponding sizes.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes
+   * Defines the image sizes for different viewport widths to help the browser select the optimal image from `srcSet`. This is a comma-separated list of media conditions and corresponding sizes (for example, `"(max-width: 600px) 480px, 800px"`). The browser uses this with `srcSet` to determine which image variant to download based on the device's screen size and pixel density, improving performance by loading appropriately-sized images. For example, mobile devices receive smaller images while desktops get larger, higher-resolution versions. When `srcSet` provides multiple image sizes, `sizes` tells the browser the rendered size at different viewport widths. If omitted, the browser assumes `100vw` (full viewport width). This only affects which image is selected, not how it's displayed—use CSS or `inlineSize` for display sizing. Learn more about [`sizes` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes).
    */
   sizes?: string;
   /**
-   * The image source (either a remote URL or a local file resource).
-   *
-   * When the image is loading or no `src` is provided, a placeholder will be rendered.
+   * The primary image source URL. Accepts absolute URLs (`https://example.com/image.jpg`), relative paths (`/images/product.jpg`), or data URLs (`data:image/png;base64,...`). When the image is loading or if `src` is omitted/invalid, a placeholder is displayed while reserving the image's space to prevent layout shifts. The URL must be accessible (proper [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) headers for cross-origin images), use appropriate protocols ([HTTPS](https://en.wikipedia.org/wiki/HTTPS) for security), and point to valid image formats (JPEG, PNG, GIF, WebP, SVG). Failed loads trigger the `onError` callback if provided. For responsive images serving different sizes/resolutions, `srcSet` can be used in addition to `src` (which then serves as the fallback). Images are loaded asynchronously—the `loading` property controls when loading begins. Learn more about [`src` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
    *
    * @implementation Surfaces may choose the style of the placeholder, but the space the image occupies should be
-   * reserved, except in cases where the image area does not have a contextual inline or block size, which should be rare.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src
+   * reserved, except in cases where the image area doesn't have a contextual inline or block size, which should be rare.
    */
   src?: string;
   /**
-   * A set of image sources and their width or pixel density descriptors.
-   *
-   * This overrides the `src` property.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset
+   * A set of image source URLs with descriptors for responsive image selection. Provides multiple image variants at different widths or pixel densities, allowing browsers to choose the most appropriate image for the user's device and screen. Format: comma-separated list of `URL descriptor` pairs where descriptors are either width (`w`) or pixel density (`x`). For example: `"small.jpg 480w, medium.jpg 800w, large.jpg 1200w"` for different widths, or `"standard.jpg 1x, retina.jpg 2x"` for different pixel densities. The browser considers the device's screen size, resolution, network speed, and user preferences when selecting which image to download. This improves performance (smaller images on mobile) and quality (high-DPI images on retina displays). When used with `sizes`, enables fully responsive images. The `src` property serves as fallback for browsers that don't support `srcSet`. Learn more about [img srcset on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset).
    */
   srcSet?: string;
 }
+/**
+ * Properties for image elements including size, aspect ratio, loading behavior, and border styling.
+ */
 export interface ImageProps extends GlobalProps, BaseImageProps, BorderProps {
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help users
-   * navigate the page.
+   * Sets the semantic role for assistive technologies. Helps screen reader users navigate and understand page structure.
    *
    * @default 'img'
    *
    * @implementation The `img` role doesn't need to be applied if
    * the host applies it for you; for example, an HTML host rendering
-   * an `<img>` element should not apply the `img` role.
+   * an `<img>` element shouldn't apply the `img` role.
    */
   accessibilityRole?:
     | 'img'
     | ExtractStrict<AccessibilityRole, 'presentation' | 'none'>;
   /**
-   * The displayed inline width of the image.
+   * Controls the displayed width of the image. The choice depends on layout requirements—for mobile interfaces, `'fill'` with defined container dimensions ensures consistent image display, as dynamic container heights can cause layout inconsistencies in scrollable views.
+   * - `'auto'`: Displays the image at its natural size. The image won't render until it has loaded, and the aspect ratio will be ignored. Typically applied when maintaining original dimensions is important.
+   * - `'fill'`: Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Commonly applied to responsive layouts and flexible image containers.
    *
-   * - `fill`: the image will takes up 100% of the available inline size.
-   * - `auto`: the image will be displayed at its natural size.
+   * Learn more about [`width` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
    *
    * @default 'fill'
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width
    */
   inlineSize?: 'fill' | 'auto';
   /**
-   * The aspect ratio of the image.
+   * The aspect ratio of the image, expressed as width divided by height.
    *
    * The rendering of the image will depend on the `inlineSize` value:
    *
    * - `inlineSize="fill"`: the aspect ratio will be respected and the image will take the necessary space.
-   * - `inlineSize="auto"`: the image will not render until it has loaded and the aspect ratio will be ignored.
+   * - `inlineSize="auto"`: the image won't render until it has loaded and the aspect ratio will be ignored.
    *
    * For example, if the value is set as `50 / 100`, the getter returns `50 / 100`.
    * If the value is set as `0.5`, the getter returns `0.5 / 1`.
    *
-   * @default '1/1'
+   * Learn more about [`aspect-ratio` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio
+   * @default '1/1'
    */
   aspectRatio?:
     | `${number}${optionalSpace}/${optionalSpace}${number}`
     | `${number}`;
   /**
-   * Determines how the content of the image is resized to fit its container.
-   * The image is positioned in the center of the container.
+   * Controls how the image content is resized within its container:
+   * - `'contain'`: Scales the image to fit within the container while maintaining aspect ratio. The entire image will be visible, but there may be empty space. Typically applied when showing the complete image is important.
+   * - `'cover'`: Scales the image to fill the entire container while maintaining aspect ratio. Parts of the image may be cropped. Typically applied when filling the container completely is more important than showing the entire image.
+   *
+   * Learn more about [`object-fit` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).
    *
    * @default 'contain'
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
    */
   objectFit?: 'contain' | 'cover';
   /**
-   * Determines the loading behavior of the image:
-   * - `eager`: Immediately loads the image, irrespective of its position within the visible viewport.
-   * - `lazy`: Delays loading the image until it approaches a specified distance from the viewport.
+   * Controls when the browser should begin loading the image resource:
+   * - `'eager'`: Loads the image immediately when the page loads, regardless of whether it's visible in the viewport. The image downloads in parallel with other page resources. Typically applied to above-the-fold images, critical product photos, or images that will definitely be viewed. This ensures images are ready when needed but increases initial page load bandwidth.
+   * - `'lazy'`: Defers image loading until the image is approaching the viewport (typically a few hundred pixels before becoming visible). The browser only downloads the image when the user is likely to see it soon. Commonly applied to below-the-fold images, gallery images, or images in scrollable lists. This improves initial page load performance and saves bandwidth for images users may never scroll to. The browser maintains a buffer distance so images load before users reach them, preventing visible loading delays.
+   *
+   * Lazy loading is most effective for pages with many images, long scrollable content, or mobile users on limited bandwidth. Modern browsers support native lazy loading—older browsers ignore this and load eagerly. Learn more about [`loading` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading).
    *
    * @default 'eager'
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading
    */
   loading?: 'eager' | 'lazy';
   /**
-   * Invoked when load completes successfully.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload
+   * A callback function executed when the image finishes loading successfully and is ready to display. This fires after the browser has downloaded the image data and decoded it, but may fire before the image is actually painted to the screen. Common operations include hiding loading indicators, triggering dependent actions that require the image (like image processing), tracking image load metrics, or executing layout operations that depend on image dimensions. For performance tracking, timestamps between navigation start and this callback can be compared. Cached images may trigger this callback synchronously (immediately), so both async and sync invocation should be handled in code. This won't fire if the image fails to load—`onError` fires for failures. Learn more about [`onload` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload).
    */
   onLoad?: (event: Event) => void;
   /**
-   * Invoked on load error.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
+   * A callback function executed when the image fails to load due to network errors, invalid URLs, unsupported formats, [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) issues, or server errors (for example, 404, 500). The event contains limited error details for security reasons—the browser console provides specific failure reasons. Common operations include displaying fallback images (`event.target.src = 'fallback.jpg'`), showing error messages to users, logging failures for monitoring, hiding broken image icons, or providing alternative content when images are unavailable. A common pattern involves attempting to load a fallback image, and if that fails too, hiding the image container entirely. For critical images like product photos, a placeholder SVG or icon may be shown instead of a broken image indicator. This callback doesn't fire for images that are blocked by browser content policies or ad blockers. Learn more about [`onerror` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror).
    */
   onError?: (event: Event) => void;
 }
+/**
+ * Properties for modal overlay dialogs including size, padding, actions, and lifecycle callbacks.
+ */
 export interface ModalProps
   extends GlobalProps,
     BaseOverlayProps,
     BaseOverlayMethods,
     ActionSlots {
   /**
-   * A label that describes the purpose of the modal. When set,
-   * it will be announced to users using assistive technologies and will
-   * provide them with more context.
-   *
-   * This overrides the `heading` prop for screen readers.
+   * A text label that describes the purpose, function, or contents of the element for users of assistive technologies like screen readers. This label is announced by screen readers but isn't visually displayed. Typically applied when an element doesn't have visible text that adequately describes it, such as icon-only buttons, image carousels, or complex interactive regions. The label is concise yet descriptive (for example, "Close modal", "Product image carousel", "Shopping cart with 3 items"). If the element already has clear visible labels or headings, this property may be unnecessary. For form fields, the `label` property is both visible and accessible.
    */
   accessibilityLabel?: string;
   /**
-   * A title that describes the content of the Modal.
-   *
+   * The title text displayed prominently in the modal's header section. This heading identifies the modal's purpose and provides context for the modal's content. When provided along with action buttons, creates a full modal header with title and actions. If both `heading` and actions (`primaryAction`/`secondaryActions`) are omitted, the modal renders without a header section entirely, starting directly with the modal content. The heading is automatically announced by screen readers when the modal opens. Clear, descriptive headings immediately communicate the modal's purpose (for example, "Confirm deletion", "Edit product details", "Select payment method").
    */
   heading?: string;
   /**
-   * Adjust the padding around the Modal content.
-   *
-   * `base`: applies padding that is appropriate for the element.
-   *
-   * `none`: removes all padding from the element. This can be useful when elements inside the Modal need to span
-   * to the edge of the Modal. For example, a full-width image. In this case, rely on `Box` with a padding of 'base'
-   * to bring back the desired padding for the rest of the content.
+   * The padding applied to all edges of the modal content.
    *
    * @default 'base'
    */
   padding?: 'base' | 'none';
   /**
-   * Adjust the size of the Modal.
-   *
-   * `max`: expands the Modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
+   * Controls the display size of the modal:
+   * - Size keywords (for example, `'small'`, `'base'`, `'large'`): Fixed size options.
+   * - `'max'`: Modal expands to fill the maximum available space.
    *
    * @default 'base'
    */
   size?: SizeKeyword | 'max';
   /**
-   * The content of the Modal.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
 }
+/**
+ * Properties for numeric input fields with validation, constraints, and optional stepper controls.
+ */
 export interface NumberFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
@@ -2512,64 +2363,72 @@ export interface NumberFieldProps
     NumberConstraintsProps,
     FieldDecorationProps {
   /**
-   * Sets the virtual keyboard.
+   * The virtual keyboard layout displayed for numeric input on touch-enabled devices like tablets and smartphones. This property has no effect on desktop devices with physical keyboards. Not supported when using `stepper` controls.
+   * - `'decimal'`: Shows a numeric keyboard with a decimal point/comma key. Best for monetary amounts (for example, "$19.99"), measurements with precision (for example, "2.5 kg"), percentages (for example, "15.5%"), or any fractional values. The decimal separator adapts to the user's locale (period in US, comma in Europe).
+   * - `'numeric'`: Shows a numeric keyboard without decimal point, displaying only digits 0-9 and sometimes +/- symbols. Best for quantities (for example, "5 items"), whole number identifiers (for example, "Order #12345"), phone numbers, or any integer-only input. Prevents accidental decimal entry which can confuse users for whole number fields.
+   * 
+   * On mobile POS devices, choosing the correct `inputMode` significantly improves data entry speed and reduces errors by showing the most relevant keyboard. Users can still switch keyboards manually if needed. Learn more about [`inputmode` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
    * @default 'decimal'
    */
   inputMode?: 'decimal' | 'numeric';
 }
+/**
+ * Autocomplete field types applicable to number input fields.
+ */
 export type NumberAutocompleteField = ExtractStrict<
   AnyAutocompleteField,
   'one-time-code' | 'cc-number' | 'cc-csc'
 >;
+/**
+ * Properties for page-level layouts including header, breadcrumbs, actions, and sidebar content.
+ */
 export interface PageProps extends GlobalProps, ActionSlots {
   /**
-   * The content of the Page.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * The main page heading
+   * The main title text displayed prominently in the page header's title area. This heading identifies the page's primary purpose and provides context for all page content. When provided along with action buttons or breadcrumbs, creates a complete page header with navigation and actions. If both `heading` and all header elements (`primaryAction`, `secondaryActions`, `breadcrumbActions`, `accessory`) are omitted, the page renders without a header section, starting directly with page content. The heading is typically the largest text on the page and helps users understand where they are in the application. Clear, descriptive headings identify the page's purpose (for example, "Product catalog", "Customer details", "Order #1234").
    */
   heading?: string;
   /**
-   * The text to be used as subtitle.
+   * Secondary descriptive text displayed directly below the main heading in a smaller, subdued style. Provides additional context, status information, or supplementary details about the page without overwhelming the primary heading. Common content includes page descriptions ("Manage your product inventory"), status indicators ("Last updated 2 hours ago"), record counts ("145 products"), or contextual metadata. The subheading is optional and typically applied when additional context genuinely helps users understand the page. Brevity is important as it competes with the main heading for attention.
    */
   subheading?: string;
   /**
-   * Additional contextual information about the page.
+   * Additional content displayed in the header area, typically action buttons or clickable text elements that complement the primary and secondary actions. Only `Button` and `Clickable` components with text content are supported in this slot. Elements must use the `slot="accessory"` attribute to be placed in this area. Commonly displays contextual actions like "View history", "Export data", or status indicators.
    */
   accessory?: ComponentChildren;
   /**
-   * The breadcrumb actions to perform, provided as link elements.
+   * Navigation breadcrumb links displayed in the page header as a series of link elements showing the hierarchical path to the current page. Breadcrumbs help users understand their location within the app structure and provide quick navigation to parent pages (for example, "Home > Products > Electronics > Smartphones"). Each breadcrumb item is typically a clickable link except the current page, which may be displayed as plain text or a disabled link.
    */
   breadcrumbActions?: ComponentChildren;
   /**
-   * The aside element is section of a page that contains content that is tangentially related to the content around the aside element, and which could be considered separate from that content.
-   * Such sections are often represented as sidebars in printed typography.
+   * The content to display in the page's sidebar area. This area contains content that is tangentially related to the main content, such as navigation menus, contextual help, related links, or supplementary information. Elements placed here must use the `slot="aside"` attribute. The sidebar content is visually separated from the main content and may be positioned differently depending on the layout (typically to the side of the main content).
+   *
    * @implementation surfaces built ontop of the web platform should implement this using the <aside> element https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside
    */
   aside?: ComponentChildren;
   /**
-   * The inline size of the page
-   * - `base` corresponds to a set default inline size
-   * - `large` full width with whitespace
+   * Controls the maximum width of the page content.
    *
    * @default 'base'
    */
   inlineSize?: SizeKeyword;
 }
+/**
+ * Properties for POS-specific content blocks with optional heading and secondary actions.
+ */
 export interface POSBlockProps
   extends GlobalProps,
     Pick<ActionSlots, 'secondaryActions'> {
   /**
-   * The heading to display within the POSBlock.
-   *
-   * If not provided, the description of the extension will be used when a heading is appropriate.
+   * The title text displayed in the block's header section, identifying the purpose or content of this block. When provided along with `secondaryActions`, creates a block header with both title and action buttons. If both `heading` and `secondaryActions` are omitted, the block renders without a header, starting directly with the block's child content. Blocks are typically used to organize related content within a page into distinct, titled sections. Clear, descriptive headings identify the block's content type (for example, "Recent orders", "Quick actions", "Customer information").
    */
   heading?: string;
   /**
-   * The content to display within the POSBlock.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
@@ -2577,158 +2436,149 @@ export interface POSBlockProps
    */
   secondaryActions?: ComponentChildren;
 }
+/**
+ * Properties for QR code elements including content, size, border, and optional logo.
+ */
 export interface QRCodeProps extends GlobalProps {
   /**
-   * Set the border of the QR code.
-   *
-   * `base`: applies border that is appropriate for the element.
-   * `none`: removes the border from the element.
+   * Controls whether a border is displayed around the QR code.
    *
    * @default 'base'
    */
   border?: 'base' | 'none';
   /**
-   * The content to be encoded in the QR code, which can be any string such as a URL, email address, plain text, etc.
-   * Specific string formatting can trigger actions on the user's device when scanned, like opening geolocation
-   * coordinates on a map, opening a preferred app or app store entry, preparing an email, text message, and more.
+   * The content to be encoded in the QR code. This can be any string such as a URL, email address, plain text, or other data. Specific string formatting can trigger actions on the user's device when scanned, like opening geolocation coordinates on a map, opening a preferred app or app store entry, preparing an email, text message, and more.
    */
   content?: string;
   /**
-   * The displayed size of the QR code.
-   *
-   * `fill`: the QR code will takes up 100% of the available inline-size and maintain a 1:1 aspect ratio.
-   * `base`: the QR code will be displayed at its default size.
+   * Controls the display size of the QR code:
+   * - `'base'`: Fixed size QR code
+   * - `'fill'`: QR code expands to fill available space
    *
    * @default 'base'
    */
   size?: 'base' | 'fill';
   /**
-   * A label that describes the purpose or contents of the QR code. When set,
-   * it will be announced to users using assistive technologies and will
-   * provide more context about what the QR code may do when scanned.
+   * A label that describes the purpose or contents of the element. Announced to users with assistive technologies such as screen readers to provide context.
    *
    * @default 'QR code' (translated to the user's locale)
    */
   accessibilityLabel?: string;
   /**
-   * Invoked when the conversion of `content` to a QR code fails.
-   * If an error occurs, the QR code and its child elements will not be displayed.
+   * A callback function executed when the resource fails to load.
    */
   onError?: (event: Event) => void;
   /**
-   * URL of an image to be displayed in the center of the QR code.
+   * The URL of an image to be displayed in the center of the QR code.
    * This is useful for branding or to indicate to the user what scanning the QR code will do.
    * By default, no image is displayed.
    */
   logo?: string;
 }
+/**
+ * Properties for scroll-related event callbacks and edge detection.
+ */
 export interface ScrollEventProps {
   /**
-   * Callback when the scroll position reaches any edge.
+   * A callback function executed when scrolling reaches or moves away from any edge of the scrollable container.
    *
-   * Provides information about which edges have been reached:
-   * - `inline: 'start'` - reached the inline-start edge
-   * - `inline: 'end'` - reached the inline-end edge
-   * - `block: 'start'` - reached the block-start edge
-   * - `block: 'end'` - reached the block-end edge
+   * Provides information about which edges are currently reached:
+   * - `inline: 'start'` - at the inline-start edge (typically left in LTR)
+   * - `inline: 'end'` - at the inline-end edge (typically right in LTR)
+   * - `block: 'start'` - at the block-start edge (typically top)
+   * - `block: 'end'` - at the block-end edge (typically bottom)
    * - `null` - not at that edge
-   *
-   * Uses the flow‑relative axes.
    */
   onScrollToEdge?: (
     inline: 'start' | 'end' | null,
     block: 'start' | 'end' | null,
   ) => void;
   /**
-   * Distance from the edge at which `onScrollToEdge` fires.
-   * Percentage values are relative to the scrollable content's size in that axis.
-   *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
-   * supported.
-   *
-   * The order is:
+   * The threshold distance from each edge at which `onScrollToEdge` triggers. Percentage values are relative to the scrollable content's size in that axis. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) in the order:
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
+   * - 1 value: applies to all edges
    *
    * For example:
-   * - `48px` means the distance from the edge at which `onScrollToEdge` fires from block-start, inline-end, block-end and inline-start is `48px`.
-   * - `48px 0` means the distance from the edge at which `onScrollToEdge` fires from block-start and block-end is `48px`, and for inline-start and inline-end is `0`.
-   * - `48 0 48` means the distance from the edge at which `onScrollToEdge` fires from block-start is `48px`, for inline-end is `0`, for block-end is `48px` and for inline-start is `0`.
-   * - `48px 0 48px 10%` means the distance from the edge at which `onScrollToEdge` fires from block-start is `48px`, for inline-end is `0`, for block-end is `48px` and for inline-start is `10%`.
+   * - `48px` - triggers 48px from all edges
+   * - `48px 0` - triggers 48px from block edges, 0px from inline edges
+   * - `48px 0 48px 10%` - custom distance for each edge
+   *
+   * Learn more about [`scrollMargin` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/scrollMargin).
    *
    * @default '0'
-   * Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/scrollMargin) for more details.
    */
   scrollMargin?: MaybeAllValuesShorthandProperty<SizeUnits>;
 }
+/**
+ * An overflow behavior keyword.
+ */
 export type OverflowKeyword = 'auto' | 'hidden';
+/**
+ * Properties for scrollable container elements with overflow control and scroll event detection.
+ */
 export interface ScrollBoxProps
   extends GlobalProps,
     ScrollEventProps,
     Omit<BaseBoxPropsWithRole, 'overflow'> {
   /**
-   * Sets the overflow behavior of the element.
-   *
-   * - `hidden`: clips the content when it is larger than the element’s container and the element will not be scrollable in that axis.
-   * - `auto`: clips the content when it is larger than the element’s container and make it scrollable in that axis.
-   *
-   * 1-to-2-value syntax is supported but note that, contrary to the CSS, it uses flow-relative values and the order is:
-   *
-   * - 2 values: `block inline`
+   * Sets overflow behavior when content exceeds container dimensions. Use `'auto'` for scrolling or `'hidden'` to clip content. Learn more about [CSS overflow on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow).
    *
    * @default 'auto'
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/overflow
    */
   overflow?: OverflowKeyword | `${OverflowKeyword} ${OverflowKeyword}`;
 }
+/**
+ * Properties for search input fields with text validation and autocomplete support.
+ */
 export interface SearchFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
     MinMaxLengthProps,
     AutocompleteProps<SearchAutocompleteField> {}
+/**
+ * Autocomplete field types applicable to search input fields (same as text fields).
+ */
 export type SearchAutocompleteField = TextAutocompleteField;
+/**
+ * Properties for content sections with optional heading and actions.
+ */
 export interface SectionProps extends GlobalProps, ActionSlots {
   /**
-   * The content of the Section.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * A label used to describe the section that will be announced by assistive technologies.
-   *
-   * When no `heading` property is provided or included as a children of the Section, you **must** provide an
-   * `accessibilityLabel` to describe the Section. This is important as it allows assistive technologies to provide
-   * the right context to users.
+   * A text label that describes the purpose, function, or contents of the element for users of assistive technologies like screen readers. This label is announced by screen readers but isn't visually displayed. Typically applied when an element doesn't have visible text that adequately describes it, such as icon-only buttons, image carousels, or complex interactive regions. The label is concise yet descriptive (for example, "Close modal", "Product image carousel", "Shopping cart with 3 items"). If the element already has clear visible labels or headings, this property may be unnecessary. For form fields, the `label` property is both visible and accessible.
    */
   accessibilityLabel?: string;
   /**
-   * A title that describes the content of the section.
+   * The title text displayed in the section's header, identifying the thematic grouping or purpose of the section's content. Sections represent thematic groups of content, and the heading helps users understand what the section contains. When provided along with action buttons, creates a section header with both title and actions. If both `heading` and `secondaryActions` are omitted, the section renders without a header, though sections generally have headings for accessibility—screen readers rely on headings to help users navigate page structure. Descriptive headings clearly identify the section's content (for example, "Order summary", "Shipping details", "Payment options").
    */
   heading?: string;
   /**
-   * Adjust the padding of all edges.
-   *
-   * - `base`: applies padding that is appropriate for the element. Note that it may result in no padding if
-   * this is the right design decision in a particular context.
-   * - `none`: removes all padding from the element. This can be useful when elements inside the Section need to span
-   * to the edge of the Section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base'
-   * to bring back the desired padding for the rest of the content.
+   * The padding applied to all edges of the section content.
    *
    * @default 'base'
    */
   padding?: 'base' | 'none';
 }
+/**
+ * Properties for flexible layout containers with directional flow and alignment control.
+ */
 export interface StackProps
   extends GlobalProps,
     BaseBoxPropsWithRole,
     GapProps {
   /**
-   * The content of the Stack.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Sets how the children are placed within the Stack. This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
+   * The direction in which children are laid out using logical properties:
+   * - `'block'`: Vertical arrangement along the block axis (typically top to bottom) without wrapping
+   * - `'inline'`: Horizontal arrangement along the inline axis (typically left to right) with automatic wrapping when space is insufficient
    *
    * @default 'block'
    *
@@ -2736,27 +2586,27 @@ export interface StackProps
    */
   direction?: MaybeResponsive<'block' | 'inline'>;
   /**
-   * Aligns the Stack along the main axis.
+   * Controls the distribution and alignment of children along the main axis (the axis defined by the `direction` property). Learn more about [`justify-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
    * @default 'normal'
    */
   justifyContent?: MaybeResponsive<JustifyContentKeyword>;
   /**
-   * Aligns the Stack's children along the cross axis.
+   * Controls the alignment of individual children along the cross axis (perpendicular to the main axis). Learn more about [`align-items` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
    * @default 'normal'
    */
   alignItems?: MaybeResponsive<AlignItemsKeyword>;
   /**
-   * Aligns the Stack along the cross axis.
+   * Controls the distribution of space between and around lines of wrapped content along the cross axis. Learn more about [`align-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
    * @default 'normal'
    */
   alignContent?: MaybeResponsive<AlignContentKeyword>;
 }
+/**
+ * Properties for inline text elements with semantic meaning and styling options.
+ */
 export interface TextProps
   extends GlobalProps,
     AccessibilityVisibilityProps,
@@ -2764,13 +2614,11 @@ export interface TextProps
     DisplayProps,
     Pick<InteractionProps, 'interestFor'> {
   /**
-   * The content of the Text.
+   * The child elements to render within this component.
    */
   children?: ComponentChildren;
   /**
-   * Provide semantic meaning and default styling to the text.
-   *
-   * Other presentation properties on Text override the default styling.
+   * The semantic meaning of the text, which may affect its default styling and how screen readers announce it. Other presentation properties can override the default styling.
    *
    * @default 'generic'
    */
@@ -2778,225 +2626,178 @@ export interface TextProps
 }
 export type TextType =
   /**
-   * Indicate the text is contact information. Typically used for addresses.
+   * Indicates that the text is contact information. Typically used for addresses.
    *
    * This must have `inline` layout (despite the default being `block` in HTML hosts).
    *
    * Surfaces may apply styling to this type.
    *
-   * In an HTML host, the text will be rendered in an `<address>` element.
+   * In an HTML host, the text will be rendered in an `<address>` element. Learn more about the [`address` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address).
    *
    * @implementation vertical alignment should be `baseline` (`vertical-align: baseline`)
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
    */
   | 'address'
   /**
-   * Indicate the text is no longer accurate or no longer relevant. One such use-case is discounted prices.
+   * Indicates that the text is no longer accurate or no longer relevant. One such use-case is discounted prices.
    *
    * Surfaces should apply styling to this type to suggest its content no longer applies.
    *
-   * In an HTML host, the text will be rendered in a `<s>` element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
+   * In an HTML host, the text will be rendered in a `<s>` element. Learn more about the [`s` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s).
    */
   | 'redundant'
   /**
-   * Indicate the text is marked or highlighted and relevant to the user’s current action.
+   * Indicates that the text is marked or highlighted and relevant to the user's current action.
    * One such use-case is to indicate the characters that matched a search query.
    *
    * Surfaces should apply styling to this type to draw attention to the content.
    *
-   * In an HTML host, the text will be rendered in a `<mark>` element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
+   * In an HTML host, the text will be rendered in a `<mark>` element. Learn more about the [`mark` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark).
    */
   | 'mark'
   /**
-   * Indicate emphatic stress. Typically for words that have a stressed emphasis compared to surrounding text.
+   * Indicates emphatic stress. Typically for words that have a stressed emphasis compared to surrounding text.
    *
    * Surfaces should apply styling to this type to distinguish it from surrounding text. Italicization is a common choice, but not required.
    *
-   * In an HTML host, the text will be rendered in an `<em>` element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
+   * In an HTML host, the text will be rendered in an `<em>` element. Learn more about the [`em` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em).
    */
   | 'emphasis'
   /**
-   * Indicate an offset from the normal prose of the text. Typically used to indicate
+   * Indicates an offset from the normal prose of the text. Typically used to indicate
    * a foreign word, fictional character thoughts, or when the text refers to the definition of a word
    * instead of representing its semantic meaning.
    *
    * Surfaces should italicize this content by default.
    *
-   * In an HTML host, the text will be rendered in a `<i>` tag.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
+   * In an HTML host, the text will be rendered in a `<i>` tag. Learn more about the [`i` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i).
    */
   | 'offset'
   /**
-   * Indicate strong importance, seriousness, or urgency.
+   * Indicates strong importance, seriousness, or urgency.
    *
    * Surfaces should render this content bold by default.
    *
-   * In an HTML host, the text will be rendered in a `<strong>` tag.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
+   * In an HTML host, the text will be rendered in a `<strong>` tag. Learn more about the [`strong` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong).
    */
   | 'strong'
   /**
-   * Indicates the text is considered less important than the main content, but is still necessary for the reader to understand.
+   * Indicates that the text is considered less important than the main content, but is still necessary for the reader to understand.
    * It can be used for secondary content but also for disclaimers, terms and conditions, or legal information.
    *
    * Surfaces should apply a smaller font size than the default size.
    *
-   * In an HTML host, the text will be rendered in a `<small>` element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
+   * In an HTML host, the text will be rendered in a `<small>` element. Learn more about the [`small` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small).
    */
   | 'small'
   /**
-   * No additional semantics or styling is applied.
+   * Indicates that no additional semantics or styling is applied.
    *
    * Surfaces must not apply any default styling to this type.
    *
-   * In an HTML host, the text will be rendered in a `<span>` tag.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
+   * In an HTML host, the text will be rendered in a `<span>` tag. Learn more about the [`span` element on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span).
    */
   | 'generic';
+/**
+ * Properties for multi-line text input areas with character length constraints and autocomplete support.
+ */
 export interface TextAreaProps
   extends GlobalProps,
     BaseTextFieldProps,
     MinMaxLengthProps,
     AutocompleteProps<TextAutocompleteField> {
   /**
-   * A number of visible text lines.
+   * The number of visible text lines that determines the initial height of the text area. Each row represents one line of text at the current font size. When users enter more content than fits in the specified rows, the text area becomes scrollable vertically, allowing access to overflow content. The text area doesn't auto-expand beyond this height. For example, `rows={3}` displays three lines of text at once. Use smaller values (2-3) for brief inputs like comments or notes, larger values (5-10) for substantial text entry like descriptions or feedback. This only sets initial height—users can resize the text area if the browser/surface allows it. The actual pixel height depends on font size and line height.
    *
    * @default 2
    */
   rows?: number;
 }
+/**
+ * Properties for single-line text input fields with decorations, constraints, and autocomplete support.
+ */
 export interface TextFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
     MinMaxLengthProps,
     AutocompleteProps<TextAutocompleteField>,
     FieldDecorationProps {}
+/**
+ * Properties for clickable tile elements with heading, subheading, and optional count indicator.
+ */
 export interface TileProps
   extends GlobalProps,
     Pick<BaseClickableProps, 'onClick' | 'disabled'> {
   /**
-   * A title that describes the content of the Tile.
+   * The primary title text that describes the tile's purpose or action. Clear, action-oriented language immediately communicates what the tile does (for example, "Apply loyalty discount", "Add popular item").
    *
    * @default ''
    */
   heading?: string;
   /**
-   * Supporting text displayed below the heading.
+   * Supporting text displayed below the heading that provides additional context or dynamic information. Common content includes cart totals, eligibility requirements, current status, or helpful details that complement the heading.
    *
    * @default ''
    */
   subheading?: string;
   /**
-   * A numeric indicator rendered within the Tile (for example, a count or a step number).
-   *
-   * - When provided, the indicator is displayed inside the tile.
-   * - Intended for small integers. It may clamp, truncate, or abbreviate larger values.
-   *
+   * A numeric indicator displayed within the tile, typically used for counts, notifications, or step numbers. When provided, the indicator appears inside the tile. Intended for small integers—larger values may be clamped, truncated, or abbreviated by the system.
    */
   itemCount?: number;
   /**
-   * Sets the tone of the Tile, based on the intention of the information being conveyed.
+   * Sets the visual tone of the tile based on the intention of the information being conveyed. Use `'accent'` to highlight important or primary actions, `'neutral'` for standard actions, or `'auto'` (default) to let the system determine the appropriate tone based on context.
+   *
    * @default 'auto'
    */
   tone?: ExtractStrict<ToneKeyword, 'auto' | 'neutral' | 'accent'>;
 }
+/**
+ * Properties for an interactive time picker component with allow/disallow time ranges.
+ */
 export interface TimePickerProps
   extends GlobalProps,
     InputProps,
     FocusEventProps {
   /**
-   * Times that can be selected.
-   *
-   * A comma-separated list of allowed time ranges. Whitespace is allowed after commas.
-   *
-   * The default `''` allows all times.
-   *
-   * Each time range is in `HH:MM--HH:MM` format.
-   *
-   * The end of the range is exclusive, so `09:00--10:00` allows selecting `09:00` but not `10:00`.
-   *
-   * Either side of `--` can be omitted to create an unbounded range.
-   *
-   * Whitespace is allowed either side of `--`.
+   * Specifies allowed time values or ranges for selection. Uses 24-hour format (HH:mm or HH:mm:ss). Supports range syntax with `--` separator and comma-separated values.
    *
    * @default ''
    *
    * @example
-   * `09:00--10:00, 13:00--14:00` - assuming the step is 1 hour, this allows selecting `09:00` or `13:00`.
-   * `12:00--` - allows selecting `12:00` and all times after it.
+   * `09:00--10:00, 13:00--14:00` - allows selecting times within these ranges based on step value
+   * `12:00--` - allows selecting `12:00` and all times after it
    */
   allow?: string;
   /**
-   * Times that cannot be selected. This subtracts from `allow`.
-   *
-   * A comma-separated list of allowed time ranges. Whitespace is allowed after commas.
-   *
-   * The default `''` has no effect on `allow`.
-   *
-   * Each time range is in `HH:MM--HH:MM` format.
-   *
-   * The end of the range is exclusive, so `09:00--10:00` disallows selecting `09:00` but not `10:00`.
-   *
-   * Either side of `--` can be omitted to create an unbounded range.
-   *
-   * Whitespace is allowed either side of `--`.
+   * Specifies disallowed time values or ranges that can't be selected. Uses 24-hour format (HH:mm or HH:mm:ss). Supports range syntax with `--` separator and comma-separated values. Takes precedence over `allow`.
    *
    * @default ''
    *
    * @example
-   * `09:00--10:00, 13:00--14:00` - assuming the step is 1 hour, this disallows selecting `09:00` or `13:00`.
+   * `09:00--10:00, 13:00--14:00` - disallows selecting times within these ranges
    */
   disallow?: string;
   /**
-   * Default selected value.
-   *
-   * The default, `''`, means no time is selected.
-   *
-   * The value must be a 24-hour time in `HH:mm:ss` format, with leading zeros.
-   *
-   * Examples: `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`.
-   *
-   * This follows the HTML time input value format, which is always 24-hour with
-   * leading zeros regardless of UI presentation.
-   *
-   * See: https://developer.mozilla.org/docs/Web/HTML/Element/input/time
-   *
-   * If the provided value is invalid, '' is used as the value.
+   * The default time value used when the field is first rendered, in 24-hour format with leading zeros (HH:mm:ss format, for example, `"09:05:00"`). An empty string means no default time. Only applies if no `value` prop is provided.
    *
    * @default ''
    */
   defaultValue?: string;
   /**
-   * Current selected value.
-   *
-   * The default, `''`, means no time is selected.
-   *
-   * The value must be a 24-hour time in `HH:mm:ss` format, with leading zeros.
-   *
-   * Examples: `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`.
-   *
-   * This follows the HTML time input value format, which is always 24-hour with
-   * leading zeros regardless of UI presentation.
-   *
-   * See: https://developer.mozilla.org/docs/Web/HTML/Element/input/time
-   *
-   * If the provided value is invalid, '' is used as the value.
+   * The currently selected time value in 24-hour format with leading zeros (HH:mm:ss format, for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). An empty string means no time is selected. This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value).
    *
    * @default ''
    */
   value?: string;
   /**
-   * The step between selectable times, in seconds.
+   * The increment step between selectable time values, specified in seconds. For example, `60` for one-minute intervals or `3600` for one-hour intervals.
    *
    * @default 60
    */
   step?: number;
 }
+/**
+ * Properties for a text-based time input field with validation and time range constraints.
+ */
 export interface TimeFieldProps
   extends GlobalProps,
     BaseTextFieldProps,
@@ -3005,49 +2806,15 @@ export interface TimeFieldProps
       'value' | 'defaultValue' | 'allow' | 'disallow' | 'step'
     > {
   /**
-   * Callback when the field has an invalid time.
-   * This callback will be called, if the time typed is invalid or disabled.
-   *
-   * Times that don’t exist or have formatting errors are considered invalid. Some examples of invalid times are:
-   * - 24:00
-   * - 12:60
-   *
-   * Disallowed times are considered invalid.
-   *
-   * It’s important to note that this callback will be called only when the user **finishes editing** the time,
-   * and it’s called right after the `onChange` callback.
-   * The field is **not** validated on every change to the input. Once the buyer has signalled that
-   * they have finished editing the field (typically, by blurring the field), the field gets validated and the callback is run if the value is invalid.
+   * A callback function executed when the user enters an invalid value. Fires after change validation fails.
    */
   onInvalid?: (event: Event) => void;
   /**
-   * Current selected value.
-   *
-   * The default, `''`, means no time is selected.
-   *
-   * The value must be a 24-hour time in `HH:mm:ss` format, with leading zeros.
-   *
-   * Examples: `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`.
-   *
-   * This follows the HTML time input value format, which is always 24-hour with
-   * leading zeros regardless of UI presentation.
-   *
-   * See: https://developer.mozilla.org/docs/Web/HTML/Element/input/time
+   * The currently selected time value in 24-hour format with leading zeros (HH:mm:ss format, for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). An empty string means no time is selected.
    */
   value?: string;
   /**
-   * Default selected value.
-   *
-   * The default, `''`, means no time is selected.
-   *
-   * The value must be a 24-hour time in `HH:mm:ss` format, with leading zeros.
-   *
-   * Examples: `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`.
-   *
-   * This follows the HTML time input value format, which is always 24-hour with
-   * leading zeros regardless of UI presentation.
-   *
-   * See: https://developer.mozilla.org/docs/Web/HTML/Element/input/time
+   * The default time value used when the field is first rendered, in 24-hour format with leading zeros (HH:mm:ss format, for example, `"09:05:00"`). An empty string means no default time. Only applies if no `value` prop is provided.
    */
   defaultValue?: string;
 }
@@ -3061,7 +2828,7 @@ export interface VNode<P = {}> {
   };
   key: Key;
   /**
-   * ref is not guaranteed by React.ReactElement, for compatibility reasons
+   * ref isn't guaranteed by React.ReactElement, for compatibility reasons
    * with popular react libs we define it as optional too
    */
   ref?: Ref<any> | null;
@@ -3157,9 +2924,9 @@ declare abstract class Component<P, S> {
   static displayName?: string;
   static defaultProps?: any;
   static contextType?: Context<any>;
-  // Static members cannot reference class type parameters. This is not
+  // Static members can't reference class type parameters. This isn't
   // supported in TypeScript. Reusing the same type arguments from `Component`
-  // will lead to an impossible state where one cannot satisfy the type
+  // will lead to an impossible state where one can't satisfy the type
   // constraint under no circumstances, see #1356.In general type arguments
   // seem to be a bit buggy and not supported well at the time of this
   // writing with TS 3.3.3333.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
@@ -101,7 +101,7 @@ export interface FocusEventProps {
   onFocus?: (event: FocusEvent) => void;
 }
 /**
- * A size scale keyword ranging from smallest (`'small-500'`) to largest (`'large-500'`).
+ * Defines the available size options for icons using a semantic scale. Provides granular control over icon dimensions from compact inline sizes to prominent display sizes.
  */
 export type SizeKeyword =
   | 'small-500'
@@ -118,7 +118,7 @@ export type SizeKeyword =
   | 'large-400'
   | 'large-500';
 /**
- * A color intensity keyword from subtle (`'subdued'`) to prominent (`'strong'`).
+ * Defines the available color intensity options for icons. Controls the visual prominence and contrast of icon elements within the interface.
  */
 export type ColorKeyword = 'subdued' | 'base' | 'strong';
 /**
@@ -137,12 +137,7 @@ export interface BackgroundProps {
   background?: BackgroundColorKeyword;
 }
 /**
- * A property for defining the color treatment and semantic meaning of a component.
- *
- * A tone can apply a grouping of colors to a component. For example,
- * critical may have a specific text color and background color.
- *
- * In some cases, like for Banner, the tone may also affect the semantic and accessibility treatment of the component.
+ * Defines the semantic tone options for icons. Controls the color and visual emphasis based on the information type and importance being communicated.
  *
  * @default 'auto'
  */
@@ -714,7 +709,7 @@ export type IconType = (typeof privateIconArray)[number];
  */
 export type ExtractStrict<T, U extends T> = Extract<T, U>;
 /**
- * A utility type for properties that support 1-to-4-value shorthand syntax.
+ * A utility type for properties that support [1-to-4-value shorthand syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box).
  */
 export type MaybeAllValuesShorthandProperty<T extends string> =
   | T
@@ -722,7 +717,7 @@ export type MaybeAllValuesShorthandProperty<T extends string> =
   | `${T} ${T} ${T}`
   | `${T} ${T} ${T} ${T}`;
 /**
- * A utility type for properties that support 1-to-2-value shorthand syntax.
+ * Defines a shorthand property that accepts either a single value or two space-separated values for directional properties like padding and spacing.
  */
 export type MaybeTwoValuesShorthandProperty<T extends string> = T | `${T} ${T}`;
 /**
@@ -1006,7 +1001,7 @@ export interface LabelAccessibilityVisibilityProps {
   >;
 }
 /**
- * A padding size keyword including the option for no padding.
+ * Defines the available padding size options using a semantic scale. Provides consistent spacing values that align with the POS design system.
  */
 export type PaddingKeyword = SizeKeyword | 'none';
 /**
@@ -1014,17 +1009,18 @@ export type PaddingKeyword = SizeKeyword | 'none';
  */
 export interface PaddingProps {
   /**
-   * The padding applied to all edges of the element. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   * The padding applied to all edges of the container. Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#edges_of_a_box) using flow-relative values in the order:
+   *
    * - 4 values: `block-start inline-end block-end inline-start`
    * - 3 values: `block-start inline block-end`
    * - 2 values: `block inline`
-   * - 1 value: all edges
    *
    * For example:
-   * - `large` applies `large` padding to all edges.
-   * - `large none` applies `large` to block edges and `none` to inline edges.
-   * - `large none large` applies `large` to block-start, `none` to inline edges, `large` to block-end.
-   * - `large none large small` applies different padding to each edge in order.
+   *
+   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
+   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
+   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
+   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
    *
    * An `auto` value inherits the default padding from the closest container that has removed its usual padding.
    *
@@ -1032,7 +1028,7 @@ export interface PaddingProps {
    */
   padding?: MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>;
   /**
-   * The block-axis padding for the element (typically vertical in horizontal writing modes). Supports two-value syntax where `large none` sets block-start to `large` and block-end to `none`. Overrides the block axis values from the `padding` property.
+   * The block-axis padding for the container. Overrides the block value of the `padding` property.
    *
    * @default '' - meaning no override
    */
@@ -1040,19 +1036,19 @@ export interface PaddingProps {
     MaybeTwoValuesShorthandProperty<PaddingKeyword> | ''
   >;
   /**
-   * The block-start padding for the element (typically top in horizontal writing modes). Overrides the block-start value from the `paddingBlock` property.
+   * The block-start padding for the container. Overrides the block-start value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * The block-end padding for the element (typically bottom in horizontal writing modes). Overrides the block-end value from the `paddingBlock` property.
+   * The block-end padding for the container. Overrides the block-end value of the `paddingBlock` property.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * The inline-axis padding for the element (typically horizontal in horizontal writing modes). Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline axis values from the `padding` property.
+   * The inline-axis padding for the container. Supports two-value syntax where `large none` sets inline-start to `large` and inline-end to `none`. Overrides the inline value of the `padding` property.
    *
    * @default '' - meaning no override
    */
@@ -1060,28 +1056,28 @@ export interface PaddingProps {
     MaybeTwoValuesShorthandProperty<PaddingKeyword> | ''
   >;
   /**
-   * The inline-start padding for the element (typically left in LTR, right in RTL). Overrides the inline-start value from the `paddingInline` property.
+   * The inline-start padding for the container. Overrides the inline-start value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart?: MaybeResponsive<PaddingKeyword | ''>;
   /**
-   * The inline-end padding for the element (typically right in LTR, left in RTL). Overrides the inline-end value from the `paddingInline` property.
+   * The inline-end padding for the container. Overrides the inline-end value of the `paddingInline` property.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd?: MaybeResponsive<PaddingKeyword | ''>;
 }
 /**
- * A size value in pixels, percentage, or zero.
+ * Defines exact size measurements without automatic or unconstrained options. Limited to specific pixel values, percentages, or zero.
  */
 export type SizeUnits = `${number}px` | `${number}%` | `0`;
 /**
- * A size value with automatic sizing option.
+ * Defines size values that can be specified as exact measurements or automatic sizing. Supports pixel values, percentages, zero, or automatic sizing based on content.
  */
 export type SizeUnitsOrAuto = SizeUnits | 'auto';
 /**
- * A size value with no constraint option.
+ * Defines size values that can be specified as exact measurements or no constraint. Supports pixel values, percentages, zero, or no maximum limit.
  */
 export type SizeUnitsOrNone = SizeUnits | 'none';
 /**
@@ -1089,37 +1085,37 @@ export type SizeUnitsOrNone = SizeUnits | 'none';
  */
 export interface SizingProps {
   /**
-   * The block size (height in horizontal writing modes) of the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container. Learn more about [`block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
+   * The block size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   blockSize?: MaybeResponsive<SizeUnitsOrAuto>;
   /**
-   * The minimum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container. Learn more about [`min-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
+   * The minimum block size constraint for the container.
    *
    * @default '0'
    */
   minBlockSize?: MaybeResponsive<SizeUnits>;
   /**
-   * The maximum block size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container. Learn more about [`max-block-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
+   * The maximum block size constraint for the container.
    *
    * @default 'none'
    */
   maxBlockSize?: MaybeResponsive<SizeUnitsOrNone>;
   /**
-   * The inline size (width in horizontal writing modes) of the element. Learn more about [`inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
+   * The inline size of the container. Auto automatically sizes based on the container's children.
    *
    * @default 'auto'
    */
   inlineSize?: MaybeResponsive<SizeUnitsOrAuto>;
   /**
-   * The minimum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container. Learn more about [`min-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
+   * The minimum inline size constraint for the container.
    *
    * @default '0'
    */
   minInlineSize?: MaybeResponsive<SizeUnits>;
   /**
-   * The maximum inline size constraint for the element. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container. Learn more about [`max-inline-size` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
+   * The maximum inline size constraint for the container.
    *
    * @default 'none'
    */
@@ -1360,12 +1356,13 @@ export interface ButtonProps extends GlobalProps, BaseClickableProps {
    */
   variant?: 'auto' | 'primary' | 'secondary' | 'tertiary';
   /**
-   * Sets the tone of the button, based on the intention of the action being performed:
-   * - `'auto'`: Automatically determines the appropriate tone based on context
-   * - `'neutral'`: The standard tone for general actions and interactions
-   * - `'caution'`: Indicates actions that require careful consideration
-   * - `'warning'`: Alerts users to potential issues or important information
-   * - `'critical'`: Used for destructive actions like deleting or removing content
+   * Sets the tone of the button, based on the intention of the information being conveyed.
+   *
+   * - `'auto'` - Automatically determines the appropriate tone based on context.
+   * - `'neutral'` - The standard tone for general actions and interactions.
+   * - `'caution'` - Indicates actions that require careful consideration.
+   * - `'warning'` - Alerts users to potential issues or important information.
+   * - `'critical'` - Used for destructive actions like deleting or removing content.
    *
    * @default 'auto'
    */
@@ -1540,9 +1537,10 @@ export interface NumberConstraintsProps {
   step?: number;
   /**
    * The type of controls displayed for the field:
-   * - `'auto'`: An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
-   * - `'stepper'`: Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
-   * - `'none'`: A control type with no visible controls where users must input the value manually using the keyboard.
+   *
+   * - `'auto'` - An automatic setting where the presence of controls depends on the surface and context. The system determines the most appropriate control type based on the usage scenario.
+   * - `'stepper'` - Displays increment (+) and decrement (-) buttons for adjusting the numeric value. When `stepper` controls are enabled, the field behavior is constrained: it accepts only integer values, always contains a value (never empty), and automatically validates against `min` and `max` bounds. The `label`, `details`, `placeholder`, `error`, `required`, and `inputMode` properties aren't supported with `stepper` controls.
+   * - `'none'` - A control type with no visible controls where users must input the value manually using the keyboard.
    *
    * @default 'auto'
    */
@@ -2003,7 +2001,7 @@ export interface DateSpinnerProps
 export interface DividerProps extends GlobalProps {
   /**
    * The direction of the divider using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values). An inline divider runs horizontally across the content flow, while a block divider runs vertically along the content flow.
-   * 
+   *
    * Available options:
    * - `'inline'`: A horizontal divider that runs perpendicular to the text direction, creating separation between vertically stacked content sections.
    * - `'block'`: A vertical divider that runs parallel to the text direction, creating separation between horizontally arranged content sections.
@@ -2197,13 +2195,13 @@ export interface IconProps
   extends GlobalProps,
     Pick<InteractionProps, 'interestFor'> {
   /**
-   * The semantic tone of the icon, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * Sets the tone of the icon, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * The color intensity of the icon. Controls how prominent or subtle the icon appears within the interface.
+   * Modify the color to be more or less intense. Use `'subdued'` for secondary icons, `'base'` for standard visibility, or `'strong'` for emphasized icons that need to stand out.
    *
    * @default 'base'
    */
@@ -2215,7 +2213,7 @@ export interface IconProps
    */
   size?: SizeKeyword;
   /**
-   * The icon identifier specifying which icon to display. Accepts any valid icon name from the icon set.
+   * The type of icon to display.
    */
   type?: IconType | AnyString;
 }
@@ -2234,7 +2232,7 @@ export interface BaseImageProps {
    */
   sizes?: string;
   /**
-   * The primary image source URL. Accepts absolute URLs (`https://example.com/image.jpg`), relative paths (`/images/product.jpg`), or data URLs (`data:image/png;base64,...`). When the image is loading or if `src` is omitted/invalid, a placeholder is displayed while reserving the image's space to prevent layout shifts. The URL must be accessible (proper [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) headers for cross-origin images), use appropriate protocols ([HTTPS](https://en.wikipedia.org/wiki/HTTPS) for security), and point to valid image formats (JPEG, PNG, GIF, WebP, SVG). Failed loads trigger the `onError` callback if provided. For responsive images serving different sizes/resolutions, `srcSet` can be used in addition to `src` (which then serves as the fallback). Images are loaded asynchronously—the `loading` property controls when loading begins. Learn more about [`src` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
+   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are properly formatted and properly formatted.
    *
    * @implementation Surfaces may choose the style of the placeholder, but the space the image occupies should be
    * reserved, except in cases where the image area doesn't have a contextual inline or block size, which should be rare.
@@ -2262,11 +2260,10 @@ export interface ImageProps extends GlobalProps, BaseImageProps, BorderProps {
     | 'img'
     | ExtractStrict<AccessibilityRole, 'presentation' | 'none'>;
   /**
-   * Controls the displayed width of the image. The choice depends on layout requirements—for mobile interfaces, `'fill'` with defined container dimensions ensures consistent image display, as dynamic container heights can cause layout inconsistencies in scrollable views.
-   * - `'auto'`: Displays the image at its natural size. The image won't render until it has loaded, and the aspect ratio will be ignored. Typically applied when maintaining original dimensions is important.
-   * - `'fill'`: Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Commonly applied to responsive layouts and flexible image containers.
+   * Controls the displayed width of the image. Choose based on your layout requirements. For mobile interfaces, consider using `'fill'` with defined container dimensions to ensure consistent image display, as dynamic container heights can cause layout inconsistencies in scrollable views.
    *
-   * Learn more about [`width` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
+   * - `'auto'` - Displays the image at its natural size. The image will not render until it has loaded, and the aspect ratio will be ignored. Use for images where maintaining original dimensions is important.
+   * - `'fill'` - Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Use for responsive layouts and flexible image containers.
    *
    * @default 'fill'
    */
@@ -2282,19 +2279,16 @@ export interface ImageProps extends GlobalProps, BaseImageProps, BorderProps {
    * For example, if the value is set as `50 / 100`, the getter returns `50 / 100`.
    * If the value is set as `0.5`, the getter returns `0.5 / 1`.
    *
-   * Learn more about [`aspect-ratio` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).
-   *
    * @default '1/1'
    */
   aspectRatio?:
     | `${number}${optionalSpace}/${optionalSpace}${number}`
     | `${number}`;
   /**
-   * Controls how the image content is resized within its container:
-   * - `'contain'`: Scales the image to fit within the container while maintaining aspect ratio. The entire image will be visible, but there may be empty space. Typically applied when showing the complete image is important.
-   * - `'cover'`: Scales the image to fill the entire container while maintaining aspect ratio. Parts of the image may be cropped. Typically applied when filling the container completely is more important than showing the entire image.
+   * Controls how the image content is resized within its container.
    *
-   * Learn more about [`object-fit` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).
+   * - `'contain'` - Scales the image to fit within the container while maintaining aspect ratio. The entire image will be visible, but there may be empty space. Use when showing the complete image is important.
+   * - `'cover'` - Scales the image to fill the entire container while maintaining aspect ratio. Parts of the image may be cropped. Use when filling the container completely is more important than showing the entire image.
    *
    * @default 'contain'
    */
@@ -2363,11 +2357,10 @@ export interface NumberFieldProps
     NumberConstraintsProps,
     FieldDecorationProps {
   /**
-   * The virtual keyboard layout displayed for numeric input on touch-enabled devices like tablets and smartphones. This property has no effect on desktop devices with physical keyboards. Not supported when using `stepper` controls.
-   * - `'decimal'`: Shows a numeric keyboard with a decimal point/comma key. Best for monetary amounts (for example, "$19.99"), measurements with precision (for example, "2.5 kg"), percentages (for example, "15.5%"), or any fractional values. The decimal separator adapts to the user's locale (period in US, comma in Europe).
-   * - `'numeric'`: Shows a numeric keyboard without decimal point, displaying only digits 0-9 and sometimes +/- symbols. Best for quantities (for example, "5 items"), whole number identifiers (for example, "Order #12345"), phone numbers, or any integer-only input. Prevents accidental decimal entry which can confuse users for whole number fields.
-   * 
-   * On mobile POS devices, choosing the correct `inputMode` significantly improves data entry speed and reduces errors by showing the most relevant keyboard. Users can still switch keyboards manually if needed. Learn more about [`inputmode` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
+   * The virtual keyboard layout that the field displays for numeric input. This property isn't supported when using `stepper` controls.
+   *
+   * - `'decimal'` - A keyboard layout that includes decimal point support for entering fractional numbers, prices, or measurements with decimal precision.
+   * - `'numeric'` - A keyboard layout optimized for integer-only entry without decimal point support, ideal for quantities, counts, or whole number values.
    *
    * @default 'decimal'
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseApi.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseApi.ts
@@ -1,3 +1,6 @@
 import {StorageApi} from '../../api/storage-api/storage-api';
 
+/**
+ * Base API access provided to extension targets, currently providing access to persistent storage for saving and retrieving extension data across sessions.
+ */
 export type BaseApi = StorageApi;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseData.ts
@@ -1,8 +1,23 @@
 import type {ConnectivityState, Device, Session} from '../../../point-of-sale';
 
+/**
+ * Base data object provided to all extension targets containing device information, session context, and connectivity state. This data is available at extension initialization and provides essential context about the runtime environment.
+ */
 export interface BaseData {
+  /**
+   * The current Internet connectivity state of the POS device. Indicates whether the device is connected to or disconnected from the Internet. This state updates in real-time as connectivity changes, allowing extensions to adapt behavior for offline scenarios, show connectivity warnings, or queue operations for when connectivity is restored.
+   */
   connectivity: ConnectivityState;
+  /**
+   * Comprehensive information about the physical POS device where the extension is currently running. Includes the device name, unique device ID, and form factor information (tablet vs other). This data is static for the session and helps extensions adapt to different device types, log device-specific information, or implement device-based configurations.
+   */
   device: Device;
+  /**
+   * The [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) locale string for the current POS session (for example, `"en-US"`, `"fr-CA"`, `"de-DE"`). This indicates the merchant's language and regional preferences. Commonly used for internationalization (i18n), locale-specific date/time/number formatting, translating UI text, and providing localized content. The locale remains constant for the session and reflects the language selected in POS settings.
+   */
   locale: string;
+  /**
+   * Comprehensive information about the current POS session including shop ID and domain, authenticated user, pinned staff member, active location, currency settings, and POS version. This session data remains constant for the session duration and provides critical context for business logic, permissions, API authentication, and transaction processing. Session data updates when users switch locations or change pinned staff members.
+   */
   session: Session;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/CartUpdateEventData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/CartUpdateEventData.ts
@@ -2,6 +2,12 @@ import {BaseData} from './BaseData';
 import {Cart} from '../../api';
 import {BaseApi} from './BaseApi';
 
+/**
+ * The data object provided to cart update extension targets. Contains the current cart state along with device, session, and connectivity information. This data is passed to extensions whenever the cart changes, enabling real-time cart monitoring and cart-based business logic.
+ */
 export interface CartUpdateEventData extends BaseData, BaseApi {
+  /**
+   * The complete current `Cart` object containing all cart data including line items with products and quantities, pricing totals (subtotal, tax, grand total), associated customer information, applied discounts, custom properties, and editability state. This represents the cart's state at the moment the extension is triggered, reflecting all recent changes. The cart object is read-only in this context—modifications should be made through the Cart API methods.
+   */
   cart: Cart;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/CashTrackingSessionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/CashTrackingSessionData.ts
@@ -1,17 +1,44 @@
 import {BaseData} from './BaseData';
 import {BaseApi} from './BaseApi';
 
+/**
+ * The data object provided to cash tracking session start extension targets. Contains information about a newly opened cash tracking session along with device and session context.
+ */
 export interface CashTrackingSessionStartData extends BaseData, BaseApi {
+  /**
+   * The cash tracking session start data containing the session identifier and the time when the session began. Cash tracking sessions represent the period during which a cash drawer is open and being used for transactions, typically corresponding to a staff member's shift.
+   */
   cashTrackingSessionStart: {
+    /**
+     * The unique numeric identifier for this cash tracking session. This ID distinguishes this session from other cash tracking sessions and can be used for session-specific operations, reporting, or linking transactions to sessions. The ID is assigned when the session opens and remains constant until the session closes.
+     */
     id: number;
+    /**
+     * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the cash tracking session was opened and cash drawer operations began (for example, `"2024-05-15T09:00:00Z"`). This marks the start of the staff member's shift or cash handling period. Commonly used for calculating session duration, shift reporting, or determining which transactions belong to which session.
+     */
     openingTime: string;
   };
 }
 
+/**
+ * The data object provided to cash tracking session complete extension targets. Contains information about a completed cash tracking session including when it opened and closed, along with device and session context.
+ */
 export interface CashTrackingSessionCompleteData extends BaseData, BaseApi {
+  /**
+   * The cash tracking session complete data containing the session identifier, opening time, and closing time. This represents the full lifecycle of a cash drawer session from opening to closing.
+   */
   cashTrackingSessionComplete: {
+    /**
+     * The unique numeric identifier for this cash tracking session. This ID matches the ID from when the session was opened and can be used to correlate session start and end events, retrieve session-specific data, or link all transactions that occurred during this session.
+     */
     id: number;
+    /**
+     * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the cash tracking session was opened and began (for example, `"2024-05-15T09:00:00Z"`). This marks the start of the session and can be compared with `closingTime` to calculate the total session duration or shift length.
+     */
     openingTime: string;
+    /**
+     * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the cash tracking session was closed and ended (for example, `"2024-05-15T17:30:00Z"`). This marks when the staff member completed their shift, closed out the cash drawer, and finalized the session. The time between `openingTime` and `closingTime` represents the active session duration. Commonly used for shift reporting, calculating hours worked, or determining the timeframe for session-specific transactions.
+     */
     closingTime: string;
   };
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
@@ -1,10 +1,28 @@
 import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {LineItem} from '../../types/cart';
 
+/**
+ * Defines the data structure for completed exchange transactions. Contains all information about an atomic swap where a customer returns items and simultaneously purchases replacement items in a single transaction.
+ */
 export interface ExchangeTransactionData extends BaseTransactionComplete {
+  /**
+   * The transaction type identifier, always `'Exchange'` for exchange transactions. This discriminator allows TypeScript to narrow the union type and helps systems identify exchanges vs sales or returns when processing mixed transaction types.
+   */
   transactionType: 'Exchange';
+  /**
+   * The unique numeric identifier for the return portion of this exchange in Shopify's system. This ID tracks the items being returned back to the merchant and can be used for return reporting, inventory management, or linking to the original sale. Returns `undefined` when the return ID hasn't been assigned yet or when processed through a different tracking mechanism.
+   */
   returnId?: number;
+  /**
+   * The unique numeric identifier for this exchange transaction in Shopify's system. This ID represents the entire exchange operation (both return and new sale portions combined) and can be used for exchange tracking, reporting, or customer service lookups. Returns `undefined` when the exchange ID hasn't been assigned yet or when the exchange is still being processed.
+   */
   exchangeId?: number;
+  /**
+   * An array of new line items that the customer is purchasing as part of the exchange. These are the replacement items being added to the customer—they represent products leaving inventory just like a regular sale. Each line item contains product details, quantities, pricing, and any discounts applied to the new items. The pricing totals in `BaseTransactionComplete` reflect the net transaction after accounting for both returned and new items. This array can be empty for exchanges where the customer is only returning items without taking new ones (though this is more commonly processed as a regular return).
+   */
   lineItemsAdded: LineItem[];
+  /**
+   * An array of line items that the customer is returning as part of the exchange. These are the original items coming back to the merchant—they represent products being returned to inventory. Each line item contains the original product details, quantities being returned, and original pricing. The quantities indicate how many units of each item are being returned, not the original purchase quantity. Together with `lineItemsAdded`, this shows the complete picture of what's being swapped. This array can be empty for exchanges where the customer is only taking new items without returning anything (though this is more commonly processed as a regular sale).
+   */
   lineItemsRemoved: LineItem[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
@@ -2,27 +2,27 @@ import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {LineItem} from '../../types/cart';
 
 /**
- * Defines the data structure for completed exchange transactions. Contains all information about an atomic swap where a customer returns items and simultaneously purchases replacement items in a single transaction.
+ * Defines the data structure for completed exchange transactions.
  */
 export interface ExchangeTransactionData extends BaseTransactionComplete {
   /**
-   * The transaction type identifier, always `'Exchange'` for exchange transactions. This discriminator allows TypeScript to narrow the union type and helps systems identify exchanges vs sales or returns when processing mixed transaction types.
+   * The transaction type identifier, always 'Sale' for sale transactions.
    */
   transactionType: 'Exchange';
   /**
-   * The unique numeric identifier for the return portion of this exchange in Shopify's system. This ID tracks the items being returned back to the merchant and can be used for return reporting, inventory management, or linking to the original sale. Returns `undefined` when the return ID hasn't been assigned yet or when processed through a different tracking mechanism.
+   * The return ID for the completed return transaction.
    */
   returnId?: number;
   /**
-   * The unique numeric identifier for this exchange transaction in Shopify's system. This ID represents the entire exchange operation (both return and new sale portions combined) and can be used for exchange tracking, reporting, or customer service lookups. Returns `undefined` when the exchange ID hasn't been assigned yet or when the exchange is still being processed.
+   * The exchange ID if the return is part of an exchange transaction.
    */
   exchangeId?: number;
   /**
-   * An array of new line items that the customer is purchasing as part of the exchange. These are the replacement items being added to the customer—they represent products leaving inventory just like a regular sale. Each line item contains product details, quantities, pricing, and any discounts applied to the new items. The pricing totals in `BaseTransactionComplete` reflect the net transaction after accounting for both returned and new items. This array can be empty for exchanges where the customer is only returning items without taking new ones (though this is more commonly processed as a regular return).
+   * An array of line items added to the customer in the exchange.
    */
   lineItemsAdded: LineItem[];
   /**
-   * An array of line items that the customer is returning as part of the exchange. These are the original items coming back to the merchant—they represent products being returned to inventory. Each line item contains the original product details, quantities being returned, and original pricing. The quantities indicate how many units of each item are being returned, not the original purchase quantity. Together with `lineItemsAdded`, this shows the complete picture of what's being swapped. This array can be empty for exchanges where the customer is only taking new items without returning anything (though this is more commonly processed as a regular sale).
+   * An array of line items removed from the customer in the exchange.
    */
   lineItemsRemoved: LineItem[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
@@ -1,7 +1,16 @@
 import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {OrderLineItem} from '../../types/order';
 
+/**
+ * Defines the data structure for receipt reprint requests. Contains information from the original completed transaction that is being reprinted, allowing receipt extensions to regenerate receipts for historical transactions.
+ */
 export interface ReprintReceiptData extends BaseTransactionComplete {
+  /**
+   * The transaction type identifier, always `'Reprint'` for receipt reprint operations. This discriminator indicates that this isn't a new transaction but rather a reprint of an existing transaction's receipt. No new order is created, no inventory changes occur, and no payment is processed—this only regenerates the receipt document.
+   */
   transactionType: 'Reprint';
+  /**
+   * An array of order line items from the original transaction being reprinted. These are `OrderLineItem` objects (not regular `LineItem` objects) which include additional order-specific data like `currentQuantity` (remaining after refunds) and `refunds` (refund history). This allows receipt reprints to accurately reflect the transaction's current state, showing which items were refunded since the original receipt was printed. The line items represent the historical data from when the transaction was originally completed, updated with any subsequent refunds or modifications.
+   */
   lineItems: OrderLineItem[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
@@ -2,15 +2,15 @@ import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {OrderLineItem} from '../../types/order';
 
 /**
- * Defines the data structure for receipt reprint requests. Contains information from the original completed transaction that is being reprinted, allowing receipt extensions to regenerate receipts for historical transactions.
+ * Defines the data structure for receipt reprint requests.
  */
 export interface ReprintReceiptData extends BaseTransactionComplete {
   /**
-   * The transaction type identifier, always `'Reprint'` for receipt reprint operations. This discriminator indicates that this isn't a new transaction but rather a reprint of an existing transaction's receipt. No new order is created, no inventory changes occur, and no payment is processed—this only regenerates the receipt document.
+   * The transaction type identifier, always 'Sale' for sale transactions.
    */
   transactionType: 'Reprint';
   /**
-   * An array of order line items from the original transaction being reprinted. These are `OrderLineItem` objects (not regular `LineItem` objects) which include additional order-specific data like `currentQuantity` (remaining after refunds) and `refunds` (refund history). This allows receipt reprints to accurately reflect the transaction's current state, showing which items were refunded since the original receipt was printed. The line items represent the historical data from when the transaction was originally completed, updated with any subsequent refunds or modifications.
+   * An array of line items included in the sale transaction.
    */
   lineItems: OrderLineItem[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
@@ -2,27 +2,27 @@ import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {LineItem} from '../../types/cart';
 
 /**
- * Defines the data structure for completed return transactions. Contains all information about items being returned to the merchant, refund amounts, and associated IDs for tracking returns through the Shopify system.
+ * Defines the data structure for completed return transactions.
  */
 export interface ReturnTransactionData extends BaseTransactionComplete {
   /**
-   * The transaction type identifier, always `'Return'` for return transactions. This discriminator allows TypeScript to narrow the union type and helps systems identify returns vs sales or exchanges when processing mixed transaction types.
+   * The transaction type identifier, always 'Sale' for sale transactions.
    */
   transactionType: 'Return';
   /**
-   * The unique numeric identifier for the refund record created when processing this return. This ID links to Shopify's refund tracking system and can be used for refund lookups, audit trails, or accounting reconciliation. Returns `undefined` when the return doesn't generate a refund (for example, store credit only, exchange-only returns) or when the refund is still being processed asynchronously.
+   * The refund ID if a refund was issued for the return.
    */
   refundId?: number;
   /**
-   * The unique numeric identifier for this return transaction in Shopify's system. This ID distinguishes this return from other returns and can be used for return tracking, reporting, or customer service lookups. Returns `undefined` when the return ID hasn't been assigned yet or when the return is processed through a different mechanism.
+   * The return ID for the completed return transaction.
    */
   returnId?: number;
   /**
-   * The unique numeric identifier linking this return to an associated exchange transaction. When present, indicates this return is the return portion of an exchange where the customer is swapping items. The exchange ID connects the return (items coming back) with the sale (items going out) in a single atomic exchange operation. Returns `undefined` for standalone returns that aren't part of an exchange.
+   * The exchange ID if the return is part of an exchange transaction.
    */
   exchangeId?: number;
   /**
-   * An array of all line items being returned to the merchant in this transaction. Each line item contains the product details, quantities being returned, original pricing, and any refunds applied. The quantities represent items being returned to inventory. Line items maintain their original structure from the sale but the quantities reflect only what's being returned, not the original purchase quantity. The array must contain at least one item for a valid return transaction.
+   * An array of line items included in the sale transaction.
    */
   lineItems: LineItem[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
@@ -1,10 +1,28 @@
 import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {LineItem} from '../../types/cart';
 
+/**
+ * Defines the data structure for completed return transactions. Contains all information about items being returned to the merchant, refund amounts, and associated IDs for tracking returns through the Shopify system.
+ */
 export interface ReturnTransactionData extends BaseTransactionComplete {
+  /**
+   * The transaction type identifier, always `'Return'` for return transactions. This discriminator allows TypeScript to narrow the union type and helps systems identify returns vs sales or exchanges when processing mixed transaction types.
+   */
   transactionType: 'Return';
+  /**
+   * The unique numeric identifier for the refund record created when processing this return. This ID links to Shopify's refund tracking system and can be used for refund lookups, audit trails, or accounting reconciliation. Returns `undefined` when the return doesn't generate a refund (for example, store credit only, exchange-only returns) or when the refund is still being processed asynchronously.
+   */
   refundId?: number;
+  /**
+   * The unique numeric identifier for this return transaction in Shopify's system. This ID distinguishes this return from other returns and can be used for return tracking, reporting, or customer service lookups. Returns `undefined` when the return ID hasn't been assigned yet or when the return is processed through a different mechanism.
+   */
   returnId?: number;
+  /**
+   * The unique numeric identifier linking this return to an associated exchange transaction. When present, indicates this return is the return portion of an exchange where the customer is swapping items. The exchange ID connects the return (items coming back) with the sale (items going out) in a single atomic exchange operation. Returns `undefined` for standalone returns that aren't part of an exchange.
+   */
   exchangeId?: number;
+  /**
+   * An array of all line items being returned to the merchant in this transaction. Each line item contains the product details, quantities being returned, original pricing, and any refunds applied. The quantities represent items being returned to inventory. Line items maintain their original structure from the sale but the quantities reflect only what's being returned, not the original purchase quantity. The array must contain at least one item for a valid return transaction.
+   */
   lineItems: LineItem[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/SaleTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/SaleTransactionData.ts
@@ -1,8 +1,20 @@
 import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {LineItem} from '../../types/cart';
 
+/**
+ * Defines the data structure for completed sale transactions. Contains all information about a finalized sale including purchased items, payment details, pricing totals, and customer information.
+ */
 export interface SaleTransactionData extends BaseTransactionComplete {
+  /**
+   * The transaction type identifier, always `'Sale'` for sale transactions. This discriminator allows TypeScript to narrow the union type when working with mixed transaction data and helps identify sales in transaction lists or reports.
+   */
   transactionType: 'Sale';
+  /**
+   * The [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) of the draft checkout if this sale originated from a draft order that was previously created and saved. Draft orders allow merchants to create orders offline, save them for later, send invoices to customers, or prepare complex orders before finalizing. Returns `undefined` for regular sales that weren't created from draft orders. This UUID links the completed sale back to the original draft for tracking and reconciliation.
+   */
   draftCheckoutUuid?: string;
+  /**
+   * An array of all line items purchased in this sale transaction. Each line item contains product details, quantities, pricing, discounts, properties, and tax information. The line items represent what the customer actually bought, with quantities reflecting items leaving inventory. Line items are ordered as they appeared in the cart during checkout. Empty arrays aren't expected for completed sale transactions as sales require at least one item.
+   */
   lineItems: LineItem[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/SaleTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/SaleTransactionData.ts
@@ -2,19 +2,19 @@ import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {LineItem} from '../../types/cart';
 
 /**
- * Defines the data structure for completed sale transactions. Contains all information about a finalized sale including purchased items, payment details, pricing totals, and customer information.
+ * Defines the data structure for completed sale transactions.
  */
 export interface SaleTransactionData extends BaseTransactionComplete {
   /**
-   * The transaction type identifier, always `'Sale'` for sale transactions. This discriminator allows TypeScript to narrow the union type when working with mixed transaction data and helps identify sales in transaction lists or reports.
+   * The transaction type identifier, always 'Sale' for sale transactions.
    */
   transactionType: 'Sale';
   /**
-   * The [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) of the draft checkout if this sale originated from a draft order that was previously created and saved. Draft orders allow merchants to create orders offline, save them for later, send invoices to customers, or prepare complex orders before finalizing. Returns `undefined` for regular sales that weren't created from draft orders. This UUID links the completed sale back to the original draft for tracking and reconciliation.
+   * The UUID of the draft checkout if the sale originated from a draft order.
    */
   draftCheckoutUuid?: string;
   /**
-   * An array of all line items purchased in this sale transaction. Each line item contains product details, quantities, pricing, discounts, properties, and tax information. The line items represent what the customer actually bought, with quantities reflecting items leaving inventory. Line items are ordered as they appeared in the cart during checkout. Empty arrays aren't expected for completed sale transactions as sales require at least one item.
+   * An array of line items included in the sale transaction.
    */
   lineItems: LineItem[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/TransactionCompleteData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/TransactionCompleteData.ts
@@ -10,6 +10,10 @@ import {BaseApi} from './BaseApi';
  */
 export interface TransactionCompleteData extends BaseData, BaseApi {
   /**
+   * Provides access to persistent local storage methods for your POS UI extension. Use this to store, retrieve, and manage data that persists across sessions.
+   */
+  storage: BaseApi['storage'];
+  /**
    * The transaction data, which can be one of the following types:
    * - `SaleTransactionData`: Defines the data structure for completed sale transactions.
    * - `ReturnTransactionData`: Defines the data structure for completed return transactions.
@@ -22,9 +26,13 @@ export interface TransactionCompleteData extends BaseData, BaseApi {
 }
 
 /**
- * The data object provided to this target containing transaction details and reprint information.
+ * The data object provided to receipt targets containing transaction details and reprint information.
  */
 export interface TransactionCompleteWithReprintData extends BaseData, BaseApi {
+  /**
+   * Provides access to persistent local storage methods for your POS UI extension. Use this to store, retrieve, and manage data that persists across sessions.
+   */
+  storage: BaseApi['storage'];
   /**
    * The transaction data, which can be one of the following types:
    * - `SaleTransactionData`: Defines the data structure for completed sale transactions.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/TransactionCompleteData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/TransactionCompleteData.ts
@@ -5,14 +5,33 @@ import type {ReturnTransactionData} from './ReturnTransactionData';
 import type {ReprintReceiptData} from './ReprintReceiptData';
 import {BaseApi} from './BaseApi';
 
+/**
+ * The data object provided to receipt targets containing transaction details.
+ */
 export interface TransactionCompleteData extends BaseData, BaseApi {
+  /**
+   * The transaction data, which can be one of the following types:
+   * - `SaleTransactionData`: Defines the data structure for completed sale transactions.
+   * - `ReturnTransactionData`: Defines the data structure for completed return transactions.
+   * - `ExchangeTransactionData`: Defines the data structure for completed exchange transactions.
+   */
   transaction:
     | SaleTransactionData
     | ReturnTransactionData
     | ExchangeTransactionData;
 }
 
+/**
+ * The data object provided to this target containing transaction details and reprint information.
+ */
 export interface TransactionCompleteWithReprintData extends BaseData, BaseApi {
+  /**
+   * The transaction data, which can be one of the following types:
+   * - `SaleTransactionData`: Defines the data structure for completed sale transactions.
+   * - `ReturnTransactionData`: Defines the data structure for completed return transactions.
+   * - `ExchangeTransactionData`: Defines the data structure for completed exchange transactions.
+   * - `ReprintReceiptData`: Defines the data structure for receipt reprint requests.
+   */
   transaction:
     | SaleTransactionData
     | ReturnTransactionData

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/output/BaseOutput.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/output/BaseOutput.ts
@@ -1,8 +1,25 @@
+/**
+ * Represents an error or warning generated during extension execution. Extends the standard JavaScript Error interface with severity level classification.
+ */
 interface ExtensionError extends Error {
+  /**
+   * The severity level of this error:
+   * - `'error'`: A critical error that prevents the extension from completing successfully. Errors typically block the user workflow and require resolution before proceeding.
+   * - `'warning'`: A non-critical issue that doesn't prevent extension execution but indicates a problem or unexpected condition. Warnings allow the workflow to continue but should be logged or displayed to users.
+   */
   level: 'error' | 'warning';
+  /**
+   * The human-readable error message describing what went wrong. This message should be clear and actionable, helping merchants understand the issue and how to resolve it (for example, "Product not found", "Invalid discount code", "Insufficient inventory"). The message may be displayed to users in the POS interface depending on the error severity and context.
+   */
   message: string;
 }
 
+/**
+ * Base output structure that extensions can return to communicate errors and warnings back to the POS system. Extensions populate this interface when they encounter issues during execution.
+ */
 export interface BaseOutput {
+  /**
+   * An array of errors or warnings encountered during extension execution. Each error includes a severity level (`'error'` or `'warning'`) and a descriptive message. Multiple errors can be reported simultaneously. Returns `undefined` or empty array when the extension executes successfully without issues. Critical errors may prevent transaction completion, while warnings allow the transaction to proceed but indicate issues that should be addressed.
+   */
   errors?: ExtensionError[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
@@ -43,56 +43,116 @@ export interface EventExtensionTargets {
 }
 
 export interface RenderExtensionTargets {
+  /**
+   * Renders a single interactive tile component on the POS home screen's smart grid. The tile appears once during home screen initialization and remains persistent until navigation occurs. Use this target for high-frequency actions, status displays, or entry points to workflows that merchants need daily.
+   *
+   * Extensions at this target can dynamically update properties like enabled state and badge values in response to cart changes or device conditions. Tiles typically invoke `shopify.action.presentModal()` to launch the companion modal for complete workflows.
+   */
   'pos.home.tile.render': RenderExtension<
     StandardApi<'pos.home.tile.render'> & ActionApi & CartApi,
     SmartGridComponents
   >;
+  /**
+   * Renders a full-screen modal interface launched from smart grid tiles. The modal appears when users tap a companion tile. Use this target for complete workflow experiences that require more space and functionality than the tile interface provides, such as multi-step processes, detailed information displays, or complex user interactions.
+   *
+   * Extensions at this target support full navigation hierarchies with multiple screens, scroll views, and interactive components to handle sophisticated workflows.
+   */
   'pos.home.modal.render': RenderExtension<
     ActionTargetApi<'pos.home.modal.render'> & CartApi,
     BasicComponents
   >;
+  /**
+   * Renders a single interactive button component as a menu item in the post-return action menu. Use this target for post-return operations like generating return receipts, processing restocking workflows, or collecting return feedback.
+   *
+   * Extensions at this target can access the order identifier through the Order API to perform return-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-return workflows.
+   */
   'pos.return.post.action.menu-item.render': RenderExtension<
     StandardApi<'pos.return.post.action.menu-item.render'> &
       ActionApi &
       OrderApi,
     ActionExtensionComponents
   >;
+  /**
+   * Renders a full-screen modal interface launched from post-return menu items. Use this target for complex post-return workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
+   *
+   * Extensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.
+   */
   'pos.return.post.action.render': RenderExtension<
     ActionTargetApi<'pos.return.post.action.render'> & OrderApi,
     BasicComponents
   >;
+  /**
+   * Renders a custom information section within the post-return screen. Use this target for displaying supplementary return data like completion status, refund confirmations, or follow-up workflows alongside standard return details.
+   *
+   * Extensions at this target appear as persistent blocks within the post-return interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-return operations.
+   */
   'pos.return.post.block.render': RenderExtension<
     StandardApi<'pos.return.post.block.render'> & OrderApi & ActionApi,
     BlockExtensionComponents
   >;
+  /**
+   * Renders a single interactive button component as a menu item in the post-exchange action menu. Use this target for post-exchange operations like generating exchange receipts, processing restocking workflows, or collecting exchange feedback.
+   *
+   * Extensions at this target can access the order identifier through the Order API to perform exchange-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-exchange workflows.
+   */
   'pos.exchange.post.action.menu-item.render': RenderExtension<
     StandardApi<'pos.exchange.post.action.menu-item.render'> &
       ActionApi &
       OrderApi,
     ActionExtensionComponents
   >;
+  /**
+   * Renders a full-screen modal interface launched from post-exchange menu items. Use this target for complex post-exchange workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
+   *
+   * Extensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.
+   */
   'pos.exchange.post.action.render': RenderExtension<
     ActionTargetApi<'pos.exchange.post.action.render'> & OrderApi,
     BasicComponents
   >;
+  /**
+   * Renders a custom information section within the post-exchange screen. Use this target for displaying supplementary exchange data like completion status, payment adjustments, or follow-up workflows alongside standard exchange details.
+   *
+   * Extensions at this target appear as persistent blocks within the post-exchange interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-exchange operations.
+   */
   'pos.exchange.post.block.render': RenderExtension<
     StandardApi<'pos.exchange.post.block.render'> & OrderApi & ActionApi,
     BlockExtensionComponents
   >;
+  /**
+   * Renders a single interactive button component as a menu item in the post-purchase action menu. Use this target for post-purchase operations like sending receipts, collecting customer feedback, or launching follow-up workflows after completing a sale.
+   *
+   * Extensions at this target can access the order identifier through the Order API to perform purchase-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-purchase workflows.
+   */
   'pos.purchase.post.action.menu-item.render': RenderExtension<
     StandardApi<'pos.purchase.post.action.menu-item.render'> &
       ActionApi &
       OrderApi,
     ActionExtensionComponents
   >;
+  /**
+   * Renders a full-screen modal interface launched from post-purchase menu items. Use this target for complex post-purchase workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
+   *
+   * Extensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.
+   */
   'pos.purchase.post.action.render': RenderExtension<
     ActionTargetApi<'pos.purchase.post.action.render'> & OrderApi,
     BasicComponents
   >;
+  /**
+   * Renders a custom information section within the post-purchase screen. Use this target for displaying supplementary purchase data like completion status, customer feedback prompts, or next-step workflows alongside standard purchase details.
+   *
+   * Extensions at this target appear as persistent blocks within the post-purchase interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-purchase operations.
+   */
   'pos.purchase.post.block.render': RenderExtension<
     StandardApi<'pos.purchase.post.block.render'> & OrderApi & ActionApi,
     BlockExtensionComponents
   >;
+  /**
+   * Renders a single interactive button component as a menu item in the product details action menu. Use this target for product-specific operations like inventory adjustments, product analytics, or integration with external product management systems.
+   *
+   * Extensions at this target can access the product identifier through the Product API to perform product-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete product workflows.
+   */
   'pos.product-details.action.menu-item.render': RenderExtension<
     StandardApi<'pos.product-details.action.menu-item.render'> &
       ActionApi &
@@ -100,10 +160,20 @@ export interface RenderExtensionTargets {
       ProductApi,
     ActionExtensionComponents
   >;
+  /**
+   * Renders a full-screen modal interface launched from product details menu items. Use this target for complex product workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
+   *
+   * Extensions at this target have access to product and cart data through the Product API and support workflows with multiple screens, navigation, and interactive components.
+   */
   'pos.product-details.action.render': RenderExtension<
     ActionTargetApi<'pos.product-details.action.render'> & CartApi & ProductApi,
     BasicComponents
   >;
+  /**
+   * Renders a custom information section within the product details screen. Use this target for displaying supplementary product data like detailed specifications, inventory status, or related product recommendations alongside standard product details.
+   *
+   * Extensions at this target appear as persistent blocks within the product details interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex product operations.
+   */
   'pos.product-details.block.render': RenderExtension<
     StandardApi<'pos.product-details.block.render'> &
       CartApi &
@@ -111,6 +181,11 @@ export interface RenderExtensionTargets {
       ActionApi,
     BlockExtensionComponents
   >;
+  /**
+   * Renders a single interactive button component as a menu item in the order details action menu. Use this target for order-specific operations like reprints, refunds, exchanges, or launching fulfillment workflows.
+   *
+   * Extensions at this target can access the order identifier through the Order API to perform order-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete order workflows.
+   */
   'pos.order-details.action.menu-item.render': RenderExtension<
     StandardApi<'pos.order-details.action.menu-item.render'> &
       ActionApi &
@@ -118,10 +193,20 @@ export interface RenderExtensionTargets {
       OrderApi,
     ActionExtensionComponents
   >;
+  /**
+   * Renders a full-screen modal interface launched from order details menu items. Use this target for complex order workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
+   *
+   * Extensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.
+   */
   'pos.order-details.action.render': RenderExtension<
     ActionTargetApi<'pos.order-details.action.render'> & CartApi & OrderApi,
     BasicComponents
   >;
+  /**
+   * Renders a custom information section within the order details screen. Use this target for displaying supplementary order data like fulfillment status, tracking numbers, or custom order analytics alongside standard order details.
+   *
+   * Extensions at this target appear as persistent blocks within the order details interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex order operations.
+   */
   'pos.order-details.block.render': RenderExtension<
     StandardApi<'pos.order-details.block.render'> &
       CartApi &
@@ -129,6 +214,11 @@ export interface RenderExtensionTargets {
       ActionApi,
     BlockExtensionComponents
   >;
+  /**
+   * Renders a single interactive button component as a menu item in the draft order details action menu. Use this target for draft order-specific operations like sending invoices, updating payment status, or launching custom workflow processes for pending orders.
+   *
+   * Extensions at this target can access draft order information including order ID, name, and associated customer through the Draft Order API. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete draft order workflows.
+   */
   'pos.draft-order-details.action.menu-item.render': RenderExtension<
     StandardApi<'pos.draft-order-details.action.menu-item.render'> &
       ActionApi &
@@ -136,12 +226,22 @@ export interface RenderExtensionTargets {
       DraftOrderApi,
     ActionExtensionComponents
   >;
+  /**
+   * Renders a full-screen modal interface launched from draft order details menu items. Use this target for complex draft order workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
+   *
+   * Extensions at this target have access to draft order data through the Draft Order API and support workflows with multiple screens, navigation, and interactive components.
+   */
   'pos.draft-order-details.action.render': RenderExtension<
     ActionTargetApi<'pos.draft-order-details.action.render'> &
       DraftOrderApi &
       CartApi,
     BasicComponents
   >;
+  /**
+   * Renders a custom information section within the draft order details screen. Use this target for displaying supplementary order information like processing status, payment status, or workflow indicators alongside standard draft order details.
+   *
+   * Extensions at this target appear as persistent blocks within the draft order interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex draft order operations.
+   */
   'pos.draft-order-details.block.render': RenderExtension<
     StandardApi<'pos.draft-order-details.block.render'> &
       ActionApi &
@@ -149,6 +249,11 @@ export interface RenderExtensionTargets {
       DraftOrderApi,
     BlockExtensionComponents
   >;
+  /**
+   * Renders a single interactive button component as a menu item in the customer details action menu. Use this target for customer-specific operations like applying customer discounts, processing loyalty redemptions, or launching profile update workflows.
+   *
+   * Extensions at this target can access the customer identifier through the Customer API to perform customer-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete customer workflows.
+   */
   'pos.customer-details.action.menu-item.render': RenderExtension<
     StandardApi<'pos.customer-details.action.menu-item.render'> &
       ActionApi &
@@ -156,12 +261,22 @@ export interface RenderExtensionTargets {
       CustomerApi,
     ActionExtensionComponents
   >;
+  /**
+   * Renders a full-screen modal interface launched from customer details menu items. Use this target for complex customer workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
+   *
+   * Extensions at this target have access to customer data through the Customer API and support workflows with multiple screens, navigation, and interactive components.
+   */
   'pos.customer-details.action.render': RenderExtension<
     ActionTargetApi<'pos.customer-details.action.render'> &
       CartApi &
       CustomerApi,
     BasicComponents
   >;
+  /**
+   * Renders a custom information section within the customer details screen. Use this target for displaying supplementary customer data like loyalty status, points balance, or personalized information alongside standard customer details.
+   *
+   * Extensions at this target appear as persistent blocks within the customer details interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex customer operations.
+   */
   'pos.customer-details.block.render': RenderExtension<
     StandardApi<'pos.customer-details.block.render'> &
       CartApi &
@@ -169,6 +284,11 @@ export interface RenderExtensionTargets {
       ActionApi,
     BlockExtensionComponents
   >;
+  /**
+   * Renders a single interactive button component as a menu item in the cart line item action menu. Use this target for item-specific operations like applying discounts, adding custom properties, or launching verification workflows for individual cart items.
+   *
+   * Extensions at this target can access detailed line item information including title, quantity, price, discounts, properties, and product metadata through the Cart Line Item API. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete workflows.
+   */
   'pos.cart.line-item-details.action.menu-item.render': RenderExtension<
     StandardApi<'pos.cart.line-item-details.action.menu-item.render'> &
       ActionApi &
@@ -176,6 +296,11 @@ export interface RenderExtensionTargets {
       CartLineItemApi,
     ActionExtensionComponents
   >;
+  /**
+   * Renders a full-screen modal interface launched from cart line item menu items. Use this target for complex line item workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
+   *
+   * Extensions at this target have access to detailed line item data through the Cart Line Item API and support workflows with multiple screens, navigation, and interactive components.
+   */
   'pos.cart.line-item-details.action.render': RenderExtension<
     ActionTargetApi<'pos.cart.line-item-details.action.render'> &
       ActionApi &
@@ -183,10 +308,20 @@ export interface RenderExtensionTargets {
       CartLineItemApi,
     BasicComponents
   >;
+  /**
+   * Renders a custom section in the footer of printed receipts. Use this target for adding contact details, return policies, social media links, or customer engagement elements like survey links or marketing campaigns at the bottom of receipts.
+   *
+   * Extensions at this target appear in the receipt footer area and support limited components optimized for print formatting, including text content for information display.
+   */
   'pos.receipt-footer.block.render': RenderExtension<
     {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
     ReceiptComponents
   >;
+  /**
+   * Renders a custom section in the header of printed receipts. Use this target for adding custom branding, logos, promotional messages, or store-specific information at the top of receipts.
+   *
+   * Extensions at this target appear in the receipt header area and support limited components optimized for print formatting, including text content for information display.
+   */
   'pos.receipt-header.block.render': RenderExtension<
     {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
     ReceiptComponents

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
@@ -57,5 +57,8 @@ export interface BaseTransactionComplete {
    * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the transaction was executed and completed (for example, `"2024-05-15T14:30:00Z"`). This marks the exact moment the transaction was finalized, payment was processed, and the order was created. Commonly used for transaction history, chronological sorting, reporting, audit trails, and synchronization with external systems.
    */
   executedAt: string;
+  /**
+   * The tip amount added to this transaction as a `Money` object. This represents the gratuity the customer chose to add on top of the grand total, typically for service-based businesses or hospitality transactions. Tipping can be enabled through POS settings and may be added as a percentage or fixed amount. Returns `undefined` when no tip was added or when tipping is not enabled for the transaction.
+   */
   tipAmount?: Money;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
@@ -5,17 +5,56 @@ import type {ShippingLine} from './shipping-line';
 import type {TaxLine} from './tax-line';
 import type {TransactionType} from './transaction-type';
 
+/**
+ * Base interface for completed transaction data shared across all transaction types.
+ */
 export interface BaseTransactionComplete {
+  /**
+   * The transaction type identifier indicating which kind of transaction was completed (for example, `'Sale'` for new purchases, `'Return'` for refunds, `'Exchange'` for item swaps, `'Reprint'` for receipt reprints). This determines the transaction's business logic, receipt format, and inventory impact.
+   */
   transactionType: TransactionType;
+  /**
+   * The unique numeric identifier for the Shopify order created by this transaction. This ID links the POS transaction to the order record in Shopify's system and can be used for order lookups, tracking, and API operations. Returns `undefined` for transactions that don't create orders (for example, reprints) or when order creation is pending.
+   */
   orderId?: number;
+  /**
+   * The customer information if this transaction is associated with a customer account. Contains the customer ID for linking to customer records. Returns `undefined` for guest transactions where no customer was selected or when the transaction doesn't support customer association.
+   */
   customer?: Customer;
+  /**
+   * An array of all discounts applied to this transaction, including cart-level discounts, automatic discounts, and discount codes. Each discount entry contains the discount amount, type, and description. Returns `undefined` or empty array when no discounts were applied. The sum of discount amounts reduces the final transaction total.
+   */
   discounts?: Discount[];
+  /**
+   * The total tax amount charged on this transaction as a `Money` object. This is the sum of all tax lines and represents the combined tax from all applicable tax jurisdictions and rules. Tax calculations are based on the location, products, customer, and tax settings configured in Shopify.
+   */
   taxTotal: Money;
+  /**
+   * The subtotal amount before taxes and after discounts are applied, as a `Money` object. This represents the sum of all line item prices (quantity × unit price) minus any discounts, but before tax is added. This is the taxable base amount for most tax calculations.
+   */
   subtotal: Money;
+  /**
+   * The final total amount the customer pays for this transaction as a `Money` object. This includes all line items, shipping charges, taxes, and accounts for all discounts. This is the amount that must be tendered through payment methods. Calculated as: subtotal + taxTotal + shipping - discounts.
+   */
   grandTotal: Money;
+  /**
+   * An array of all payment methods used to complete this transaction. Each payment entry specifies the payment type (for example, cash, credit card), amount tendered, and currency. Multiple entries indicate split payments where the customer paid using multiple methods (for example, part cash, part credit card). The sum of all payment amounts should equal or exceed the `grandTotal`.
+   */
   paymentMethods: Payment[];
+  /**
+   * The remaining balance still owed on this transaction as a `Money` object. Typically `{amount: 0, currency: "USD"}` for fully paid transactions. A positive balance indicates partial payment or layaway scenarios. A negative balance indicates overpayment, where change should be returned to the customer. Calculated as: grandTotal minus sum of all payment amounts.
+   */
   balanceDue: Money;
+  /**
+   * An array of shipping charges applied to this transaction. Each shipping line represents a shipping method with its price and associated taxes. Multiple entries can exist when different shipping methods apply to different items or when combining shipping with pickup. Returns `undefined` or empty array for transactions with no shipping charges (for example, in-store purchases, digital products).
+   */
   shippingLines?: ShippingLine[];
+  /**
+   * An array of individual tax lines showing the detailed tax breakdown by jurisdiction and tax type. Each tax line represents a specific tax (for example, state tax, federal tax, VAT, GST) with its rate and calculated amount. Multiple tax lines can apply to a single transaction based on location, product taxability, and tax rules. Returns `undefined` or empty array for tax-exempt transactions or when detailed tax breakdown isn't available.
+   */
   taxLines?: TaxLine[];
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the transaction was executed and completed (for example, `"2024-05-15T14:30:00Z"`). This marks the exact moment the transaction was finalized, payment was processed, and the order was created. Commonly used for transaction history, chronological sorting, reporting, audit trails, and synchronization with external systems.
+   */
   executedAt: string;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -2,200 +2,396 @@ import {CountryCode} from './country-code';
 import {TaxLine} from './tax-line';
 import {DiscountAllocation} from './discount-allocation';
 
+/**
+ * Represents the shopping cart state, including line items, pricing, customer information, and applied discounts. Provides comprehensive access to all cart data and operations.
+ */
 export interface Cart {
   /**
-   * Indicates whether the cart is currently editable.
-   *
-   * An undefined value should be treated as `true` for backward compatibility.
+   * Whether the cart is currently editable. An `undefined` value is treated as `true` for backward compatibility. When `false`, cart modification operations aren't allowed.
    */
   editable?: boolean;
+  /**
+   * The subtotal amount of the cart before taxes and discounts, formatted as a currency string.
+   */
   subtotal: string;
+  /**
+   * The total tax amount for the cart, formatted as a currency string.
+   */
   taxTotal: string;
+  /**
+   * The final total amount including all items, taxes, and discounts, formatted as a currency string.
+   */
   grandTotal: string;
+  /**
+   * The cart note to set during bulk update. Replaces existing note or sets new note if none exists. Set to `undefined` to remove current note.
+   */
   note?: string;
+  /**
+   * The cart-level discount to apply during bulk update. Replaces existing cart discount. Set to `undefined` to remove current discount.
+   */
   cartDiscount?: Discount;
+  /**
+   * An array of cart-level discounts to apply during bulk update. Replaces all existing cart discounts with the provided array.
+   */
   cartDiscounts: Discount[];
+  /**
+   * The customer to associate with the cart during bulk update. Replaces existing customer or converts guest cart to customer cart.
+   */
   customer?: Customer;
+  /**
+   * An array of line items to set during bulk update. Completely replaces existing cart contents—removes all current items and adds the provided ones.
+   */
   lineItems: LineItem[];
+  /**
+   * The custom key-value properties attached to this line item. Empty object if no properties are set. Commonly used for metadata, customization options, or integration data.
+   */
   properties: Record<string, string>;
 }
 
+/**
+ * Specifies the parameters for updating cart information. Includes options for modifying customer data, notes, references, and other cart-level metadata.
+ */
 export interface CartUpdateInput {
+  /**
+   * The cart note to set during bulk update. Replaces existing note or sets new note if none exists. Set to `undefined` to remove current note.
+   */
   note?: string;
+  /**
+   * The cart-level discount to apply during bulk update. Replaces existing cart discount. Set to `undefined` to remove current discount.
+   */
   cartDiscount?: Discount;
+  /**
+   * An array of cart-level discounts to apply during bulk update. Replaces all existing cart discounts with the provided array.
+   */
   cartDiscounts: Discount[];
+  /**
+   * The customer to associate with the cart during bulk update. Replaces existing customer or converts guest cart to customer cart.
+   */
   customer?: Customer;
+  /**
+   * An array of line items to set during bulk update. Completely replaces existing cart contents—removes all current items and adds the provided ones.
+   */
   lineItems: LineItem[];
+  /**
+   * The custom key-value properties attached to this line item. Empty object if no properties are set. Commonly used for metadata, customization options, or integration data.
+   */
   properties: Record<string, string>;
 }
 
+/**
+ * Represents basic customer identification information. Contains the customer ID for linking to detailed customer data and enabling customer-specific features.
+ */
 export interface Customer {
+  /**
+   * The unique identifier of the selling plan. Commonly used for selling plan operations and management.
+   */
   id: number;
 }
 
+/**
+ * Represents an individual item in the shopping cart. Contains product information, pricing, quantity, discounts, and customization details for a single cart entry.
+ */
 export interface LineItem {
+  /**
+   * The unique [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) string identifier for this specific line item within the cart. This identifier is generated when the line item is added to the cart and remains constant for that line item throughout its lifecycle. The UUID distinguishes this line item from other line items in the cart, even if they represent the same product or variant. This is the primary key for line item operations—all Cart API methods that target specific line items require this UUID. Commonly used for updating line item properties, applying line item discounts, removing items from cart, setting selling plans, or tracking individual line items through the checkout process.
+   */
   uuid: string;
+  /**
+   * The unit price of a single unit of this line item as a numeric value in the store's currency. This is the price per item before any line item discounts are applied (though cart-level discounts affecting the subtotal are already factored in). For example, if selling a product for $19.99 each, this value is `19.99`. Returns `undefined` for custom sales where no price is set or when price information isn't available. The total line item cost before discounts is calculated as `price × quantity`. Commonly used for displaying item prices, calculating line totals, showing price comparisons, or implementing pricing-based business logic.
+   */
   price?: number;
+  /**
+   * The number of units of this item in the cart. This is always a positive integer (minimum 1) representing how many of this specific item/variant the customer is purchasing. When quantity changes (increased or decreased), the same line item UUID is updated rather than creating a new line item. Quantities of 0 aren't allowed—removing the last unit removes the entire line item from the cart. Commonly used for quantity displays in cart UI, calculating line totals (`price × quantity`), inventory availability checks, or quantity-based business logic (bulk pricing, quantity limits).
+   */
   quantity: number;
+  /**
+   * The customer-facing display name for this line item. For product-based line items, this is typically the product or variant title (for example, "Blue Cotton T-Shirt - Large"). For custom sales, this is the custom title entered by the merchant. Returns `undefined` for line items without titles, though most line items have titles for display purposes. This is the primary text shown to customers in cart views, receipts, and order confirmations. Commonly used for cart displays, receipt generation, order summaries, or search/filter functionality within the cart.
+   */
   title?: string;
+  /**
+   * The unique numeric identifier for the product variant this line item represents. This ID links to a specific variant in the Shopify catalog with particular options (size, color, material). Returns `undefined` for custom sale line items that aren't linked to catalog products, or for gift cards and other non-product line items. When present, this ID can be used to fetch complete variant details (inventory, price, SKU, barcode, images) using the Product Search API. Commonly used for variant-specific operations (inventory checks, variant detail lookups), determining if the line item is a catalog product, or linking to variant records in external systems.
+   */
   variantId?: number;
+  /**
+   * The unique numeric identifier for the product this line item represents. This ID links to the parent product in the Shopify catalog. Returns `undefined` for custom sale line items that aren't linked to catalog products, or for gift cards and other non-product line items. When present, this ID can be used to fetch complete product information (all variants, images, description, tags) using the Product Search API. A line item has both `productId` and `variantId` when it's a catalog product—the product ID identifies the product family while the variant ID identifies the specific configuration. Commonly used for product-specific operations (loading product details, checking product-level settings), grouping line items by product, or linking to product records in external systems.
+   */
   productId?: number;
+  /**
+   * An array of all discounts applied specifically to this line item (not cart-level discounts). Each discount object contains the amount, type, and description. The array is empty when no line item-specific discounts are applied. Multiple discounts can apply to a single line item when discount stacking is enabled. The sum of discount amounts reduces the line item's contribution to the cart total. Commonly used for displaying line item savings ("You save $5.00"), showing discount breakdowns in itemized views, calculating effective prices after discounts, or implementing discount-aware business logic.
+   */
   discounts: Discount[];
+  /**
+   * An array of discount allocation objects providing detailed breakdown of how each discount amount is calculated and distributed across this line item. This includes information about discount priority, combination rules, and exact allocated amounts. Returns `undefined` when allocation tracking isn't available or when no discounts are applied. Discount allocations provide visibility into complex discount scenarios where multiple discounts interact, combine, or have caps. Commonly used for advanced discount reporting, audit trails showing how final discounts were calculated, compliance reporting, or implementing discount allocation displays.
+   */
   discountAllocations?: DiscountAllocation[];
+  /**
+   * Whether this line item is subject to tax calculations. When `true`, taxes are calculated and applied to this line item based on the product's tax settings, location tax rules, and customer tax exemptions. When `false`, this line item is tax-exempt and contributes no tax to the cart total (though it still counts toward the subtotal). Tax exemption can occur for tax-free products (food in some regions), non-profit sales, or products with explicit tax exemption settings. Commonly used for tax calculations, determining if tax lines should be shown for this item, compliance reporting, or implementing tax-aware pricing displays.
+   */
   taxable: boolean;
+  /**
+   * An array of individual tax lines applied to this line item, showing the detailed tax breakdown by jurisdiction and tax type. Each tax line represents a specific tax (for example, state tax, county tax, city tax, VAT) with its own rate and calculated amount. Multiple tax lines exist when the item is subject to multiple tax jurisdictions or tax types. The sum of all tax line amounts equals the total tax for this line item. Empty array when the line item is tax-exempt (`taxable: false`) or when detailed tax breakdown isn't available. Commonly used for displaying itemized tax information, tax reporting and compliance, receipt generation with tax details, or implementing tax-aware business logic.
+   */
   taxLines: TaxLine[];
+  /**
+   * The Stock Keeping Unit (SKU) identifier for this line item as configured in the product catalog. SKUs are merchant-defined alphanumeric codes used for inventory tracking, fulfillment, and product identification (for example, "TSHIRT-BLU-LG", "12345-A"). Returns `undefined` when no SKU is configured for the product variant, which is common for products without inventory tracking or custom sales. The SKU is unique within the merchant's catalog and is often used with barcode scanners or inventory management systems. Commonly used for inventory tracking, displaying product codes on receipts, integrating with warehouse management systems, or matching products with external SKU-based systems.
+   */
   sku?: string;
+  /**
+   * The vendor or brand name for this line item as configured in the product catalog (for example, "Nike", "Acme Corp", "House Brand"). This indicates who manufactures or supplies the product. Returns `undefined` when no vendor is set for the product, which is common for products where vendor tracking isn't used. Vendors are merchant-defined and not standardized. Commonly used for vendor-specific displays in cart or receipts, filtering or grouping products by vendor, implementing vendor-based business logic (special handling for certain suppliers), or reporting sales by vendor.
+   */
   vendor?: string;
+  /**
+   * The custom key-value properties attached to this line item. Properties are merchant-defined metadata used to store additional information about the line item beyond standard fields. Keys and values are both strings. The object is empty `{}` when no properties are set. Properties persist through checkout and appear on orders. Common uses include customization details (engraving text, color preferences), configuration options (gift wrapping, special instructions), integration data (external IDs, tracking codes), or workflow metadata (fulfillment notes, custom fields). Properties are set using the Cart API's `addLineItemProperties` method and can be displayed in cart UI, included on receipts, or used for fulfillment instructions.
+   */
   properties: {[key: string]: string};
+  /**
+   * Whether this line item is a gift card product. When `true`, indicates this is a Shopify gift card (digital or physical) which has special handling—gift cards don't affect inventory, have different tax treatment in some jurisdictions, and generate gift card codes upon purchase. When `false`, this is a regular product, custom sale, or other non-gift-card item. Gift card line items may have restrictions on discounts or combinations with other line items. Commonly used for implementing gift card-specific UI, applying gift card business rules, excluding gift cards from certain promotions, or separating gift card sales in reporting.
+   */
   isGiftCard: boolean;
+  /**
+   * The unique numeric identifier for the staff member attributed to this specific line item for sales tracking and commission purposes. This represents which staff member should receive credit for selling this item, which may differ from the staff member who completed the overall transaction. Returns `undefined` when no staff attribution is set, which can occur for online orders or when staff attribution isn't used. Staff attribution is set using the Cart API's `setAttributedStaffToLineItem` method. Commonly used for commission calculations, sales performance tracking by staff member, reporting individual staff contributions to sales, or implementing staff-specific business logic (quotas, incentives).
+   */
   attributedUserId?: number;
+  /**
+   * Whether this line item's product requires a selling plan (subscription/recurring purchase plan) to be purchased. When `true`, the product can't be purchased as a one-time item—a selling plan must be selected before checkout can complete. When `false` or `undefined`, the product can be purchased without a subscription. This is set at the product level in the Shopify catalog. Returns `undefined` when selling plan information isn't available or the product doesn't have selling plan configuration. Commonly used for enforcing selling plan selection in UI, showing/hiding selling plan selectors, validating cart before checkout, or implementing subscription-only product workflows.
+   */
   requiresSellingPlan?: boolean;
+  /**
+   * Whether this line item's product has selling plan groups (subscription options) available for customer selection. When `true`, the product offers subscription/recurring purchase options that customers can choose from, though selection may be optional unless `requiresSellingPlan` is also `true`. When `false` or `undefined`, the product doesn't offer subscription options. Returns `undefined` when selling plan information isn't available. Commonly used for determining whether to show subscription option UI, enabling subscription toggles, or implementing subscription-eligible product workflows.
+   */
   hasSellingPlanGroups?: boolean;
   /**
-   * The currently selected selling plan for this line item.
+   * The currently selected selling plan (subscription/recurring purchase plan) applied to this line item. Contains the selling plan details including unique identifier (`id`), display name (`name`), and delivery schedule information (frequency, interval). Returns `undefined` when no selling plan is selected, which occurs for one-time purchases or when the product doesn't support subscriptions. Selling plans enable recurring deliveries at specified intervals (for example, every 2 weeks, monthly). Commonly used for displaying subscription details in cart ("Delivers every 30 days"), showing subscription pricing, managing recurring purchase configuration, calculating subscription discounts, or implementing subscription modification workflows.
    */
   sellingPlan?: SellingPlan;
   /**
-   * Bundle components for this line item. Only present for product bundles.
-   * Each component represents an individual item within the bundle with its own tax information.
+   * An array of individual component items that make up a [product bundle](/docs/apps/build/product-merchandising/bundles) when this line item represents a bundled product. Each component is a separate product included in the bundle with its own quantity, pricing, and tax calculation. For example, a "Home Office Bundle" line item might have components for a desk, chair, and lamp. The bundle itself is the line item, and the components array details what's included in that bundle. Returns `undefined` for non-bundle line items (regular products, custom sales, gift cards). Bundle components affect inventory separately—each component's inventory is decremented according to its quantity multiplied by the parent line item's quantity. Commonly used for displaying bundle contents to customers ("This bundle includes:"), calculating bundle-specific taxes (each component may have different tax treatment), showing itemized bundle pricing, or implementing bundle fulfillment logic where components ship separately.
    */
   components?: LineItemComponent[];
 }
 
 /**
- * Represents a component of a product bundle line item.
- * Bundle components contain the individual items that make up a bundle,
- * each with their own pricing and tax information.
+ * Represents an individual component item within a [product bundle](/docs/apps/build/product-merchandising/bundles) line item. Each component is a separate product that is included as part of the bundle, with its own quantity and pricing that contributes to the overall bundle line item.
  */
 export interface LineItemComponent {
-  /** The title/name of the component product */
+  /**
+   * The customer-facing display name for this bundle component product (for example, "Wireless Mouse", "USB-C Cable"). This is the product or variant title from the Shopify catalog. Returns `undefined` for components without titles. Commonly used for displaying the bundle contents list, showing what's included in the bundle on receipts, or itemizing bundle components in the cart UI.
+   */
   title?: string;
-  /** The quantity of this component in the bundle */
+  /**
+   * The number of units of this component product included in the bundle. This is the quantity per bundle unit, not the total quantity in cart. For example, if a bundle includes 2 pens and the customer buys 3 bundles, this value is `2` (pens per bundle) while the actual quantity leaving inventory would be 6 (2 pens × 3 bundles). Always a positive integer. Commonly used for displaying component quantities ("2× Wireless Mouse"), calculating total component quantities when considering the parent line item quantity, or managing component inventory deductions.
+   */
   quantity: number;
-  /** The price of this component */
+  /**
+   * The unit price of a single unit of this component product as configured in the bundle. This is the price per component unit, which may differ from the component's regular standalone price. Returns `undefined` when price information isn't specified for the component. Component prices are typically used for bundle pricing breakdowns or tax calculations. Commonly used for showing itemized bundle pricing, calculating component-level costs, or displaying price breakdowns for transparent bundle pricing.
+   */
   price?: number;
-  /** Whether this component is taxable */
+  /**
+   * Whether this component product is subject to tax calculations. When `true`, taxes are calculated for this component based on its price, quantity, and applicable tax rules. When `false`, this component is tax-exempt. Tax treatment can vary by component within a bundle—for example, a bundle containing taxable apparel and tax-exempt food items would have different taxability for each component. Commonly used for calculating accurate bundle taxes, compliance reporting, or implementing component-specific tax logic.
+   */
   taxable: boolean;
-  /** Tax lines applied to this component */
+  /**
+   * An array of tax lines applied specifically to this bundle component, showing the tax breakdown by jurisdiction and type. Each tax line has its own rate and calculated amount. The tax is calculated based on this component's price, quantity, and taxability. Empty array when the component is tax-exempt. Bundle component tax lines contribute to the overall line item tax total. Commonly used for detailed bundle tax reporting, showing per-component tax in itemized displays, or compliance documentation.
+   */
   taxLines: TaxLine[];
-  /** The variant ID of this component, if applicable */
+  /**
+   * The unique numeric identifier for the product variant this bundle component represents. Links to a specific variant in the Shopify catalog. Returns `undefined` for custom components or non-catalog items within the bundle. When present, this ID can be used to fetch full variant details or verify component inventory. Commonly used for component inventory management, linking bundle components to catalog records, or loading component variant details.
+   */
   variantId?: number;
-  /** The product ID of this component, if applicable */
+  /**
+   * The unique numeric identifier for the product this bundle component represents. Links to the parent product in the Shopify catalog. Returns `undefined` for custom components or non-catalog items within the bundle. When present, this ID can be used to fetch full product information about the component. Commonly used for component product lookups, grouping bundle components, or linking to product records.
+   */
   productId?: number;
 }
 
 /**
- * Represents a selling plan associated with a line item.
+ * Represents a selling plan (subscription/recurring purchase plan) associated with a line item. Contains delivery schedule, plan identification, and billing cycle information for subscription products.
  */
 export interface SellingPlan {
   /**
-   * The unique identifier of the selling plan.
+   * The unique numeric identifier for the selling plan in Shopify's system. This ID is consistent across all Shopify systems and links to the selling plan configuration in the merchant's catalog. The ID can be used to fetch full selling plan details using GraphQL queries or match against available selling plans for a product. Commonly used for selling plan operations (adding/removing selling plans from line items), matching user selections to plan configurations, tracking which plan was selected, or integrating with subscription management systems.
    */
   id: number;
   /**
-   * The name of the selling plan.
+   * The customer-facing display name for the selling plan (for example, "Deliver every 30 days", "Subscribe and save 10%", "Monthly subscription"). This name is shown to customers in the cart, checkout, and subscription management interfaces to describe the recurring purchase option. The name is configured by the merchant in the Shopify admin. Commonly used for displaying subscription plan options to customers, showing the selected plan in cart summaries, including plan details on receipts, or describing the subscription in customer communications.
    */
   name: string;
   /**
-   * The fingerprint of the applied selling plan within this cart session.
-   * Provided by POS. Not available during refund / exchanges.
+   * A unique fingerprint string identifying this specific selling plan selection within the current cart session. This fingerprint is generated and provided by POS when a selling plan is applied to a line item. The fingerprint is session-specific and not persistent across different carts or transactions. Returns `undefined` during refund/exchange operations (where no new subscription is being created) or when fingerprint generation isn't applicable. Not available in all contexts. Commonly used internally by POS for selling plan tracking, validation, and ensuring plan consistency during the checkout process.
    */
   digest?: string;
   /**
-   * The interval of the selling plan. (DAY, WEEK, MONTH, YEAR).
+   * The billing and delivery interval unit for the selling plan's recurring schedule. Indicates how often the subscription recurs and deliveries are made (for example, `'DAY'` for daily, `'WEEK'` for weekly, `'MONTH'` for monthly, `'YEAR'` for yearly). This works together with `deliveryIntervalCount` to define the complete schedule—for example, `deliveryInterval: 'MONTH'` with `deliveryIntervalCount: 2` means "every 2 months". Returns `undefined` when interval information isn't available or not applicable. Commonly used for displaying delivery frequency to customers, calculating next delivery dates, or showing subscription schedules in readable format.
    */
   deliveryInterval?: string;
   /**
-   * The number of intervals between deliveries.
+   * The numeric multiplier for the billing and delivery interval, defining how many interval units pass between each delivery. Works together with `deliveryInterval` to create the complete schedule. For example, `deliveryIntervalCount: 2` with `deliveryInterval: 'WEEK'` means "every 2 weeks", while `deliveryIntervalCount: 3` with `deliveryInterval: 'MONTH'` means "every 3 months". A value of `1` means every single interval (every day, every week, every month). Always a positive integer when present. Returns `undefined` when count information isn't available or not applicable. Commonly used for displaying complete delivery frequency to customers (combining with interval to show "Every 2 weeks"), calculating next delivery dates, or formatting subscription schedules for human readability.
    */
   deliveryIntervalCount?: number;
 }
 
+/**
+ * Represents a discount applied to a cart or transaction, including amount and description.
+ */
 export interface Discount {
+  /**
+   * The monetary amount of the discount as a numeric value. For percentage discounts, this represents the percentage value (for example, `10` for 10% off). For fixed amount discounts, this represents the absolute currency amount to deduct (for example, `5.00` for $5 off). The interpretation depends on the discount `type`.
+   */
   amount: number;
+  /**
+   * The three-letter [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code for the discount amount (for example, `"USD"`, `"EUR"`, `"GBP"`). This indicates which currency the `amount` is expressed in. Returns `undefined` when currency information isn't available or the discount is percentage-based.
+   */
   currency?: string;
+  /**
+   * A human-readable description of the discount shown to merchants and customers. This typically includes the discount name, promotion details, or discount code (for example, "SUMMER2024", "10% off entire order", "Buy 2 Get 1 Free"). Returns `undefined` when no description is provided.
+   */
   discountDescription?: string;
+  /**
+   * The discount type identifier indicating the discount category or calculation method (for example, `"Percentage"`, `"FixedAmount"`, `"Code"`). This determines how the discount `amount` is interpreted and applied. Returns `undefined` when type information isn't specified.
+   */
   type?: string;
 }
 
 /**
- * Parameters for adding custom properties to a line item.
+ * Specifies the parameters for adding custom properties to line items. Properties are key-value pairs used for storing metadata, tracking information, or integration data.
  */
 export interface SetLineItemPropertiesInput {
   /**
-   * The uuid belonging to the line item which should receive the custom properties.
+   * The target line item `UUID` for selling plan assignment. Must match an existing line item in the cart.
    */
   lineItemUuid: string;
   /**
-   * The custom properties to apply to the line item.
+   * The custom key-value properties attached to this line item. Empty object if no properties are set. Commonly used for metadata, customization options, or integration data.
    */
   properties: Record<string, string>;
 }
 
 /**
- * Parameters for adding a line item discount.
+ * Specifies the parameters for applying discounts to individual line items. Includes the discount type, value, and reason for audit and reporting purposes.
  */
 export interface SetLineItemDiscountInput {
   /**
-   * The uuid belonging to the line item which should receive the discount.
+   * The target line item `UUID` for selling plan assignment. Must match an existing line item in the cart.
    */
   lineItemUuid: string;
   /**
-   * The discount to be applied to the line item.
+   * The discount details to apply to the line item. Contains title, type (`'Percentage'` or `'FixedAmount'`), and amount value.
    */
   lineItemDiscount: LineItemDiscount;
 }
 
+/**
+ * Represents a discount applied to an individual line item in the cart.
+ */
 export interface LineItemDiscount {
   /**
-   * The title of the line item discount.
+   * The display title of the line item. Returns `undefined` for items without titles. Commonly used for customer-facing displays and cart item identification.
    */
   title: string;
   /**
-   * The discount type.
+   * The [discount type](https://help.shopify.com/en/manual/discounts/discount-types) applied to this line item. Can be either `'Percentage'` for percentage-based discounts or `'FixedAmount'` for fixed monetary amount discounts. This determines how the discount amount is calculated and displayed.
    */
   type: 'Percentage' | 'FixedAmount';
   /**
-   * The percentage or fixed amount for the discount.
+   * The discount value to apply. For `'Percentage'` type, this represents the percentage value (For example, "10" for 10% off). For `'FixedAmount'` type, this represents the fixed monetary amount to deduct from the line item price. Commonly used for discount calculations and displaying the discount value to merchants.
    */
   amount: string;
 }
 
+/**
+ * Represents a custom sale item that isn't linked to a product in the merchant's catalog. Custom sales allow merchants to add arbitrary items to the cart with manually entered details—useful for services, custom orders, one-off items, or products not in the catalog.
+ */
 export interface CustomSale {
+  /**
+   * The number of units of this custom sale item to add to the cart. Must be a positive integer (minimum 1) representing how many of this custom item the customer is purchasing. Since custom sales don't have inventory tracking, any quantity can be entered without stock validation. Commonly used for specifying how many of the custom item to charge for, calculating line totals (price × quantity), or displaying quantity on receipts and invoices.
+   */
   quantity: number;
+  /**
+   * The customer-facing display name for this custom sale item. This is the text that will appear on receipts, in the cart, and on order confirmations to describe what was sold. Should be descriptive and clear (for example, "Repair Service", "Custom Engraving", "Consultation Fee", "Special Order Item"). This is required to create a custom sale. Commonly used for cart and receipt displays, order identification, or describing the custom item in customer communications.
+   */
   title: string;
+  /**
+   * The unit price for a single unit of this custom sale item as a string value. This represents the price per item in the store's currency (for example, `"25.00"` for $25.00, `"99.99"` for $99.99). String format ensures precision for financial calculations. The total line item cost is calculated as this price multiplied by the quantity. Commonly used for pricing the custom sale, calculating line totals, displaying the charge to customers, or generating receipts with itemized pricing.
+   */
   price: string;
+  /**
+   * Whether this custom sale item is subject to tax calculations. When `true`, taxes are calculated and applied to this item based on location tax rules and settings. When `false`, this item is tax-exempt and no tax is charged. Tax exemption might apply for services, specific product categories, or non-taxable items depending on jurisdiction. Commonly used for determining whether to calculate taxes on this custom sale, compliance with tax regulations, displaying tax-inclusive vs tax-exclusive pricing, or generating accurate tax reports.
+   */
   taxable: boolean;
 }
 
+/**
+ * Represents physical address information for customer shipping and billing. Contains standard address fields including street, city, region, postal code, and country data.
+ */
 export interface Address {
+  /**
+   * The primary street address line containing the street number and name (for example, "123 Main Street", "456 Oak Avenue"). This is the first line of the mailing address and is typically required for shipping and billing operations. Returns `undefined` when not provided or not applicable. Commonly used for displaying addresses, calculating shipping rates based on location, validating address completeness, or sending to shipping carriers for label generation.
+   */
   address1?: string;
+  /**
+   * The secondary address line for additional location details like apartment number, suite, unit, floor, or building information (for example, "Apt 4B", "Suite 200", "Floor 3"). This field is optional and supplements the primary address line. Returns `undefined` when not provided. Commonly used for complete address display, ensuring deliveries reach the correct destination in multi-unit buildings, or providing detailed shipping instructions.
+   */
   address2?: string;
+  /**
+   * The city or locality name for the address (for example, "New York", "Toronto", "London"). Required for most shipping and billing operations as it's needed for calculating shipping zones, determining tax jurisdictions, and routing deliveries. Returns `undefined` when not provided. Commonly used for address display, shipping rate calculations based on destination city, tax determination, or filtering addresses by location.
+   */
   city?: string;
+  /**
+   * The company or business name associated with the address (for example, "Acme Corporation", "Smith & Co."). This field is optional and typically used for B2B transactions, business deliveries, or when the shipping/billing address is a commercial location rather than residential. Returns `undefined` for individual/residential addresses. Commonly used for business customer identification, commercial shipping labels, B2B order processing, or company-based address organization.
+   */
   company?: string;
+  /**
+   * The first name (given name) of the person associated with this address (for example, "John", "Maria"). Commonly used for personalizing shipping labels, customer communications, and ensuring deliveries reach the correct recipient. Returns `undefined` when not provided. Typically combined with `lastName` for full name display.
+   */
   firstName?: string;
+  /**
+   * The last name (family name/surname) of the person associated with this address (for example, "Smith", "Garcia"). Commonly used for complete customer identification, shipping labels, and formal address displays. Returns `undefined` when not provided. Typically combined with `firstName` for full name display (for example, "John Smith").
+   */
   lastName?: string;
+  /**
+   * The contact phone number for this address (for example, "+1-555-123-4567", "(555) 123-4567"). Phone numbers enable carriers to contact recipients for delivery coordination, provide delivery notifications using SMS, or reach customers for address clarification. Format varies by region and may include country codes, area codes, and extensions. Returns `undefined` when not provided. Commonly used for delivery notifications, customer contact during shipping issues, or SMS updates about order status.
+   */
   phone?: string;
+  /**
+   * The province, state, or region name for the address (for example, "California", "Ontario", "New South Wales"). Required for calculating regional shipping rates, determining state/provincial taxes, and routing deliveries correctly. The format is the full name rather than abbreviated code. Returns `undefined` when not provided or not applicable (some countries don't have province/state divisions). Commonly used for shipping rate calculations, tax jurisdiction determination, or displaying complete addresses.
+   */
   province?: string;
+  /**
+   * The country name for the address in English (for example, "United States", "Canada", "United Kingdom"). Required for international shipping, determining country-specific tax rules, and customs documentation. The full country name is used rather than an abbreviated code. Returns `undefined` when not provided. Commonly used for shipping calculations, tax compliance, customs forms, or country-based address validation.
+   */
   country?: string;
+  /**
+   * The postal code or ZIP code for the address (for example, "90210", "M5V 3A8", "SW1A 1AA"). Format varies by country—US uses 5 or 9-digit ZIP codes, Canada uses alphanumeric postal codes, UK uses alphanumeric postcodes. Required for accurate shipping rate calculations, address verification, and location-based services. Returns `undefined` when not provided. Commonly used for shipping rate lookup, address validation, geographic sorting, or carrier integration.
+   */
   zip?: string;
+  /**
+   * A customer-defined label or nickname for this address to make it easily identifiable (for example, "Home", "Work", "Main Office", "Warehouse"). This friendly name helps distinguish between multiple saved addresses for the same customer. Returns `undefined` when no custom name is assigned. Commonly used for displaying address selection lists ("Ship to: Home"), organizing customer addresses, or showing address nicknames in dropdowns.
+   */
   name?: string;
+  /**
+   * The standardized province or state code (for example, "CA" for California, "ON" for Ontario, "NSW" for New South Wales). This is typically a 2-3 character abbreviation that complements the full `province` name. Codes follow regional standards and enable programmatic province/state matching. Returns `undefined` when not applicable or not provided. Commonly used for precise regional identification in shipping APIs, automated tax calculations, address validation services, or integrating with carriers that require standardized codes.
+   */
   provinceCode?: string;
+  /**
+   * The standardized [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code (for example, `"US"` for United States, `"CA"` for Canada, `"GB"` for United Kingdom). This is a two-letter code that precisely identifies the country in a machine-readable format. Complements the full `country` name and is required by many shipping carriers and tax services. Returns `undefined` when not provided. Commonly used for precise country identification in shipping operations, international tax calculations, address validation, customs documentation, or carrier API integration.
+   */
   countryCode?: CountryCode;
 }
 
+/**
+ * Specifies the parameters for assigning a selling plan (subscription/recurring purchase plan) to a cart line item. This input is used with the Cart API's `addLineItemSellingPlan` method to configure subscription options for a product.
+ */
 export interface SetLineItemSellingPlanInput {
   /**
-   * The uuid of the line item to which the selling plan should be applied.
+   * The [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) of the target line item to which the selling plan should be applied. This must match the `uuid` of an existing line item in the current cart. If the UUID doesn't exist in the cart, the operation will fail. The line item's product must support selling plans—attempting to add a selling plan to a line item whose product doesn't have selling plan groups will result in an error. Commonly used to identify which cart item is being configured with a subscription plan.
    */
   lineItemUuid: string;
   /**
-   * The ID of the selling plan to apply to the line item.
+   * The unique numeric identifier for the selling plan to apply to the line item. This must be a valid selling plan ID that's available for the line item's product—arbitrary selling plan IDs. The selling plan must be configured in the merchant's Shopify admin and associated with the product. Invalid selling plan IDs or IDs not associated with the product will cause the operation to fail. Commonly used to specify which subscription option the customer selected (for example, monthly delivery, bi-weekly delivery).
    */
   sellingPlanId: number;
   /**
-   * The name of the selling plan to apply to the line item.
-   * If not provided, POS will try to fetch it from the server after syncing the cart.
+   * The optional display name for the selling plan (for example, "Deliver every 30 days", "Monthly subscription"). When provided, this name is used immediately for UI display without waiting for server synchronization. When omitted, POS will fetch the selling plan name from the server after cart synchronization completes, which may cause a brief delay before the name appears in the UI. Providing the name improves perceived performance and user experience by showing the plan name immediately. The name should match the actual selling plan name configured in Shopify. Returns `undefined` when not provided. Commonly used to optimize UI performance by avoiding server round-trips for plan name retrieval.
    */
   sellingPlanName?: string;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -7,7 +7,7 @@ import {DiscountAllocation} from './discount-allocation';
  */
 export interface Cart {
   /**
-   * Whether the cart is currently editable. An `undefined` value is treated as `true` for backward compatibility. When `false`, cart modification operations aren't allowed.
+   * Indicates whether the cart is currently editable. An `undefined` value should be treated as `true` for backward compatibility. Use this to determine if cart modification operations are allowed.
    */
   editable?: boolean;
   /**
@@ -43,7 +43,7 @@ export interface Cart {
    */
   lineItems: LineItem[];
   /**
-   * The custom key-value properties attached to this line item. Empty object if no properties are set. Commonly used for metadata, customization options, or integration data.
+   * The custom key-value properties to apply to the line item. Merged with existing properties—duplicate keys overwrite existing values.
    */
   properties: Record<string, string>;
 }
@@ -73,7 +73,7 @@ export interface CartUpdateInput {
    */
   lineItems: LineItem[];
   /**
-   * The custom key-value properties attached to this line item. Empty object if no properties are set. Commonly used for metadata, customization options, or integration data.
+   * The custom key-value properties to apply to the line item. Merged with existing properties—duplicate keys overwrite existing values.
    */
   properties: Record<string, string>;
 }
@@ -83,7 +83,7 @@ export interface CartUpdateInput {
  */
 export interface Customer {
   /**
-   * The unique identifier of the selling plan. Commonly used for selling plan operations and management.
+   * The unique numeric identifier for the customer in Shopify's system. This ID is consistent across all Shopify systems and APIs. Used to link this customer reference to the full customer record with complete profile information. Commonly used for customer lookups, applying customer-specific pricing or discounts, linking orders to customer accounts, or integrating with customer management systems.
    */
   id: number;
 }
@@ -93,139 +93,139 @@ export interface Customer {
  */
 export interface LineItem {
   /**
-   * The unique [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) string identifier for this specific line item within the cart. This identifier is generated when the line item is added to the cart and remains constant for that line item throughout its lifecycle. The UUID distinguishes this line item from other line items in the cart, even if they represent the same product or variant. This is the primary key for line item operations—all Cart API methods that target specific line items require this UUID. Commonly used for updating line item properties, applying line item discounts, removing items from cart, setting selling plans, or tracking individual line items through the checkout process.
+   * The unique identifier for this line item within the cart. Use for line item-specific operations like updates, removals, or property modifications.
    */
   uuid: string;
   /**
-   * The unit price of a single unit of this line item as a numeric value in the store's currency. This is the price per item before any line item discounts are applied (though cart-level discounts affecting the subtotal are already factored in). For example, if selling a product for $19.99 each, this value is `19.99`. Returns `undefined` for custom sales where no price is set or when price information isn't available. The total line item cost before discounts is calculated as `price × quantity`. Commonly used for displaying item prices, calculating line totals, showing price comparisons, or implementing pricing-based business logic.
+   * The unit price of the line item. Returns 'undefined' for custom sales without set prices. Use for pricing calculations and displays.
    */
   price?: number;
   /**
-   * The number of units of this item in the cart. This is always a positive integer (minimum 1) representing how many of this specific item/variant the customer is purchasing. When quantity changes (increased or decreased), the same line item UUID is updated rather than creating a new line item. Quantities of 0 aren't allowed—removing the last unit removes the entire line item from the cart. Commonly used for quantity displays in cart UI, calculating line totals (`price × quantity`), inventory availability checks, or quantity-based business logic (bulk pricing, quantity limits).
+   * The quantity of this item in the cart. Always a positive integer. Use for quantity displays, calculations, and inventory management.
    */
   quantity: number;
   /**
-   * The customer-facing display name for this line item. For product-based line items, this is typically the product or variant title (for example, "Blue Cotton T-Shirt - Large"). For custom sales, this is the custom title entered by the merchant. Returns `undefined` for line items without titles, though most line items have titles for display purposes. This is the primary text shown to customers in cart views, receipts, and order confirmations. Commonly used for cart displays, receipt generation, order summaries, or search/filter functionality within the cart.
+   * The display title of the line item. Returns 'undefined' for items without titles. Use for customer-facing displays and cart item identification.
    */
   title?: string;
   /**
-   * The unique numeric identifier for the product variant this line item represents. This ID links to a specific variant in the Shopify catalog with particular options (size, color, material). Returns `undefined` for custom sale line items that aren't linked to catalog products, or for gift cards and other non-product line items. When present, this ID can be used to fetch complete variant details (inventory, price, SKU, barcode, images) using the Product Search API. Commonly used for variant-specific operations (inventory checks, variant detail lookups), determining if the line item is a catalog product, or linking to variant records in external systems.
+   * The product variant 'ID' this line item represents. Returns 'undefined' for custom sales or non-variant items. Use for variant-specific operations and product details.
    */
   variantId?: number;
   /**
-   * The unique numeric identifier for the product this line item represents. This ID links to the parent product in the Shopify catalog. Returns `undefined` for custom sale line items that aren't linked to catalog products, or for gift cards and other non-product line items. When present, this ID can be used to fetch complete product information (all variants, images, description, tags) using the Product Search API. A line item has both `productId` and `variantId` when it's a catalog product—the product ID identifies the product family while the variant ID identifies the specific configuration. Commonly used for product-specific operations (loading product details, checking product-level settings), grouping line items by product, or linking to product records in external systems.
+   * The product 'ID' this line item represents. Returns 'undefined' for custom sales or non-product items. Use for product-specific operations and linking to product details.
    */
   productId?: number;
   /**
-   * An array of all discounts applied specifically to this line item (not cart-level discounts). Each discount object contains the amount, type, and description. The array is empty when no line item-specific discounts are applied. Multiple discounts can apply to a single line item when discount stacking is enabled. The sum of discount amounts reduces the line item's contribution to the cart total. Commonly used for displaying line item savings ("You save $5.00"), showing discount breakdowns in itemized views, calculating effective prices after discounts, or implementing discount-aware business logic.
+   * An array of discounts applied to this line item. Empty array if no discounts are active. Use for displaying line item savings and discount details.
    */
   discounts: Discount[];
   /**
-   * An array of discount allocation objects providing detailed breakdown of how each discount amount is calculated and distributed across this line item. This includes information about discount priority, combination rules, and exact allocated amounts. Returns `undefined` when allocation tracking isn't available or when no discounts are applied. Discount allocations provide visibility into complex discount scenarios where multiple discounts interact, combine, or have caps. Commonly used for advanced discount reporting, audit trails showing how final discounts were calculated, compliance reporting, or implementing discount allocation displays.
+   * An array of discount allocations applied to this line item, providing detailed breakdown of how discounts are distributed. Returns 'undefined' if no allocations exist. Use for enhanced discount tracking and reporting.
    */
   discountAllocations?: DiscountAllocation[];
   /**
-   * Whether this line item is subject to tax calculations. When `true`, taxes are calculated and applied to this line item based on the product's tax settings, location tax rules, and customer tax exemptions. When `false`, this line item is tax-exempt and contributes no tax to the cart total (though it still counts toward the subtotal). Tax exemption can occur for tax-free products (food in some regions), non-profit sales, or products with explicit tax exemption settings. Commonly used for tax calculations, determining if tax lines should be shown for this item, compliance reporting, or implementing tax-aware pricing displays.
+   * Determines whether this line item is subject to tax calculations. Use for tax computation, compliance, and pricing displays.
    */
   taxable: boolean;
   /**
-   * An array of individual tax lines applied to this line item, showing the detailed tax breakdown by jurisdiction and tax type. Each tax line represents a specific tax (for example, state tax, county tax, city tax, VAT) with its own rate and calculated amount. Multiple tax lines exist when the item is subject to multiple tax jurisdictions or tax types. The sum of all tax line amounts equals the total tax for this line item. Empty array when the line item is tax-exempt (`taxable: false`) or when detailed tax breakdown isn't available. Commonly used for displaying itemized tax information, tax reporting and compliance, receipt generation with tax details, or implementing tax-aware business logic.
+   * An array of tax lines applied to this line item, containing tax amounts and rates. Use for detailed tax reporting and compliance.
    */
   taxLines: TaxLine[];
   /**
-   * The Stock Keeping Unit (SKU) identifier for this line item as configured in the product catalog. SKUs are merchant-defined alphanumeric codes used for inventory tracking, fulfillment, and product identification (for example, "TSHIRT-BLU-LG", "12345-A"). Returns `undefined` when no SKU is configured for the product variant, which is common for products without inventory tracking or custom sales. The SKU is unique within the merchant's catalog and is often used with barcode scanners or inventory management systems. Commonly used for inventory tracking, displaying product codes on receipts, integrating with warehouse management systems, or matching products with external SKU-based systems.
+   * The Stock Keeping Unit (SKU) identifier for this line item. Returns 'undefined' if no SKU is configured. Use for inventory tracking and product identification.
    */
   sku?: string;
   /**
-   * The vendor or brand name for this line item as configured in the product catalog (for example, "Nike", "Acme Corp", "House Brand"). This indicates who manufactures or supplies the product. Returns `undefined` when no vendor is set for the product, which is common for products where vendor tracking isn't used. Vendors are merchant-defined and not standardized. Commonly used for vendor-specific displays in cart or receipts, filtering or grouping products by vendor, implementing vendor-based business logic (special handling for certain suppliers), or reporting sales by vendor.
+   * The vendor or brand name for this line item. Returns 'undefined' if no vendor is set. Use for vendor-specific displays and organization.
    */
   vendor?: string;
   /**
-   * The custom key-value properties attached to this line item. Properties are merchant-defined metadata used to store additional information about the line item beyond standard fields. Keys and values are both strings. The object is empty `{}` when no properties are set. Properties persist through checkout and appear on orders. Common uses include customization details (engraving text, color preferences), configuration options (gift wrapping, special instructions), integration data (external IDs, tracking codes), or workflow metadata (fulfillment notes, custom fields). Properties are set using the Cart API's `addLineItemProperties` method and can be displayed in cart UI, included on receipts, or used for fulfillment instructions.
+   * The custom key-value properties attached to this line item. Empty object if no properties are set. Use for metadata, customization options, or integration data.
    */
   properties: {[key: string]: string};
   /**
-   * Whether this line item is a gift card product. When `true`, indicates this is a Shopify gift card (digital or physical) which has special handling—gift cards don't affect inventory, have different tax treatment in some jurisdictions, and generate gift card codes upon purchase. When `false`, this is a regular product, custom sale, or other non-gift-card item. Gift card line items may have restrictions on discounts or combinations with other line items. Commonly used for implementing gift card-specific UI, applying gift card business rules, excluding gift cards from certain promotions, or separating gift card sales in reporting.
+   * Determines whether this line item is a gift card. Gift cards have special handling requirements and business logic. Use for implementing gift card-specific workflows.
    */
   isGiftCard: boolean;
   /**
-   * The unique numeric identifier for the staff member attributed to this specific line item for sales tracking and commission purposes. This represents which staff member should receive credit for selling this item, which may differ from the staff member who completed the overall transaction. Returns `undefined` when no staff attribution is set, which can occur for online orders or when staff attribution isn't used. Staff attribution is set using the Cart API's `setAttributedStaffToLineItem` method. Commonly used for commission calculations, sales performance tracking by staff member, reporting individual staff contributions to sales, or implementing staff-specific business logic (quotas, incentives).
+   * The staff member 'ID' attributed to this line item. Returns 'undefined' if no staff attribution is set. Use for commission tracking and performance analytics.
    */
   attributedUserId?: number;
   /**
-   * Whether this line item's product requires a selling plan (subscription/recurring purchase plan) to be purchased. When `true`, the product can't be purchased as a one-time item—a selling plan must be selected before checkout can complete. When `false` or `undefined`, the product can be purchased without a subscription. This is set at the product level in the Shopify catalog. Returns `undefined` when selling plan information isn't available or the product doesn't have selling plan configuration. Commonly used for enforcing selling plan selection in UI, showing/hiding selling plan selectors, validating cart before checkout, or implementing subscription-only product workflows.
+   * Determines whether this line item requires a selling plan (subscription) to be purchased. Returns 'undefined' if selling plan information is unavailable. Use for implementing subscription-based product handling.
    */
   requiresSellingPlan?: boolean;
   /**
-   * Whether this line item's product has selling plan groups (subscription options) available for customer selection. When `true`, the product offers subscription/recurring purchase options that customers can choose from, though selection may be optional unless `requiresSellingPlan` is also `true`. When `false` or `undefined`, the product doesn't offer subscription options. Returns `undefined` when selling plan information isn't available. Commonly used for determining whether to show subscription option UI, enabling subscription toggles, or implementing subscription-eligible product workflows.
+   * Determines whether this line item has selling plan groups (subscription options) available. Returns 'undefined' if selling plan information is unavailable. Use for displaying subscription options.
    */
   hasSellingPlanGroups?: boolean;
   /**
-   * The currently selected selling plan (subscription/recurring purchase plan) applied to this line item. Contains the selling plan details including unique identifier (`id`), display name (`name`), and delivery schedule information (frequency, interval). Returns `undefined` when no selling plan is selected, which occurs for one-time purchases or when the product doesn't support subscriptions. Selling plans enable recurring deliveries at specified intervals (for example, every 2 weeks, monthly). Commonly used for displaying subscription details in cart ("Delivers every 30 days"), showing subscription pricing, managing recurring purchase configuration, calculating subscription discounts, or implementing subscription modification workflows.
+   * The currently selected selling plan for this line item. Returns 'undefined' if no selling plan is applied. Contains selling plan details including 'ID', name, and delivery intervals. Use for subscription management and recurring purchase functionality.
    */
   sellingPlan?: SellingPlan;
   /**
-   * An array of individual component items that make up a [product bundle](/docs/apps/build/product-merchandising/bundles) when this line item represents a bundled product. Each component is a separate product included in the bundle with its own quantity, pricing, and tax calculation. For example, a "Home Office Bundle" line item might have components for a desk, chair, and lamp. The bundle itself is the line item, and the components array details what's included in that bundle. Returns `undefined` for non-bundle line items (regular products, custom sales, gift cards). Bundle components affect inventory separately—each component's inventory is decremented according to its quantity multiplied by the parent line item's quantity. Commonly used for displaying bundle contents to customers ("This bundle includes:"), calculating bundle-specific taxes (each component may have different tax treatment), showing itemized bundle pricing, or implementing bundle fulfillment logic where components ship separately.
+   * Bundle components for this line item. Only present for [product bundles](/docs/apps/build/product-merchandising/bundles). Each component represents an individual item within the bundle with its own tax information.
    */
   components?: LineItemComponent[];
 }
 
 /**
- * Represents an individual component item within a [product bundle](/docs/apps/build/product-merchandising/bundles) line item. Each component is a separate product that is included as part of the bundle, with its own quantity and pricing that contributes to the overall bundle line item.
+ * Represents a component of a [product bundle](/docs/apps/build/product-merchandising/bundles) line item. Bundle components contain the individual items that make up a bundle, each with their own pricing and tax information.
  */
 export interface LineItemComponent {
   /**
-   * The customer-facing display name for this bundle component product (for example, "Wireless Mouse", "USB-C Cable"). This is the product or variant title from the Shopify catalog. Returns `undefined` for components without titles. Commonly used for displaying the bundle contents list, showing what's included in the bundle on receipts, or itemizing bundle components in the cart UI.
+   * The display name for the custom sale item. Appears on receipts and in cart displays. Should be descriptive and customer-friendly.
    */
   title?: string;
   /**
-   * The number of units of this component product included in the bundle. This is the quantity per bundle unit, not the total quantity in cart. For example, if a bundle includes 2 pens and the customer buys 3 bundles, this value is `2` (pens per bundle) while the actual quantity leaving inventory would be 6 (2 pens × 3 bundles). Always a positive integer. Commonly used for displaying component quantities ("2× Wireless Mouse"), calculating total component quantities when considering the parent line item quantity, or managing component inventory deductions.
+   * The quantity of the custom sale item. Must be a positive integer. Use for quantity-based pricing and inventory management.
    */
   quantity: number;
   /**
-   * The unit price of a single unit of this component product as configured in the bundle. This is the price per component unit, which may differ from the component's regular standalone price. Returns `undefined` when price information isn't specified for the component. Component prices are typically used for bundle pricing breakdowns or tax calculations. Commonly used for showing itemized bundle pricing, calculating component-level costs, or displaying price breakdowns for transparent bundle pricing.
+   * The price for the custom sale item as currency string. Must be a valid positive amount. Use for non-catalog items and custom pricing.
    */
   price?: number;
   /**
-   * Whether this component product is subject to tax calculations. When `true`, taxes are calculated for this component based on its price, quantity, and applicable tax rules. When `false`, this component is tax-exempt. Tax treatment can vary by component within a bundle—for example, a bundle containing taxable apparel and tax-exempt food items would have different taxability for each component. Commonly used for calculating accurate bundle taxes, compliance reporting, or implementing component-specific tax logic.
+   * Determines whether the custom sale item is taxable. Set to `true` to apply tax calculations, `false` to exempt from taxes.
    */
   taxable: boolean;
   /**
-   * An array of tax lines applied specifically to this bundle component, showing the tax breakdown by jurisdiction and type. Each tax line has its own rate and calculated amount. The tax is calculated based on this component's price, quantity, and taxability. Empty array when the component is tax-exempt. Bundle component tax lines contribute to the overall line item tax total. Commonly used for detailed bundle tax reporting, showing per-component tax in itemized displays, or compliance documentation.
+   * An array of tax lines applied to this component.
    */
   taxLines: TaxLine[];
   /**
-   * The unique numeric identifier for the product variant this bundle component represents. Links to a specific variant in the Shopify catalog. Returns `undefined` for custom components or non-catalog items within the bundle. When present, this ID can be used to fetch full variant details or verify component inventory. Commonly used for component inventory management, linking bundle components to catalog records, or loading component variant details.
+   * The unique numeric identifier for the product variant this component represents, if applicable.
    */
   variantId?: number;
   /**
-   * The unique numeric identifier for the product this bundle component represents. Links to the parent product in the Shopify catalog. Returns `undefined` for custom components or non-catalog items within the bundle. When present, this ID can be used to fetch full product information about the component. Commonly used for component product lookups, grouping bundle components, or linking to product records.
+   * The unique numeric identifier for the product this component represents, if applicable.
    */
   productId?: number;
 }
 
 /**
- * Represents a selling plan (subscription/recurring purchase plan) associated with a line item. Contains delivery schedule, plan identification, and billing cycle information for subscription products.
+ * Represents a selling plan (subscription) associated with a line item, containing delivery schedule and plan identification details.
  */
 export interface SellingPlan {
   /**
-   * The unique numeric identifier for the selling plan in Shopify's system. This ID is consistent across all Shopify systems and links to the selling plan configuration in the merchant's catalog. The ID can be used to fetch full selling plan details using GraphQL queries or match against available selling plans for a product. Commonly used for selling plan operations (adding/removing selling plans from line items), matching user selections to plan configurations, tracking which plan was selected, or integrating with subscription management systems.
+   * The unique identifier of the selling plan.
    */
   id: number;
   /**
-   * The customer-facing display name for the selling plan (for example, "Deliver every 30 days", "Subscribe and save 10%", "Monthly subscription"). This name is shown to customers in the cart, checkout, and subscription management interfaces to describe the recurring purchase option. The name is configured by the merchant in the Shopify admin. Commonly used for displaying subscription plan options to customers, showing the selected plan in cart summaries, including plan details on receipts, or describing the subscription in customer communications.
+   * The name of the POS device.
    */
   name: string;
   /**
-   * A unique fingerprint string identifying this specific selling plan selection within the current cart session. This fingerprint is generated and provided by POS when a selling plan is applied to a line item. The fingerprint is session-specific and not persistent across different carts or transactions. Returns `undefined` during refund/exchange operations (where no new subscription is being created) or when fingerprint generation isn't applicable. Not available in all contexts. Commonly used internally by POS for selling plan tracking, validation, and ensuring plan consistency during the checkout process.
+   * The fingerprint of the applied selling plan within this cart session. Provided by POS. Not available during refund / exchanges.
    */
   digest?: string;
   /**
-   * The billing and delivery interval unit for the selling plan's recurring schedule. Indicates how often the subscription recurs and deliveries are made (for example, `'DAY'` for daily, `'WEEK'` for weekly, `'MONTH'` for monthly, `'YEAR'` for yearly). This works together with `deliveryIntervalCount` to define the complete schedule—for example, `deliveryInterval: 'MONTH'` with `deliveryIntervalCount: 2` means "every 2 months". Returns `undefined` when interval information isn't available or not applicable. Commonly used for displaying delivery frequency to customers, calculating next delivery dates, or showing subscription schedules in readable format.
+   * The interval of the selling plan. (DAY, WEEK, MONTH, YEAR).
    */
   deliveryInterval?: string;
   /**
-   * The numeric multiplier for the billing and delivery interval, defining how many interval units pass between each delivery. Works together with `deliveryInterval` to create the complete schedule. For example, `deliveryIntervalCount: 2` with `deliveryInterval: 'WEEK'` means "every 2 weeks", while `deliveryIntervalCount: 3` with `deliveryInterval: 'MONTH'` means "every 3 months". A value of `1` means every single interval (every day, every week, every month). Always a positive integer when present. Returns `undefined` when count information isn't available or not applicable. Commonly used for displaying complete delivery frequency to customers (combining with interval to show "Every 2 weeks"), calculating next delivery dates, or formatting subscription schedules for human readability.
+   * The number of intervals between deliveries.
    */
   deliveryIntervalCount?: number;
 }
@@ -235,11 +235,11 @@ export interface SellingPlan {
  */
 export interface Discount {
   /**
-   * The monetary amount of the discount as a numeric value. For percentage discounts, this represents the percentage value (for example, `10` for 10% off). For fixed amount discounts, this represents the absolute currency amount to deduct (for example, `5.00` for $5 off). The interpretation depends on the discount `type`.
+   * The discount value to apply. For `'Percentage'` type, this represents the percentage value (For example, "10" for 10% off). For `'FixedAmount'` type, this represents the fixed monetary amount to deduct from the line item price. Commonly used for discount calculations and displaying the discount value to merchants.
    */
   amount: number;
   /**
-   * The three-letter [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code for the discount amount (for example, `"USD"`, `"EUR"`, `"GBP"`). This indicates which currency the `amount` is expressed in. Returns `undefined` when currency information isn't available or the discount is percentage-based.
+   * The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code associated with the location currently active on POS.
    */
   currency?: string;
   /**
@@ -247,7 +247,7 @@ export interface Discount {
    */
   discountDescription?: string;
   /**
-   * The discount type identifier indicating the discount category or calculation method (for example, `"Percentage"`, `"FixedAmount"`, `"Code"`). This determines how the discount `amount` is interpreted and applied. Returns `undefined` when type information isn't specified.
+   * The [discount type](https://help.shopify.com/en/manual/discounts/discount-types) applied to this line item. Can be either `'Percentage'` for percentage-based discounts or `'FixedAmount'` for fixed monetary amount discounts. This determines how the discount amount is calculated and displayed.
    */
   type?: string;
 }
@@ -261,7 +261,7 @@ export interface SetLineItemPropertiesInput {
    */
   lineItemUuid: string;
   /**
-   * The custom key-value properties attached to this line item. Empty object if no properties are set. Commonly used for metadata, customization options, or integration data.
+   * The custom key-value properties to apply to the line item. Merged with existing properties—duplicate keys overwrite existing values.
    */
   properties: Record<string, string>;
 }
@@ -285,37 +285,37 @@ export interface SetLineItemDiscountInput {
  */
 export interface LineItemDiscount {
   /**
-   * The display title of the line item. Returns `undefined` for items without titles. Commonly used for customer-facing displays and cart item identification.
+   * The display name for the custom sale item. Appears on receipts and in cart displays. Should be descriptive and customer-friendly.
    */
   title: string;
   /**
-   * The [discount type](https://help.shopify.com/en/manual/discounts/discount-types) applied to this line item. Can be either `'Percentage'` for percentage-based discounts or `'FixedAmount'` for fixed monetary amount discounts. This determines how the discount amount is calculated and displayed.
+   * The discount type.
    */
   type: 'Percentage' | 'FixedAmount';
   /**
-   * The discount value to apply. For `'Percentage'` type, this represents the percentage value (For example, "10" for 10% off). For `'FixedAmount'` type, this represents the fixed monetary amount to deduct from the line item price. Commonly used for discount calculations and displaying the discount value to merchants.
+   * The percentage or fixed amount for the discount.
    */
   amount: string;
 }
 
 /**
- * Represents a custom sale item that isn't linked to a product in the merchant's catalog. Custom sales allow merchants to add arbitrary items to the cart with manually entered details—useful for services, custom orders, one-off items, or products not in the catalog.
+ * Represents a custom sale item that is not associated with a product in the catalog. Includes pricing, taxation, and descriptive information for manually created line items.
  */
 export interface CustomSale {
   /**
-   * The number of units of this custom sale item to add to the cart. Must be a positive integer (minimum 1) representing how many of this custom item the customer is purchasing. Since custom sales don't have inventory tracking, any quantity can be entered without stock validation. Commonly used for specifying how many of the custom item to charge for, calculating line totals (price × quantity), or displaying quantity on receipts and invoices.
+   * The quantity of the custom sale item. Must be a positive integer. Use for quantity-based pricing and inventory management.
    */
   quantity: number;
   /**
-   * The customer-facing display name for this custom sale item. This is the text that will appear on receipts, in the cart, and on order confirmations to describe what was sold. Should be descriptive and clear (for example, "Repair Service", "Custom Engraving", "Consultation Fee", "Special Order Item"). This is required to create a custom sale. Commonly used for cart and receipt displays, order identification, or describing the custom item in customer communications.
+   * The display name for the custom sale item. Appears on receipts and in cart displays. Should be descriptive and customer-friendly.
    */
   title: string;
   /**
-   * The unit price for a single unit of this custom sale item as a string value. This represents the price per item in the store's currency (for example, `"25.00"` for $25.00, `"99.99"` for $99.99). String format ensures precision for financial calculations. The total line item cost is calculated as this price multiplied by the quantity. Commonly used for pricing the custom sale, calculating line totals, displaying the charge to customers, or generating receipts with itemized pricing.
+   * The price for the custom sale item as currency string. Must be a valid positive amount. Use for non-catalog items and custom pricing.
    */
   price: string;
   /**
-   * Whether this custom sale item is subject to tax calculations. When `true`, taxes are calculated and applied to this item based on location tax rules and settings. When `false`, this item is tax-exempt and no tax is charged. Tax exemption might apply for services, specific product categories, or non-taxable items depending on jurisdiction. Commonly used for determining whether to calculate taxes on this custom sale, compliance with tax regulations, displaying tax-inclusive vs tax-exclusive pricing, or generating accurate tax reports.
+   * Determines whether the custom sale item is taxable. Set to `true` to apply tax calculations, `false` to exempt from taxes.
    */
   taxable: boolean;
 }
@@ -325,73 +325,73 @@ export interface CustomSale {
  */
 export interface Address {
   /**
-   * The primary street address line containing the street number and name (for example, "123 Main Street", "456 Oak Avenue"). This is the first line of the mailing address and is typically required for shipping and billing operations. Returns `undefined` when not provided or not applicable. Commonly used for displaying addresses, calculating shipping rates based on location, validating address completeness, or sending to shipping carriers for label generation.
+   * The primary street address line. Required for most shipping and billing operations. Should contain street number and name.
    */
   address1?: string;
   /**
-   * The secondary address line for additional location details like apartment number, suite, unit, floor, or building information (for example, "Apt 4B", "Suite 200", "Floor 3"). This field is optional and supplements the primary address line. Returns `undefined` when not provided. Commonly used for complete address display, ensuring deliveries reach the correct destination in multi-unit buildings, or providing detailed shipping instructions.
+   * The secondary address line for apartment, suite, or unit information. Optional field for additional address details.
    */
   address2?: string;
   /**
-   * The city or locality name for the address (for example, "New York", "Toronto", "London"). Required for most shipping and billing operations as it's needed for calculating shipping zones, determining tax jurisdictions, and routing deliveries. Returns `undefined` when not provided. Commonly used for address display, shipping rate calculations based on destination city, tax determination, or filtering addresses by location.
+   * The city name for the address. Required for shipping calculations and location-based services.
    */
   city?: string;
   /**
-   * The company or business name associated with the address (for example, "Acme Corporation", "Smith & Co."). This field is optional and typically used for B2B transactions, business deliveries, or when the shipping/billing address is a commercial location rather than residential. Returns `undefined` for individual/residential addresses. Commonly used for business customer identification, commercial shipping labels, B2B order processing, or company-based address organization.
+   * The company name associated with the address. Optional field for business customers and B2B transactions.
    */
   company?: string;
   /**
-   * The first name (given name) of the person associated with this address (for example, "John", "Maria"). Commonly used for personalizing shipping labels, customer communications, and ensuring deliveries reach the correct recipient. Returns `undefined` when not provided. Typically combined with `lastName` for full name display.
+   * The first name for the address contact. Used for personalized shipping labels and customer communication.
    */
   firstName?: string;
   /**
-   * The last name (family name/surname) of the person associated with this address (for example, "Smith", "Garcia"). Commonly used for complete customer identification, shipping labels, and formal address displays. Returns `undefined` when not provided. Typically combined with `firstName` for full name display (for example, "John Smith").
+   * The last name for the address contact. Required for complete customer identification and shipping labels.
    */
   lastName?: string;
   /**
-   * The contact phone number for this address (for example, "+1-555-123-4567", "(555) 123-4567"). Phone numbers enable carriers to contact recipients for delivery coordination, provide delivery notifications using SMS, or reach customers for address clarification. Format varies by region and may include country codes, area codes, and extensions. Returns `undefined` when not provided. Commonly used for delivery notifications, customer contact during shipping issues, or SMS updates about order status.
+   * The phone number for the address contact. Used for delivery notifications, shipping updates, and customer communication.
    */
   phone?: string;
   /**
-   * The province, state, or region name for the address (for example, "California", "Ontario", "New South Wales"). Required for calculating regional shipping rates, determining state/provincial taxes, and routing deliveries correctly. The format is the full name rather than abbreviated code. Returns `undefined` when not provided or not applicable (some countries don't have province/state divisions). Commonly used for shipping rate calculations, tax jurisdiction determination, or displaying complete addresses.
+   * The province or state name for the address. Required for regional shipping rates and tax calculations.
    */
   province?: string;
   /**
-   * The country name for the address in English (for example, "United States", "Canada", "United Kingdom"). Required for international shipping, determining country-specific tax rules, and customs documentation. The full country name is used rather than an abbreviated code. Returns `undefined` when not provided. Commonly used for shipping calculations, tax compliance, customs forms, or country-based address validation.
+   * The country name for the address. Required for international shipping, tax calculations, and compliance.
    */
   country?: string;
   /**
-   * The postal code or ZIP code for the address (for example, "90210", "M5V 3A8", "SW1A 1AA"). Format varies by country—US uses 5 or 9-digit ZIP codes, Canada uses alphanumeric postal codes, UK uses alphanumeric postcodes. Required for accurate shipping rate calculations, address verification, and location-based services. Returns `undefined` when not provided. Commonly used for shipping rate lookup, address validation, geographic sorting, or carrier integration.
+   * The postal or ZIP code for the address. Required for accurate shipping rates and location-based services.
    */
   zip?: string;
   /**
-   * A customer-defined label or nickname for this address to make it easily identifiable (for example, "Home", "Work", "Main Office", "Warehouse"). This friendly name helps distinguish between multiple saved addresses for the same customer. Returns `undefined` when no custom name is assigned. Commonly used for displaying address selection lists ("Ship to: Home"), organizing customer addresses, or showing address nicknames in dropdowns.
+   * The full name for the address contact. Use when first and last names are combined or unavailable as separate fields.
    */
   name?: string;
   /**
-   * The standardized province or state code (for example, "CA" for California, "ON" for Ontario, "NSW" for New South Wales). This is typically a 2-3 character abbreviation that complements the full `province` name. Codes follow regional standards and enable programmatic province/state matching. Returns `undefined` when not applicable or not provided. Commonly used for precise regional identification in shipping APIs, automated tax calculations, address validation services, or integrating with carriers that require standardized codes.
+   * The standardized province or state code. Use for precise regional identification and automated shipping calculations.
    */
   provinceCode?: string;
   /**
-   * The standardized [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code (for example, `"US"` for United States, `"CA"` for Canada, `"GB"` for United Kingdom). This is a two-letter code that precisely identifies the country in a machine-readable format. Complements the full `country` name and is required by many shipping carriers and tax services. Returns `undefined` when not provided. Commonly used for precise country identification in shipping operations, international tax calculations, address validation, customs documentation, or carrier API integration.
+   * The standardized country code (ISO format). Use for precise country identification and international shipping operations.
    */
   countryCode?: CountryCode;
 }
 
 /**
- * Specifies the parameters for assigning a selling plan (subscription/recurring purchase plan) to a cart line item. This input is used with the Cart API's `addLineItemSellingPlan` method to configure subscription options for a product.
+ * Specifies the parameters for assigning selling plans to line items. Used to add subscription or purchase option configurations to products.
  */
 export interface SetLineItemSellingPlanInput {
   /**
-   * The [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) of the target line item to which the selling plan should be applied. This must match the `uuid` of an existing line item in the current cart. If the UUID doesn't exist in the cart, the operation will fail. The line item's product must support selling plans—attempting to add a selling plan to a line item whose product doesn't have selling plan groups will result in an error. Commonly used to identify which cart item is being configured with a subscription plan.
+   * The target line item `UUID` for selling plan assignment. Must match an existing line item in the cart.
    */
   lineItemUuid: string;
   /**
-   * The unique numeric identifier for the selling plan to apply to the line item. This must be a valid selling plan ID that's available for the line item's product—arbitrary selling plan IDs. The selling plan must be configured in the merchant's Shopify admin and associated with the product. Invalid selling plan IDs or IDs not associated with the product will cause the operation to fail. Commonly used to specify which subscription option the customer selected (for example, monthly delivery, bi-weekly delivery).
+   * The selling plan `ID` to apply to the line item. Must be a valid selling plan available for the product.
    */
   sellingPlanId: number;
   /**
-   * The optional display name for the selling plan (for example, "Deliver every 30 days", "Monthly subscription"). When provided, this name is used immediately for UI display without waiting for server synchronization. When omitted, POS will fetch the selling plan name from the server after cart synchronization completes, which may cause a brief delay before the name appears in the UI. Providing the name improves perceived performance and user experience by showing the plan name immediately. The name should match the actual selling plan name configured in Shopify. Returns `undefined` when not provided. Commonly used to optimize UI performance by avoiding server round-trips for plan name retrieval.
+   * The selling plan name for display purposes. Required for proper selling plan display in the cart.
    */
   sellingPlanName?: string;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/country-code.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/country-code.ts
@@ -1,5 +1,8 @@
 /* eslint @shopify/typescript/prefer-pascal-case-enums: off */
 
+/**
+ * The two-letter [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes representing all countries and territories. These standard codes are used for addresses, shipping destinations, tax jurisdictions, and regional settings.
+ */
 export enum CountryCode {
   AF = 'AF',
   AX = 'AX',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/device.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/device.ts
@@ -1,14 +1,17 @@
+/**
+ * Defines information about the POS device where the extension is running. Contains device identification, form factor details, and configuration information.
+ */
 export interface Device {
   /**
-   * The name of the device
+   * The device name as configured by the merchant or system administrator. This is the friendly name displayed in device lists, admin interfaces, and device selection screens (for example, "Front Counter iPad", "Mobile Register 3", "Checkout Station A"). The name helps merchants identify which physical device is being used.
    */
   name: string;
   /**
-   * The ID of the device
+   * The unique numeric identifier for this specific POS device within the merchant's system. This ID is persistent across sessions and uniquely identifies the physical device. Commonly used for device-specific settings, logging, analytics tracking, or implementing device-based permissions and configurations.
    */
   deviceId: number;
   /**
-   * Whether the device is a tablet
+   * Whether the device is a tablet form factor (for example, iPad, Android tablet). When `true`, indicates a touchscreen tablet device. When `false`, indicates a different form factor such as a desktop POS terminal, mobile phone, or specialized POS hardware. This information can inform UI decisions like touch target sizes, layout adaptations, or feature availability.
    */
   isTablet: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/device.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/device.ts
@@ -1,17 +1,17 @@
 /**
- * Defines information about the POS device where the extension is running. Contains device identification, form factor details, and configuration information.
+ * Defines information about the POS device where the extension is running.
  */
 export interface Device {
   /**
-   * The device name as configured by the merchant or system administrator. This is the friendly name displayed in device lists, admin interfaces, and device selection screens (for example, "Front Counter iPad", "Mobile Register 3", "Checkout Station A"). The name helps merchants identify which physical device is being used.
+   * The name of the POS device.
    */
   name: string;
   /**
-   * The unique numeric identifier for this specific POS device within the merchant's system. This ID is persistent across sessions and uniquely identifies the physical device. Commonly used for device-specific settings, logging, analytics tracking, or implementing device-based permissions and configurations.
+   * The unique identifier for the POS device.
    */
   deviceId: number;
   /**
-   * Whether the device is a tablet form factor (for example, iPad, Android tablet). When `true`, indicates a touchscreen tablet device. When `false`, indicates a different form factor such as a desktop POS terminal, mobile phone, or specialized POS hardware. This information can inform UI decisions like touch target sizes, layout adaptations, or feature availability.
+   * Whether the device is a tablet form factor.
    */
   isTablet: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/direct-api-request-body.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/direct-api-request-body.ts
@@ -1,13 +1,13 @@
 /**
- * Interface representing the structure of a direct API request body for GraphQL operations.
+ * Represents the structure of a direct API request body for [GraphQL](https://graphql.org/) operations. Contains the query/mutation string and optional variables for parameterized queries.
  */
 export interface DirectApiRequestBody {
   /**
-   * The GraphQL query or mutation string to be executed.
+   * The GraphQL query or mutation string to be executed against the Shopify API. This is the complete GraphQL operation definition including operation type (query/mutation), field selections, and any embedded arguments. For example, a query string might be `"query { product(id: 123) { title price } }"` or a mutation like `"mutation UpdateProduct($id: ID!, $title: String!) { productUpdate(id: $id, title: $title) { product { title } } }"`. Variables should be extracted into the `variables` field rather than embedded directly in the query string for security and reusability.
    */
   query: string;
   /**
-   * Optional variables to be passed along with the GraphQL query.
+   * Optional variables to be passed along with the GraphQL query, used for parameterized queries and mutations. This is a key-value object where keys match the variable names declared in the `query` string (prefixed with `$`) and values are the actual data to substitute. For example, if the query declares `$id: ID!`, the variables object would include `{id: "123"}`. Variables provide security by preventing injection attacks, enable query reuse with different parameters, and improve GraphQL caching. Returns `undefined` when the query has no variables or uses inline arguments instead.
    */
   variables?: Record<string, any>;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-allocation.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-allocation.ts
@@ -1,5 +1,11 @@
 import type {MoneyV2} from './money';
 
+/**
+ * Represents a discount allocation showing how discounts are distributed across line items or carts. Discount allocations provide detailed breakdowns of how discount amounts are calculated and applied, particularly useful when multiple discounts interact or when discounts are split across multiple items.
+ */
 export interface DiscountAllocation {
+  /**
+   * The monetary amount allocated for this specific discount as a `MoneyV2` object with high-precision string-based calculation. This represents the actual discount value applied to the line item or cart after all discount calculations, combinations, and limitations are resolved. For example, if a 10% discount applies to a $100 item, the allocated amount would be `{amount: "10.00", currencyCode: "USD"}`. When multiple discounts apply to the same item, multiple allocation entries track how each discount contributes to the total savings.
+   */
   allocatedAmount: MoneyV2;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-allocation.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/discount-allocation.ts
@@ -1,11 +1,11 @@
 import type {MoneyV2} from './money';
 
 /**
- * Represents a discount allocation showing how discounts are distributed across line items or carts. Discount allocations provide detailed breakdowns of how discount amounts are calculated and applied, particularly useful when multiple discounts interact or when discounts are split across multiple items.
+ * Represents the allocation of a discount to a specific line item.
  */
 export interface DiscountAllocation {
   /**
-   * The monetary amount allocated for this specific discount as a `MoneyV2` object with high-precision string-based calculation. This represents the actual discount value applied to the line item or cart after all discount calculations, combinations, and limitations are resolved. For example, if a 10% discount applies to a $100 item, the allocated amount would be `{amount: "10.00", currencyCode: "USD"}`. When multiple discounts apply to the same item, multiple allocation entries track how each discount contributes to the total savings.
+   * The amount of discount allocated.
    */
   allocatedAmount: MoneyV2;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/money.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/money.ts
@@ -1,27 +1,27 @@
 /**
- * Represents a monetary amount with currency information. The amount is represented as a number.
+ * Represents a monetary amount with currency information.
  */
 export interface Money {
   /**
-   * The monetary amount as a numeric value in the currency's base unit. For example, `100` represents $100.00 USD or €100.00 EUR. This uses JavaScript's number type which has precision limitations for very large amounts or calculations requiring exact decimal arithmetic (floating-point arithmetic issues). For calculations requiring exact precision, consider using `MoneyV2` with string-based amounts.
+   * The monetary amount as a number.
    */
   amount: number;
   /**
-   * The three-letter [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code identifying which currency the amount is expressed in (for example, `"USD"` for US dollars, `"CAD"` for Canadian dollars, `"EUR"` for euros, `"GBP"` for British pounds). This code determines how the amount should be formatted and displayed, including the currency symbol, decimal separator, and number of decimal places.
+   * The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code associated with the location currently active on POS.
    */
   currency: string;
 }
 
 /**
- * Represents a monetary amount with currency information. The amount is represented as a string for precision.
+ * Represents a monetary amount as a string with explicit currency code.
  */
 export interface MoneyV2 {
   /**
-   * The monetary amount as a string value for high-precision decimal calculations. For example, `"100.00"` represents $100.00 or `"19.99"` represents $19.99. String representation avoids floating-point precision issues that can occur with JavaScript numbers, ensuring exact decimal arithmetic for financial calculations. This is critical for accurate tax calculations, discount applications, and currency conversions where precision errors would cause accounting discrepancies.
+   * The monetary amount as a string.
    */
   amount: string;
   /**
-   * The three-letter [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code identifying which currency the amount is expressed in (for example, `"USD"` for US dollars, `"CAD"` for Canadian dollars, `"EUR"` for euros, `"GBP"` for British pounds). This code determines how the amount should be formatted and displayed, including the currency symbol, decimal separator, and number of decimal places.
+   * The ISO currency code (for example, USD, CAD).
    */
   currencyCode: string;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/money.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/money.ts
@@ -1,9 +1,27 @@
+/**
+ * Represents a monetary amount with currency information. The amount is represented as a number.
+ */
 export interface Money {
+  /**
+   * The monetary amount as a numeric value in the currency's base unit. For example, `100` represents $100.00 USD or €100.00 EUR. This uses JavaScript's number type which has precision limitations for very large amounts or calculations requiring exact decimal arithmetic (floating-point arithmetic issues). For calculations requiring exact precision, consider using `MoneyV2` with string-based amounts.
+   */
   amount: number;
+  /**
+   * The three-letter [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code identifying which currency the amount is expressed in (for example, `"USD"` for US dollars, `"CAD"` for Canadian dollars, `"EUR"` for euros, `"GBP"` for British pounds). This code determines how the amount should be formatted and displayed, including the currency symbol, decimal separator, and number of decimal places.
+   */
   currency: string;
 }
 
+/**
+ * Represents a monetary amount with currency information. The amount is represented as a string for precision.
+ */
 export interface MoneyV2 {
+  /**
+   * The monetary amount as a string value for high-precision decimal calculations. For example, `"100.00"` represents $100.00 or `"19.99"` represents $19.99. String representation avoids floating-point precision issues that can occur with JavaScript numbers, ensuring exact decimal arithmetic for financial calculations. This is critical for accurate tax calculations, discount applications, and currency conversions where precision errors would cause accounting discrepancies.
+   */
   amount: string;
+  /**
+   * The three-letter [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code identifying which currency the amount is expressed in (for example, `"USD"` for US dollars, `"CAD"` for Canadian dollars, `"EUR"` for euros, `"GBP"` for British pounds). This code determines how the amount should be formatted and displayed, including the currency symbol, decimal separator, and number of decimal places.
+   */
   currencyCode: string;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/multiple-resource-result.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/multiple-resource-result.ts
@@ -1,14 +1,13 @@
 /**
- * The result of a fetch function where the input is multiple IDs.
- * This object contains the resources that were found, as well as an array of IDs specifying which IDs, if any, did not correspond to a resource.
+ * Represents the result of a bulk resource lookup operation. Contains successfully found resources and identifiers for resources that weren't found.
  */
 export interface MultipleResourceResult<T> {
   /**
-   * The resources that were fetched using the IDs provided.
+   * An array of resources that were successfully fetched using the IDs provided in the request. Each item in this array corresponds to a resource that exists and is accessible on the POS device. The order of items may not match the order of requested IDs. This array is empty when none of the requested IDs were found. Commonly used to access the actual product or variant data retrieved from bulk fetch operations.
    */
   fetchedResources: T[];
   /**
-   * The IDs for which a resource was not found.
+   * An array of numeric IDs for which no matching resource was found on the POS device. Resources may be missing because they don't exist, were deleted, aren't available to this location, or aren't synced to the POS device. This allows distinguishing between successful and failed lookups in a single operation. When all requested resources are found, this array is empty. Commonly used to handle missing products or variants gracefully, provide user feedback about unavailable items ("Product X not found"), log missing data for debugging, or implement fallback logic for missing resources.
    */
   idsForResourcesNotFound: number[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/multiple-resource-result.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/multiple-resource-result.ts
@@ -1,13 +1,13 @@
 /**
- * Represents the result of a bulk resource lookup operation. Contains successfully found resources and identifiers for resources that weren't found.
+ * Represents the result of a bulk resource lookup operation. Contains successfully found resources and identifiers for resources that were not found.
  */
 export interface MultipleResourceResult<T> {
   /**
-   * An array of resources that were successfully fetched using the IDs provided in the request. Each item in this array corresponds to a resource that exists and is accessible on the POS device. The order of items may not match the order of requested IDs. This array is empty when none of the requested IDs were found. Commonly used to access the actual product or variant data retrieved from bulk fetch operations.
+   * The resources that were fetched using the IDs provided.
    */
   fetchedResources: T[];
   /**
-   * An array of numeric IDs for which no matching resource was found on the POS device. Resources may be missing because they don't exist, were deleted, aren't available to this location, or aren't synced to the POS device. This allows distinguishing between successful and failed lookups in a single operation. When all requested resources are found, this array is empty. Commonly used to handle missing products or variants gracefully, provide user feedback about unavailable items ("Product X not found"), log missing data for debugging, or implement fallback logic for missing resources.
+   * The IDs for which a resource was not found.
    */
   idsForResourcesNotFound: number[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/order.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/order.ts
@@ -1,12 +1,29 @@
 import {LineItem} from './cart';
 
+/**
+ * Represents a refund applied to a line item, including when it was created and the quantity refunded.
+ */
 export interface LineItemRefund {
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the refund was created and processed (for example, `"2024-05-15T14:30:00Z"`). This indicates when the refund was initiated and can be used for chronological sorting, refund history displays, or audit trails.
+   */
   createdAt: string;
+  /**
+   * The number of units refunded in this refund transaction. This must be a positive integer representing how many items were returned to inventory or credited back to the customer. Multiple refunds can exist for the same line item if partial refunds were processed over time.
+   */
   quantity: number;
 }
 
+/**
+ * Represents a line item from an order, extending the base line item with current quantity and refund information.
+ */
 export interface OrderLineItem extends LineItem {
-  // Number of remaining goods
+  /**
+   * The current quantity of items that remain with the customer after accounting for refunds. This is calculated as the original `quantity` minus any refunded quantities. For example, if 5 items were ordered and 2 were refunded, `currentQuantity` would be `3`. This value reflects the net quantity the customer kept from this line item.
+   */
   currentQuantity: number;
+  /**
+   * An array of all refund transactions applied to this line item, ordered chronologically. Each refund entry tracks when the refund occurred and how many units were refunded. Multiple entries indicate partial refunds processed over time. Returns `undefined` or empty array when no refunds have been applied to this line item.
+   */
   refunds?: LineItemRefund[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/paginated-result.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/paginated-result.ts
@@ -3,17 +3,17 @@
  */
 export interface PaginatedResult<T> {
   /**
-   * The items returned from the fetch operation. Contains the actual search results or fetched resources. Commonly used to access the product or variant data returned from search and fetch operations.
+   * The items returned from the fetch.
    */
   items: T[];
 
   /**
-   * The pagination cursor pointing to the last item in the current result set. This opaque string token can be passed as the `afterCursor` parameter in subsequent search requests to fetch the next page of results. The cursor format varies depending on whether POS is fetching from the remote API or its local database, but this implementation detail doesn't affect usage—simply pass the cursor value as-is to pagination functions. Returns `undefined` when this is the last page of results (when `hasNextPage` is `false`).
+   * The cursor of the last item. This can be used to fetch more results. The format of this cursor may look different depending on if POS is fetching results from the remote API, or its local database. However, that should not affect its usage with the search functions.
    */
   lastCursor?: string;
 
   /**
-   * Whether there is another page of results that can be fetched. Commonly used to determine whether to show "Load More" buttons, pagination controls, or implement infinite scrolling functionality.
+   * Whether or not there is another page of results that can be fetched.
    */
   hasNextPage: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/paginated-result.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/paginated-result.ts
@@ -1,20 +1,19 @@
 /**
- * Contains a page of fetched results.
+ * Represents the result of a paginated query. Contains the data items, pagination cursors for navigating pages, and information about whether more results exist.
  */
 export interface PaginatedResult<T> {
   /**
-   * The items returned from the fetch.
+   * The items returned from the fetch operation. Contains the actual search results or fetched resources. Commonly used to access the product or variant data returned from search and fetch operations.
    */
   items: T[];
 
   /**
-   * The cursor of the last item. This can be used to fetch more results.
-   * The format of this cursor may look different depending on if POS is fetching results from the remote API, or its local database. However, that should not affect its usage with the search functions.
+   * The pagination cursor pointing to the last item in the current result set. This opaque string token can be passed as the `afterCursor` parameter in subsequent search requests to fetch the next page of results. The cursor format varies depending on whether POS is fetching from the remote API or its local database, but this implementation detail doesn't affect usage—simply pass the cursor value as-is to pagination functions. Returns `undefined` when this is the last page of results (when `hasNextPage` is `false`).
    */
   lastCursor?: string;
 
   /**
-   * Whether or not there is another page of results that can be fetched.
+   * Whether there is another page of results that can be fetched. Commonly used to determine whether to show "Load More" buttons, pagination controls, or implement infinite scrolling functionality.
    */
   hasNextPage: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/payment.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/payment.ts
@@ -18,15 +18,15 @@ export type PaymentMethod =
  */
 export interface Payment {
   /**
-   * The payment amount as a numeric value in the currency's base unit. For example, `100` represents $100.00 USD or €100.00 EUR. This is the actual amount tendered by the customer using this specific payment method. When multiple payment methods are used for a single transaction, multiple Payment objects exist, each with its own amount.
+   * The payment amount.
    */
   amount: number;
   /**
-   * The three-letter [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code for this payment (for example, `"USD"` for US dollars, `"CAD"` for Canadian dollars, `"EUR"` for euros, `"GBP"` for British pounds). This indicates which currency was used for this specific payment tender and determines how the amount is interpreted and displayed.
+   * The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code associated with the location currently active on POS.
    */
   currency: string;
   /**
-   * The payment method type used for this tender. Indicates how the customer paid (for example, `'Cash'` for physical cash, `'CreditCard'` for card payments, `'GiftCard'` for gift card redemption, `'ShopPay'` for Shop Pay, `'StoreCredit'` for store credit). Multiple payment types can be combined in a single transaction through multiple Payment objects.
+   * The payment method type.
    */
   type: PaymentMethod;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/payment.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/payment.ts
@@ -1,3 +1,6 @@
+/**
+ * The available payment method types for POS transactions.
+ */
 export type PaymentMethod =
   | 'Cash'
   | 'Custom'
@@ -9,8 +12,21 @@ export type PaymentMethod =
   | 'ShopPay'
   | 'StoreCredit'
   | 'Unknown';
+
+/**
+ * Represents a payment applied to a transaction, including the amount, currency, and payment method type.
+ */
 export interface Payment {
+  /**
+   * The payment amount as a numeric value in the currency's base unit. For example, `100` represents $100.00 USD or €100.00 EUR. This is the actual amount tendered by the customer using this specific payment method. When multiple payment methods are used for a single transaction, multiple Payment objects exist, each with its own amount.
+   */
   amount: number;
+  /**
+   * The three-letter [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code for this payment (for example, `"USD"` for US dollars, `"CAD"` for Canadian dollars, `"EUR"` for euros, `"GBP"` for British pounds). This indicates which currency was used for this specific payment tender and determines how the amount is interpreted and displayed.
+   */
   currency: string;
+  /**
+   * The payment method type used for this tender. Indicates how the customer paid (for example, `'Cash'` for physical cash, `'CreditCard'` for card payments, `'GiftCard'` for gift card redemption, `'ShopPay'` for Shop Pay, `'StoreCredit'` for store credit). Multiple payment types can be combined in a single transaction through multiple Payment objects.
+   */
   type: PaymentMethod;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
@@ -1,71 +1,89 @@
+/**
+ * Represents the result of a PIN pad interaction, indicating whether PIN entry was completed and providing the entered PIN if available.
+ */
 export interface PinPadResult {
   /**
-   * Whether the PIN entry was completed (not cancelled)
+   * Whether the PIN entry was completed successfully. When `true`, the user entered a PIN and submitted it (or it was auto-submitted). When `false`, the user canceled the PIN pad modal without completing entry, typically by clicking a cancel button or dismissing the modal.
    */
   completed: boolean;
   /**
-   * The entered PIN (only present if completed is true)
+   * The entered PIN as an array of individual digits (for example, `[1, 2, 3, 4]` for PIN "1234"). Each element is a number from 0-9. This array's length will be between `minPinLength` and `maxPinLength` inclusive. Only present when `completed` is `true`—when `completed` is `false`, this field is `undefined` since no PIN was entered.
    */
   pin?: number[];
 }
 
 /**
- * Represents the result of the pin pad onSubmit function.
- * @typedef {{result: 'accept'} | {result: 'reject'; errorMessage?: string}} PinValidationResult
+ * Represents the validation outcome for an entered PIN. Indicates whether the PIN should be accepted or rejected, with optional error messaging for rejected PINs.
  */
 export type PinValidationResult =
+  /** The validation result indicating the PIN should be accepted for valid PINs. */
   | {result: 'accept'}
+  /** The validation result indicating the PIN should be rejected. Optionally includes an error message to display to the user explaining why the PIN was rejected. For example, "Invalid PIN" or "PIN expired". */
   | {result: 'reject'; errorMessage?: string};
 
+/**
+ * The valid PIN length values (4-10 digits). Commonly used to configure minimum and maximum PIN length requirements.
+ */
 export type PinLength = 4 | 5 | 6 | 7 | 8 | 9 | 10;
 
+/**
+ * Defines a custom action button for the PIN pad interface with a label and click handler.
+ */
 export interface PinPadActionType {
+  /**
+   * The button label text displayed to the user on the PIN pad interface. This text appears on a clickable action button and should clearly describe what the button does (for example, "Use default PIN", "Try biometric", "Skip PIN"). The label should be concise and action-oriented to guide users.
+   */
   label: string;
+  /**
+   * The function called when the action button is clicked. This function should return the PIN value as an array of digits, either synchronously or as a Promise. For example, returning `[1, 2, 3, 4]` would auto-fill the PIN with "1234". This enables custom PIN entry workflows like retrieving stored PINs, using biometric authentication, or implementing fallback authentication methods.
+   */
   onClick: () => Promise<number[]> | number[];
 }
 
+/**
+ * Specifies configuration options for displaying the PIN pad interface. Includes callback functions for PIN entry events, dismissal handling, and customizable labels and messaging.
+ */
 export interface PinPadOptions {
   /**
-   * The function to be called whenever the entered PIN is updated
+   * The function to be called when a pin is entered. Commonly used for real-time PIN validation, progress feedback, or implementing custom PIN entry handling logic.
    */
   onPinEntry?: (pin: number[]) => void;
   /**
-   * The function to be called when the PIN pad modal is dismissed
+   * The function to be called when the pin pad modal is dismissed. Receives a `PinPadResult` indicating whether PIN entry was completed and the entered PIN if available. Commonly used for handling modal dismissal and processing final PIN results.
    */
   onDismissed?: (result: PinPadResult) => void;
   /**
-   * The content for the prompt on the PIN pad. This will be overridden by any
-   * `errorMessage` provided when rejecting a PIN from the `onSubmit` callback.
+   * The content for the prompt on the pin pad. Commonly used to provide clear instructions or context about what the PIN is being used for.
    */
   label?: string;
   /**
-   * Whether the entered PIN should be masked
+   * Whether the entered PIN should be masked for security. When `true`, PIN digits are hidden from view. Commonly used for secure PIN entry where visual privacy is important.
    *
    * @default true
    */
   masked?: boolean;
   /**
-   * The minimum length of the PIN
+   * The minimum length of the PIN (4-10 digits). Commonly used to enforce PIN length requirements based on your security policies or authentication system requirements.
    *
    * @default 4
    */
   minPinLength?: PinLength;
   /**
-   * The maximum length of the PIN
+   * The maximum length of the PIN (4-10 digits). Commonly used to limit PIN length based on your security policies or authentication system constraints.
    *
    * @default 6
    */
   maxPinLength?: PinLength;
   /**
-   * The call to action between the entry view and the keypad
+   * The call to action between the entry view and the keypad, consisting of a label and function that returns the pin. Commonly used for custom PIN entry workflows or implementing specific authentication patterns.
    */
   pinPadAction?: PinPadActionType;
   /**
-   * Title shown in the modal header
+   * The title shown in the modal header. Commonly used to provide context about the PIN entry purpose or identify the specific authentication requirement.
    */
   title?: string;
   /**
-   * Whether the PIN should be automatically submitted when the user has entered the maximum PIN length
+   * Whether the pin should be automatically submitted when the user has entered the maximum PIN length. Commonly used for PIN entry experiences where users don't need to manually submit after entering the required digits.
    *
    * @default false
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
@@ -31,11 +31,11 @@ export type PinLength = 4 | 5 | 6 | 7 | 8 | 9 | 10;
  */
 export interface PinPadActionType {
   /**
-   * The button label text displayed to the user on the PIN pad interface. This text appears on a clickable action button and should clearly describe what the button does (for example, "Use default PIN", "Try biometric", "Skip PIN"). The label should be concise and action-oriented to guide users.
+   * The content for the prompt on the pin pad. Use to provide clear instructions or context about what the PIN is being used for.
    */
   label: string;
   /**
-   * The function called when the action button is clicked. This function should return the PIN value as an array of digits, either synchronously or as a Promise. For example, returning `[1, 2, 3, 4]` would auto-fill the PIN with "1234". This enables custom PIN entry workflows like retrieving stored PINs, using biometric authentication, or implementing fallback authentication methods.
+   * A callback function executed when the action button is clicked. Can return the PIN digits directly as an array of numbers, or return a Promise that resolves to the PIN array. Use for implementing custom PIN retrieval logic or validation workflows.
    */
   onClick: () => Promise<number[]> | number[];
 }
@@ -45,45 +45,45 @@ export interface PinPadActionType {
  */
 export interface PinPadOptions {
   /**
-   * The function to be called when a pin is entered. Commonly used for real-time PIN validation, progress feedback, or implementing custom PIN entry handling logic.
+   * The function to be called when a pin is entered. Use for real-time PIN validation, progress feedback, or implementing custom PIN entry handling logic.
    */
   onPinEntry?: (pin: number[]) => void;
   /**
-   * The function to be called when the pin pad modal is dismissed. Receives a `PinPadResult` indicating whether PIN entry was completed and the entered PIN if available. Commonly used for handling modal dismissal and processing final PIN results.
+   * The function to be called when the pin pad modal is dismissed. Receives a `PinPadResult` indicating whether PIN entry was completed and the entered PIN if available. Use for handling modal dismissal and processing final PIN results.
    */
   onDismissed?: (result: PinPadResult) => void;
   /**
-   * The content for the prompt on the pin pad. Commonly used to provide clear instructions or context about what the PIN is being used for.
+   * The content for the prompt on the pin pad. Use to provide clear instructions or context about what the PIN is being used for.
    */
   label?: string;
   /**
-   * Whether the entered PIN should be masked for security. When `true`, PIN digits are hidden from view. Commonly used for secure PIN entry where visual privacy is important.
+   * Whether the entered PIN should be masked for security. When `true`, PIN digits are hidden from view. Use for secure PIN entry where visual privacy is important.
    *
    * @default true
    */
   masked?: boolean;
   /**
-   * The minimum length of the PIN (4-10 digits). Commonly used to enforce PIN length requirements based on your security policies or authentication system requirements.
+   * The minimum length of the PIN (4-10 digits). Use to enforce PIN length requirements based on your security policies or authentication system requirements.
    *
    * @default 4
    */
   minPinLength?: PinLength;
   /**
-   * The maximum length of the PIN (4-10 digits). Commonly used to limit PIN length based on your security policies or authentication system constraints.
+   * The maximum length of the PIN (4-10 digits). Use to limit PIN length based on your security policies or authentication system constraints.
    *
    * @default 6
    */
   maxPinLength?: PinLength;
   /**
-   * The call to action between the entry view and the keypad, consisting of a label and function that returns the pin. Commonly used for custom PIN entry workflows or implementing specific authentication patterns.
+   * The call to action between the entry view and the keypad, consisting of a label and function that returns the pin. Use for custom PIN entry workflows or implementing specific authentication patterns.
    */
   pinPadAction?: PinPadActionType;
   /**
-   * The title shown in the modal header. Commonly used to provide context about the PIN entry purpose or identify the specific authentication requirement.
+   * The title shown in the modal header. Use to provide context about the PIN entry purpose or identify the specific authentication requirement.
    */
   title?: string;
   /**
-   * Whether the pin should be automatically submitted when the user has entered the maximum PIN length. Commonly used for PIN entry experiences where users don't need to manually submit after entering the required digits.
+   * Whether the pin should be automatically submitted when the user has entered the maximum PIN length. Use for PIN entry experiences where users don't need to manually submit after entering the required digits.
    *
    * @default false
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/product.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/product.ts
@@ -3,103 +3,103 @@
  */
 export interface Product {
   /**
-   * The unique identifier for the product variant. Use this ID for variant-specific operations, cart additions, or inventory lookups. This ID is consistent across all Shopify systems.
+   * The unique identifier for the product. Use this ID for product-specific operations, API calls, or linking to product details. This ID is consistent across all Shopify systems and can be used for external integrations.
    */
   id: number;
   /**
-   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was created. Commonly used for sorting variants by creation date, implementing "new product" features, or tracking product catalog changes over time.
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product was created. Use for sorting products by creation date, implementing "new product" features, or tracking product catalog growth over time.
    */
   createdAt: string;
   /**
-   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was last updated. Commonly used for cache invalidation, tracking recent changes, or implementing "recently updated" product features.
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product was last updated. Use for cache invalidation, tracking recent changes, or implementing "recently updated" product features.
    */
   updatedAt: string;
   /**
-   * The variant's display title, typically showing the option combinations. For example, `"Large / Blue"`. Commonly used for variant selection interfaces, cart displays, or anywhere users need to distinguish between variants.
+   * The product's display name as configured by the merchant. Use for product listings, search results, and customer-facing displays. This is the primary product identifier that customers will recognize.
    */
   title: string;
   /**
-   * The product's plain text description without HTML formatting. Commonly used for displaying product information in contexts where HTML isn't supported or when you need clean text content for processing.
+   * The product's plain text description without HTML formatting. Use for displaying product information in contexts where HTML is not supported or when you need clean text content for processing.
    */
   description: string;
   /**
-   * The product's description with HTML formatting preserved. Typically applied when you need to display rich text content with formatting, links, or other HTML elements in your extension interface.
+   * The product's description with HTML formatting preserved. Use when you need to display rich text content with formatting, links, or other HTML elements in your extension interface.
    */
   descriptionHtml: string;
   /**
-   * The URL of the product's featured image, if one is set. Returns `undefined` if no featured image is configured. Commonly used for displaying product images in search results, product listings, or detailed product views.
+   * The URL of the product's featured image, if one is set. Returns `undefined` if no featured image is configured. Use for displaying product images in search results, product listings, or detailed product views.
    */
   featuredImage?: string;
   /**
-   * Whether this product is a gift card. Gift cards have special handling requirements and different business logic. Commonly used to implement gift card-specific workflows, validation, or display special gift card interfaces.
+   * Whether this product is a gift card. Gift cards have special handling requirements and different business logic. Use to implement gift card-specific workflows, validation, or display special gift card interfaces.
    */
   isGiftCard: boolean;
   /**
-   * Whether inventory tracking is enabled for this product. When `false`, inventory quantities may not be accurate or meaningful. Commonly used to determine whether to display inventory information or implement inventory-based business logic.
+   * Whether inventory tracking is enabled for this product. When `false`, inventory quantities may not be accurate or meaningful. Use to determine whether to display inventory information or implement inventory-based business logic.
    */
   tracksInventory: boolean;
   /**
-   * The product's vendor or brand name as configured by the merchant. Commonly used for filtering products by brand, displaying vendor information, or organizing products by supplier.
+   * The product's vendor or brand name as configured by the merchant. Use for filtering products by brand, displaying vendor information, or organizing products by supplier.
    */
   vendor: string;
   /**
-   * The lowest price among all product variants, formatted as a string. Commonly used for displaying price ranges, implementing price-based filtering, or showing starting prices in product listings.
+   * The lowest price among all product variants, formatted as a string. Use for displaying price ranges, implementing price-based filtering, or showing starting prices in product listings.
    */
   minVariantPrice: string;
   /**
-   * The highest price among all product variants, formatted as a string. Commonly used for displaying price ranges, implementing price-based filtering, or showing complete pricing information for products with multiple variants.
+   * The highest price among all product variants, formatted as a string. Use for displaying price ranges, implementing price-based filtering, or showing complete pricing information for products with multiple variants.
    */
   maxVariantPrice: string;
   /**
-   * The product type category as defined by the merchant (For example, "T-Shirt," "Electronics," "Books"). Commonly used for product categorization, filtering, or implementing category-specific business logic.
+   * The product type category as defined by the merchant (For example, "T-Shirt," "Electronics," "Books"). Use for product categorization, filtering, or implementing category-specific business logic.
    */
   productType: string;
   /**
-   * The standardized product category classification. Commonly used for product categorization, implementing category-specific business logic, or organizing products by standardized categories.
+   * The standardized product category classification. Use for product categorization, implementing category-specific business logic, or organizing products by standardized categories.
    */
   productCategory: string;
   /**
-   * An array of tags associated with the product for categorization and organization. Commonly used for product filtering, search enhancement, or implementing tag-based business logic and promotions.
+   * An array of tags associated with the product for categorization and organization. Use for product filtering, search enhancement, or implementing tag-based business logic and promotions.
    */
   tags: string[];
   /**
-   * The total number of variants available for this product. Commonly used to determine whether to show variant selection interfaces, implement variant-specific logic, or optimize variant loading strategies.
+   * The total number of variants available for this product. Use to determine whether to show variant selection interfaces, implement variant-specific logic, or optimize variant loading strategies.
    */
   numVariants: number;
   /**
-   * The total available inventory across all variants and locations, if tracking is enabled. Returns `undefined` when inventory tracking is disabled. Commonly used for availability checks, stock level displays, or implementing low-stock alerts.
+   * The total available inventory across all variants and locations, if tracking is enabled. Returns `undefined` when inventory tracking is disabled. Use for availability checks, stock level displays, or implementing low-stock alerts.
    */
   totalAvailableInventory?: number;
   /**
-   * The total inventory count across all variants and locations for this product. Commonly used for inventory management, stock level displays, or implementing low-stock warnings and alerts.
+   * The total inventory count across all variants and locations for this product. Use for inventory management, stock level displays, or implementing low-stock warnings and alerts.
    */
   totalInventory: number;
   /**
-   * An array of all product variants associated with this product. Each variant contains detailed information including pricing, inventory, and options. Commonly used for building variant selectors, displaying inventory information, or implementing variant-specific functionality.
+   * An array of all product variants associated with this product. Each variant contains detailed information including pricing, inventory, and options. Use for building variant selectors, displaying inventory information, or implementing variant-specific functionality.
    */
   variants: ProductVariant[];
   /**
-   * An array of option name-value pairs that define this variant's configuration. For example, `[{name: "Size," value: "Large"}, {name: "Color," value: "Blue"}]`. Returns `undefined` for products with only default variants. Commonly used for displaying variant options, building variant selectors, or implementing variant-based logic.
+   * An array of product options that define available variant configurations. For example, size and color. Each option includes available values. Use for building variant selection interfaces or understanding product configuration possibilities.
    */
   options: ProductOption[];
   /**
-   * Whether the product has only a default variant (no custom options). When `true`, the product doesn't require variant selection. Commonly used to simplify product interfaces and skip variant selection steps for single-variant products.
+   * Whether the product has only a default variant (no custom options). When `true`, the product doesn't require variant selection. Use to simplify product interfaces and skip variant selection steps for single-variant products.
    */
   hasOnlyDefaultVariant: boolean;
   /**
-   * Whether this variant currently has inventory in stock. Returns `undefined` when inventory information isn't available. Commonly used for stock status displays, availability checks, or filtering in-stock variants.
+   * Whether the product has any variants currently in stock. Returns `undefined` when inventory information is not available. Use for stock status displays, availability filtering, or implementing out-of-stock product handling.
    */
   hasInStockVariants?: boolean;
   /**
-   * The URL of the product on the online store, if available. Returns `undefined` when the product isn't published online or the store doesn't have an online presence. Commonly used for linking to online product pages or sharing product information.
+   * The URL of the product on the online store, if available. Returns `undefined` when the product is not published online or the store doesn't have an online presence. Use for linking to online product pages or sharing product information.
    */
   onlineStoreUrl?: string;
   /**
-   * Whether the product requires a selling plan (subscription) to be purchased. Returns `undefined` when selling plan information isn't available. Commonly used for implementing subscription-based product handling or selling plan selection interfaces.
+   * Indicates whether this product or line item requires a selling plan (subscription) to be purchased. When `true`, the customer must select a subscription or payment plan before adding to cart. When `false`, the item can be purchased as a one-time purchase without a selling plan.
    */
   requiresSellingPlan?: boolean;
   /**
-   * Whether the product has selling plan groups (subscription options) available. Returns `undefined` when selling plan information isn't available. Commonly used for displaying subscription options or implementing subscription-based purchasing workflows.
+   * Indicates whether this product or line item has selling plan groups (subscription options) available. When `true`, the product offers subscription or recurring payment options that customers can select. When `false`, the product is only available for one-time purchase without subscription options.
    */
   hasSellingPlanGroups?: boolean;
 }
@@ -113,79 +113,79 @@ export interface ProductVariant {
    */
   id: number;
   /**
-   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was created. Commonly used for sorting variants by creation date, implementing "new product" features, or tracking product catalog changes over time.
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was created. Use for sorting variants by creation date, implementing "new product" features, or tracking product catalog changes over time.
    */
   createdAt: string;
   /**
-   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was last updated. Commonly used for cache invalidation, tracking recent changes, or implementing "recently updated" product features.
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was last updated. Use for cache invalidation, tracking recent changes, or implementing "recently updated" product features.
    */
   updatedAt: string;
   /**
-   * The variant's display title, typically showing the option combinations. For example, `"Large / Blue"`. Commonly used for variant selection interfaces, cart displays, or anywhere users need to distinguish between variants.
+   * The variant's display title, typically showing the option combinations. For example, `"Large / Blue"`. Use for variant selection interfaces, cart displays, or anywhere users need to distinguish between variants.
    */
   title: string;
   /**
-   * The variant's selling price formatted as a string. Commonly used for price displays, cart calculations, or implementing pricing logic. This represents the current selling price for the variant.
+   * The variant's selling price formatted as a string. Use for price displays, cart calculations, or implementing pricing logic. This represents the current selling price for the variant.
    */
   price: string;
   /**
-   * The variant's compare-at price (original or MSRP price) formatted as a string, if set. Returns `undefined` when no compare-at price is configured. Commonly used for displaying discounts, sale pricing, or savings calculations.
+   * The variant's compare-at price (original or MSRP price) formatted as a string, if set. Returns `undefined` when no compare-at price is configured. Use for displaying discounts, sale pricing, or savings calculations.
    */
   compareAtPrice?: string;
   /**
-   * Whether this variant is subject to tax calculations. Commonly used for tax computation logic, pricing displays, or implementing tax-exempt product handling.
+   * Whether this variant is subject to tax calculations. Use for tax computation logic, pricing displays, or implementing tax-exempt product handling.
    */
   taxable: boolean;
   /**
-   * The variant's Stock Keeping Unit (SKU) identifier, if configured. Returns `undefined` when no SKU is set. Commonly used for inventory management, product identification, or integration with external systems that use SKU-based tracking.
+   * The variant's Stock Keeping Unit (SKU) identifier, if configured. Returns `undefined` when no SKU is set. Use for inventory management, product identification, or integration with external systems that use SKU-based tracking.
    */
   sku?: string;
   /**
-   * The variant's barcode identifier, if configured. Returns `undefined` when no barcode is set. Commonly used for barcode scanning functionality, inventory tracking, or integration with barcode-based systems.
+   * The variant's barcode identifier, if configured. Returns `undefined` when no barcode is set. Use for barcode scanning functionality, inventory tracking, or integration with barcode-based systems.
    */
   barcode?: string;
   /**
-   * The variant's formatted display name for user interfaces. This may differ from the title and is optimized for display purposes. Commonly used for customer-facing variant names in product listings, cart items, or receipt displays.
+   * The variant's formatted display name for user interfaces. This may differ from the title and is optimized for display purposes. Use for customer-facing variant names in product listings, cart items, or receipt displays.
    */
   displayName: string;
   /**
-   * The URL of the variant-specific image, if one is configured. Returns `undefined` when no variant image is set. Commonly used for displaying variant-specific images in selection interfaces or product galleries.
+   * The URL of the variant-specific image, if one is configured. Returns `undefined` when no variant image is set. Use for displaying variant-specific images in selection interfaces or product galleries.
    */
   image?: string;
   /**
-   * Whether inventory tracking is enabled for this specific variant. When `false`, inventory quantities may not be accurate. Commonly used to determine whether to display inventory information or implement inventory-based business logic for this variant.
+   * Whether inventory tracking is enabled for this specific variant. When `false`, inventory quantities may not be accurate. Use to determine whether to display inventory information or implement inventory-based business logic for this variant.
    */
   inventoryIsTracked: boolean;
   /**
-   * The inventory quantity available at the current POS location, if inventory tracking is enabled. Returns `undefined` when inventory tracking is disabled. Commonly used for location-specific inventory displays, stock availability checks, or local inventory management.
+   * The inventory quantity available at the current POS location, if inventory tracking is enabled. Returns `undefined` when inventory tracking is disabled. Use for location-specific inventory displays, stock availability checks, or local inventory management.
    */
   inventoryAtLocation?: number;
   /**
-   * The total inventory quantity across all locations for this variant, if available. Returns `undefined` when this information isn't accessible. Commonly used for comprehensive inventory views, transfer planning, or multi-location inventory management.
+   * The total inventory quantity across all locations for this variant, if available. Returns `undefined` when this information is not available. Use for comprehensive inventory views, transfer planning, or multi-location inventory management.
    */
   inventoryAtAllLocations?: number;
   /**
-   * The inventory policy for this variant, either "DENY" (prevent sales when out of stock) or "CONTINUE" (allow sales when out of stock). Commonly used to implement inventory validation logic and determine whether to allow purchases of out-of-stock items.
+   * The inventory policy for this variant, either "DENY" (prevent sales when out of stock) or "CONTINUE" (allow sales when out of stock). Use to implement inventory validation logic and determine whether to allow purchases of out-of-stock items.
    */
   inventoryPolicy: ProductVariantInventoryPolicy;
   /**
-   * Whether this variant currently has inventory in stock. Returns `undefined` when inventory information isn't available. Commonly used for stock status displays, availability checks, or filtering in-stock variants.
+   * Whether this variant currently has inventory in stock. Returns `undefined` when inventory information is not available. Use for stock status displays, availability checks, or filtering in-stock variants.
    */
   hasInStockVariants?: boolean;
   /**
-   * An array of option name-value pairs that define this variant's configuration. For example, `[{name: "Size," value: "Large"}, {name: "Color," value: "Blue"}]`. Returns `undefined` for products with only default variants. Commonly used for displaying variant options, building variant selectors, or implementing variant-based logic.
+   * An array of option name-value pairs that define this variant's configuration. For example, `[{name: "Size," value: "Large"}, {name: "Color," value: "Blue"}]`. Returns `undefined` for products with only default variants. Use for displaying variant options, building variant selectors, or implementing variant-based logic.
    */
   options?: ProductVariantOption[];
   /**
-   * Reference to the parent Product object that this variant belongs to. Returns `undefined` in some contexts to avoid circular references. Typically applied when you need access to product-level information from a variant context.
+   * Reference to the parent Product object that this variant belongs to. Returns `undefined` in some contexts to avoid circular references. Use when you need access to product-level information from a variant context.
    */
   product?: Product;
   /**
-   * The ID of the parent product that this variant belongs to. Commonly used for linking variants back to their parent product, implementing product-level operations, or organizing variants by product.
+   * The ID of the parent product that this variant belongs to. Use for linking variants back to their parent product, implementing product-level operations, or organizing variants by product.
    */
   productId: number;
   /**
-   * The variant's position order within the product's variant list. Commonly used for maintaining consistent variant ordering in selection interfaces or implementing custom variant sorting logic.
+   * The variant's position order within the product's variant list. Use for maintaining consistent variant ordering in selection interfaces or implementing custom variant sorting logic.
    */
   position: number;
 }
@@ -195,11 +195,11 @@ export interface ProductVariant {
  */
 export interface ProductVariantOption {
   /**
-   * The option category name as defined in the product configuration (for example, `"Size"`, `"Color"`, `"Material"`, `"Style"`). This is the option type or attribute being specified, not the selected value. Products can have up to 3 option names. The name is set at the product level and shared across all variants. Commonly used for displaying option labels in variant selectors, building dynamic variant selection UI, or organizing variant attributes.
+   * The option category name (for example, "Size", "Color", "Material", "Style", "Flavor"). This is the attribute or dimension along which the product varies. Each product can have up to 3 option names, and each option name can have multiple values. The name is visible to customers in variant selection interfaces. Commonly used for displaying option labels in variant selectors ("Select Size:", "Choose Color:"), building dynamic product configuration UI, or organizing product variations by attribute type.
    */
   name: string;
   /**
-   * The selected value for this option that defines this specific variant (for example, `"Large"`, `"Blue"`, `"Cotton"`, `"V-Neck"`). This is the specific choice from the available option values that characterizes this variant. For example, if `name` is "Size", the `value` might be "Large" or "Small". Values are set at the variant level—each variant has a unique combination of option values. Commonly used for displaying the variant's configuration ("Size: Large, Color: Blue"), building variant selection dropdowns, or matching user selections to variants.
+   * The selected value for this option that defines this specific variant (for example, "Large", "Blue", "Cotton", "V-Neck"). This is the specific choice from the available option values that characterizes this variant. For example, if `name` is "Size", the `value` might be "Large" or "Small". Values are set at the variant level—each variant has a unique combination of option values. Commonly used for displaying the variant's configuration ("Size: Large, Color: Blue"), building variant selection dropdowns, or matching user selections to variants.
    */
   value: string;
 }
@@ -220,7 +220,7 @@ export interface ProductOption {
    */
   id: number;
   /**
-   * The option category name (for example, `"Size"`, `"Color"`, `"Material"`, `"Style"`, `"Flavor"`). This is the attribute or dimension along which the product varies. Each product can have up to 3 option names, and each option name can have multiple values. The name is visible to customers in variant selection interfaces. Commonly used for displaying option labels in variant selectors ("Select Size:", "Choose Color:"), building dynamic product configuration UI, or organizing product variations by attribute type.
+   * The option category name (for example, "Size", "Color", "Material", "Style", "Flavor"). This is the attribute or dimension along which the product varies. Each product can have up to 3 option names, and each option name can have multiple values. The name is visible to customers in variant selection interfaces. Commonly used for displaying option labels in variant selectors ("Select Size:", "Choose Color:"), building dynamic product configuration UI, or organizing product variations by attribute type.
    */
   name: string;
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/product.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/product.ts
@@ -1,64 +1,234 @@
+/**
+ * Represents comprehensive product information including metadata, pricing, variants, and availability. Contains all data needed to display and work with products in the POS interface.
+ */
 export interface Product {
+  /**
+   * The unique identifier for the product variant. Use this ID for variant-specific operations, cart additions, or inventory lookups. This ID is consistent across all Shopify systems.
+   */
   id: number;
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was created. Commonly used for sorting variants by creation date, implementing "new product" features, or tracking product catalog changes over time.
+   */
   createdAt: string;
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was last updated. Commonly used for cache invalidation, tracking recent changes, or implementing "recently updated" product features.
+   */
   updatedAt: string;
+  /**
+   * The variant's display title, typically showing the option combinations. For example, `"Large / Blue"`. Commonly used for variant selection interfaces, cart displays, or anywhere users need to distinguish between variants.
+   */
   title: string;
+  /**
+   * The product's plain text description without HTML formatting. Commonly used for displaying product information in contexts where HTML isn't supported or when you need clean text content for processing.
+   */
   description: string;
+  /**
+   * The product's description with HTML formatting preserved. Typically applied when you need to display rich text content with formatting, links, or other HTML elements in your extension interface.
+   */
   descriptionHtml: string;
+  /**
+   * The URL of the product's featured image, if one is set. Returns `undefined` if no featured image is configured. Commonly used for displaying product images in search results, product listings, or detailed product views.
+   */
   featuredImage?: string;
+  /**
+   * Whether this product is a gift card. Gift cards have special handling requirements and different business logic. Commonly used to implement gift card-specific workflows, validation, or display special gift card interfaces.
+   */
   isGiftCard: boolean;
+  /**
+   * Whether inventory tracking is enabled for this product. When `false`, inventory quantities may not be accurate or meaningful. Commonly used to determine whether to display inventory information or implement inventory-based business logic.
+   */
   tracksInventory: boolean;
+  /**
+   * The product's vendor or brand name as configured by the merchant. Commonly used for filtering products by brand, displaying vendor information, or organizing products by supplier.
+   */
   vendor: string;
+  /**
+   * The lowest price among all product variants, formatted as a string. Commonly used for displaying price ranges, implementing price-based filtering, or showing starting prices in product listings.
+   */
   minVariantPrice: string;
+  /**
+   * The highest price among all product variants, formatted as a string. Commonly used for displaying price ranges, implementing price-based filtering, or showing complete pricing information for products with multiple variants.
+   */
   maxVariantPrice: string;
+  /**
+   * The product type category as defined by the merchant (For example, "T-Shirt," "Electronics," "Books"). Commonly used for product categorization, filtering, or implementing category-specific business logic.
+   */
   productType: string;
+  /**
+   * The standardized product category classification. Commonly used for product categorization, implementing category-specific business logic, or organizing products by standardized categories.
+   */
   productCategory: string;
+  /**
+   * An array of tags associated with the product for categorization and organization. Commonly used for product filtering, search enhancement, or implementing tag-based business logic and promotions.
+   */
   tags: string[];
+  /**
+   * The total number of variants available for this product. Commonly used to determine whether to show variant selection interfaces, implement variant-specific logic, or optimize variant loading strategies.
+   */
   numVariants: number;
+  /**
+   * The total available inventory across all variants and locations, if tracking is enabled. Returns `undefined` when inventory tracking is disabled. Commonly used for availability checks, stock level displays, or implementing low-stock alerts.
+   */
   totalAvailableInventory?: number;
+  /**
+   * The total inventory count across all variants and locations for this product. Commonly used for inventory management, stock level displays, or implementing low-stock warnings and alerts.
+   */
   totalInventory: number;
+  /**
+   * An array of all product variants associated with this product. Each variant contains detailed information including pricing, inventory, and options. Commonly used for building variant selectors, displaying inventory information, or implementing variant-specific functionality.
+   */
   variants: ProductVariant[];
+  /**
+   * An array of option name-value pairs that define this variant's configuration. For example, `[{name: "Size," value: "Large"}, {name: "Color," value: "Blue"}]`. Returns `undefined` for products with only default variants. Commonly used for displaying variant options, building variant selectors, or implementing variant-based logic.
+   */
   options: ProductOption[];
+  /**
+   * Whether the product has only a default variant (no custom options). When `true`, the product doesn't require variant selection. Commonly used to simplify product interfaces and skip variant selection steps for single-variant products.
+   */
   hasOnlyDefaultVariant: boolean;
+  /**
+   * Whether this variant currently has inventory in stock. Returns `undefined` when inventory information isn't available. Commonly used for stock status displays, availability checks, or filtering in-stock variants.
+   */
   hasInStockVariants?: boolean;
+  /**
+   * The URL of the product on the online store, if available. Returns `undefined` when the product isn't published online or the store doesn't have an online presence. Commonly used for linking to online product pages or sharing product information.
+   */
   onlineStoreUrl?: string;
+  /**
+   * Whether the product requires a selling plan (subscription) to be purchased. Returns `undefined` when selling plan information isn't available. Commonly used for implementing subscription-based product handling or selling plan selection interfaces.
+   */
   requiresSellingPlan?: boolean;
+  /**
+   * Whether the product has selling plan groups (subscription options) available. Returns `undefined` when selling plan information isn't available. Commonly used for displaying subscription options or implementing subscription-based purchasing workflows.
+   */
   hasSellingPlanGroups?: boolean;
 }
 
+/**
+ * Represents a specific variant of a product with its own SKU, price, and inventory. Contains variant-specific attributes including options, availability, and identification data.
+ */
 export interface ProductVariant {
+  /**
+   * The unique identifier for the product variant. Use this ID for variant-specific operations, cart additions, or inventory lookups. This ID is consistent across all Shopify systems.
+   */
   id: number;
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was created. Commonly used for sorting variants by creation date, implementing "new product" features, or tracking product catalog changes over time.
+   */
   createdAt: string;
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was last updated. Commonly used for cache invalidation, tracking recent changes, or implementing "recently updated" product features.
+   */
   updatedAt: string;
+  /**
+   * The variant's display title, typically showing the option combinations. For example, `"Large / Blue"`. Commonly used for variant selection interfaces, cart displays, or anywhere users need to distinguish between variants.
+   */
   title: string;
+  /**
+   * The variant's selling price formatted as a string. Commonly used for price displays, cart calculations, or implementing pricing logic. This represents the current selling price for the variant.
+   */
   price: string;
+  /**
+   * The variant's compare-at price (original or MSRP price) formatted as a string, if set. Returns `undefined` when no compare-at price is configured. Commonly used for displaying discounts, sale pricing, or savings calculations.
+   */
   compareAtPrice?: string;
+  /**
+   * Whether this variant is subject to tax calculations. Commonly used for tax computation logic, pricing displays, or implementing tax-exempt product handling.
+   */
   taxable: boolean;
+  /**
+   * The variant's Stock Keeping Unit (SKU) identifier, if configured. Returns `undefined` when no SKU is set. Commonly used for inventory management, product identification, or integration with external systems that use SKU-based tracking.
+   */
   sku?: string;
+  /**
+   * The variant's barcode identifier, if configured. Returns `undefined` when no barcode is set. Commonly used for barcode scanning functionality, inventory tracking, or integration with barcode-based systems.
+   */
   barcode?: string;
+  /**
+   * The variant's formatted display name for user interfaces. This may differ from the title and is optimized for display purposes. Commonly used for customer-facing variant names in product listings, cart items, or receipt displays.
+   */
   displayName: string;
+  /**
+   * The URL of the variant-specific image, if one is configured. Returns `undefined` when no variant image is set. Commonly used for displaying variant-specific images in selection interfaces or product galleries.
+   */
   image?: string;
+  /**
+   * Whether inventory tracking is enabled for this specific variant. When `false`, inventory quantities may not be accurate. Commonly used to determine whether to display inventory information or implement inventory-based business logic for this variant.
+   */
   inventoryIsTracked: boolean;
+  /**
+   * The inventory quantity available at the current POS location, if inventory tracking is enabled. Returns `undefined` when inventory tracking is disabled. Commonly used for location-specific inventory displays, stock availability checks, or local inventory management.
+   */
   inventoryAtLocation?: number;
+  /**
+   * The total inventory quantity across all locations for this variant, if available. Returns `undefined` when this information isn't accessible. Commonly used for comprehensive inventory views, transfer planning, or multi-location inventory management.
+   */
   inventoryAtAllLocations?: number;
+  /**
+   * The inventory policy for this variant, either "DENY" (prevent sales when out of stock) or "CONTINUE" (allow sales when out of stock). Commonly used to implement inventory validation logic and determine whether to allow purchases of out-of-stock items.
+   */
   inventoryPolicy: ProductVariantInventoryPolicy;
+  /**
+   * Whether this variant currently has inventory in stock. Returns `undefined` when inventory information isn't available. Commonly used for stock status displays, availability checks, or filtering in-stock variants.
+   */
   hasInStockVariants?: boolean;
+  /**
+   * An array of option name-value pairs that define this variant's configuration. For example, `[{name: "Size," value: "Large"}, {name: "Color," value: "Blue"}]`. Returns `undefined` for products with only default variants. Commonly used for displaying variant options, building variant selectors, or implementing variant-based logic.
+   */
   options?: ProductVariantOption[];
+  /**
+   * Reference to the parent Product object that this variant belongs to. Returns `undefined` in some contexts to avoid circular references. Typically applied when you need access to product-level information from a variant context.
+   */
   product?: Product;
+  /**
+   * The ID of the parent product that this variant belongs to. Commonly used for linking variants back to their parent product, implementing product-level operations, or organizing variants by product.
+   */
   productId: number;
+  /**
+   * The variant's position order within the product's variant list. Commonly used for maintaining consistent variant ordering in selection interfaces or implementing custom variant sorting logic.
+   */
   position: number;
 }
 
+/**
+ * Represents a single option selection for a product variant, showing one chosen value from a product's configuration options. For example, if a product has Size and Color options, a variant might have one option for Size=Large and another for Color=Blue.
+ */
 export interface ProductVariantOption {
+  /**
+   * The option category name as defined in the product configuration (for example, `"Size"`, `"Color"`, `"Material"`, `"Style"`). This is the option type or attribute being specified, not the selected value. Products can have up to 3 option names. The name is set at the product level and shared across all variants. Commonly used for displaying option labels in variant selectors, building dynamic variant selection UI, or organizing variant attributes.
+   */
   name: string;
+  /**
+   * The selected value for this option that defines this specific variant (for example, `"Large"`, `"Blue"`, `"Cotton"`, `"V-Neck"`). This is the specific choice from the available option values that characterizes this variant. For example, if `name` is "Size", the `value` might be "Large" or "Small". Values are set at the variant level—each variant has a unique combination of option values. Commonly used for displaying the variant's configuration ("Size: Large, Color: Blue"), building variant selection dropdowns, or matching user selections to variants.
+   */
   value: string;
 }
 
+/**
+ * The inventory policy determining whether sales can continue when a variant has no inventory available:
+ * - `'DENY'`: Sales are prevented when inventory reaches zero. Customers can't purchase out-of-stock variants. The "Add to cart" action is disabled or shows "Out of stock". This is the default and recommended policy for most physical products to prevent overselling.
+ * - `'CONTINUE'`: Sales are allowed even when inventory is zero or negative. Customers can purchase out-of-stock variants, creating backorders. This enables pre-orders, made-to-order products, or drop-shipped items where inventory tracking is less critical.
+ */
 export type ProductVariantInventoryPolicy = 'DENY' | 'CONTINUE';
 
+/**
+ * Represents a product option definition showing one of the configurable attributes for a product (like Size, Color, Material) along with all the possible values customers can choose from. Products can have up to 3 options.
+ */
 export interface ProductOption {
+  /**
+   * The unique numeric identifier for this product option configuration. This ID identifies the option definition itself (not a specific option value or variant). Commonly used for option-specific operations, tracking option configurations, or linking options in external systems.
+   */
   id: number;
+  /**
+   * The option category name (for example, `"Size"`, `"Color"`, `"Material"`, `"Style"`, `"Flavor"`). This is the attribute or dimension along which the product varies. Each product can have up to 3 option names, and each option name can have multiple values. The name is visible to customers in variant selection interfaces. Commonly used for displaying option labels in variant selectors ("Select Size:", "Choose Color:"), building dynamic product configuration UI, or organizing product variations by attribute type.
+   */
   name: string;
+  /**
+   * An array of all available values for this option that customers can choose from (for example, `["Small", "Medium", "Large", "X-Large"]` for a Size option, or `["Red", "Blue", "Green", "Black"]` for a Color option). The order of values in this array typically represents the display order in variant selectors. Each combination of option values across all options creates a unique variant. For example, a product with Size: [Small, Large] and Color: [Red, Blue] would have 4 variants (Small/Red, Small/Blue, Large/Red, Large/Blue). Commonly used for building variant selection dropdowns, radio buttons, or swatches, validating user selections, or displaying all available choices for an attribute.
+   */
   optionValues: string[];
+  /**
+   * The unique numeric identifier of the parent product to which this option belongs. This links the option definition back to the product it configures. Commonly used for linking options to their parent product, organizing options by product, or implementing product-level option management.
+   */
   productId: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/session.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/session.ts
@@ -1,39 +1,41 @@
 import type {CurrencyCode} from '../../../shared';
 
+/**
+ * Defines information about the current POS session. Contains authentication details, location context, and configuration settings that remain constant for the duration of the session.
+ */
 export interface Session {
   /**
-   * The shop ID associated with the shop currently logged into POS.
+   * The unique numeric identifier for the Shopify shop currently logged into POS. This ID is consistent across all Shopify systems and APIs. Commonly used for shop-specific data queries, API authentication, or multi-shop configurations.
    */
   shopId: number;
 
   /**
-   * The user ID associated with the Shopify account currently authenticated on POS.
+   * The unique numeric identifier for the Shopify account currently authenticated on POS. This represents the logged-in user's account, which may be the shop owner, an admin, or a staff member with POS access. This ID can differ from `staffMemberId` when a different staff member is pinned in for the transaction. Commonly used for user-specific permissions, audit trails, or tracking who performed actions.
    */
   userId: number;
 
   /**
-   * The shop domain associated with the shop currently logged into POS.
+   * The shop's `.myshopify.com` domain name (for example, `"my-store.myshopify.com"`). This is the shop's permanent Shopify domain, not custom domains. Commonly used for constructing API URLs, identifying the shop in external systems, or building shop-specific links.
    */
   shopDomain: string;
 
   /**
-   * The location ID associated with the POS' current location.
+   * The unique numeric identifier for the physical retail location where this POS device is currently operating. Locations represent distinct retail sites, warehouses, or pop-up shops within a merchant's business. This determines which inventory is available, which staff can access the POS, and which location appears on receipts and orders. Commonly used for location-specific inventory queries, sales reports, or implementing location-based features.
    */
   locationId: number;
 
   /**
-   * The staff ID who is currently pinned into the POS.
-   * Note that this staff member ID may be different to the User ID, as the staff member who enters their PIN may be different to the User who logged onto POS.
+   * The unique numeric identifier for the staff member currently pinned into the POS session. This represents who is actively using the POS for transactions, which may differ from `userId` when a manager is logged in but a different staff member is pinned for sales attribution. Returns `undefined` when no staff member is pinned. Commonly used for sales attribution, commission tracking, or staff-specific workflows.
    */
   staffMemberId?: number;
 
   /**
-   * The currency code associated with the location currently in on POS.
+   * The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code for the location currently active on POS (for example, `"USD"`, `"CAD"`, `"EUR"`, `"GBP"`). This determines how prices are displayed, which currency symbol appears, and how monetary calculations are performed. The currency is set at the location level and affects all transactions processed on this device.
    */
   currency: CurrencyCode;
 
   /**
-   * The POS version.
+   * The version string of [the POS app](https://apps.shopify.com/shopify-pos) currently running on this device (for example, `"8.42.0"`, `"9.1.2"`). This version number follows semantic versioning and can be used for feature detection, compatibility checks, or debugging issues specific to certain POS versions.
    */
   posVersion: string;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/session.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/session.ts
@@ -1,41 +1,41 @@
 import type {CurrencyCode} from '../../../shared';
 
 /**
- * Defines information about the current POS session. Contains authentication details, location context, and configuration settings that remain constant for the duration of the session.
+ * Defines information about the current POS session.
  */
 export interface Session {
   /**
-   * The unique numeric identifier for the Shopify shop currently logged into POS. This ID is consistent across all Shopify systems and APIs. Commonly used for shop-specific data queries, API authentication, or multi-shop configurations.
+   * The shop ID associated with the shop currently logged into POS.
    */
   shopId: number;
 
   /**
-   * The unique numeric identifier for the Shopify account currently authenticated on POS. This represents the logged-in user's account, which may be the shop owner, an admin, or a staff member with POS access. This ID can differ from `staffMemberId` when a different staff member is pinned in for the transaction. Commonly used for user-specific permissions, audit trails, or tracking who performed actions.
+   * The user ID associated with the Shopify account currently authenticated on POS.
    */
   userId: number;
 
   /**
-   * The shop's `.myshopify.com` domain name (for example, `"my-store.myshopify.com"`). This is the shop's permanent Shopify domain, not custom domains. Commonly used for constructing API URLs, identifying the shop in external systems, or building shop-specific links.
+   * The shop domain associated with the shop currently logged into POS.
    */
   shopDomain: string;
 
   /**
-   * The unique numeric identifier for the physical retail location where this POS device is currently operating. Locations represent distinct retail sites, warehouses, or pop-up shops within a merchant's business. This determines which inventory is available, which staff can access the POS, and which location appears on receipts and orders. Commonly used for location-specific inventory queries, sales reports, or implementing location-based features.
+   * The location ID associated with the POS device's current location.
    */
   locationId: number;
 
   /**
-   * The unique numeric identifier for the staff member currently pinned into the POS session. This represents who is actively using the POS for transactions, which may differ from `userId` when a manager is logged in but a different staff member is pinned for sales attribution. Returns `undefined` when no staff member is pinned. Commonly used for sales attribution, commission tracking, or staff-specific workflows.
+   * The staff ID of the staff member currently pinned into the POS. This may differ from the user ID if the pinned staff member is different from the logged-in user.
    */
   staffMemberId?: number;
 
   /**
-   * The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code for the location currently active on POS (for example, `"USD"`, `"CAD"`, `"EUR"`, `"GBP"`). This determines how prices are displayed, which currency symbol appears, and how monetary calculations are performed. The currency is set at the location level and affects all transactions processed on this device.
+   * The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code associated with the location currently active on POS.
    */
   currency: CurrencyCode;
 
   /**
-   * The version string of [the POS app](https://apps.shopify.com/shopify-pos) currently running on this device (for example, `"8.42.0"`, `"9.1.2"`). This version number follows semantic versioning and can be used for feature detection, compatibility checks, or debugging issues specific to certain POS versions.
+   * The version of [the POS app](https://apps.shopify.com/shopify-pos) currently running.
    */
   posVersion: string;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/shipping-line.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/shipping-line.ts
@@ -1,18 +1,50 @@
 import type {Money} from './money';
 import type {TaxLine} from './tax-line';
 
+/**
+ * Represents a shipping charge applied to an order, including the price and applicable taxes.
+ */
 export interface ShippingLine {
+  /**
+   * A unique string identifier for this shipping line entry. This handle distinguishes between multiple shipping options on the same order and is commonly used for tracking, updates, or API operations. Returns `undefined` when no handle is assigned.
+   */
   handle?: string;
+  /**
+   * The shipping charge amount as a Money object containing both the numeric value and currency information. This is the cost the customer pays for shipping, excluding any taxes which are tracked separately in `taxLines`.
+   */
   price: Money;
+  /**
+   * The customer-facing display name for the shipping method (for example, "Standard Shipping", "Express Delivery", "Local Pickup", "Free Shipping"). This title appears on receipts, order confirmations, and in the checkout flow. Returns `undefined` when no title is provided.
+   */
   title?: string;
+  /**
+   * An array of tax lines applied to this shipping charge. Each tax line represents a separate tax jurisdiction or type (for example, state tax, federal tax, VAT). The sum of all tax line amounts represents the total tax on shipping. Returns `undefined` or empty array when shipping is tax-exempt or tax information isn't available.
+   */
   taxLines?: TaxLine[];
 }
 
+/**
+ * Represents a calculated shipping line with specific shipping or retail method type.
+ */
 export interface CalculatedShippingLine extends ShippingLine {
+  /**
+   * The type identifier for calculated shipping. This is always `'Calculated'` to distinguish from custom shipping lines. Calculated shipping rates are determined by carrier APIs, zone-based rules, or automated shipping calculators.
+   */
   type: 'Calculated';
+  /**
+   * The shipping method category indicating whether this is standard shipping delivery or in-store retail pickup:
+   * - `'SHIPPING'`: Traditional carrier-based shipping where items are delivered to a customer address.
+   * - `'RETAIL'`: In-store pickup or buy-online-pickup-in-store (BOPIS) where customers collect items at a physical location.
+   */
   methodType: 'SHIPPING' | 'RETAIL';
 }
 
+/**
+ * Represents a custom shipping line with merchant-defined shipping charges.
+ */
 export interface CustomShippingLine extends ShippingLine {
+  /**
+   * The type identifier for custom shipping. This is always `'Custom'` to distinguish from calculated shipping lines. Custom shipping rates are manually set by merchants rather than calculated by carrier APIs or automated systems.
+   */
   type: 'Custom';
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/shipping-line.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/shipping-line.ts
@@ -6,19 +6,19 @@ import type {TaxLine} from './tax-line';
  */
 export interface ShippingLine {
   /**
-   * A unique string identifier for this shipping line entry. This handle distinguishes between multiple shipping options on the same order and is commonly used for tracking, updates, or API operations. Returns `undefined` when no handle is assigned.
+   * The handle identifier for the shipping method.
    */
   handle?: string;
   /**
-   * The shipping charge amount as a Money object containing both the numeric value and currency information. This is the cost the customer pays for shipping, excluding any taxes which are tracked separately in `taxLines`.
+   * The price of the shipping as a Money object.
    */
   price: Money;
   /**
-   * The customer-facing display name for the shipping method (for example, "Standard Shipping", "Express Delivery", "Local Pickup", "Free Shipping"). This title appears on receipts, order confirmations, and in the checkout flow. Returns `undefined` when no title is provided.
+   * The display title of the shipping method.
    */
   title?: string;
   /**
-   * An array of tax lines applied to this shipping charge. Each tax line represents a separate tax jurisdiction or type (for example, state tax, federal tax, VAT). The sum of all tax line amounts represents the total tax on shipping. Returns `undefined` or empty array when shipping is tax-exempt or tax information isn't available.
+   * An array of individual tax lines showing tax breakdown.
    */
   taxLines?: TaxLine[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -19,6 +19,10 @@ export interface Storage<
    * @param key - The key to set the value for.
    * @param value - The value to set for the key.
    * @throws StorageError when:
+   * - Maximum number of records is exceeded (`code: 'RecordsCount'`)
+   * - Individual record size exceeds the limit (`code: 'RecordSize'`)
+   * - Key is not a string (`code: 'KeyType'`)
+   * - Key size exceeds the limit (`code: 'KeySize'`)
    */
   set<
     StorageTypes extends BaseStorageTypes = BaseStorageTypes,
@@ -43,7 +47,7 @@ export interface Storage<
   ): Promise<StorageTypes[Keys] | undefined>;
 
   /**
-   * Removes all stored data for the extension. This operation is irreversible and affects all key-value pairs stored by your extension. Commonly used for resetting extension state, handling user logout scenarios, or implementing "factory reset" functionality.
+   * Clears all data from storage, removing all key-value pairs.
    */
   clear: () => Promise<void>;
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -7,19 +7,18 @@ export class StorageError extends Error {
     super(message);
   }
 }
+/**
+ * Defines the storage interface for persisting extension data across sessions.
+ */
 export interface Storage<
   BaseStorageTypes extends Record<string, any> = Record<string, unknown>,
 > {
   /**
-   * Sets the value of a key in the storage.
+   * Stores a value under the specified key, overwriting any existing value. Values must be JSON-serializable and return `StorageError` when storage limits are exceeded. Commonly used for storing user preferences, caching API responses, or passing contextual data from tiles to modals.
    *
    * @param key - The key to set the value for.
    * @param value - The value to set for the key.
-   * Can be any primitive type supported by `JSON.stringify`.
    * @throws StorageError when:
-   *    the extension exceeds its allotted storage limit.
-   *    the value exceeds its allotted storage limit.
-   *    the key is not a string or exceeds its allotted size.
    */
   set<
     StorageTypes extends BaseStorageTypes = BaseStorageTypes,
@@ -30,12 +29,11 @@ export interface Storage<
   ): Promise<void>;
 
   /**
-   * Gets the value of a key in the storage.
+   * Retrieves the value associated with a key, returning `undefined` if the key doesn't exist. Always handle the `undefined` case by providing fallback values or conditional logic. Commonly used for loading user preferences, retrieving cached data, or accessing contextual information passed between extension targets.
    *
    * @param key - The key to get the value for.
    * @returns The value of the key.
-   * If no value for the key exists, the resolved value is undefined.
-   * @throws StorageError when the key is not a string or exceeds its allotted size.
+   * @throws StorageError when the key isn't a string or exceeds its allotted size.
    */
   get<
     StorageTypes extends BaseStorageTypes = BaseStorageTypes,
@@ -45,12 +43,12 @@ export interface Storage<
   ): Promise<StorageTypes[Keys] | undefined>;
 
   /**
-   * Clears the storage.
+   * Removes all stored data for the extension. This operation is irreversible and affects all key-value pairs stored by your extension. Commonly used for resetting extension state, handling user logout scenarios, or implementing "factory reset" functionality.
    */
   clear: () => Promise<void>;
 
   /**
-   * Deletes a key from the storage.
+   * Deletes a specific key from storage and returns `true` if the key existed, `false` if it didn't exist. Returns `false` for non-existent keys rather than throwing an error. Commonly used for cleaning up temporary workflow data, removing expired cache entries, or handling user preference changes.
    *
    * @param key - The key to delete.
    */
@@ -62,7 +60,7 @@ export interface Storage<
   ): Promise<boolean>;
 
   /**
-   * Gets all the keys and values in the storage.
+   * Retrieves all stored key-value pairs as an array of tuples, preserving original data types. Returns all data at once which may impact memory usage with large datasets. Commonly used for debugging storage contents, implementing data export features, or performing bulk operations across stored data.
    *
    * @returns An array containing all the keys and values in the storage.
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/tax-line.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/tax-line.ts
@@ -1,31 +1,31 @@
 import type {Money} from './money';
 
 /**
- * Represents an individual tax line item showing tax details including title, amount, and rate.
+ * Represents a tax line applied to an item or transaction.
  */
 export interface TaxLine {
   /**
-   * The display name of the tax as shown to merchants and customers (for example, "Sales Tax", "VAT", "GST", "State Tax"). This title identifies which tax jurisdiction or type is being applied to the item.
+   * The title or name of the tax.
    */
   title: string;
   /**
-   * The calculated tax amount as a `Money` object containing both the numeric value and currency information. This represents the actual tax charged on the item or cart, calculated by multiplying the taxable amount by the tax rate.
+   * The tax amount as a Money object.
    */
   price: Money;
   /**
-   * The tax rate as a decimal value between 0 and 1. For example, `0.05` represents 5% tax, `0.13` represents 13% tax, and `0.20` represents 20% tax. This rate is applied to the taxable amount to calculate the tax price.
+   * The tax rate as a decimal number.
    */
   rate: number;
   /**
-   * A unique identifier for this specific tax line entry. Commonly used for tracking individual tax applications, reconciliation, or referencing specific tax calculations. Returns `undefined` when no identifier is assigned.
+   * The unique identifier for this tax line.
    */
   uuid?: string;
   /**
-   * The range of possible tax rates when the tax has variable rates based on conditions like product type, customer location, or tax thresholds. Contains `min` and `max` values as decimals (for example, `{min: 0.05, max: 0.10}` for 5-10% variable tax). Returns `undefined` for fixed-rate taxes.
+   * The range of tax rates if applicable.
    */
   rateRange?: {min: number; max: number};
   /**
-   * Whether this tax is currently active and being applied. When `false`, the tax exists in configuration but isn't being charged. Returns `undefined` when enable status isn't specified.
+   * Whether this tax is currently enabled.
    */
   enabled?: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/tax-line.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/tax-line.ts
@@ -1,10 +1,31 @@
 import type {Money} from './money';
 
+/**
+ * Represents an individual tax line item showing tax details including title, amount, and rate.
+ */
 export interface TaxLine {
+  /**
+   * The display name of the tax as shown to merchants and customers (for example, "Sales Tax", "VAT", "GST", "State Tax"). This title identifies which tax jurisdiction or type is being applied to the item.
+   */
   title: string;
+  /**
+   * The calculated tax amount as a `Money` object containing both the numeric value and currency information. This represents the actual tax charged on the item or cart, calculated by multiplying the taxable amount by the tax rate.
+   */
   price: Money;
+  /**
+   * The tax rate as a decimal value between 0 and 1. For example, `0.05` represents 5% tax, `0.13` represents 13% tax, and `0.20` represents 20% tax. This rate is applied to the taxable amount to calculate the tax price.
+   */
   rate: number;
+  /**
+   * A unique identifier for this specific tax line entry. Commonly used for tracking individual tax applications, reconciliation, or referencing specific tax calculations. Returns `undefined` when no identifier is assigned.
+   */
   uuid?: string;
+  /**
+   * The range of possible tax rates when the tax has variable rates based on conditions like product type, customer location, or tax thresholds. Contains `min` and `max` values as decimals (for example, `{min: 0.05, max: 0.10}` for 5-10% variable tax). Returns `undefined` for fixed-rate taxes.
+   */
   rateRange?: {min: number; max: number};
+  /**
+   * Whether this tax is currently active and being applied. When `false`, the tax exists in configuration but isn't being charged. Returns `undefined` when enable status isn't specified.
+   */
   enabled?: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/transaction-type.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/transaction-type.ts
@@ -1,1 +1,8 @@
+/**
+ * The types of transactions that can be processed in POS:
+ * - `'Sale'`: A new sale transaction where a customer purchases products or services. This creates a new order and processes payment. The most common transaction type in POS operations.
+ * - `'Return'`: A return transaction where a customer returns previously purchased items for a refund. This credits back payment to the customer and returns items to inventory.
+ * - `'Exchange'`: An exchange transaction where a customer returns items and simultaneously purchases replacement items. This combines return and sale operations in a single transaction, often with a price adjustment.
+ * - `'Reprint'`: A receipt reprint operation where an existing transaction's receipt is reprinted. No new transaction is created—this only regenerates the receipt document for an existing sale, return, or exchange.
+ */
 export type TransactionType = 'Sale' | 'Return' | 'Exchange' | 'Reprint';


### PR DESCRIPTION
## This PR: 
- Improves all target, API, and component descriptions in the POS UI extensions docs for version 2025-10
- Improves all target, API, and component example titles and example descriptions in the POS UI extensions docs for version 2025-10
- Adds best practices and limitations content
- Reorganizes the sub-categories in the IA to match the [prototype](https://pr-62503.shopify-dev.shopify.io/docs/api/templated-refs-v2)
- Partially fixes https://github.com/Shopify/shopify-dev/issues/64745
- Partially fixes https://github.com/Shopify/shopify-dev/issues/64910
- Partially fixes https://github.com/Shopify/shopify-dev/issues/65232
- Partially fixes https://github.com/Shopify/shopify-dev/issues/65233
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8884
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8285
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8603
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8614
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8622
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8753
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8757
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8758
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/5569
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/6121
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/6279
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/6302
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/6619
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/7194
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/5294
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/5348
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/7906
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8156
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8222
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8318
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8320
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8325
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8378
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8455
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8576
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8600
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8651
- Closes https://github.com/Shopify/shopify-dev-feedback/issues/8764

### Tophatting

1. In the `ui-extensions` repo, run `yarn docs:point-of-sale 2025-10`.
2. In `shopify-dev`, run a server (`dev server`) and review the 2025-10 docs (descriptions for targets, APIs, and components) at https://shopify-dev.shop.dev/docs/api/pos-ui-extensions/2025-10

### Known issues

- **Unable to create different descriptions on API and component index pages versus detailed API and component pages**. For the time being, I've just added the long description that is intended for the details pages.
- **Some nested descriptions get duplicated, given the existing generated docs infrastructure**. Hoping that we can resolve this as we continue the templated refs project work.

### Focus for reviewers

I'm mainly looking for a gut-check on the following:

- Do the descriptions convey the necessary context?
- Are the descriptions positioned in the right place? (Typically, above interfaces and fields)
- Are the changes scoped to descriptions only? Or have we accidentally updated / added types?