### PR TITLE
Adds point of sale LineItemComponent type export

### DIFF
--- a/.changeset/legal-eggs-roll.md
+++ b/.changeset/legal-eggs-roll.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Exports LineItemComponent from point-of-sale API so POS can import the type

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -89,6 +89,7 @@ export type {
   CartUpdateInput,
   Customer,
   LineItem,
+  LineItemComponent,
   Discount,
   SetLineItemPropertiesInput,
   SetLineItemDiscountInput,


### PR DESCRIPTION
Adding this export allows the point of sale app to import the type from ui-extensions instead of defining it manually. Also added to [2025-10](https://github.com/Shopify/ui-extensions/pull/3575) and [2026-01-rc](https://github.com/Shopify/ui-extensions/pull/3574).