### PR TITLE
[App Gen] Updated Docs For Modal Bug in App Gen

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
@@ -39,13 +39,7 @@ export type RequiredAlignedModalProps = Required<ModalProps$1>;
 export interface ModalProps
   extends Pick<
     RequiredAlignedModalProps,
-    | 'accessibilityLabel'
-    | 'heading'
-    | 'padding'
-    | 'size'
-    | 'hideOverlay'
-    | 'showOverlay'
-    | 'toggleOverlay'
+    'accessibilityLabel' | 'heading' | 'padding' | 'size'
   > {
   /**
    * Adjust the size of the Modal.
@@ -54,6 +48,24 @@ export interface ModalProps
     ModalProps$1['size'],
     'small-100' | 'small' | 'base' | 'large' | 'large-100'
   >;
+  /**
+   * Imperative method to hide the modal. Call this method on the modal element instance (e.g., via a ref).
+   * This is not a prop, do not pass as an attribute. For hiding via user interaction, use commandFor
+   * and command="--hide" on buttons, or handle the onHide event.
+   */
+  hideOverlay: () => void;
+  /**
+   * Imperative method to show the modal. Call this method on the modal element instance (e.g., via a ref).
+   * This is not a prop, do not pass as an attribute. For showing via user interaction, use commandFor
+   * and command="--show" on buttons or links.
+   */
+  showOverlay: () => void;
+  /**
+   * Imperative method to toggle the modal's visibility. Call this method on the modal element instance (e.g., via a ref).
+   * This is not a prop, do not pass as an attribute. For controlling visibility via user interaction,
+   * prefer using commandFor with command="--show" or command="--hide" on buttons.
+   */
+  toggleOverlay: () => void;
 }
 
 export type Styles = string;


### PR DESCRIPTION
 ### Background

Resolves [shop/issues-sidekick/issues/#2055](https://github.com/shop/issues-sidekick/issues/2055)

Improves the TypeScript definitions for the Modal component's overlay control methods.

### Problem
The documentation for modal overlay methods (`hideOverlay`, `showOverlay`, and `toggleOverlay`) lacks clarity on how these methods should be used programmatically versus through user interactions..

### Solution

This PR updates the TypeScript definitions for the `Modal` component by moving the overlay control methods (`hideOverlay`, `showOverlay`, and `toggleOverlay`) from the excluded props list to be properly defined as methods with detailed JSDoc comments. 

The added documentation clarifies that these methods are meant to be called imperatively on the modal element instance (via refs) rather than being passed as props. It also provides guidance on the proper usage patterns for controlling modal visibility through user interactions.

### 🎩

- Verify that TypeScript correctly recognizes these methods when using refs with Modal components
- Check that the documentation appears correctly in IDE tooltips

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation