### PR TITLE
Update extension toml uids

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/discount-example/shopify.extension.toml
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/discount-example/shopify.extension.toml
@@ -1,5 +1,6 @@
 ...
 name = "Discount"
 handle = "discount"
+uid = "bdff5acd-d192-ddcd-05cf-ad6d759e978ac7c62980"
 description = "Add discount"
 ...

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/print-example/shopify.extension.toml
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/print-example/shopify.extension.toml
@@ -4,6 +4,7 @@ api_version = "2025-10"
 type = "ui_extension"
 name = "Print Tutorial"
 handle = "print-tutorial"
+uid = "ccf7edf4-a12d-b60a-9d4a-1cb8691864d6ec6a83e2"
 description = "POS UI extension print tutorial"
 
 [[extensions.targeting]]


### PR DESCRIPTION
Add deterministic UID based on extension handle

Relates to: https://github.com/Shopify/shopify-dev/issues/65152

Purpose:
The uid field is now required in shopify.extension.toml files for all extensions. UIDs are generated deterministically from the handle to ensure consistent values and allow users to safely copy examples without replacing placeholders.