### PR TITLE
[POS UI extensions]: Improved API, component, and prop descriptions for 2024-04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
       - id: typescript-cache
         name: Restore TypeScript cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: |
             packages/*/build/ts
@@ -31,7 +31,7 @@ jobs:
 
       - id: jest-cache
         name: Restore jest cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .loom/cache/jest/
           key: ${{ runner.os }}-jest-v1-${{ github.sha }}
@@ -50,7 +50,7 @@ jobs:
 
       - id: eslint-cache
         name: Restore ESLint cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .loom/cache/eslint
           key: ${{ runner.os }}-eslint-v1-${{ github.sha }}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/action-api/action-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/action-api/action-api.ts
@@ -1,14 +1,16 @@
 export interface ActionApiContent {
-  /** Presents the `action-overlay.render` extension target on top of present view.
+  /**
+   * Presents the corresponding action (modal) target extension target as a full-screen modal overlay on top of the current view. The modal target is automatically determined based on the current extension point—for example, calling this from `pos.purchase.post.action.menu-item.render` presents the `pos.purchase.post.action.render` modal target.
    *
-   * For example: if we are calling presentModal() from pos.purchase.post.action.menu-item.render,
-   * it should present pos.purchase.post.action.render.
+   * The modal appears with a standard header (typically including a close button and title), occupies the full screen with proper backdrop/overlay, and blocks interaction with the underlying content until dismissed. The modal can be closed programmatically using `window.close()` or by the user dismissing it through UI controls. The method returns immediately without waiting for modal dismissal.
+   *
+   * Commonly used to launch detailed workflows requiring full screen space (multi-step wizards, complex forms, detailed product configuration), display rich content (product galleries, reports, charts), or present flows that need user focus without distractions from the main POS interface.
    */
   presentModal(): void;
 }
 
 /**
- * Access the Action API to present your app in a full screen modal.
+ * The `ActionApi` object provides methods for presenting modal interfaces. Access these methods through `api.action` to launch full-screen modal experiences.
  */
 export interface ActionApi {
   action: ActionApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -9,7 +9,7 @@ import type {
 } from '../types/cart';
 
 /**
- * Access and modify the merchant’s current cart.
+ * The `CartApi` object provides access to cart management functionality and real-time cart state monitoring. Access these properties through `api.cart` to interact with the current POS cart.
  */
 export interface CartApi {
   cart: CartApiContent;
@@ -26,19 +26,25 @@ export type DiscountType =
   | 'PriceOverride'
   | 'Code';
 
+/**
+ * Defines the type of discount applied at the cart level. Specifies whether the discount is percentage-based, fixed amount, or discount code redemption.
+ */
 export type CartDiscountType = 'Percentage' | 'FixedAmount' | 'Code';
 
+/**
+ * Defines the type of discount applied to individual line items. Specifies whether the discount is percentage-based or a fixed amount reduction.
+ */
 export type LineItemDiscountType = 'Percentage' | 'FixedAmount';
 
 export interface CartApiContent {
-  /** Provides a subscription to POS cart changes.
-   * Provides an initial value and a callback to subsribe to value changes. Currently supports only one subscription.
-   * You can utilize `makeStatefulSubscribable` on a `RemoteSubscribable` to implement multiple subscriptions.
-   * Using `makeStatefulSubscribable` or the corresponding hooks counts as a subscription.
+  /**
+   * Subscribes to real-time cart state changes. Provides initial cart value and triggers callbacks on updates. Supports only one active subscription—use `makeStatefulSubscribable` for multiple subscribers.
    */
   subscribable: RemoteSubscribable<Cart>;
 
-  /** Apply a cart level discount
+  /**
+   * Apply a cart-level discount with the specified type (`'Percentage'`, `'FixedAmount'`, or `'Code'`), title, and optional amount. For discount codes, omit the `amount` parameter. Enhanced validation ensures proper discount application.
+   *
    * @param type the type of discount applied (example: 'Percentage')
    * @param title the title attributed with the discount
    * @param amount the percentage or fixed monetary amount deducted with the discount. Pass in `undefined` if using discount codes.
@@ -49,57 +55,81 @@ export interface CartApiContent {
     amount?: string,
   ): Promise<void>;
 
-  /** Add a code discount to the cart
+  /**
+   * Apply a discount code to the cart. The system will validate the code and apply the appropriate discount if the code is valid and applicable to the current cart contents.
+   *
    * @param code the code for the discount to add to the cart
    */
   addCartCodeDiscount(code: string): Promise<void>;
 
-  /** Remove the cart discount */
+  /**
+   * Remove the current cart-level discount. This only affects cart-level discounts and doesn't impact line item discounts or automatic discount eligibility.
+   */
   removeCartDiscount(): Promise<void>;
 
-  /** Remove all cart and line item discounts
+  /**
+   * Remove all discounts from both the cart and individual line items. Set `disableAutomaticDiscounts` to `true` to prevent automatic discounts from being reapplied after removal.
+   *
    * @param disableAutomaticDiscounts Whether or not automatic discounts should be enabled after removing the discounts.
    */
   removeAllDiscounts(disableAutomaticDiscounts: boolean): Promise<void>;
 
-  /** Clear the cart */
+  /**
+   * Remove all line items and reset the cart to an empty state. This action can't be undone and will clear all cart contents including line items, discounts, properties, and selling plans.
+   */
   clearCart(): Promise<void>;
 
-  /** Set the customer in the cart
+  /**
+   * Associate a customer with the current cart using the customer object containing the customer `ID`. This enables customer-specific pricing, discounts, and checkout features with customer data validation.
+   *
    * @param customer the customer object to add to the cart
    */
   setCustomer(customer: Customer): Promise<void>;
 
-  /** Remove the current customer from the cart */
+  /**
+   * Remove the currently associated customer from the cart, converting it back to a guest cart without customer-specific benefits or information while preserving cart contents.
+   */
   removeCustomer(): Promise<void>;
 
-  /** Add a custom sale to the cart
+  /**
+   * Add a custom sale item to the cart with specified quantity, title, price, and taxable status.
+   *
    * @param customSale the custom sale object to add to the cart
    */
   addCustomSale(customSale: CustomSale): Promise<void>;
 
-  /** Add a line item by variant ID to the cart
+  /**
+   * Add a product variant to the cart by its numeric `ID` with the specified quantity.
+   *
    * @param variantId the product variant's numeric ID to add to the cart
    * @param quantity the number of this variant to add to the cart
    */
   addLineItem(variantId: number, quantity: number): Promise<void>;
 
-  /** Remove the line item at this uuid from the cart
+  /**
+   * Remove a specific line item from the cart using its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier). The line item will be completely removed from the cart along with any associated discounts, properties, or selling plans.
+   *
    * @param uuid the uuid of the line item that should be removed
    */
   removeLineItem(uuid: string): Promise<void>;
 
-  /** Adds custom properties to the cart
+  /**
+   * Add custom key-value properties to the cart for storing metadata, tracking information, or integration data. Properties are merged with existing cart properties.
+   *
    * @param properties the custom key to value object to attribute to the cart
    */
   addCartProperties(properties: Record<string, string>): Promise<void>;
 
-  /** Removes the specified cart properties
+  /**
+   * Remove specific cart properties by their keys. Only the specified property keys will be removed while other properties remain intact.
+   *
    * @param keys the collection of keys to be removed from the cart properties
    */
   removeCartProperties(keys: string[]): Promise<void>;
 
-  /** Adds custom properties to the specified line item
+  /**
+   * Add custom properties to a specific line item using its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier). Properties are merged with existing line item properties for metadata storage and tracking.
+   *
    * @param uuid the uuid of the line item to which the properties should be stringd
    * @param properties the custom key to value object to attribute to the line item
    */
@@ -108,20 +138,26 @@ export interface CartApiContent {
     properties: Record<string, string>,
   ): Promise<void>;
 
-  /** Adds custom properties to multiple line items at the same time.
+  /**
+   * Add properties to multiple line items simultaneously using an array of inputs containing line item [UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier) and their respective properties for efficient bulk operations.
+   *
    * @param lineItemProperties the collection of custom line item properties to apply to their respective line items.
    */
   bulkAddLineItemProperties(
     lineItemProperties: SetLineItemPropertiesInput[],
   ): Promise<void>;
 
-  /** Removes the specified line item properties
+  /**
+   * Remove specific properties from a line item by `UUID` and property keys. Only the specified keys will be removed while other properties remain intact.
+   *
    * @param uuid the uuid of the line item to which the properties should be removed
    * @param keys the collection of keys to be removed from the line item properties
    */
   removeLineItemProperties(uuid: string, keys: string[]): Promise<void>;
 
-  /** Add a discount on a line item to the cart
+  /**
+   * Apply a discount to a specific line item using its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier). Specify the discount type (`'Percentage'` or `'FixedAmount'`), title, and amount value.
+   *
    * @param uuid the uuid of the line item that should receive a discount
    * @param type the type of discount applied (example: 'Percentage')
    * @param title the title attributed with the discount
@@ -134,19 +170,25 @@ export interface CartApiContent {
     amount: string,
   ): Promise<void>;
 
-  /** Set line item discounts to multiple line items at the same time.
+  /**
+   * Apply discounts to multiple line items simultaneously. Each input specifies the line item `UUID` and discount details for efficient bulk discount operations.
+   *
    * @param lineItemDiscounts a map of discounts to add. They key is the uuid of the line item you want to add the discount to. The value is the discount input.
    */
   bulkSetLineItemDiscounts(
     lineItemDiscounts: SetLineItemDiscountInput[],
   ): Promise<void>;
 
-  /** Sets an attributed staff to all line items in the cart.
+  /**
+   * Set the attributed staff member for all line items in the cart using the staff `ID`. Pass `undefined` to clear staff attribution from all line items.
+   *
    * @param staffId the ID of the staff. Providing undefined will clear the attributed staff from all line items.
    */
   setAttributedStaff(staffId: number | undefined): Promise<void>;
 
-  /** Sets an attributed staff to a specific line items in the cart.
+  /**
+   * Set the attributed staff member for a specific line item using the staff `ID` and line item `UUID`. Pass `undefined` as `staffId` to clear attribution from the line item.
+   *
    * @param staffId the ID of the staff. Providing undefined will clear the attributed staff on the line item.
    * @param lineItemUuid the UUID of the line item.
    */
@@ -155,23 +197,30 @@ export interface CartApiContent {
     lineItemUuid: string,
   ): Promise<void>;
 
-  /** Remove all discounts from a line item
+  /**
+   * Remove all discounts from a specific line item identified by its `UUID`. This will clear any custom discounts applied to the line item while preserving discount allocation history.
+   *
    * @param uuid the uuid of the line item whose discounts should be removed
    */
   removeLineItemDiscount(uuid: string): Promise<void>;
 
-  /** Add an address to the customer (Customer must be present)
+  /**
+   * Add a new address to the customer associated with the cart. The customer must be present in the cart before adding addresses.
+   *
    * @param address the address object to add to the customer in cart
    */
   addAddress(address: Address): Promise<void>;
 
   /**
-   * Delete an address from the customer (Customer must be present)
+   * Delete an existing address from the customer using the address `ID`. The customer must be present in the cart to perform this operation.
+   *
    * @param addressId the address ID to delete
    */
   deleteAddress(addressId: number): Promise<void>;
 
-  /** Update the default address for the customer (Customer must be present)
+  /**
+   * Set a specific address as the default address for the customer using the address `ID`. The customer must be present in the cart to update the default address.
+   *
    * @param addressId the address ID to set as the default address
    */
   updateDefaultAddress(addressId: number): Promise<void>;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/connectivity-api/connectivity-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/connectivity-api/connectivity-api.ts
@@ -2,23 +2,29 @@ import type {RemoteSubscribable} from '@remote-ui/async-subscription';
 
 export type ConnectivityStateSeverity = 'Connected' | 'Disconnected';
 
+/**
+ * Represents the current Internet connectivity status of the device. Indicates whether the device has an active Internet connection or is offline.
+ */
 export interface ConnectivityState {
   /**
-   * Whether the device is connected to the internet
+   * Whether the device is connected to the Internet. Returns `'Connected'` when the device has an active Internet connection and can communicate with remote servers, or `'Disconnected'` when the device is offline and can't reach the Internet.
+   *
+   * This state reflects the actual network connectivity, not just WiFi/cellular availability—a device can be connected to WiFi but still show `'Disconnected'` if that network has no Internet access.
+   *
+   * Commonly used for implementing offline-aware functionality (queuing operations, showing cached data), displaying connectivity indicators in the UI, disabling network-dependent features when offline, or providing user feedback about connection status.
    */
   internetConnected: ConnectivityStateSeverity;
 }
 
 export interface ConnectivityApiContent {
   /**
-   * Creates a subscription to changes in connectivity.
-   * Provides an initial value and a callback to subscribe to value changes.
+   * Creates a subscription to changes in connectivity. Provides an initial value and a callback to subscribe to value changes. Use for implementing offline-aware functionality and reactive connectivity handling.
    */
   subscribable: RemoteSubscribable<ConnectivityState>;
 }
 
 /**
- * Access information about the device connectivity
+ * The `ConnectivityApi` object provides access to current connectivity information and change notifications. Access these properties through `api.connectivity` to monitor network status.
  */
 export interface ConnectivityApi {
   connectivity: ConnectivityApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
@@ -1,20 +1,24 @@
 export interface DeviceApiContent {
   /**
-   * The name of the device
+   * The friendly name of the device as configured by the merchant or system administrator (for example, "Front Counter iPad", "Mobile Register 3", "Checkout Station A"). This name is displayed in device lists, admin interfaces, and device selection screens to help merchants identify which physical device is being used. The name is static for the session and reflects the device's configuration in Shopify admin.
    */
   name: string;
   /**
-   * The string ID of the device
+   * Retrieves the unique string identifier for this specific POS device. Returns a promise that resolves to the device ID, which is a persistent identifier that remains constant across sessions and app updates. The ID format is implementation-specific but guaranteed unique within the merchant's shop.
+   *
+   * Commonly used for device-specific data storage (storing preferences per device), analytics tracking (grouping events by device), implementing device-based permissions, or creating device-specific configurations. The async nature allows the system to fetch the ID from secure storage if not immediately available.
    */
   getDeviceId(): Promise<string>;
   /**
-   * Whether the device is a tablet
+   * Determines whether the current device is a tablet form factor (for example, iPad, Android tablet). Returns a promise that resolves to `true` for touchscreen tablet devices, or `false` for other device types like desktop POS terminals, mobile phones, or specialized POS hardware.
+   *
+   * Commonly used for implementing responsive design (adjusting layouts for tablet screens), optimizing touch target sizes (larger buttons on tablets), or enabling/disabling features based on device capabilities. The async nature accounts for cases where form factor detection requires system queries.
    */
   isTablet(): Promise<boolean>;
 }
 
 /**
- * Access information about the device, like name and ID
+ * The `DeviceApi` object provides access to device information and capabilities. Access these properties and methods through `api.device` to retrieve device details and check device characteristics.
  */
 export interface DeviceApi {
   device: DeviceApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/locale-api/locale-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/locale-api/locale-api.ts
@@ -1,15 +1,14 @@
 import type {RemoteSubscribable} from '@remote-ui/async-subscription';
 
 export interface LocaleApiContent {
-  /** IETF-formatted locale at time of page load and a callback to subsribe to value changes. Current supports only one subscription.
-   * You can utilize `makeStatefulSubscribable` on a `RemoteSubscribable` to implement multiple subscriptions.
-   * Using `makeStatefulSubscribable` or the corresponding hooks counts as a subscription.
+  /**
+   * Provides the current IETF-formatted locale (for example, "en-US") and allows you to subscribe to locale changes. Supports only one subscription at a time. To enable multiple subscriptions, use `makeStatefulSubscribable` on the `RemoteSubscribable` object. Using `makeStatefulSubscribable` or related hooks counts as an active subscription.
    */
   subscribable: RemoteSubscribable<string>;
 }
 
 /**
- * Access the merchant’s current locale (in [IETF format](https://en.wikipedia.org/wiki/IETF_language_tag)) to internationalize your extension content.
+ * The `LocaleApi` object provides access to current locale information and change notifications. Access these properties through `api.locale` to retrieve and monitor locale data.
  */
 export interface LocaleApi {
   locale: LocaleApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -1,20 +1,26 @@
 export interface NavigationApiContent {
-  /** Navigate to a route in current navigation tree.
-   * Pushes the specified screen if it isn't present in the navigation tree, goes back to a created screen otherwise.
-   * @param screenName the name of the screen you want to navigate to.
-   * @param params the parameters you want to pass to that screen.
+  /**
+   * Navigates to a specific URL within the extension, creating a new entry in the navigation history stack. The URL parameter specifies the destination path (for example, `/products`, `/settings/account`), and optional state data can be attached to the history entry.
+   *
+   * The method returns a promise that resolves when the navigation transition completes and the new view is rendered. Navigation is asynchronous to allow for animation transitions, data loading, or cleanup operations before the new view appears. If navigation fails (invalid URL, navigation prevented), the promise rejects with an error.
+   *
+   * Commonly used for programmatic navigation between extension screens (navigating on button clicks, redirecting after save operations), implementing custom navigation controls (sidebar navigation, breadcrumbs), handling navigation logic based on user actions or data state, or deep-linking to specific modal states with preserved context using the state parameter.
    */
   navigate(screenName: string, params?: any): void;
 
-  /** Pops the currently shown screen */
+  /**
+   * Pops the currently shown screen from the navigation stack. Use for implementing back navigation, returning to previous screens, or programmatically navigating backward in multi-screen workflows.
+   */
   pop(): void;
 
-  /** Dismisses the modal highest on the stack */
+  /**
+   * Dismisses the extension modal completely. Use for closing the modal when workflows are complete, cancelled, or when users need to return to the main POS interface.
+   */
   dismiss(): void;
 }
 
 /**
- * Access the navigation API for navigation functionality from a full screen modal.
+ * The `NavigationApi` object provides screen-based navigation functionality for modal interfaces. Access these methods through `api.navigation` to manage screen navigation and modal dismissal.
  */
 export interface NavigationApi {
   navigation: NavigationApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.tsx
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.tsx
@@ -1,5 +1,5 @@
 /**
- * Interface to access the order
+ * The `OrderApi` object provides access to order data in order-specific extension contexts. Access this property through `api.order` to retrieve information about the order currently being viewed or interacted with in the POS interface.
  */
 export interface OrderApi {
   order: OrderAPIContent;
@@ -10,17 +10,23 @@ export interface OrderApi {
  */
 export interface OrderAPIContent {
   /**
-   * The unique identifier for the order
+   * The unique numeric identifier for the order currently in context. This ID is consistent across all Shopify systems and APIs, allowing you to retrieve full order details using GraphQL queries, link to order records in external systems, or perform order-specific operations. The ID corresponds to the order whose details page is currently open in POS or the order associated with the current extension context.
+   *
+   * Commonly used for loading complete order information (line items, fulfillment status, payments, shipping), fetching order data from external order management systems, implementing order-based business logic (special handling for certain order types), tracking order-specific analytics, or integrating order data with shipping carriers or accounting systems.
    */
   id: number;
 
   /**
-   * The name of the order
+   * The human-readable order name or number as configured by the merchant (for example, "#1001", "#1002"). This is the customer-facing order identifier shown on receipts, confirmation emails, and in the customer's order history. The name follows the merchant's order numbering scheme configured in Shopify settings and is typically sequential.
+   *
+   * Commonly used for displaying the order reference in UI, communicating order numbers to customers, searching for orders, or including in customer communications and support interactions. This is different from the `id` which is an internal numeric identifier.
    */
   name: string;
 
   /**
-   * The unique identifier of the customer associated with the order
+   * The unique numeric identifier of the customer associated with this order. This links the order to a customer account in Shopify. Returns `undefined` for guest orders where no customer account was selected or created during checkout, or when the order doesn't have customer association.
+   *
+   * When present, this ID can be used to retrieve full customer details, load customer history, apply customer-specific logic, or link to customer records in external systems. The customer ID corresponds to the same customer available through the Customer API if accessed in customer contexts.
    */
   customerId?: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
@@ -9,75 +9,122 @@ export type ProductSortType =
   | 'ALPHABETICAL_Z_TO_A';
 
 /**
- * Base interface for pagination.
+ * Specifies parameters for cursor-based pagination. Includes the cursor position and the number of results to retrieve per page.
  */
 export interface PaginationParams {
   /**
-   * Specifies the number of results to be returned in this page. The maximum number of items that will be returned is 50.
+   * Specifies the number of results to be returned in this page. The maximum value is 50—values above 50 are clamped to 50. Smaller page sizes (10-20) provide faster initial response times and lower memory usage. Larger page sizes (40-50) reduce the number of API calls needed but increase initial load time and memory consumption. The actual number of items returned may be less than requested if fewer items exist or if you're on the last page.
+   *
+   * Commonly used to control page size based on UI layout (items per screen), performance requirements (device capabilities), or user preference (configurable pagination).
    */
   first?: number;
   /**
-   * Specifies the page cursor. Items after this cursor will be returned.
+   * The pagination cursor pointing to a specific position in the result set. When provided, the API returns items that come after this cursor position, enabling sequential page navigation. This is an opaque string token obtained from the `lastCursor` field of previous search results—its internal format is implementation-specific and shouldn't be parsed or constructed manually.
+   *
+   * To fetch the next page, the `lastCursor` from the current page is passed as the `afterCursor` for the next request. Returns items from the beginning of the result set when omitted. The cursor is only valid for the same search query and sort order—changing query parameters invalidates previous cursors.
    */
   afterCursor?: string;
 }
 
 /**
- * Interface for product search
+ * Specifies the parameters for searching products. Includes query text, pagination options, and sorting preferences for product search operations.
  */
 export interface ProductSearchParams extends PaginationParams {
   /**
-   * The search term to be used to search for POS products.
+   * The search term used to find products by name, description, SKU, barcode, tags, or other searchable product fields. The search is case-insensitive and supports partial matches—searching for "blue shirt" will find products with "Blue Cotton Shirt" or "Shirt - Blue". When provided, results are automatically sorted by relevance to the query (most relevant first), overriding any `sortType` setting.
+   *
+   * When omitted or empty, all products are returned subject to `sortType` and pagination. Special characters and punctuation are normalized during search. Commonly used for implementing text-based product search, autocomplete suggestions, or filtered product browsing.
    */
   queryString?: string;
   /**
-   * Specifies the order in which products should be sorted. When a `queryString` is provided, sortType will not have any effect, as the results will be returned in order by relevance to the `queryString`.
+   * Specifies the order in which products should be sorted. When a `queryString` is provided, `sortType` won't have any effect, as the results will be returned in order by relevance to the `queryString`. Available options:
+   *
+   * - **`RECENTLY_ADDED`** - Sorts products by creation date in descending order, displaying the most recently added products first. Commonly used to highlight new inventory additions or showcase latest product arrivals.
+   * - **`RECENTLY_ADDED_ASCENDING`** - Sorts products by creation date in ascending order, displaying the oldest products first. Typically applied when prioritizing established products or implementing chronological browsing from earliest to newest
+   * - **`ALPHABETICAL_A_TO_Z`** - Sorts products alphabetically by title from A to Z. Commonly used for product catalogs where alphabetical organization improves browsing efficiency and helps users locate products by name quickly.
+   * - **`ALPHABETICAL_Z_TO_A`** - Sorts products alphabetically by title from Z to A in reverse order. Typically applied when reverse alphabetical sorting is needed for specialized browsing patterns or user preferences.
    */
   sortType?: ProductSortType;
 }
 
 export interface ProductSearchApiContent {
-  /** Search for products on the POS device.
+  /**
+   * Searches for products stored locally on the POS device using text queries, sorting options, and pagination. Returns paginated results with up to 50 products per page. The search operates on the device's local product database (synced from Shopify), ensuring fast results even offline.
+   *
+   * When a `queryString` is provided, results are automatically sorted by relevance to the search term. When no query is provided, returns all available products in the specified sort order. The search includes product titles, descriptions, SKUs, barcodes, and tags. Results only include products that are available to this POS location based on inventory settings.
+   *
+   * Commonly used for implementing custom product search interfaces, building product catalogs, implementing barcode-based product lookup, or creating filtered product selection workflows.
+   *
    * @param searchParams The parameters for the product search.
    */
   searchProducts(
     searchParams: ProductSearchParams,
   ): Promise<PaginatedResult<Product>>;
 
-  /** Fetches a single product's details.
+  /**
+   * Retrieves complete detailed information for a single product by its unique numeric ID. Returns a full `Product` object with all product data including title, description, images, variants, pricing, inventory, and options. Returns `undefined` if the product doesn't exist in Shopify, isn't synced to this POS device, or isn't available to this location. The product data is fetched from the device's local database for fast access.
+   *
+   * Commonly used for displaying full product details, validating product availability before adding to cart, loading product information by ID from external sources, or building product-specific features that need complete product data.
+   *
    * @param productId The ID of the product to lookup.
    */
   fetchProductWithId(productId: number): Promise<Product | undefined>;
 
-  /** Fetches multiple products' details.
+  /**
+   * Retrieves detailed information for multiple products in a single bulk operation by their IDs. Limited to 50 products maximum—if more than 50 IDs are provided, only the first 50 are processed and additional IDs are automatically removed. Returns a `MultipleResourceResult` containing two arrays: `fetchedResources` with successfully found products, and `idsForResourcesNotFound` with IDs that couldn't be found.
+   *
+   * This allows handling partial success scenarios where some IDs are valid and others aren't. Products may be missing because they don't exist, aren't synced to this device, or aren't available to this location.
+   *
+   * Commonly used for bulk product lookups (validating lists of IDs), building product collections from ID arrays, displaying multiple products simultaneously, or validating product availability across multiple items.
+   *
    * @param productIds Specifies the array of product IDs to lookup. This is limited to 50 products. All excess requested IDs will be removed from the array.
    */
   fetchProductsWithIds(
     productIds: number[],
   ): Promise<MultipleResourceResult<Product>>;
 
-  /** Fetches a single product variant's details.
+  /**
+   * Retrieves complete detailed information for a single product variant by its unique numeric ID. Returns a full `ProductVariant` object with all variant data including pricing, inventory levels, SKU, barcode, weight, options (size, color), and images. Returns `undefined` if the variant doesn't exist in Shopify, isn't synced to this POS device, or isn't available to this location. The variant data is fetched from the device's local database.
+   *
+   * Commonly used for displaying variant-specific details when a specific variant is already known, loading variant information when adding specific configurations to cart, checking inventory for a particular variant, or retrieving variant details by scanned barcode.
+   *
    * @param productVariantId The ID of the product variant to lookup.
    */
   fetchProductVariantWithId(
     productVariantId: number,
   ): Promise<ProductVariant | undefined>;
 
-  /** Fetches multiple product variants' details.
+  /**
+   * Retrieves detailed information for multiple product variants in a single bulk operation by their IDs. Limited to 50 variants maximum—if more than 50 IDs are provided, only the first 50 are processed and additional IDs are automatically removed. Returns a `MultipleResourceResult` containing two arrays: `fetchedResources` with successfully found variants, and `idsForResourcesNotFound` with IDs that couldn't be found.
+   *
+   * This allows handling partial success scenarios where some variant IDs are valid and others aren't. Variants may be missing because they don't exist, were deleted, aren't synced to this device, or aren't available to this location.
+   *
+   * Commonly used for bulk variant inventory checks across multiple products, validating variant ID lists before operations, loading variant data for multiple cart items, or building variant comparison features.
+   *
    * @param productVariantIds Specifies the array of product variant IDs to lookup. This is limited to 50 product variants. All excess requested IDs will be removed from the array.
    */
   fetchProductVariantsWithIds(
     productVariantIds: number[],
   ): Promise<MultipleResourceResult<ProductVariant>>;
 
-  /** Fetches all product variants associated with a product.
+  /**
+   * Retrieves all product variants associated with a specific product ID in a single call without pagination. Returns a complete array of all variants for the product, regardless of how many variants exist. For products with many variants (50+), this loads all variants at once which may impact performance and memory usage—consider using `fetchPaginatedProductVariantsWithProductId` instead for products with extensive variant catalogs. The variant order in the returned array follows the product's variant configuration.
+   *
+   * Commonly used for displaying complete variant selection interfaces (showing all available size/color/material combinations), building variant comparison tables, loading all variant options upfront for product detail pages, or when the complete variant set is needed immediately.
+   *
    * @param productId The product ID. All variants' details associated with this product ID are returned.
    */
   fetchProductVariantsWithProductId(
     productId: number,
   ): Promise<ProductVariant[]>;
 
-  /** Fetches a page of product variants associated with a product.
+  /**
+   * Retrieves product variants for a specific product with pagination support, loading variants in pages rather than all at once. Returns paginated results with up to 50 variants per page. The method accepts a product ID and pagination parameters (`first` for page size, `afterCursor` for position). Each page includes a cursor for fetching the next page and a flag indicating whether more pages exist.
+   *
+   * Typically applied when a product has many variants (100+) and loading them all at once would impact performance, memory usage, or user experience. This is ideal for products with extensive variant collections (for example, apparel with hundreds of size/color/style combinations, configurable products with many option permutations) that would be too large or slow to load in a single request.
+   *
+   * Enables implementing progressive loading patterns like infinite scroll, "Load more" buttons, or lazy loading of additional variants as users browse.
+   *
    * @param paginationParams The parameters for pagination.
    */
   fetchPaginatedProductVariantsWithProductId(
@@ -87,7 +134,7 @@ export interface ProductSearchApiContent {
 }
 
 /**
- * Access Point of Sale's native product search functionality.
+ * The `ProductSearchApi` object provides methods for searching and retrieving product information. Access these methods through `api.productSearch` to search products and fetch detailed product data.
  */
 export interface ProductSearchApi {
   productSearch: ProductSearchApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
@@ -3,28 +3,42 @@ import type {RemoteSubscribable} from '@remote-ui/async-subscription';
 /** The scanner source the POS device supports. */
 export type ScannerSource = 'camera' | 'external' | 'embedded';
 
+/**
+ * Represents the data from a scanner event. Contains the scanned string data and the hardware source that captured the scan.
+ */
 export interface ScannerSubscriptionResult {
-  /** The string data from the last scanner event received. */
+  /**
+   * The string data from the last scanner event received. Contains the decoded content from the scanned barcode, QR code, or other machine-readable format. The format and content depend on what was scanned—product barcodes return product identifiers (UPC, EAN), QR codes return their encoded text or URL, and other formats return their respective data encodings. The string is already decoded and ready to use (no additional parsing of barcode formats needed). Returns `undefined` when no scan has occurred yet or when the scan data isn't available.
+   *
+   * Commonly used to look up products by barcode, process QR code data, implement scan-to-add-to-cart workflows, or trigger actions based on scanned content.
+   */
   data?: string;
-  /** The scanning source from which the scan event came. */
+  /**
+   * The scanning source from which the scan event came. Returns one of the following scanner types:
+   *
+   * - `'camera'` - Device camera for scanning through the camera interface (available on most mobile POS devices)
+   * - `'external'` - External scanner hardware connected using USB, Bluetooth, or other methods (handheld scanners, dedicated devices)
+   * - `'embedded'` - Built-in scanning hardware integrated into the POS device (specialized terminals with integrated scanning)
+   *
+   * Returns `undefined` when no scan source is available. Use to implement source-specific logic or provide feedback about scanning method.
+   */
   source?: ScannerSource;
 }
 
 export interface ScannerApiContent {
-  /** Creates a subscription to scan events
-   * Provides an initial value and a callback to subsribe to value changes. Currently supports only one subscription.
-   * You can utilize `makeStatefulSubscribable` on a `RemoteSubscribable` to implement multiple subscriptions.
-   * Using `makeStatefulSubscribable` or the corresponding hooks counts as a subscription.
+  /**
+   * Subscribe to scan events to receive barcode and QR code data when scanned. Supports one subscription at a time. To enable multiple subscriptions, use `makeStatefulSubscribable` on the `RemoteSubscribable` object. Using `makeStatefulSubscribable` or related hooks counts as an active subscription. Use for receiving real-time scan results.
    */
   scannerDataSubscribable: RemoteSubscribable<ScannerSubscriptionResult>;
-  /** Creates a subscription to the scanning sources available on the POS device.
-   * Provides an initial value and a callback to subsribe to value changes. Currently supports only one subscription.
-   * You can utilize `makeStatefulSubscribable` on a `RemoteSubscribable` to implement multiple subscriptions.
-   * Using `makeStatefulSubscribable` or the corresponding hooks counts as a subscription.
+  /**
+   * Subscribe to changes in available scanner sources on the device. Supports one subscription at a time. To enable multiple subscriptions, use `makeStatefulSubscribable` on the `RemoteSubscribable` object. Using `makeStatefulSubscribable` or related hooks counts as an active subscription. Use to monitor which scanners are available (camera, external, or embedded).
    */
   scannerSourcesSubscribable: RemoteSubscribable<ScannerSource[]>;
 }
 
+/**
+ * The `ScannerApi` object provides access to scanning functionality and scanner source information. Access these properties through `api.scanner` to monitor scan events and available scanner sources.
+ */
 export interface ScannerApi {
   scanner: ScannerApiContent;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
@@ -2,18 +2,17 @@ import type {Session} from '../types/session';
 
 export interface SessionApiContent {
   /**
-   * Access information on the current POS session.
+   * Provides comprehensive information about the current POS session including shop details, user authentication, location data, staff member information, currency settings, and POS version. This data is static for the duration of the session and updates when users switch locations or staff members change.
    */
   currentSession: Session;
   /**
-   * Get a fresh session token for communication with your app's backend service.
-   * Calls to Shopify APIs must be made by your app’s backend service.
+   * Generates a fresh session token for secure communication with your app's backend service. Returns `undefined` when the authenticated user lacks proper app permissions. The token is a Shopify [OpenID Connect](https://en.wikipedia.org/wiki/OpenID#OpenID_Connect_(OIDC)) ID Token that should be used in `Authorization` headers for backend API calls. This is based on the authenticated user, not the pinned staff member.
    */
   getSessionToken: () => Promise<string | undefined>;
 }
 
 /**
- * Access information on the current Session, including data on the current shop, user, staff and location.
+ * The `SessionApi` object provides access to current session information and authentication methods. Access these properties and methods through `api.session` to retrieve shop data and generate secure tokens. These methods enable secure API calls while maintaining user privacy and [app permissions](https://help.api.com/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).
  */
 export interface SessionApi {
   session: SessionApiContent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
@@ -1,16 +1,30 @@
+/**
+ * Specifies configuration options for displaying toast notifications. Controls the duration and display behavior of temporary notification messages.
+ */
 export interface ShowToastOptions {
+  /**
+   * The duration in milliseconds that the toast message remains visible before automatically dismissing. If not specified, the toast uses the default system duration (typically 3-5 seconds depending on the platform).
+   *
+   * Shorter durations (1000-2000ms) work well for simple confirmations like "Item added" or "Saved". Longer durations (5000-7000ms) provide adequate reading time for important messages or multi-sentence notifications. Very short durations (< 1000ms) may not give users enough time to read the message. The toast dismisses automatically after the specified duration, but users may also manually dismiss it if the system supports swipe-to-dismiss gestures.
+   */
   duration?: number;
 }
 
 export interface ToastApiContent {
   /**
-   * Show a toast.
+   * Displays a toast notification with the specified text content. The message appears as a temporary, non-blocking overlay (typically at the top or bottom of the screen) that automatically dismisses after the specified duration. The toast doesn't interrupt the user's workflow—users can continue interacting with the POS while the toast is visible. Toast messages should be brief and scannable (1-2 short sentences maximum) since they disappear automatically.
+   *
+   * Commonly used for providing immediate user feedback ("Product added to cart"), confirming actions ("Changes saved"), displaying success messages ("Order completed"), or communicating status updates ("Syncing inventory") without requiring user acknowledgment. Multiple toasts may queue or stack depending on the platform implementation.
+   *
    * @param content The text content to display.
    * @param options An object containing ShowToastOptions.
    */
   show: (content: string, options?: ShowToastOptions) => void;
 }
 
+/**
+ * The `ToastApi` object provides methods for displaying temporary notification messages. Access these methods through `api.toast` to show user feedback and status updates.
+ */
 export interface ToastApi {
   toast: ToastApiContent;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/types/cart.ts
@@ -1,108 +1,267 @@
 import {CountryCode} from './country-code';
 
+/**
+ * Represents the shopping cart state, including line items, pricing, customer information, and applied discounts. Provides comprehensive access to all cart data and operations.
+ */
 export interface Cart {
+  /**
+   * The subtotal amount of the cart before taxes and discounts, formatted as a currency string.
+   */
   subtotal: string;
+  /**
+   * The total tax amount for the cart, formatted as a currency string.
+   */
   taxTotal: string;
+  /**
+   * The final total amount including all items, taxes, and discounts, formatted as a currency string.
+   */
   grandTotal: string;
+  /**
+   * The cart note to set during bulk update. Replaces existing note or sets new note if none exists. Set to `undefined` to remove current note.
+   */
   note?: string;
+  /**
+   * The cart-level discount to apply during bulk update. Replaces existing cart discount. Set to `undefined` to remove current discount.
+   */
   cartDiscount?: Discount;
+  /**
+   * An array of cart-level discounts to apply during bulk update. Replaces all existing cart discounts with the provided array.
+   */
   cartDiscounts: Discount[];
+  /**
+   * The customer to associate with the cart during bulk update. Replaces existing customer or converts guest cart to customer cart.
+   */
   customer?: Customer;
+  /**
+   * An array of line items to set during bulk update. Completely replaces existing cart contents—removes all current items and adds the provided ones.
+   */
   lineItems: LineItem[];
+  /**
+   * The custom key-value properties attached to this line item. Empty object if no properties are set. Commonly used for metadata, customization options, or integration data.
+   */
   properties: Record<string, string>;
 }
 
+/**
+ * Represents basic customer identification information. Contains the customer ID for linking to detailed customer data and enabling customer-specific features.
+ */
 export interface Customer {
+  /**
+   * The unique numeric identifier for the customer in Shopify's system. This ID is consistent across all Shopify systems and APIs. Used to link this customer reference to the full customer record with complete profile information. Commonly used for customer lookups, applying customer-specific pricing or discounts, linking orders to customer accounts, or integrating with customer management systems.
+   */
   id: number;
+  /**
+   * The customer's email address for communication and account identification. Used for sending order confirmations, receipts, marketing communications, and account recovery. Returns `undefined` when no email is associated with the customer account.
+   */
   email?: string;
+  /**
+   * The customer's first name (given name) as stored in their Shopify account. Used for personalizing communications and displaying customer information on receipts and orders. Returns `undefined` when first name isn't provided.
+   */
   firstName?: string;
+  /**
+   * The customer's last name (family name/surname) as stored in their Shopify account. Used for personalizing communications and displaying customer information on receipts and orders. Returns `undefined` when last name isn't provided.
+   */
   lastName?: string;
+  /**
+   * Internal notes about this customer for merchant reference only. This field is not visible to the customer and can contain information like preferences, special instructions, or account history. Returns `undefined` when no notes have been added. Commonly used for tracking customer preferences, recording important account details, or communicating information between staff members.
+   */
   note?: string;
 }
 
+/**
+ * Represents an individual item in the shopping cart. Contains product information, pricing, quantity, discounts, and customization details for a single cart entry.
+ */
 export interface LineItem {
+  /**
+   * The unique [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) string identifier for this specific line item within the cart. This identifier is generated when the line item is added to the cart and remains constant for that line item throughout its lifecycle. The UUID distinguishes this line item from other line items in the cart, even if they represent the same product or variant. This is the primary key for line item operations—all Cart API methods that target specific line items require this UUID. Commonly used for updating line item properties, applying line item discounts, removing items from cart, setting selling plans, or tracking individual line items through the checkout process.
+   */
   uuid: string;
+  /**
+   * The unit price for a single unit of this custom sale item as a string value. This represents the price per item in the store's currency (for example, `"25.00"` for $25.00, `"99.99"` for $99.99). String format ensures precision for financial calculations. The total line item cost is calculated as this price multiplied by the quantity. Commonly used for pricing the custom sale, calculating line totals, displaying the charge to customers, or generating receipts with itemized pricing.
+   */
   price?: number;
+  /**
+   * The number of units of this custom sale item to add to the cart. Must be a positive integer (minimum 1) representing how many of this custom item the customer is purchasing. Since custom sales don't have inventory tracking, any quantity can be entered without stock validation. Commonly used for specifying how many of the custom item to charge for, calculating line totals (price × quantity), or displaying quantity on receipts and invoices.
+   */
   quantity: number;
+  /**
+   * The customer-facing display name for this custom sale item. This is the text that will appear on receipts, in the cart, and on order confirmations to describe what was sold. Should be descriptive and clear (for example, "Repair Service", "Custom Engraving", "Consultation Fee", "Special Order Item"). This is required to create a custom sale. Commonly used for cart and receipt displays, order identification, or describing the custom item in customer communications.
+   */
   title?: string;
+  /**
+   * The unique numeric identifier for the product variant this bundle component represents. Links to a specific variant in the Shopify catalog. Returns `undefined` for custom components or non-catalog items within the bundle. When present, this ID can be used to fetch full variant details or verify component inventory. Commonly used for component inventory management, linking bundle components to catalog records, or loading component variant details.
+   */
   variantId?: number;
+  /**
+   * The unique numeric identifier for the product this bundle component represents. Links to the parent product in the Shopify catalog. Returns `undefined` for custom components or non-catalog items within the bundle. When present, this ID can be used to fetch full product information about the component. Commonly used for component product lookups, grouping bundle components, or linking to product records.
+   */
   productId?: number;
+  /**
+   * An array of all discounts applied specifically to this line item (not cart-level discounts). Each discount object contains the amount, type, and description. The array is empty when no line item-specific discounts are applied. Multiple discounts can apply to a single line item when discount stacking is enabled. The sum of discount amounts reduces the line item's contribution to the cart total. Commonly used for displaying line item savings ("You save $5.00"), showing discount breakdowns in itemized views, calculating effective prices after discounts, or implementing discount-aware business logic.
+   */
   discounts: Discount[];
+  /**
+   * Whether this custom sale item is subject to tax calculations. When `true`, taxes are calculated and applied to this item based on location tax rules and settings. When `false`, this item is tax-exempt and no tax is charged. Tax exemption might apply for services, specific product categories, or non-taxable items depending on jurisdiction. Commonly used for determining whether to calculate taxes on this custom sale, compliance with tax regulations, displaying tax-inclusive vs tax-exclusive pricing, or generating accurate tax reports.
+   */
   taxable: boolean;
+  /**
+   * The Stock Keeping Unit (SKU) identifier for this line item as configured in the product catalog. SKUs are merchant-defined alphanumeric codes used for inventory tracking, fulfillment, and product identification (for example, "TSHIRT-BLU-LG", "12345-A"). Returns `undefined` when no SKU is configured for the product variant, which is common for products without inventory tracking or custom sales. The SKU is unique within the merchant's catalog and is often used with barcode scanners or inventory management systems. Commonly used for inventory tracking, displaying product codes on receipts, integrating with warehouse management systems, or matching products with external SKU-based systems.
+   */
   sku?: string;
+  /**
+   * The vendor or brand name for this line item as configured in the product catalog (for example, "Nike", "Acme Corp", "House Brand"). This indicates who manufactures or supplies the product. Returns `undefined` when no vendor is set for the product, which is common for products where vendor tracking isn't used. Vendors are merchant-defined and not standardized. Commonly used for vendor-specific displays in cart or receipts, filtering or grouping products by vendor, implementing vendor-based business logic (special handling for certain suppliers), or reporting sales by vendor.
+   */
   vendor?: string;
+  /**
+   * The custom key-value properties attached to this line item. Empty object if no properties are set. Commonly used for metadata, customization options, or integration data.
+   */
   properties: {[key: string]: string};
+  /**
+   * Whether this line item is a gift card product. When `true`, indicates this is a Shopify gift card (digital or physical) which has special handling—gift cards don't affect inventory, have different tax treatment in some jurisdictions, and generate gift card codes upon purchase. When `false`, this is a regular product, custom sale, or other non-gift-card item. Gift card line items may have restrictions on discounts or combinations with other line items. Commonly used for implementing gift card-specific UI, applying gift card business rules, excluding gift cards from certain promotions, or separating gift card sales in reporting.
+   */
   isGiftCard: boolean;
 }
 
+/**
+ * Represents a discount applied to a cart or transaction, including amount and description.
+ */
 export interface Discount {
+  /**
+   * The discount value to apply. For `'Percentage'` type, this represents the percentage value (For example, "10" for 10% off). For `'FixedAmount'` type, this represents the fixed monetary amount to deduct from the line item price. Commonly used for discount calculations and displaying the discount value to merchants.
+   */
   amount: number;
+  /**
+   * A human-readable description of the discount shown to merchants and customers. This typically includes the discount name, promotion details, or discount code (for example, "SUMMER2024", "10% off entire order", "Buy 2 Get 1 Free"). Returns `undefined` when no description is provided.
+   */
   discountDescription?: string;
+  /**
+   * The [discount type](https://help.api.com/en/manual/discounts/discount-types) applied to this line item. Can be either `'Percentage'` for percentage-based discounts or `'FixedAmount'` for fixed monetary amount discounts. This determines how the discount amount is calculated and displayed.
+   */
   type?: string;
 }
 
 /**
- * Parameters for adding custom properties to a line item.
+ * Specifies the parameters for adding custom properties to line items. Properties are key-value pairs used for storing metadata, tracking information, or integration data.
  */
 export interface SetLineItemPropertiesInput {
   /**
-   * The uuid belonging to the line item which should receive the custom properties.
+   * The [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) of the target line item to which the selling plan should be applied. This must match the `uuid` of an existing line item in the current cart. If the UUID doesn't exist in the cart, the operation will fail. The line item's product must support selling plans—attempting to add a selling plan to a line item whose product doesn't have selling plan groups will result in an error. Commonly used to identify which cart item is being configured with a subscription plan.
    */
   lineItemUuid: string;
   /**
-   * The custom properties to apply to the line item.
+   * The custom key-value properties attached to this line item. Empty object if no properties are set. Commonly used for metadata, customization options, or integration data.
    */
   properties: Record<string, string>;
 }
 
 /**
- * Parameters for adding a line item discount.
+ * Specifies the parameters for applying discounts to individual line items. Includes the discount type, value, and reason for audit and reporting purposes.
  */
 export interface SetLineItemDiscountInput {
   /**
-   * The uuid belonging to the line item which should receive the discount.
+   * The [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) of the target line item to which the selling plan should be applied. This must match the `uuid` of an existing line item in the current cart. If the UUID doesn't exist in the cart, the operation will fail. The line item's product must support selling plans—attempting to add a selling plan to a line item whose product doesn't have selling plan groups will result in an error. Commonly used to identify which cart item is being configured with a subscription plan.
    */
   lineItemUuid: string;
   /**
-   * The discount to be applied to the line item.
+   * The discount details to apply to the line item. Contains title, type (`'Percentage'` or `'FixedAmount'`), and amount value.
    */
   lineItemDiscount: LineItemDiscount;
 }
 
+/**
+ * Represents a discount applied to an individual line item in the cart.
+ */
 export interface LineItemDiscount {
   /**
-   * The title of the line item discount.
+   * The customer-facing display name for this custom sale item. This is the text that will appear on receipts, in the cart, and on order confirmations to describe what was sold. Should be descriptive and clear (for example, "Repair Service", "Custom Engraving", "Consultation Fee", "Special Order Item"). This is required to create a custom sale. Commonly used for cart and receipt displays, order identification, or describing the custom item in customer communications.
    */
   title: string;
   /**
-   * The discount type.
+   * The [discount type](https://help.api.com/en/manual/discounts/discount-types) applied to this line item. Can be either `'Percentage'` for percentage-based discounts or `'FixedAmount'` for fixed monetary amount discounts. This determines how the discount amount is calculated and displayed.
    */
   type: 'Percentage' | 'FixedAmount';
   /**
-   * The percentage or fixed amount for the discount.
+   * The discount value to apply. For `'Percentage'` type, this represents the percentage value (For example, "10" for 10% off). For `'FixedAmount'` type, this represents the fixed monetary amount to deduct from the line item price. Commonly used for discount calculations and displaying the discount value to merchants.
    */
   amount: string;
 }
 
+/**
+ * Represents a custom sale item that isn't linked to a product in the merchant's catalog. Custom sales allow merchants to add arbitrary items to the cart with manually entered details—useful for services, custom orders, one-off items, or products not in the catalog.
+ */
 export interface CustomSale {
+  /**
+   * The number of units of this custom sale item to add to the cart. Must be a positive integer (minimum 1) representing how many of this custom item the customer is purchasing. Since custom sales don't have inventory tracking, any quantity can be entered without stock validation. Commonly used for specifying how many of the custom item to charge for, calculating line totals (price × quantity), or displaying quantity on receipts and invoices.
+   */
   quantity: number;
+  /**
+   * The customer-facing display name for this custom sale item. This is the text that will appear on receipts, in the cart, and on order confirmations to describe what was sold. Should be descriptive and clear (for example, "Repair Service", "Custom Engraving", "Consultation Fee", "Special Order Item"). This is required to create a custom sale. Commonly used for cart and receipt displays, order identification, or describing the custom item in customer communications.
+   */
   title: string;
+  /**
+   * The unit price for a single unit of this custom sale item as a string value. This represents the price per item in the store's currency (for example, `"25.00"` for $25.00, `"99.99"` for $99.99). String format ensures precision for financial calculations. The total line item cost is calculated as this price multiplied by the quantity. Commonly used for pricing the custom sale, calculating line totals, displaying the charge to customers, or generating receipts with itemized pricing.
+   */
   price: string;
+  /**
+   * Whether this custom sale item is subject to tax calculations. When `true`, taxes are calculated and applied to this item based on location tax rules and settings. When `false`, this item is tax-exempt and no tax is charged. Tax exemption might apply for services, specific product categories, or non-taxable items depending on jurisdiction. Commonly used for determining whether to calculate taxes on this custom sale, compliance with tax regulations, displaying tax-inclusive vs tax-exclusive pricing, or generating accurate tax reports.
+   */
   taxable: boolean;
 }
 
+/**
+ * Represents physical address information for customer shipping and billing. Contains standard address fields including street, city, region, postal code, and country data.
+ */
 export interface Address {
+  /**
+   * The primary street address line containing the street number and name (for example, "123 Main Street", "456 Oak Avenue"). This is the first line of the mailing address and is typically required for shipping and billing operations. Returns `undefined` when not provided or not applicable. Commonly used for displaying addresses, calculating shipping rates based on location, validating address completeness, or sending to shipping carriers for label generation.
+   */
   address1?: string;
+  /**
+   * The secondary address line for additional location details like apartment number, suite, unit, floor, or building information (for example, "Apt 4B", "Suite 200", "Floor 3"). This field is optional and supplements the primary address line. Returns `undefined` when not provided. Commonly used for complete address display, ensuring deliveries reach the correct destination in multi-unit buildings, or providing detailed shipping instructions.
+   */
   address2?: string;
+  /**
+   * The city or locality name for the address (for example, "New York", "Toronto", "London"). Required for most shipping and billing operations as it's needed for calculating shipping zones, determining tax jurisdictions, and routing deliveries. Returns `undefined` when not provided. Commonly used for address display, shipping rate calculations based on destination city, tax determination, or filtering addresses by location.
+   */
   city?: string;
+  /**
+   * The company or business name associated with the address (for example, "Acme Corporation", "Smith & Co."). This field is optional and typically used for B2B transactions, business deliveries, or when the shipping/billing address is a commercial location rather than residential. Returns `undefined` for individual/residential addresses. Commonly used for business customer identification, commercial shipping labels, B2B order processing, or company-based address organization.
+   */
   company?: string;
+  /**
+   * The first name (given name) of the person associated with this address (for example, "John", "Maria"). Commonly used for personalizing shipping labels, customer communications, and ensuring deliveries reach the correct recipient. Returns `undefined` when not provided. Typically combined with `lastName` for full name display.
+   */
   firstName?: string;
+  /**
+   * The last name (family name/surname) of the person associated with this address (for example, "Smith", "Garcia"). Commonly used for complete customer identification, shipping labels, and formal address displays. Returns `undefined` when not provided. Typically combined with `firstName` for full name display (for example, "John Smith").
+   */
   lastName?: string;
+  /**
+   * The contact phone number for this address (for example, "+1-555-123-4567", "(555) 123-4567"). Phone numbers enable carriers to contact recipients for delivery coordination, provide delivery notifications using SMS, or reach customers for address clarification. Format varies by region and may include country codes, area codes, and extensions. Returns `undefined` when not provided. Commonly used for delivery notifications, customer contact during shipping issues, or SMS updates about order status.
+   */
   phone?: string;
+  /**
+   * The province, state, or region name for the address (for example, "California", "Ontario", "New South Wales"). Required for calculating regional shipping rates, determining state/provincial taxes, and routing deliveries correctly. The format is the full name rather than abbreviated code. Returns `undefined` when not provided or not applicable (some countries don't have province/state divisions). Commonly used for shipping rate calculations, tax jurisdiction determination, or displaying complete addresses.
+   */
   province?: string;
+  /**
+   * The country name for the address in English (for example, "United States", "Canada", "United Kingdom"). Required for international shipping, determining country-specific tax rules, and customs documentation. The full country name is used rather than an abbreviated code. Returns `undefined` when not provided. Commonly used for shipping calculations, tax compliance, customs forms, or country-based address validation.
+   */
   country?: string;
+  /**
+   * The postal code or ZIP code for the address (for example, "90210", "M5V 3A8", "SW1A 1AA"). Format varies by country—US uses 5 or 9-digit ZIP codes, Canada uses alphanumeric postal codes, UK uses alphanumeric postcodes. Required for accurate shipping rate calculations, address verification, and location-based services. Returns `undefined` when not provided. Commonly used for shipping rate lookup, address validation, geographic sorting, or carrier integration.
+   */
   zip?: string;
+  /**
+   * A customer-defined label or nickname for this address to make it easily identifiable (for example, "Home", "Work", "Main Office", "Warehouse"). This friendly name helps distinguish between multiple saved addresses for the same customer. Returns `undefined` when no custom name is assigned. Commonly used for displaying address selection lists ("Ship to: Home"), organizing customer addresses, or showing address nicknames in dropdowns.
+   */
   name?: string;
+  /**
+   * The standardized province or state code (for example, "CA" for California, "ON" for Ontario, "NSW" for New South Wales). This is typically a 2-3 character abbreviation that complements the full `province` name. Codes follow regional standards and enable programmatic province/state matching. Returns `undefined` when not applicable or not provided. Commonly used for precise regional identification in shipping APIs, automated tax calculations, address validation services, or integrating with carriers that require standardized codes.
+   */
   provinceCode?: string;
+  /**
+   * The standardized [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code (for example, `"US"` for United States, `"CA"` for Canada, `"GB"` for United Kingdom). This is a two-letter code that precisely identifies the country in a machine-readable format. Complements the full `country` name and is required by many shipping carriers and tax services. Returns `undefined` when not provided. Commonly used for precise country identification in shipping operations, international tax calculations, address validation, customs documentation, or carrier API integration.
+   */
   countryCode?: CountryCode;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/types/country-code.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/types/country-code.ts
@@ -1,5 +1,8 @@
 /* eslint @shopify/typescript/prefer-pascal-case-enums: off */
 
+/**
+ * The two-letter [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes representing all countries and territories. These standard codes are used for addresses, shipping destinations, tax jurisdictions, and regional settings.
+ */
 export enum CountryCode {
   AF = 'AF',
   AX = 'AX',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/types/multiple-resource-result.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/types/multiple-resource-result.ts
@@ -1,14 +1,13 @@
 /**
- * The result of a fetch function where the input is multiple IDs.
- * This object contains the resources that were found, as well as an array of IDs specifying which IDs, if any, did not correspond to a resource.
+ * Represents the result of a bulk resource lookup operation. Contains successfully found resources and identifiers for resources that weren't found.
  */
 export interface MultipleResourceResult<T> {
   /**
-   * The resources that were fetched using the IDs provided.
+   * An array of resources that were successfully fetched using the IDs provided in the request. Each item in this array corresponds to a resource that exists and is accessible on the POS device. The order of items may not match the order of requested IDs. This array is empty when none of the requested IDs were found. Commonly used to access the actual product or variant data retrieved from bulk fetch operations.
    */
   fetchedResources: T[];
   /**
-   * The IDs for which a resource was not found.
+   * An array of numeric IDs for which no matching resource was found on the POS device. Resources may be missing because they don't exist, were deleted, aren't available to this location, or aren't synced to the POS device. This allows distinguishing between successful and failed lookups in a single operation. When all requested resources are found, this array is empty. Commonly used to handle missing products or variants gracefully, provide user feedback about unavailable items ("Product X not found"), log missing data for debugging, or implement fallback logic for missing resources.
    */
   idsForResourcesNotFound: number[];
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/types/paginated-result.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/types/paginated-result.ts
@@ -1,20 +1,19 @@
 /**
- * Contains a page of fetched results.
+ * Represents the result of a paginated query. Contains the data items, pagination cursors for navigating pages, and information about whether more results exist.
  */
 export interface PaginatedResult<T> {
   /**
-   * The items returned from the fetch.
+   * The items returned from the fetch operation. Contains the actual search results or fetched resources. Commonly used to access the product or variant data returned from search and fetch operations.
    */
   items: T[];
 
   /**
-   * The cursor of the last item. This can be used to fetch more results.
-   * The format of this cursor may look different depending on if POS is fetching results from the remote API, or its local database. However, that should not affect its usage with the search functions.
+   * The pagination cursor pointing to the last item in the current result set. This opaque string token can be passed as the `afterCursor` parameter in subsequent search requests to fetch the next page of results. The cursor format varies depending on whether POS is fetching from the remote API or its local database, but this implementation detail doesn't affect usage—simply pass the cursor value as-is to pagination functions. Returns `undefined` when this is the last page of results (when `hasNextPage` is `false`).
    */
   lastCursor?: string;
 
   /**
-   * Whether or not there is another page of results that can be fetched.
+   * Whether there is another page of results that can be fetched. Commonly used to determine whether to show "Load More" buttons, pagination controls, or implement infinite scrolling functionality.
    */
   hasNextPage: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/types/product.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/types/product.ts
@@ -1,62 +1,226 @@
+/**
+ * Represents comprehensive product information including metadata, pricing, variants, and availability. Contains all data needed to display and work with products in the POS interface.
+ */
 export interface Product {
+  /**
+   * The unique numeric identifier for this product option configuration. This ID identifies the option definition itself (not a specific option value or variant). Commonly used for option-specific operations, tracking option configurations, or linking options in external systems.
+   */
   id: number;
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was created. Commonly used for sorting variants by creation date, implementing "new product" features, or tracking product catalog changes over time.
+   */
   createdAt: string;
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was last updated. Commonly used for cache invalidation, tracking recent changes, or implementing "recently updated" product features.
+   */
   updatedAt: string;
+  /**
+   * The variant's display title, typically showing the option combinations. For example, `"Large / Blue"`. Commonly used for variant selection interfaces, cart displays, or anywhere users need to distinguish between variants.
+   */
   title: string;
+  /**
+   * The product's plain text description without HTML formatting. Commonly used for displaying product information in contexts where HTML isn't supported or when you need clean text content for processing.
+   */
   description: string;
+  /**
+   * The product's description with HTML formatting preserved. Typically applied when you need to display rich text content with formatting, links, or other HTML elements in your extension interface.
+   */
   descriptionHtml: string;
+  /**
+   * The URL of the product's featured image, if one is set. Returns `undefined` if no featured image is configured. Commonly used for displaying product images in search results, product listings, or detailed product views.
+   */
   featuredImage?: string;
+  /**
+   * Whether this product is a gift card. Gift cards have special handling requirements and different business logic. Commonly used to implement gift card-specific workflows, validation, or display special gift card interfaces.
+   */
   isGiftCard: boolean;
+  /**
+   * Whether inventory tracking is enabled for this product. When `false`, inventory quantities may not be accurate or meaningful. Commonly used to determine whether to display inventory information or implement inventory-based business logic.
+   */
   tracksInventory: boolean;
+  /**
+   * The product's vendor or brand name as configured by the merchant. Commonly used for filtering products by brand, displaying vendor information, or organizing products by supplier.
+   */
   vendor: string;
+  /**
+   * The lowest price among all product variants, formatted as a string. Commonly used for displaying price ranges, implementing price-based filtering, or showing starting prices in product listings.
+   */
   minVariantPrice: string;
+  /**
+   * The highest price among all product variants, formatted as a string. Commonly used for displaying price ranges, implementing price-based filtering, or showing complete pricing information for products with multiple variants.
+   */
   maxVariantPrice: string;
+  /**
+   * The product type category as defined by the merchant (For example, "T-Shirt," "Electronics," "Books"). Commonly used for product categorization, filtering, or implementing category-specific business logic.
+   */
   productType: string;
+  /**
+   * The standardized product category classification. Commonly used for product categorization, implementing category-specific business logic, or organizing products by standardized categories.
+   */
   productCategory: string;
+  /**
+   * An array of tags associated with the product for categorization and organization. Commonly used for product filtering, search enhancement, or implementing tag-based business logic and promotions.
+   */
   tags: string[];
+  /**
+   * The total number of variants available for this product. Commonly used to determine whether to show variant selection interfaces, implement variant-specific logic, or optimize variant loading strategies.
+   */
   numVariants: number;
+  /**
+   * The total available inventory across all variants and locations, if tracking is enabled. Returns `undefined` when inventory tracking is disabled. Commonly used for availability checks, stock level displays, or implementing low-stock alerts.
+   */
   totalAvailableInventory?: number;
+  /**
+   * The total inventory count across all variants and locations for this product. Commonly used for inventory management, stock level displays, or implementing low-stock warnings and alerts.
+   */
   totalInventory: number;
+  /**
+   * An array of all product variants associated with this product. Each variant contains detailed information including pricing, inventory, and options. Commonly used for building variant selectors, displaying inventory information, or implementing variant-specific functionality.
+   */
   variants: ProductVariant[];
+  /**
+   * An array of option name-value pairs that define this variant's configuration. For example, `[{name: "Size," value: "Large"}, {name: "Color," value: "Blue"}]`. Returns `undefined` for products with only default variants. Commonly used for displaying variant options, building variant selectors, or implementing variant-based logic.
+   */
   options: ProductOption[];
+  /**
+   * Whether the product has only a default variant (no custom options). When `true`, the product doesn't require variant selection. Commonly used to simplify product interfaces and skip variant selection steps for single-variant products.
+   */
   hasOnlyDefaultVariant: boolean;
+  /**
+   * Whether this variant currently has inventory in stock. Returns `undefined` when inventory information isn't available. Commonly used for stock status displays, availability checks, or filtering in-stock variants.
+   */
   hasInStockVariants?: boolean;
+  /**
+   * The URL of the product on the online store, if available. Returns `undefined` when the product isn't published online or the store doesn't have an online presence. Commonly used for linking to online product pages or sharing product information.
+   */
   onlineStoreUrl?: string;
 }
 
+/**
+ * Represents a specific variant of a product with its own SKU, price, and inventory. Contains variant-specific attributes including options, availability, and identification data.
+ */
 export interface ProductVariant {
+  /**
+   * The unique numeric identifier for this product option configuration. This ID identifies the option definition itself (not a specific option value or variant). Commonly used for option-specific operations, tracking option configurations, or linking options in external systems.
+   */
   id: number;
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was created. Commonly used for sorting variants by creation date, implementing "new product" features, or tracking product catalog changes over time.
+   */
   createdAt: string;
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the product variant was last updated. Commonly used for cache invalidation, tracking recent changes, or implementing "recently updated" product features.
+   */
   updatedAt: string;
+  /**
+   * The variant's display title, typically showing the option combinations. For example, `"Large / Blue"`. Commonly used for variant selection interfaces, cart displays, or anywhere users need to distinguish between variants.
+   */
   title: string;
+  /**
+   * The variant's selling price formatted as a string. Commonly used for price displays, cart calculations, or implementing pricing logic. This represents the current selling price for the variant.
+   */
   price: string;
+  /**
+   * The variant's compare-at price (original or MSRP price) formatted as a string, if set. Returns `undefined` when no compare-at price is configured. Commonly used for displaying discounts, sale pricing, or savings calculations.
+   */
   compareAtPrice?: string;
+  /**
+   * Whether this variant is subject to tax calculations. Commonly used for tax computation logic, pricing displays, or implementing tax-exempt product handling.
+   */
   taxable: boolean;
+  /**
+   * The variant's Stock Keeping Unit (SKU) identifier, if configured. Returns `undefined` when no SKU is set. Commonly used for inventory management, product identification, or integration with external systems that use SKU-based tracking.
+   */
   sku?: string;
+  /**
+   * The variant's barcode identifier, if configured. Returns `undefined` when no barcode is set. Commonly used for barcode scanning functionality, inventory tracking, or integration with barcode-based systems.
+   */
   barcode?: string;
+  /**
+   * The variant's formatted display name for user interfaces. This may differ from the title and is optimized for display purposes. Commonly used for customer-facing variant names in product listings, cart items, or receipt displays.
+   */
   displayName: string;
+  /**
+   * The URL of the variant-specific image, if one is configured. Returns `undefined` when no variant image is set. Commonly used for displaying variant-specific images in selection interfaces or product galleries.
+   */
   image?: string;
+  /**
+   * Whether inventory tracking is enabled for this specific variant. When `false`, inventory quantities may not be accurate. Commonly used to determine whether to display inventory information or implement inventory-based business logic for this variant.
+   */
   inventoryIsTracked: boolean;
+  /**
+   * The inventory quantity available at the current POS location, if inventory tracking is enabled. Returns `undefined` when inventory tracking is disabled. Commonly used for location-specific inventory displays, stock availability checks, or local inventory management.
+   */
   inventoryAtLocation?: number;
+  /**
+   * The total inventory quantity across all locations for this variant, if available. Returns `undefined` when this information isn't accessible. Commonly used for comprehensive inventory views, transfer planning, or multi-location inventory management.
+   */
   inventoryAtAllLocations?: number;
+  /**
+   * The inventory policy for this variant, either "DENY" (prevent sales when out of stock) or "CONTINUE" (allow sales when out of stock). Commonly used to implement inventory validation logic and determine whether to allow purchases of out-of-stock items.
+   */
   inventoryPolicy: ProductVariantInventoryPolicy;
+  /**
+   * Whether this variant currently has inventory in stock. Returns `undefined` when inventory information isn't available. Commonly used for stock status displays, availability checks, or filtering in-stock variants.
+   */
   hasInStockVariants?: boolean;
+  /**
+   * An array of option name-value pairs that define this variant's configuration. For example, `[{name: "Size," value: "Large"}, {name: "Color," value: "Blue"}]`. Returns `undefined` for products with only default variants. Commonly used for displaying variant options, building variant selectors, or implementing variant-based logic.
+   */
   options?: ProductVariantOption[];
+  /**
+   * Reference to the parent Product object that this variant belongs to. Returns `undefined` in some contexts to avoid circular references. Typically applied when you need access to product-level information from a variant context.
+   */
   product?: Product;
+  /**
+   * The unique numeric identifier of the parent product to which this option belongs. This links the option definition back to the product it configures. Commonly used for linking options to their parent product, organizing options by product, or implementing product-level option management.
+   */
   productId: number;
+  /**
+   * The variant's position order within the product's variant list. Commonly used for maintaining consistent variant ordering in selection interfaces or implementing custom variant sorting logic.
+   */
   position: number;
 }
 
+/**
+ * Represents a single option selection for a product variant, showing one chosen value from a product's configuration options. For example, if a product has Size and Color options, a variant might have one option for Size=Large and another for Color=Blue.
+ */
 export interface ProductVariantOption {
+  /**
+   * The option category name (for example, `"Size"`, `"Color"`, `"Material"`, `"Style"`, `"Flavor"`). This is the attribute or dimension along which the product varies. Each product can have up to 3 option names, and each option name can have multiple values. The name is visible to customers in variant selection interfaces. Commonly used for displaying option labels in variant selectors ("Select Size:", "Choose Color:"), building dynamic product configuration UI, or organizing product variations by attribute type.
+   */
   name: string;
+  /**
+   * The selected value for this option that defines this specific variant (for example, `"Large"`, `"Blue"`, `"Cotton"`, `"V-Neck"`). This is the specific choice from the available option values that characterizes this variant. For example, if `name` is "Size", the `value` might be "Large" or "Small". Values are set at the variant level—each variant has a unique combination of option values. Commonly used for displaying the variant's configuration ("Size: Large, Color: Blue"), building variant selection dropdowns, or matching user selections to variants.
+   */
   value: string;
 }
 
+/**
+ * The inventory policy determining whether sales can continue when a variant has no inventory available:
+ * - `'DENY'`: Sales are prevented when inventory reaches zero. Customers can't purchase out-of-stock variants. The "Add to cart" action is disabled or shows "Out of stock". This is the default and recommended policy for most physical products to prevent overselling.
+ * - `'CONTINUE'`: Sales are allowed even when inventory is zero or negative. Customers can purchase out-of-stock variants, creating backorders. This enables pre-orders, made-to-order products, or drop-shipped items where inventory tracking is less critical.
+ */
 export type ProductVariantInventoryPolicy = 'DENY' | 'CONTINUE';
 
+/**
+ * Represents a product option definition showing one of the configurable attributes for a product (like Size, Color, Material) along with all the possible values customers can choose from. Products can have up to 3 options.
+ */
 export interface ProductOption {
+  /**
+   * The unique numeric identifier for this product option configuration. This ID identifies the option definition itself (not a specific option value or variant). Commonly used for option-specific operations, tracking option configurations, or linking options in external systems.
+   */
   id: number;
+  /**
+   * The option category name (for example, `"Size"`, `"Color"`, `"Material"`, `"Style"`, `"Flavor"`). This is the attribute or dimension along which the product varies. Each product can have up to 3 option names, and each option name can have multiple values. The name is visible to customers in variant selection interfaces. Commonly used for displaying option labels in variant selectors ("Select Size:", "Choose Color:"), building dynamic product configuration UI, or organizing product variations by attribute type.
+   */
   name: string;
+  /**
+   * An array of all available values for this option that customers can choose from (for example, `["Small", "Medium", "Large", "X-Large"]` for a Size option, or `["Red", "Blue", "Green", "Black"]` for a Color option). The order of values in this array typically represents the display order in variant selectors. Each combination of option values across all options creates a unique variant. For example, a product with Size: [Small, Large] and Color: [Red, Blue] would have 4 variants (Small/Red, Small/Blue, Large/Red, Large/Blue). Commonly used for building variant selection dropdowns, radio buttons, or swatches, validating user selections, or displaying all available choices for an attribute.
+   */
   optionValues: string[];
+  /**
+   * The unique numeric identifier of the parent product to which this option belongs. This links the option definition back to the product it configures. Commonly used for linking options to their parent product, organizing options by product, or implementing product-level option management.
+   */
   productId: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/types/session.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/types/session.ts
@@ -1,27 +1,29 @@
+/**
+ * Defines information about the current POS session. Contains authentication details, location context, and configuration settings that remain constant for the duration of the session.
+ */
 export interface Session {
   /**
-   * The shop ID associated with the shop currently logged into POS.
+   * The unique numeric identifier for the Shopify shop currently logged into POS. This ID is consistent across all Shopify systems and APIs. Commonly used for shop-specific data queries, API authentication, or multi-shop configurations.
    */
   shopId: number;
 
   /**
-   * The user ID associated with the Shopify account currently authenticated on POS.
+   * The unique numeric identifier for the Shopify account currently authenticated on POS. This represents the logged-in user's account, which may be the shop owner, an admin, or a staff member with POS access. This ID can differ from `staffMemberId` when a different staff member is pinned in for the transaction. Commonly used for user-specific permissions, audit trails, or tracking who performed actions.
    */
   userId: number;
 
   /**
-   * The shop domain associated with the shop currently logged into POS.
+   * The shop's `.myapi.com` domain name (for example, `"my-store.myapi.com"`). This is the shop's permanent Shopify domain, not custom domains. Commonly used for constructing API URLs, identifying the shop in external systems, or building shop-specific links.
    */
   shopDomain: string;
 
   /**
-   * The location ID associated with the POS' current location.
+   * The unique numeric identifier for the physical retail location where this POS device is currently operating. Locations represent distinct retail sites, warehouses, or pop-up shops within a merchant's business. This determines which inventory is available, which staff can access the POS, and which location appears on receipts and orders. Commonly used for location-specific inventory queries, sales reports, or implementing location-based features.
    */
   locationId: number;
 
   /**
-   * The staff ID who is currently pinned into the POS.
-   * Note that this staff member ID may be different to the User ID, as the staff member who enters their PIN may be different to the User who logged onto POS.
+   * The unique numeric identifier for the staff member currently pinned into the POS session. This represents who is actively using the POS for transactions, which may differ from `userId` when a manager is logged in but a different staff member is pinned for sales attribution. Returns `undefined` when no staff member is pinned. Commonly used for sales attribution, commission tracking, or staff-specific workflows.
    */
   staffMemberId?: number;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.ts
@@ -8,10 +8,30 @@ export type BadgeVariant =
   | 'highlight';
 
 export type BadgeStatus = 'empty' | 'partial' | 'complete';
-
 export interface BadgeProps {
+  /**
+   * The text content displayed within the badge. Keep this concise and descriptive to clearly communicate status or category information. Examples include "Paid," "Pending," "Out of Stock," or "VIP Customer."
+   */
   text: string;
+
+  /**
+   * Controls the visual styling and semantic meaning of the badge. Available options:
+   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis. Use for general status updates and standard information.
+   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action. Use for urgent issues that need immediate merchant attention.
+   * - `'warning'` - Orange styling for important notices that require merchant awareness. Use for situations that need attention but aren't critical.
+   * - `'success'` - Green styling for positive states, completed actions, and successful operations. Use for positive outcomes and successful processes.
+   * - `'highlight'` - Bright styling for featured content, promotions, or emphasized information. Use for featured content that should stand out.
+   */
   variant: BadgeVariant;
+
+  /**
+   * Displays a circular status indicator alongside the badge text. Available options:
+   * - `'empty'` - Shows an empty circle indicator
+   * - `'partial'` - Shows a partially filled circle indicator
+   * - `'complete'` - Shows a completely filled circle indicator
+   *
+   * @deprecated No longer supported as of POS 10.0.0.
+   */
   status?: BadgeStatus;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.ts
@@ -4,34 +4,42 @@ export type BannerVariant = 'confirmation' | 'alert' | 'error' | 'information';
 
 export interface BannerProps {
   /**
-   * The title of the banner.
+   * The title text displayed prominently on the banner. This should be concise and clearly communicate the main message or purpose of the banner to merchants.
    */
   title: string;
 
   /**
-   * Banners have multiple variants that can be used to
-   * change the color and style of the banner.
+   * Controls the visual styling and semantic meaning of the banner. Available options:
+   * - `'confirmation'` - Green styling for positive outcomes, successful operations, and completed actions
+   * - `'alert'` - Orange styling for important notices and situations that require merchant attention
+   * - `'error'` - Red styling for critical errors, failures, and urgent issues requiring immediate action
+   * - `'information'` - Blue styling for general information, neutral updates, and helpful tips
    */
   variant: BannerVariant;
 
   /**
-   * @defaultValue 'dismiss'
+   * The text displayed on the action button within the banner. This provides a clear call-to-action for merchants to address the banner's message. Default is `'Dismiss'` if not specified.
+   *
+   * @defaultValue 'Dismiss'
    */
   action?: string;
 
   /**
-   * Dismisses the banner by default.
+   * The callback function executed when the banner or its action button is pressed. Use this to handle user interactions such as dismissing the banner, navigating to relevant screens, or triggering specific actions. Default behavior dismisses the banner if not specified.
+   *
+   * @defaultValue Callback which dismisses the banner
    */
   onPress?: () => void;
 
   /**
-   * Use this parameter to hide the action button.
+   * Determines whether the action button is visible on the banner. When set to `true`, the action button is hidden, creating a display-only banner. When `false`, the action button is shown with the specified action text. Default is `true` (action button hidden).
+   *
+   * @defaultValue true
    */
   hideAction?: boolean;
 
   /**
-   * Whether or not the banner is visible.
-   * @defaultValue true
+   * Controls the visibility state of the banner. When set to `true`, the banner is displayed. When `false`, it's hidden. Use this to programmatically show or hide banners based on application state or user interactions.
    */
   visible: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.ts
@@ -1,12 +1,36 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-export type ButtonType = 'primary' | 'basic' | 'destructive' | 'plain';
+export type ButtonType =
+  | 'primary'
+  | 'basic'
+  | 'destructive'
+  /** @deprecated No longer supported as of POS 10.0.0. */
+  | 'plain';
 
 export interface ButtonProps {
+  /**
+   * The text set on the button. When using a button for action (menu item) targets, the title will be ignored. The text on the menu item will be the extension's description.
+   */
   title: string;
+  /**
+   * The type of button to render. Determines the appearance of the button.
+   * - `'primary'` - Creates a prominent call-to-action button with high visual emphasis for the most important action on a screen
+   * - `'basic'` - Provides a standard button appearance for secondary actions and general interactions
+   * - `'destructive'` - Displays a warning-styled button for actions that delete, remove, or cause irreversible changes
+   * - `'plain'` - Deprecated as of POS 10.0.0. Using this option will automatically default to `'basic`'
+   */
   type?: ButtonType;
+  /**
+   * The callback that's executed when the user taps the button.
+   */
   onPress?: () => void;
+  /**
+   * Whether the button can be tapped.
+   */
   isDisabled?: boolean;
+  /**
+   * Whether the button is displaying an animated loading state.
+   */
   isLoading?: boolean;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/CameraScanner/CameraScanner.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/CameraScanner/CameraScanner.ts
@@ -1,12 +1,26 @@
 import {createRemoteComponent} from '@remote-ui/core';
-import {BannerProps} from '../Banner/Banner';
+import {BannerVariant} from '../Banner/Banner';
 
-export type CameraScannerBannerProps = Pick<
-  BannerProps,
-  'title' | 'variant' | 'visible'
->;
+export interface CameraScannerBannerProps {
+  /**
+   * The title text displayed on the banner to provide context or instructions to users.
+   */
+  title: string;
+
+  /**
+   * The appearance variant of the banner that conveys the type of message being displayed.
+   */
+  variant: BannerVariant;
+  /**
+   * Controls the visibility state of the banner within the scanner interface.
+   */
+  visible: boolean;
+}
 
 export interface CameraScannerProps {
+  /**
+   * An optional banner configuration object that displays contextual messages during scanning operations.
+   */
   bannerProps?: CameraScannerBannerProps;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.ts
@@ -1,9 +1,28 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 export interface DatePickerProps {
+  /**
+   * The currently selected date value. Defaults to the current date when not specified.
+   *
+   * @defaultValue The current time.
+   */
   selected?: string;
+  /**
+   * A callback function executed when the user selects a date, receiving the selected date string as a parameter.
+   */
   onChange?(selected: string): void;
+  /**
+   * A tuple that controls the visible state of the picker and provides a callback to set visibility to false when the dialog closes. The first element is the current visibility state, and the second is a setter function.
+   */
   visibleState: [boolean, (visible: boolean) => void];
+
+  /**
+   * The display mode for the date picker.
+   * - `inline`: A calendar-style interface that displays a full month view where users can tap specific dates. Provides visual context about weekdays, month structure, and date relationships.
+   * - `spinner`: A spinner-style selector with scrollable columns for month, day, and year. Offers a more compact interface suitable for constrained spaces or when calendar context isn't necessary.
+   *
+   * @defaultValue 'inline'
+   */
   inputMode?: 'inline' | 'spinner';
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Dialog/Dialog.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Dialog/Dialog.ts
@@ -3,14 +3,53 @@ import {createRemoteComponent} from '@remote-ui/core';
 export type DialogType = 'default' | 'alert' | 'error' | 'destructive';
 
 export interface DialogProps {
+  /**
+   * The text displayed in the title of the dialog. This should be concise and clearly communicate the purpose or action being confirmed.
+   */
   title: string;
+
+  /**
+   * The text displayed in the body of the dialog. Use this to provide additional context, instructions, or details about the action being confirmed.
+   */
   content?: string;
+
+  /**
+   * The text displayed on the primary action button of the dialog. Use clear, action-oriented language like "Delete," "Confirm," "Save," or "Continue."
+   */
   actionText: string;
+
+  /**
+   * The text displayed on the secondary action button, typically used for "Cancel," "Go Back," or alternative actions. Only displayed when `showSecondaryAction` is `true`.
+   */
   secondaryActionText?: string;
+
+  /**
+   * Controls whether a secondary action button is displayed alongside the primary action. Set to `true` to show both buttons, `false` to show only the primary action.
+   */
   showSecondaryAction?: boolean;
+
+  /**
+   * Determines the dialog's visual appearance and semantic meaning. Available options:
+   * - `'default'` - Standard styling for general-purpose dialogs and confirmations
+   * - `'alert'` - Warning styling for important notices that require attention
+   * - `'error'` - Error styling for critical issues and failure notifications
+   * - `'destructive'` - Destructive styling for actions that can't be undone, like deletions
+   */
   type?: DialogType;
+
+  /**
+   * The callback function executed when the primary action button is pressed. This should handle the main action the dialog is confirming or requesting.
+   */
   onAction: () => void;
+
+  /**
+   * The callback function executed when the secondary action button is pressed. Typically used to cancel the dialog or provide an alternative action path.
+   */
   onSecondaryAction?: () => void;
+
+  /**
+   * Controls whether the dialog is displayed or hidden. Set to `true` to show the dialog, `false` to hide it. Use this to manage dialog visibility based on user interactions or application state.
+   */
   isVisible: boolean;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
@@ -3,10 +3,29 @@ import type {AutoCapitalizationType} from '../shared/auto-capitalization-type';
 import type {BaseTextFieldProps} from '../shared/BaseTextField';
 
 export type InputType = 'text' | 'number' | 'currency' | 'giftcard' | 'email';
-
 export interface FormattedTextFieldProps extends BaseTextFieldProps {
+  /**
+   * Defines the input type options that determine which specialized keyboard layout is displayed.
+   *
+   * - `text`: A general text input type with standard keyboard layout for any text content.
+   * - `number`: A numeric input type with number-optimized keyboard for entering quantities or numeric values.
+   * - `currency`: A currency input type with keyboard optimized for monetary amounts and decimal values.
+   * - `giftcard`: A gift card input type with keyboard optimized for alphanumeric gift card codes.
+   * - `email`: An email input type with keyboard optimized for email addresses, including easy access to @ and domain symbols.
+   */
   inputType?: InputType;
+  /**
+   * Defines the auto-capitalization behavior options for text input.
+   *
+   * - `none`: No automatic capitalization is applied to the text input.
+   * - `sentences`: The first letter of each sentence is automatically capitalized.
+   * - `words`: The first letter of each word is automatically capitalized.
+   * - `characters`: Every character is automatically capitalized as it is entered.
+   */
   autoCapitalize?: AutoCapitalizationType;
+  /**
+   * Applies a custom validator that can dictate whether or not an entered value is valid.
+   */
   customValidator?: (text: string) => boolean;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.ts
@@ -1,5 +1,8 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/**
+ * The name identifier for the icon to display. Choose from the available icon set including commerce operations (`'cart'`, `'products'`, `'orders'`, `'custom-sale'`), payment methods (`'cash'`, `'credit-card'`, `'gift-card'`, `'shopify-payments'`), navigation elements (`'arrow'`, `'chevron-up'`, `'chevron-down'`, `'chevron-left'`, `'chevron-right'`), actions (`'add-customer'`, `'search'`, `'scan-barcode'`, `'refresh'`), status indicators (`'checkmark'`, `'circle-alert'`, `'circle-info'`, `'connectivity-warning'`), and system symbols (`'settings'`, `'help'`, `'menu'`, `'home'`).
+ */
 export type IconName =
   | 'add-customer'
   | 'analytics'
@@ -83,10 +86,26 @@ export type IconName =
   | 'delivery'
   | 'shop-pay';
 
+/**
+ * The size of the icon to display. Controls the icon's dimensions and visual prominence in the interface.
+ * - `'minor'` - Small size for compact spaces, secondary actions, or inline elements
+ * - `'major'` - Standard size for primary buttons and prominent UI elements (default)
+ * - `'spot'` - Larger size for featured content, empty states, or emphasis areas
+ * - `'caption'` - Tiny size for accompanying small text or dense information displays
+ * - `'badge'` - Minimal size for notification badges, indicators, or status markers
+ */
 export type IconSize = 'minor' | 'major' | 'spot' | 'caption' | 'badge';
 
 export interface IconProps {
+  /**
+   * A name used to render the icon. Choose from the available icon set including commerce-specific symbols like `'cart'`, `'payment'`, `'search'`, navigation arrows, and system indicators.
+   */
   name: IconName;
+  /**
+   * The size of the icon. Use `'minor'` for small icons, `'major'` for standard size (default), `'spot'` for larger emphasis, `'caption'` for tiny text accompaniment, or `'badge'` for small indicators.
+   *
+   * @defaultValue 'major'
+   */
   size?: IconSize;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.ts
@@ -1,6 +1,9 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 export interface ImageProps {
+  /**
+   * The URL or path to the image resource to display. This can be a remote URL (for example, `'https://example.com/image.png'`) or a relative path to a local image asset. If not provided, the image component may display a placeholder or remain empty.
+   */
   src?: string;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/List/List.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/List/List.ts
@@ -3,27 +3,43 @@ import {BadgeProps} from '../Badge/Badge';
 import {ColorType} from '../Text/Text';
 
 export interface ToggleSwitch {
+  /**
+   * The current state of the toggle switch. When `true`, the switch is in the "on" position. When `false`, it's in the "off" position.
+   */
   value?: boolean;
+
+  /**
+   * Controls whether the toggle switch can be interacted with. When `true`, the switch is disabled and users cannot change its state.
+   */
   disabled?: boolean;
 }
 
 export interface SubtitleType {
+  /**
+   * The text content to display as a subtitle beneath the main label.
+   */
   content: string;
+
+  /**
+   * The semantic color of the subtitle text that conveys meaning and intent through visual styling.
+   */
   color?: ColorType;
 }
 
 export type ListRowSubtitle = string | SubtitleType;
 
+/**
+ * Defines the content and styling options for the left side of list rows.
+ */
 export interface ListRowLeftSide {
   /**
-   * The main label that will be displayed on the left side of the row.
+   * The main label text displayed prominently on the left side of the row.
    */
   label: string;
   /**
-   * The subtitles to display beneath the main label. Up to 3 subtitles can be displayed.
-   * Subtitles can optionally be configured with colors by passing an object with a `content` and `color` properties.
+   * An array of up to three subtitles displayed beneath the main label. Each subtitle can be a string or an object with content and color properties.
    */
-  subtitle?: readonly [ListRowSubtitle, ListRowSubtitle?, ListRowSubtitle?];
+  subtitle?: [ListRowSubtitle, ListRowSubtitle?, ListRowSubtitle?];
   /**
    * @deprecated
    * badge will be removed in version 2.0.0 in favor of badges.
@@ -31,82 +47,94 @@ export interface ListRowLeftSide {
    */
   badge?: BadgeProps;
   /**
-   * Colored badges that are displayed underneath the `title` and `subtitles`.
+   * An array of colored badges displayed underneath the title and subtitles for additional status or category information.
    */
   badges?: BadgeProps[];
+  /**
+   * An image configuration object for displaying images on the far left side of the row with optional badge overlay.
+   */
   image?: {
     /**
-     * A link to an image to be displayed on the far left side of the row.
+     * A URL to an image to be displayed on the far left side of the row.
      */
     source?: string;
     /**
-     * A number that is displayed on the top right of the image.
+     * A numeric badge displayed on the top right corner of the image, typically used for counts or quantities.
      */
     badge?: number;
   };
 }
 
+/**
+ * Defines the content and interaction options for the right side of list rows.
+ */
 export interface ListRowRightSide {
   /**
-   * The main label that will be displayed on the right side of the row.
+   * An optional label text displayed on the right side of the row for additional information or values.
    */
   label?: string;
   /**
-   * Show a chevron. Set this to true if pressing on the row navigates to another screen.
+   * Controls chevron display. Set to `true` when pressing the row navigates to another screen.
+   *
    * @defaultValue `false`
    */
   showChevron?: boolean;
   /**
-   * A toggle switch that is be displayed on the right side of the row.
+   * A toggle switch configuration object displayed on the right side of the row for boolean settings or states.
    */
   toggleSwitch?: ToggleSwitch;
 }
 
+/**
+ * Defines the structure and content options for individual rows within the `List` component.
+ */
 export interface ListRow {
   /**
-   * The unique identifier for this list item.
+   * The unique identifier for the list item used for tracking and interaction handling.
    */
   id: string;
   /**
-   * The user interface of the left side of the row.
+   * The content configuration for the left side of the row, including label, subtitles, badges, and optional image.
    */
   leftSide: ListRowLeftSide;
   /**
-   * The user interface of the right side of the row.
+   * The content configuration for the right side of the row, including optional label, chevron, and toggle switch.
    */
   rightSide?: ListRowRightSide;
   /**
-   * Callback for when the user taps the row.
+   * A callback function executed when the user taps the row.
    */
   onPress?: () => void;
 }
 
 export interface ListProps {
   /**
-   * A large display title at the top of the `List`.
+   * A large display title shown at the top of the list.
    */
   title?: string;
   /**
-   * A header component for the list
+   * A header component displayed at the top of the list for additional context or controls.
    */
   listHeaderComponent?: RemoteFragment;
   /**
-   * The array of `ListRow` which will be converted into rows for this list.
+   * An array of ListRow objects that define the content and structure of each row in the list.
    */
   data: ListRow[];
   /**
-   * Whether or not more data is being loaded. Set this to `true` when paginating and fetching more data for the list.
+   * A boolean indicating whether more data is being loaded. Set to `true` when paginating and fetching additional data for the list.
    */
   isLoadingMore?: boolean;
   /**
-   * The logic behind displaying an image or placeholder. `automatic` will display an image or placeholder if it detects
-   * that a `ListItem` in `data` has an `imageUri` value. `never` will never display images or placeholders. `always` will
-   * always display images or placeholders if `imageUri` is undefined or empty.
+   * The logic for displaying images or placeholders:
+   * - `automatic`: Displays images or placeholders only when it detects that a ListRow has an image source value.
+   * - `always`: Displays images or placeholders for all rows, even when image sources are undefined or empty.
+   * - `never`: Hides all images and placeholders, creating a text-only list layout.
+   *
    * @defaultValue `automatic`
    */
   imageDisplayStrategy?: 'automatic' | 'always' | 'never';
   /**
-   * Callback for when the user reaches the end of the `List`. This can be used to fire a request to load more data.
+   * A callback function executed when the user reaches the end of the list. Use this to trigger requests for loading additional data.
    */
   onEndReached?: () => void;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Navigator/Navigator.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Navigator/Navigator.ts
@@ -1,9 +1,9 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/**
- * @property `initialScreenName` sets the initial Screen by its `name` property.
- */
 export interface NavigatorProps {
+  /**
+   * The name of the initial `Screen` component to display when the Navigator is first rendered. Must match the `name` property of a child `Screen` component.
+   */
   initialScreenName?: string;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.ts
@@ -1,16 +1,20 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import type {InputProps} from '../shared/InputField';
 
-/**
- * Represents the properties for the NumberField component.
- * @typedef {Object} NumberFieldProps
- * @property {'decimal' | 'numeric'} [inputMode] - The mode of input, can be either 'decimal' or 'numeric'.
- * @property {number} [max] - The highest decimal or integer to be accepted for the field.
- * @property {number} [min] - The lowest decimal or integer to be accepted for the field.
- */
 export interface NumberFieldProps extends InputProps {
+  /**
+   * The virtual keyboard layout to display:
+   * - `decimal`: A keyboard layout that includes decimal point support for entering fractional numbers, prices, or measurements with decimal precision.
+   * - `numeric`: A keyboard layout optimized for integer-only entry without decimal point support, ideal for quantities, counts, or whole number values.
+   */
   inputMode?: 'decimal' | 'numeric';
+  /**
+   * The highest decimal or integer to be accepted for the field. Users can still input higher numbers by keyboard—you must add appropriate validation logic.
+   */
   max?: number;
+  /**
+   * The lowest decimal or integer to be accepted for the field. Users can still input lower numbers by keyboard—you must add appropriate validation logic.
+   */
   min?: number;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PinPad/PinPad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PinPad/PinPad.ts
@@ -1,46 +1,70 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 /**
- * Represents the result of the pin pad onSubmit function.
- * @typedef {('accept'|'reject')} PinValidationResult
+ * Defines the validation result values that the `onSubmit` callback must return to indicate PIN verification status.
+ *
+ * Available values:
+ * - `accept`: A validation result indicating the PIN is correct and authentication was successful.
+ * - `reject`: A validation result indicating the PIN is incorrect and authentication failed.
  */
 export type PinValidationResult = 'accept' | 'reject';
 
 /**
- * Represents the allowed lengths of a PIN.
- * @typedef {(4|5|6|7|8|9|10)} PinLength
+ * Defines the allowed PIN length values that constrain how many digits users can enter.
+ *
+ * Available lengths:
+ * - `4`: A four-digit PIN length, commonly used for basic security codes and quick authentication.
+ * - `5`: A five-digit PIN length for moderate security requirements.
+ * - `6`: A six-digit PIN length, commonly used for enhanced security codes and verification.
+ * - `7`: A seven-digit PIN length for higher security requirements.
+ * - `8`: An eight-digit PIN length for strong security and complex authentication scenarios.
+ * - `9`: A nine-digit PIN length for very high security requirements.
+ * - `10`: A ten-digit PIN length, the maximum supported for highly secure authentication workflows.
  */
 export type PinLength = 4 | 5 | 6 | 7 | 8 | 9 | 10;
 
 /**
- * Represents an action type for the PinPad component.
- * @typedef {Object} PinPadActionType
- * @property {string} label - The label for the action button.
- * @property {function(): number[]} onPress - The function to be called when the action button is pressed.
+ * Defines the configuration object for action buttons displayed between the PIN entry view and keypad.
  */
 export interface PinPadActionType {
+  /**
+   * The label text displayed on the action button.
+   */
   label: string;
+  /**
+   * A callback function executed when the action button is pressed, returning the current PIN as an array of numbers.
+   */
   onPress: () => Promise<number[]>;
 }
 
-/**
- * Represents the properties for the PinPad component.
- * @typedef {Object} PinPadProps
- * @property {boolean} [masked] - Whether the entered PIN should be masked.
- * @property {PinLength} [minPinLength] - The minimum length of the PIN.
- * @property {PinLength} [maxPinLength] - The maximum length of the PIN.
- * @property {string} [label] - The content for the prompt on the pin pad.
- * @property {PinPadActionType} [pinPadAction] - The call to action between the entry view and the keypad, consisting of a label and function that returns the pin.
- * @property {function(pin: number[]): Promise<PinValidationResult>} onSubmit - The function to be called when the PIN is submitted.
- * @property {function(pin: number[]): void} [onPinEntry] - The function to be called when a PIN is entered.
- */
 export interface PinPadProps {
+  /**
+   * Whether the entered PIN should be masked with dots or asterisks to protect privacy and security.
+   */
   masked?: boolean;
+  /**
+   * The minimum length of the PIN that users must enter before submission is allowed.
+   */
   minPinLength?: PinLength;
+  /**
+   * The maximum length of the PIN that users can enter, constraining the number of digits.
+   */
   maxPinLength?: PinLength;
+  /**
+   * The content for the prompt displayed on the pin pad that instructs users what to enter.
+   */
   label?: string;
+  /**
+   * A call-to-action configuration displayed between the entry view and the keypad, consisting of a label and function that returns the current PIN.
+   */
   pinPadAction?: PinPadActionType;
+  /**
+   * A callback function executed when the PIN is submitted, receiving the PIN as an array of numbers. Must return a Promise that resolves to either `'accept'` or `'reject'` to indicate validation success or failure.
+   */
   onSubmit: (pin: number[]) => Promise<PinValidationResult>;
+  /**
+   * A callback function executed when a PIN is entered, receiving the PIN as an array of numbers. Use this for real-time feedback or validation during PIN entry.
+   */
   onPinEntry?: (pin: number[]) => void;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/RadioButtonList/RadioButtonList.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/RadioButtonList/RadioButtonList.ts
@@ -1,9 +1,21 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 export interface RadioButtonListProps {
+  /**
+   * An array of string values representing the radio button options available for selection.
+   */
   items: string[];
+  /**
+   * A callback function executed when a radio list item is selected, receiving the selected item string as a parameter. You must update the `initialSelectedItem` property in response to this callback to reflect the new selection.
+   */
   onItemSelected: (item: string) => void;
+  /**
+   * The name of the currently selected item. You control the selection by setting this property and updating it when `onItemSelected` fires.
+   */
   initialSelectedItem?: string;
+  /**
+   * A boolean that determines whether the initially selected item renders at the top of the list, automatically scrolling to show the selected option.
+   */
   initialOffsetToShowSelectedItem?: boolean;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Screen/Screen.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Screen/Screen.ts
@@ -1,42 +1,69 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** Represents the presentation of a screen in the navigation stack.
- * @property `sheet` displays the screen from the bottom on `navigate` when `true`.
+/**
+ * Defines the presentation options for how the screen appears when navigated to.
  */
 export interface ScreenPresentationProps {
+  /**
+   * Displays the screen from the bottom as a sheet presentation when true during navigation. The text label displayed on the secondary action button in the screen's action bar.
+   */
   sheet?: boolean;
 }
 
-/** Represents the secondary action button of a screen in the navigation stack.
- * @property `text` displays the name of the secondary action in the action bar.
- * @property `onPress` triggered when the secondary action button is pressed.
- * @property `isEnabled` displays the secondary action button when set `true`.
+/**
+ * Defines the configuration options for secondary action buttons displayed in the screen header.
  */
 export interface SecondaryActionProps {
+  /**
+   * The text label displayed on the secondary action button in the screen's action bar.
+   */
   text: string;
+  /**
+   * A callback function triggered when the secondary action button is pressed by the user.
+   */
   onPress: () => void;
+  /**
+   * Whether the secondary action button can be tapped and is interactive.
+   */
   isEnabled?: boolean;
 }
 
-/** Represents a screen in the navigation stack.
- * @property `name` used to identify this screen as a destination in the navigation stack.
- * @property `title` the title of the screen which will be displayed on the UI.
- * @property `isLoading` displays a loading indicator when `true`. Set this to `true` when performing an asynchronous task, and then to false when the data becomes available to the UI.
- * @property `secondaryAction` displays a secondary action button on the screen.
- * @property `onNavigate` triggered when the screen is navigated to.
- * @property `onNavigateBack` triggered when the user navigates back from this screen. Runs after screen is unmounted.
- * @property `overrideNavigateBack` is a callback that allows you to override the secondary navigation action. Runs when screen is mounted.
- * @property `onReceiveParams` a callback that gets triggered when the navigation event completes and the screen receives the parameters.
- */
 export interface ScreenProps {
+  /**
+   * The unique identifier used to identify this screen as a destination in the navigation stack.
+   */
   name: string;
+  /**
+   * The title text of the screen that will be displayed in the UI header.
+   */
   title: string;
+  /**
+   * A boolean that displays a loading indicator when `true`. Set this during asynchronous tasks and return to `false` when data becomes available.
+   */
   isLoading?: boolean;
+  /**
+   * The presentation configuration that dictates how the screen will be displayed when navigated to.
+   */
   presentation?: ScreenPresentationProps;
+  /**
+   * The configuration for a secondary action button displayed on the screen header.
+   */
   secondaryAction?: SecondaryActionProps;
+  /**
+   * A callback function triggered when the screen is navigated to in the navigation stack.
+   */
   onNavigate?: () => void;
+  /**
+   * A callback function triggered when the user navigates back from this screen. Runs after the screen is unmounted.
+   */
   onNavigateBack?: () => void;
+  /**
+   * A callback function that allows you to override the default back navigation action. Runs when the screen is mounted.
+   */
   overrideNavigateBack?: () => void;
+  /**
+   * A callback function triggered when the navigation event completes and the screen receives parameters passed during navigation.
+   */
   onReceiveParams?: (params: any) => void;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchBar/SearchBar.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchBar/SearchBar.ts
@@ -1,11 +1,33 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 export interface SearchBarProps {
+  /**
+   * The initial text value displayed in the search bar when first rendered. This differs from placeholder text which appears when the field is empty.
+   */
   initialValue?: string;
+  /**
+   * A callback function executed whenever the text value changes, receiving the new text value as a parameter for real-time search or filtering.
+   */
   onTextChange?: (value: string) => void;
+  /**
+   * A callback function executed when the search button is tapped, receiving the current search text as a parameter.
+   */
   onSearch: (value: string) => void;
+  /**
+   * A callback function executed when the search input field receives focus.
+   */
   onFocus?: () => void;
+  /**
+   * A callback function executed when focus is removed from the search input field.
+   */
+  onBlur?: () => void;
+  /**
+   * Whether the text can be changed by user input.
+   */
   editable?: boolean;
+  /**
+   * The placeholder text displayed in the search bar when no text is entered, providing guidance about what users can search for.
+   */
   placeholder?: string;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.ts
@@ -1,12 +1,27 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/**
+ * Defines the configuration object for the action button displayed within the section header.
+ */
 export interface SectionHeaderAction {
+  /**
+   * The title text describing the action that will be displayed on the button.
+   */
   title: string;
+  /**
+   * A callback function that is executed when the action button is pressed by the user.
+   */
   onPress: () => void;
 }
 
 export interface SectionProps {
+  /**
+   * The title text displayed at the top of the section to describe its content.
+   */
   title?: string;
+  /**
+   * An optional action configuration displayed in the top right of the section that can be triggered by user interaction.
+   */
   action?: SectionHeaderAction;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
@@ -2,28 +2,28 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export interface SectionHeaderProps {
   /**
-   * Title to be displayed.
+   * The title text displayed in the section header. Provide clear, descriptive text that accurately represents the content section below.
    */
   title: string;
   /**
-   * Action button to be displayed. The SectionHeader must have a `title` for `action` to work.
+   * An optional action button configuration to be displayed alongside the title. The `SectionHeader` must have a title for the action to work properly.
    */
   action?: {
     /**
-     * Label for the action button.
+     * The label text displayed on the action button. Use clear, descriptive labels like "Edit Settings" or "Add Item."
      */
     label: string;
     /**
-     * Function to handle action button press.
+     * A callback function executed when the action button is pressed. Use this to handle user interactions such as navigation or triggering specific actions.
      */
     onPress: () => void;
     /**
-     * Whether or not the action button is disabled.
+     * Controls whether the action button can be pressed. When `true`, the button is disabled and users can't interact with it.
      */
     disabled?: boolean;
   };
   /**
-   * Whether or not the divider line under the SectionHeader should be hidden.
+   * Whether the divider line under the `SectionHeader` should be hidden.
    */
   hideDivider?: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SegmentedControl/SegmentedControl.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SegmentedControl/SegmentedControl.ts
@@ -1,14 +1,34 @@
 import {createRemoteComponent} from '@remote-ui/core';
-
+/**
+ * Defines the structure and configuration options for individual segments within the `SegmentedControl` component.
+ */
 export interface Segment {
+  /**
+   * The unique identifier for the segment used for selection tracking and callback identification.
+   */
   id: string;
+  /**
+   * The text label displayed on the segment that users see and interact with.
+   */
   label: string;
+  /**
+   * Whether the segment is disabled and non-interactive.
+   */
   disabled: boolean;
 }
 
 export interface SegmentedControlProps {
+  /**
+   * An array of segment objects that define the available options in the segmented control.
+   */
   segments: Segment[];
+  /**
+   * The ID of the currently selected segment that determines which option is visually highlighted.
+   */
   selected: string;
+  /**
+   * A callback function executed when a segment is selected, receiving the selected segment's id as a parameter.
+   */
   onSelect: (id: string) => void;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Selectable/Selectable.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Selectable/Selectable.ts
@@ -1,7 +1,13 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 export interface SelectableProps {
+  /**
+   * The callback function that's executed when the user taps or presses the selectable component. This is the primary way to handle user interactions with the wrapped content. The function receives no parameters and should contain the logic for what happens when the selection occurs, such as navigation, state updates, or triggering other actions.
+   */
   onPress: () => void;
+  /**
+   * Controls whether the selectable component responds to user interactions. When set to `true`, the component won't react to taps or presses, the `onPress` callback won't be triggered, and the wrapped content appears non-interactive. Use this to temporarily disable selection during loading states, form validation, or when certain conditions aren't met. When `false` or undefined, the component responds normally to user interactions.
+   */
   disabled?: boolean;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stepper/Stepper.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stepper/Stepper.ts
@@ -2,34 +2,36 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export interface StepperProps {
   /**
-   * The initial value of the stepper.
+   * The initial value of the stepper that sets the starting numeric value when the component is first rendered.
    */
   initialValue: number;
 
   /**
-   * A callback that is called when the value of the stepper changes.
+   * A callback function executed when the value of the stepper changes, receiving the new numeric value as a parameter.
    */
   onValueChanged: (value: number) => void;
 
   /**
+   * The minimum value that the stepper can reach. When the value equals the minimum, the decrement button will be disabled.
+   *
    * @defaultValue 1
-   * Use to set the minimum value of the stepper.
    */
   minimumValue?: number;
 
   /**
-   * Use to set the maximum value of the stepper.
+   * The maximum value that the stepper can reach. When the value equals the maximum, the increment button will be disabled.
    */
   maximumValue?: number;
 
   /**
-   * Only use this field if you wish to override the internal state of this component.
+   * An optional value to override the internal state of the component. Only use this if you need complete control over the stepper's value from external state.
    */
   value?: number;
 
   /**
+   * Whether the field can be modified, disabling both increment and decrement buttons.
+   *
    * @defaultValue false
-   * Whether the field can be modified.
    */
   disabled?: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.ts
@@ -1,5 +1,18 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/**
+ * Defines the typography hierarchy options for text elements. Each variant provides specific sizing, weight, and styling appropriate for different content types.
+ *
+ * Available variants:
+ * - `sectionHeader`: A section header variant for titles that organize and introduce content sections.
+ * - `captionRegular`: A regular caption variant for supplementary text, labels, or secondary information.
+ * - `captionRegularTall`: A taller caption variant with increased line height for improved readability in dense layouts.
+ * - `captionMedium`: A medium-weight caption variant for slightly emphasized secondary text or important labels.
+ * - `body`: The standard body text variant for primary content, descriptions, and general text.
+ * - `headingSmall`: A small heading variant for subsection titles and secondary headings.
+ * - `headingLarge`: A large heading variant for main section titles and primary headings.
+ * - `display`: The largest display variant for prominent titles, hero text, or major interface elements.
+ */
 export type TextVariant =
   | 'sectionHeader'
   | 'captionRegular'
@@ -10,6 +23,19 @@ export type TextVariant =
   | 'headingLarge'
   | 'display';
 
+/**
+ * Defines the semantic color options for text elements. Each color conveys specific meaning and intent through visual styling.
+ *
+ * Available colors:
+ * - `TextNeutral`: A neutral text color for general content that doesn't convey specific semantic meaning.
+ * - `TextSubdued`: A subdued text color for secondary information, captions, or content that should be less prominent.
+ * - `TextDisabled`: A disabled text color for inactive or unavailable content that users can't interact with.
+ * - `TextWarning`: A warning text color for cautionary messages or content that requires user attention.
+ * - `TextCritical`: A critical text color for errors, failures, or destructive actions that require immediate attention.
+ * - `TextSuccess`: A success text color for positive outcomes, confirmations, or completed actions.
+ * - `TextInteractive`: An interactive text color for clickable elements, links, or content that users can interact with.
+ * - `TextHighlight`: A highlight text color for emphasized content that needs to stand out or draw special attention.
+ */
 export type ColorType =
   | 'TextNeutral'
   | 'TextSubdued'
@@ -21,7 +47,13 @@ export type ColorType =
   | 'TextHighlight';
 
 export interface TextProps {
+  /**
+   * The typography variant that determines the size, weight, and styling of the text within the design system hierarchy.
+   */
   variant?: TextVariant;
+  /**
+   * The semantic color of the text that conveys meaning and intent through visual styling.
+   */
   color?: ColorType;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.ts
@@ -1,12 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import type {InputProps} from '../shared/InputField';
 
-/**
- * Represents the properties for the TextField component.
- * @typedef {Object} TextAreaProps
- * @property {number} [rows] - The initial number of lines to be displayed. Maximum of 8 lines.
- */
 export interface TextAreaProps extends InputProps {
+  /**
+   * The initial number of visible text lines to be displayed. Maximum of 8 lines.
+   */
   rows?: number;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.ts
@@ -3,24 +3,54 @@ import type {BaseTextFieldProps} from '../shared/BaseTextField';
 import type {InputProps} from '../shared/InputField';
 
 export interface ActionProps {
+  /**
+   * Identifies this as an action-type embedded element.
+   */
   type: 'action';
+  /**
+   * The message or label text displayed for the action.
+   */
   message: string;
+  /**
+   * A callback function executed when the action button is pressed, receiving the current field value as a parameter.
+   */
   onPress: (value: string) => void;
 }
 
 export interface InfoProps {
+  /**
+   * Identifies this as an info-type embedded element.
+   */
   type: 'info';
+  /**
+   * The informational message text to display to the user.
+   */
   message: string;
+  /**
+   * Controls whether the info message is always visible or only shown under certain conditions.
+   */
   alwaysShow?: boolean;
 }
 
 export interface SuccessProps {
+  /**
+   * Identifies this as a success-type embedded element.
+   */
   type: 'success';
+  /**
+   * An optional success message to display when the field validation or operation succeeds.
+   */
   message?: string;
 }
 
 export interface PasswordProps {
+  /**
+   * Identifies this as a password-type embedded element.
+   */
   type: 'password';
+  /**
+   * A callback function executed when the password action button is pressed, receiving the current field value as a parameter.
+   */
   onPress: (value: string) => void;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.ts
@@ -1,11 +1,29 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 export interface TileProps {
+  /**
+   * The text displayed as the main label of the tile.
+   */
   title: string;
+  /**
+   * The text displayed as the secondary label below the title.
+   */
   subtitle?: string;
+  /**
+   * Whether the tile can be tapped and responds to user interaction. When disabled, the tile appears dimmed and doesn't respond to tap events.
+   */
   enabled?: boolean;
+  /**
+   * Sets whether the tile appears in a destructive/warning state. As of POS 10.0.0, this property creates an "active state" appearance rather than just red coloring.
+   */
   destructive?: boolean;
+  /**
+   * A numeric value displayed as a small badge in the top right corner of the tile.
+   */
   badgeValue?: number;
+  /**
+   * The callback function that's executed when users tap the tile.
+   */
   onPress?: () => void;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.ts
@@ -14,6 +14,11 @@ export interface TimeFieldProps
     | 'action'
     | 'helpText'
   > {
+  /**
+   * Whether the clock displays in 24-hour format instead of 12-hour format. This property only affects Android devices.
+   *
+   * @defaultValue false
+   */
   is24Hour?: boolean;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.ts
@@ -1,10 +1,33 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 export interface TimePickerProps {
+  /**
+   * The currently selected time value. Defaults to the current time when not specified.
+   *
+   * @defaultValue The current time.
+   */
   selected?: string;
+  /**
+   * A callback for changes.
+   */
   onChange?(selected: string): void;
+  /**
+   * A tuple that controls the visible state of the picker and provides a callback to set visibility to false when the dialog closes. The first element is the current visibility state, and the second is a setter function.
+   */
   visibleState: [boolean, (visible: boolean) => void];
+  /**
+   * Whether the clock displays in 24-hour format instead of 12-hour format. This property only affects Android devices.
+   *
+   * @defaultValue false
+   */
   is24Hour?: boolean;
+  /**
+   * The display mode for the time picker.
+   * - `inline`: A clock-style interface that displays an analog or digital clock where users can tap to select specific times. Provides visual context about time relationships. Only available on Android devices—iOS always uses spinner mode.
+   * - `spinner`: A spinner-style selector with scrollable columns for hours, minutes, and optionally seconds. Offers a more compact interface suitable for all devices and is the only mode supported on iOS.
+   *
+   * @defaultValue 'inline'
+   */
   inputMode?: 'inline' | 'spinner';
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/shared/BaseTextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/shared/BaseTextField.ts
@@ -1,9 +1,26 @@
 export interface BaseTextFieldProps {
+  /**
+   * The title text displayed for the text field.
+   */
   title?: string;
-  subtitle?: string;
+  /**
+   * The initial text value to populate the text field with when it first renders.
+   */
   initialValue?: string;
+  /**
+   * A placeholder hint displayed when the text field is empty.
+   */
   placeholder?: string;
+  /**
+   * Controls the validation state of the current value in the text field. When `false`, indicates invalid input.
+   */
   isValid?: boolean;
+  /**
+   * An error message to display to the user when validation fails.
+   */
   errorMessage?: string;
+  /**
+   * A callback function executed every time the text field value changes, receiving the new value as a parameter.
+   */
   onChangeText?: (value: string) => void;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/shared/InputField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/shared/InputField.ts
@@ -1,45 +1,72 @@
 /**
- * Represents an action type for the text field components.
- * @typedef {Object} InputAction
- * @property {string} label - The text displayed in the button.
- * @property {boolean} [disabled] - Whether the button is disabled.
- * @property {function(): void} onPress - A callback to be performed.
+ * Defines the configuration object for action buttons displayed below input fields to provide extra functionality.
  */
 export interface InputAction {
+  /**
+   * The text displayed on the action button.
+   */
   label: string;
+  /**
+   * A callback function executed when the action button is pressed.
+   */
   onPress: () => void;
+  /**
+   * Whether the action button can be pressed.
+   */
   disabled?: boolean;
 }
 
-/**
- * Represents the properties for the text field components.
- * @typedef {Object} InputProps
- * @property {boolean} [disabled] - Whether the field is disabled.
- * @property {string} [error] - Indicate an error to the user. The field will be given a specific stylistic treatment to communicate problems that have to be resolved immediately.
- * @property {string} [label] - Content to use as the field label.
- * @property {function(): void} [onBlur] - Callback when focus is blurred.
- * @property {function(value: string): void} [onChange] - Callback when the user has finished editing a field.
- * @property {function(): void} [onFocus] - Callback when input is focused.
- * @property {function(value: string): void} [onInput] - Callback when the user makes any changes in the field. As noted in the documentation for `onChange`, you **must not** use this to update `value` — use the `onChange` callback for that purpose. Use the `onInput` prop when you need to do something as soon as the user makes a change, like clearing validation errors that apply to the field as soon as the user begins making the necessary adjustments.
- * @property {string} [placeholder] - A short hint that describes the expected value of the field.
- * @property {boolean} [required] - Whether the field needs a value.
- * @property {string} [value] - The current value for the field. If omitted, the field will be empty. You should update this value in response to the `onChange` callback.
- * @property {string} [helpText] - Label under the text field which provides guidance or instructions that assist users.
- * @property {InputAction} [action] - A button under the text field to provide extra functionality.
- * @property {number?} [maxLength] - Specifies the maximum number of characters allowed.
- */
 export interface InputProps {
+  /**
+   * Controls whether the field can be modified. When `true`, the field is disabled and users cannot edit its value.
+   */
   disabled?: boolean;
+  /**
+   * An error message that indicates a problem to the user. The field is given specific stylistic treatment to communicate issues that must be resolved immediately.
+   */
   error?: string;
+  /**
+   * The content to use as the field label that describes the text information being requested.
+   */
   label: string;
+  /**
+   * A callback function executed when focus is removed from the field.
+   */
   onBlur?: () => void;
+  /**
+   * A callback function executed when the user has finished editing the field, receiving the new text value as a parameter. You should update the `value` property in response to this callback.
+   */
   onChange?: (value: string) => void;
+  /**
+   * A callback function executed when the field receives focus.
+   */
   onFocus?: () => void;
+  /**
+   * A callback function executed immediately when the user makes any change in the field. Use this for real-time feedback, such as clearing validation errors as soon as the user begins making corrections. Don't use this to update the `value` property—the `onChange` callback is the appropriate handler for updating the field's value.
+   */
   onInput?: (value: string) => void;
+  /**
+   * A short hint that describes the expected value of the field.
+   */
   placeholder?: string;
+  /**
+   * Whether the field needs a value for form submission or validation purposes.
+   */
   required?: boolean;
+  /**
+   * The current text value for the field. If omitted, the field will be empty. You should update the `value` property in response to the `onChange` callback.
+   */
   value?: string;
+  /**
+   * The label text displayed under the field that provides guidance or instructions to assist users.
+   */
   helpText?: string;
+  /**
+   * A button configuration object displayed under the text field to provide extra functionality.
+   */
   action?: InputAction;
+  /**
+   * The maximum number of characters allowed in the text field.
+   */
   maxLength?: number;
 }


### PR DESCRIPTION
## This PR: 
- Improves all API, component, and prop descriptions in the POS UI extensions docs for version 2024-04
- Relates to the [POS UI extensions reference prototype](https://pr-62503.shopify-dev.shopify.io/docs/api/templated-refs-v2/latest)
- Partially fixes https://github.com/Shopify/shopify-dev/issues/64745