### PR TITLE
Add breadcrumbs and secondary actions examples to Page component

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
@@ -106,6 +106,47 @@ const data: AdminReferenceEntityTemplateSchema = {
               ],
             },
           },
+          {
+            description:
+              'Shows a page with breadcrumb navigation and a descriptive heading, helping users understand their location in the navigation hierarchy.',
+            codeblock: {
+              title: 'Page with breadcrumbs and title',
+              tabs: [
+                {
+                  code: './examples/page-with-breadcrumbs-and-title.html',
+                  language: 'html',
+                  layout: 'none',
+                },
+                {
+                  code: './examples/page-with-breadcrumbs-and-title.jsx',
+                  language: 'preview-jsx',
+                  layout: 'none',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              'Demonstrates a page with a primary action button and secondary action buttons, showing how to provide main and related actions alongside the page heading.',
+            codeblock: {
+              title: 'Page with primary and secondary actions',
+              tabs: [
+                {
+                  code: './examples/page-with-secondary-actions.html',
+                  language: 'html',
+                  layout: 'none',
+                },
+                {
+                  code: './examples/page-with-secondary-actions.jsx',
+                  language: 'preview-jsx',
+                  layout: 'none',
+                  customStyles: {
+                    minHeight: '400px',
+                  },
+                },
+              ],
+            },
+          },
         ],
       },
     ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/examples/page-with-breadcrumbs-and-title.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/examples/page-with-breadcrumbs-and-title.html
@@ -1,0 +1,7 @@
+<s-page heading="Edit Product" inline-size="base">
+  <s-link slot="breadcrumb-actions" href="/products">Products</s-link>
+  <s-link slot="breadcrumb-actions" href="/products/123">Acme Widget</s-link>
+  <s-section>
+    <s-text>Update your product information and settings.</s-text>
+  </s-section>
+</s-page>

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/examples/page-with-breadcrumbs-and-title.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/examples/page-with-breadcrumbs-and-title.jsx
@@ -1,0 +1,7 @@
+<s-page heading="Edit Product" inlineSize="base">
+  <s-link slot="breadcrumb-actions" href="/products">Products</s-link>
+  <s-link slot="breadcrumb-actions" href="/products/123">Acme Widget</s-link>
+  <s-section>
+    <s-text>Update your product information and settings.</s-text>
+  </s-section>
+</s-page>

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/examples/page-with-secondary-actions.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/examples/page-with-secondary-actions.html
@@ -1,0 +1,8 @@
+<s-page heading="Products" inline-size="base">
+  <s-button slot="secondary-actions">Preview</s-button>
+  <s-button slot="secondary-actions">Duplicate</s-button>
+  <s-button slot="primary-action" variant="primary">Save</s-button>
+  <s-section>
+    <s-text>Manage your products and organize your catalog.</s-text>
+  </s-section>
+</s-page>

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/examples/page-with-secondary-actions.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/examples/page-with-secondary-actions.jsx
@@ -1,0 +1,8 @@
+<s-page heading="Products" inlineSize="base">
+  <s-button slot="secondary-actions">Preview</s-button>
+  <s-button slot="secondary-actions">Duplicate</s-button>
+  <s-button slot="primary-action" variant="primary">Save</s-button>
+  <s-section>
+    <s-text>Manage your products and organize your catalog.</s-text>
+  </s-section>
+</s-page>


### PR DESCRIPTION
## Summary

This PR adds two new examples to the Admin Page component documentation:

1. **Page with breadcrumbs and title** - Demonstrates how to use the `breadcrumb-actions` slot to create a breadcrumb navigation trail
2. **Page with secondary actions** - Shows how to add secondary action buttons and a primary action button using the respective slots
3. 
<img width="625" height="762" alt="Screenshot 2025-11-11 at 12 09 36 PM" src="https://github.com/user-attachments/assets/a74171d1-1c32-4263-b0fc-d368ce142f6f" />
<img width="623" height="741" alt="Screenshot 2025-11-11 at 12 09 41 PM" src="https://github.com/user-attachments/assets/84cb208c-02ed-4552-a96d-d409736cd15f" />

## Changes

- Added `page-with-breadcrumbs-and-title` example (HTML and JSX versions)
- Added `page-with-secondary-actions` example (HTML and JSX versions)
- Updated `Page.ab.doc.ts` to include these new examples in the documentation

## Purpose

These examples help developers understand how to:
- Build proper navigation hierarchies with breadcrumbs
- Add action buttons to page headers using the slots pattern
- Use the Page component's slot-based API for common UI patterns