### PR TITLE
add tipAmount to BaseTransactionComplete type

### DIFF
--- a/.changeset/funny-moons-share.md
+++ b/.changeset/funny-moons-share.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add optional tipAmount field to POS transaction data types

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
@@ -17,5 +17,6 @@ export interface BaseTransactionComplete {
   balanceDue: Money;
   shippingLines?: ShippingLine[];
   taxLines?: TaxLine[];
+  tipAmount?: Money;
   executedAt: string;
 }


### PR DESCRIPTION
### Background

Our compliance partners need tipAmount available in the data payload they receive for reporting. This PR updates the BaseTransactionComplete type to include tipAmount as optional.

https://github.com/shop/issues-retail/issues/20523  
https://github.com/shop/issues-retail/issues/20463

### Solution

Add tipAmount to BaseTransactionComplete type

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation