### PR TITLE
Add icon preview to Admin UI Extensions documentation

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-doc-extract-icons.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-doc-extract-icons.mjs
@@ -1,0 +1,63 @@
+import fs from 'fs/promises';
+import path from 'path';
+import {fileURLToPath} from 'url';
+import ts from 'typescript';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const componentsPath = path.join(
+  __dirname,
+  '../../../src/surfaces/admin/components.d.ts',
+);
+
+export async function extractIconList() {
+  const content = await fs.readFile(componentsPath, 'utf-8');
+
+  const sourceFile = ts.createSourceFile(
+    'components.d.ts',
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  let icons = [];
+
+  function visit(node) {
+    if (ts.isTypeAliasDeclaration(node) && node.name.text === 'IconType$1') {
+      if (ts.isUnionTypeNode(node.type)) {
+        icons = node.type.types
+          .filter((type) => ts.isLiteralTypeNode(type))
+          .map((type) => {
+            if (
+              ts.isStringLiteral(type.literal) ||
+              (type.literal && type.literal.text)
+            ) {
+              return type.literal.text;
+            }
+            return null;
+          })
+          .filter(Boolean);
+      }
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  if (icons.length > 0) {
+    return icons;
+  }
+
+  throw new Error(
+    'Could not find IconType$1 type definition in components.d.ts',
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  extractIconList().then((icons) => {
+    console.log(JSON.stringify(icons, null, 2));
+  });
+}

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -9,7 +9,7 @@ import {
   copyGeneratedToShopifyDev,
   replaceFileContent,
 } from '../build-doc-shared.mjs';
-import {extractIconList} from './extract-icons.mjs';
+import {extractIconList} from './build-doc-extract-icons.mjs';
 
 const EXTENSIONS_API_VERSION = process.argv[2] || 'unstable';
 
@@ -260,19 +260,14 @@ const transformJson = async (filePath, isExtensions) => {
         iconPreviewData.icons = await extractIconList();
       }
       for (const subSection of entry.subSections) {
-        if (
-          subSection.sectionContent &&
-          subSection.sectionContent.includes('{{ICON_PREVIEW_IFRAME}}')
-        ) {
+        if (subSection.sectionContent?.includes('{{ICON_PREVIEW_IFRAME}}')) {
           const renderedHtml = await renderJsxTemplate(iconPreviewData);
           const base64Html = Buffer.from(renderedHtml, 'utf-8').toString(
             'base64',
           );
-          const iframe = `<iframe width="100%" height="490px" sandbox="allow-scripts" src="data:text/html;base64,${base64Html}"></iframe>`;
-
           subSection.sectionContent = subSection.sectionContent.replace(
             /\{\{ICON_PREVIEW_IFRAME\}\}/g,
-            iframe,
+            `<iframe width="100%" height="490px" sandbox="allow-scripts" src="data:text/html;base64,${base64Html}"></iframe>`,
           );
         }
       }

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -9,6 +9,7 @@ import {
   copyGeneratedToShopifyDev,
   replaceFileContent,
 } from '../build-doc-shared.mjs';
+import {extractIconList} from './extract-icons.mjs';
 
 const EXTENSIONS_API_VERSION = process.argv[2] || 'unstable';
 
@@ -48,6 +49,10 @@ const decodeHTML = (str) => {
     .replace(/&#039;/g, "'");
 };
 
+const escapeForJSTemplate = (str) => {
+  return str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
+};
+
 const composeStyles = (...styles) => {
   return styles
     .filter(Boolean)
@@ -77,6 +82,30 @@ const stylesToString = (styles) => {
       return `${kebabProperty}: ${value}`;
     })
     .join('; ');
+};
+
+const renderJsxTemplate = async (iconPreviewData) => {
+  const templatePath = path.join(docsPath, 'templates/jsx-render.html');
+  const template = await fs.readFile(templatePath, 'utf-8');
+
+  // Read JSX code from file
+  const jsxFilePath = path.join(docsPath, iconPreviewData.jsxFile);
+  let jsxCode = await fs.readFile(jsxFilePath, 'utf-8');
+
+  // Replace __ICON_LIST__ placeholder in jsxCode
+  // Use single quotes to avoid escaping issues in HTML attributes
+  const iconListString = `[${iconPreviewData.icons
+    .map((icon) => `'${icon}'`)
+    .join(',')}]`;
+  jsxCode = jsxCode.replace(/"__ICON_LIST__"/g, iconListString);
+
+  // Escape the JSX code for use in template literal
+  const escapedJsxCode = escapeForJSTemplate(jsxCode);
+
+  return template
+    .replace(/\{\{COMPOSED_STYLES\}\}/g, iconPreviewData.customStyles || '')
+    .replace(/\{\{BODY_CONTENT\}\}/g, iconPreviewData.bodyContent || '')
+    .replace(/\{\{JSX_CODE\}\}/g, escapedJsxCode);
 };
 
 const htmlWrapper = (htmlString, layoutStyles = '', customStyles = '') => {
@@ -220,6 +249,35 @@ const templates = {
 
 const transformJson = async (filePath, isExtensions) => {
   let jsonData = JSON.parse((await fs.readFile(filePath, 'utf8')).toString());
+
+  for (const entry of jsonData) {
+    if (entry.name === 'Icon' && entry.subSections) {
+      const iconDataPath = path.join(srcPath, 'components/Icon/icon-data.json');
+      const iconData = JSON.parse(await fs.readFile(iconDataPath, 'utf-8'));
+      const iconPreviewData = iconData.iconPreviewData;
+
+      if (iconPreviewData.icons === '__AUTO_GENERATED_ICONS__') {
+        iconPreviewData.icons = await extractIconList();
+      }
+      for (const subSection of entry.subSections) {
+        if (
+          subSection.sectionContent &&
+          subSection.sectionContent.includes('{{ICON_PREVIEW_IFRAME}}')
+        ) {
+          const renderedHtml = await renderJsxTemplate(iconPreviewData);
+          const base64Html = Buffer.from(renderedHtml, 'utf-8').toString(
+            'base64',
+          );
+          const iframe = `<iframe width="100%" height="490px" sandbox="allow-scripts" src="data:text/html;base64,${base64Html}"></iframe>`;
+
+          subSection.sectionContent = subSection.sectionContent.replace(
+            /\{\{ICON_PREVIEW_IFRAME\}\}/g,
+            iframe,
+          );
+        }
+      }
+    }
+  }
 
   jsonData.forEach((entry) => {
     // Temporary to ensure that isOptional is added to all members

--- a/packages/ui-extensions/docs/surfaces/admin/templates/icon-preview.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/templates/icon-preview.jsx
@@ -1,0 +1,110 @@
+  const icons = "__ICON_LIST__";
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 10;
+
+  const filteredIcons = searchQuery
+    ? icons.filter((icon) =>
+        icon.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+    : icons;
+
+  const totalPages = Math.ceil(filteredIcons.length / pageSize);
+  const startIndex = (currentPage - 1) * pageSize;
+  const currentIcons = filteredIcons.slice(
+    startIndex,
+    startIndex + pageSize
+  );
+
+  const handleSearchChange = (e) => {
+    setSearchQuery(e.target.value);
+    setCurrentPage(1);
+  };
+
+  const changePage = (newPage) => {
+    setCurrentPage(Math.min(Math.max(newPage, 1), totalPages));
+  };
+
+  return (
+    <s-box border="base" padding="base" borderRadius="base">
+      <s-stack gap="base">
+        <s-stack direction="inline" gap="small" alignItems="center">
+          <s-search-field
+            value={searchQuery}
+            onInput={handleSearchChange}
+            placeholder="Search icons..."
+            label="Search"
+            labelAccessibilityVisibility="exclusive"
+          />
+          <s-text color="subdued">
+            {filteredIcons.length}{" "}
+            {filteredIcons.length === 1 ? "icon" : "icons"}
+          </s-text>
+        </s-stack>
+
+        {currentIcons.length > 0 ? (
+          <s-grid
+            gridTemplateColumns="repeat(2, 1fr)"
+            gap="base"
+          >
+            {currentIcons.map((icon) => (
+              <s-section key={icon}>
+                <s-stack gap="small-200" direction="inline" alignItems="center">
+                  <s-icon type={icon} />
+                  <s-paragraph>
+                    <s-text>{icon}</s-text>
+                  </s-paragraph>
+                </s-stack>
+              </s-section>
+            ))}
+          </s-grid>
+        ) : (
+          <s-stack gap="small" alignItems="center">
+            <s-paragraph>
+              <s-text>No icons found matching "{searchQuery}"</s-text>
+            </s-paragraph>
+          </s-stack>
+        )}
+        {totalPages > 1 && (
+          <s-stack
+            direction="inline"
+            gap="small"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <s-button
+              onClick={() => changePage(1)}
+              disabled={currentPage === 1}
+              variant="secondary"
+            >
+              First
+            </s-button>
+            <s-button
+              onClick={() => changePage(currentPage - 1)}
+              disabled={currentPage === 1}
+              variant="secondary"
+            >
+              Previous
+            </s-button>
+            <s-text>
+              Page {currentPage} of {totalPages}
+            </s-text>
+            <s-button
+              onClick={() => changePage(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              variant="secondary"
+            >
+              Next
+            </s-button>
+            <s-button
+              onClick={() => changePage(totalPages)}
+              disabled={currentPage === totalPages}
+              variant="secondary"
+            >
+              Last
+            </s-button>
+          </s-stack>
+        )}
+      </s-stack>
+    </s-box>
+  )

--- a/packages/ui-extensions/docs/surfaces/admin/templates/jsx-render.html
+++ b/packages/ui-extensions/docs/surfaces/admin/templates/jsx-render.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      html, body {height:100%} body {{{COMPOSED_STYLES}}}
+    </style>
+    <script src="https://cdn.shopify.com/shopifycloud/polaris.js"></script>
+    <script src="https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js"></script>
+  </head>
+  <body>
+    {{BODY_CONTENT}}
+    <script>
+      (function () {
+        const {render, h, Fragment, Component, useState} = window.preact;
+        const jsxCode = `const App = () => { {{JSX_CODE}} };`;
+        try {
+          const {code} = window.sucrase.transform(jsxCode, {
+            transforms: ['jsx'],
+            jsxPragma: 'h',
+            jsxFragmentPragma: 'Fragment',
+            production: true,
+          });
+          const fn = new Function(
+            'h',
+            'Fragment',
+            'Component',
+            'useState',
+            code + '; return App;',
+          );
+          const App = fn(h, Fragment, Component, useState);
+          const target =
+            document.getElementById('wrapper-element') || document.body;
+          if (target) render(h(App), target);
+        } catch (e) {
+          console.error('JSX Transform Error:', e);
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
@@ -5,6 +5,15 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/icon.png',
   isVisualComponent: true,
+  subSections: [
+    {
+      title: 'Available icons',
+      type: 'Generic' as const,
+      anchorLink: 'available-icons',
+      sectionContent: `Search and filter across all the available icons:
+{{ICON_PREVIEW_IFRAME}}`,
+    },
+  ],
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
@@ -10,8 +10,8 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Available icons',
       type: 'Generic' as const,
       anchorLink: 'available-icons',
-      sectionContent: `Search and filter across all the available icons:
-{{ICON_PREVIEW_IFRAME}}`,
+      sectionContent:
+        'Search and filter across all the available icons: {{ICON_PREVIEW_IFRAME}}',
     },
   ],
   definitions: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/icon-data.json
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/icon-data.json
@@ -1,0 +1,8 @@
+{
+  "iconPreviewData": {
+    "jsxFile": "./templates/icon-preview.jsx",
+    "icons": "__AUTO_GENERATED_ICONS__",
+    "bodyContent": "<div id=\"app\"></div>",
+    "customStyles": "padding: 0px; margin: 0px; max-width: 584px; overflow: hidden;"
+  }
+}

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/icon-data.json
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/icon-data.json
@@ -3,6 +3,6 @@
     "jsxFile": "./templates/icon-preview.jsx",
     "icons": "__AUTO_GENERATED_ICONS__",
     "bodyContent": "<div id=\"app\"></div>",
-    "customStyles": "padding: 0px; margin: 0px; max-width: 584px; overflow: hidden;"
+    "customStyles": "padding: 0px; margin: 0px; margin-top: 8px; max-width: 584px; overflow: hidden;"
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adds an interactive icon preview component to the Icon documentation page for Admin UI Extensions. This allows developers to browse and search through all available icons in the Shopify Admin design system.

<img width="734" height="725" alt="Screenshot 2025-11-19 at 5 47 10 PM" src="https://github.com/user-attachments/assets/5026bd61-43ac-46a3-ba6d-1717160e549f" />

### Features

- **Interactive icon browser**: Visual preview of all 500+ available icons
- **Search functionality**: Quickly find icons by name with real-time filtering
- **Pagination**: Navigate through icons in organized pages (10 icons per page)
- **Auto-generated icon list**: Automatically stays in sync with the TypeScript definitions, ensuring the documentation always shows the current set of available icons
- **Clean layout**: Icons displayed in a 2-column grid with their names for easy reference

### Why is this needed?

Developers building Admin UI Extensions need to know which icons are available for use in their applications. This visual browser makes it easy to:
- Discover available icons without checking the source code
- Search for specific icons by name
- See exactly how each icon looks
- Copy the exact icon name for use in their code

### Testing

- Icon preview displays correctly with all 513 current icons
- Search filters icons in real-time
- Pagination works for navigating through large icon sets
- Documentation builds successfully with auto-generated icon list