### PR TITLE
Fix dark mode for icon preview iframe

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/templates/icon-renderer/dark-mode-listener.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/templates/icon-renderer/dark-mode-listener.jsx
@@ -1,35 +1,29 @@
 /* eslint-disable no-undef */
 (function () {
-  function setIframeTheme(isDark) {
+  const initializedIframes = new WeakSet();
+
+  function sendThemeToIframe() {
     const iframe = document.querySelector('#icon-preview-iframe');
     if (iframe && iframe.contentWindow) {
+      const isDark = document.documentElement.classList.contains('Mode-Dark');
       iframe.contentWindow.postMessage(
         {type: 'theme', mode: isDark ? 'dark' : 'light'},
         '*',
       );
     }
   }
-  function getThemeMode() {
-    return document.documentElement.classList.contains('Mode-Dark')
-      ? 'dark'
-      : 'light';
-  }
-  const initialMode = getThemeMode();
-  const isDark = initialMode === 'dark';
-  // Wait for iframe to load before setting initial theme
-  const iframe = document.querySelector('#icon-preview-iframe');
-  if (iframe) {
-    iframe.addEventListener('load', () => {
-      setIframeTheme(isDark);
-    });
-    // If already loaded, set immediately
-    if (iframe.contentWindow) {
-      setIframeTheme(isDark);
+
+  const observer = new MutationObserver(() => {
+    const iframe = document.querySelector('#icon-preview-iframe');
+    if (iframe && !initializedIframes.has(iframe)) {
+      initializedIframes.add(iframe);
+      iframe.addEventListener('load', sendThemeToIframe);
+      sendThemeToIframe();
     }
-  }
-  window.addEventListener('theme-mode-changed', (event) => {
-    const themeMode = event.detail.themeMode;
-    const isDarkMode = themeMode === 'Mode-Dark';
-    setIframeTheme(isDarkMode);
+  });
+  observer.observe(document.body, {childList: true, subtree: true});
+
+  window.addEventListener('theme-mode-changed', () => {
+    sendThemeToIframe();
   });
 })();

--- a/packages/ui-extensions/docs/surfaces/admin/templates/icon-renderer/icon-preview.jsx
+++ b/packages/ui-extensions/docs/surfaces/admin/templates/icon-renderer/icon-preview.jsx
@@ -1,8 +1,12 @@
 const icons = "__ICON_LIST__";
 
 const styles = `
-  html, html.Mode-Light {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  html:not([data-theme]) body {
+    visibility: hidden;
+  }
+
+  html {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     --border-base: #e1e3e5;
     --border-focus: #303030;
     --border-icon-item: rgba(0, 0, 0, 0.08);
@@ -16,7 +20,7 @@ const styles = `
     --shadow-icon-item: rgba(0, 0, 0, 0.05);
   }
 
-  html.Mode-Dark {
+  html[data-theme="dark"] {
     --border-base: #505256;
     --border-focus: #ffffff;
     --border-icon-item: rgba(255, 255, 255, 0.1);
@@ -164,7 +168,7 @@ const styles = `
     margin: 0 8px;
   }
 
-  html.Mode-Dark .icon {
+  html[data-theme="dark"] .icon {
     filter: invert(1);
   }
 `;
@@ -196,16 +200,6 @@ const handleSearchChange = (e) => {
 const changePage = (newPage) => {
   setCurrentPage(Math.min(Math.max(newPage, 1), totalPages));
 };
-
-useEffect(() => {
-  window.addEventListener('message', (event) => {
-    if (event.data && event.data.type === 'theme') {
-      const isDark = event.data.mode === 'dark';
-      document.documentElement.classList.toggle('Mode-Dark', isDark);
-      document.documentElement.classList.toggle('Mode-Light', !isDark);
-    }
-  });
-}, []);
 
 useEffect(() => {
   const handleResize = () => {

--- a/packages/ui-extensions/docs/surfaces/admin/templates/icon-renderer/jsx-render.html
+++ b/packages/ui-extensions/docs/surfaces/admin/templates/icon-renderer/jsx-render.html
@@ -4,6 +4,15 @@
     <style>
       html, body {height:100%} body {{{COMPOSED_STYLES}}}
     </style>
+    <script>
+      (function() {
+        window.addEventListener('message', function(event) {
+          if (event.data && event.data.type === 'theme') {
+            document.documentElement.setAttribute('data-theme', event.data.mode);
+          }
+        });
+      })();
+    </script>
     <script src="https://cdn.shopify.com/shopifycloud/polaris.js"></script>
     <script src="https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js"></script>
     <link


### PR DESCRIPTION
## Summary
Fix icon preview iframe not applying dark mode when navigating from a page already in dark mode.

## Problem
Icon preview iframe wasn't receiving dark theme on navigation  
<img width="698" height="621" alt="Screenshot 2025-11-21 at 11 21 41 AM" src="https://github.com/user-attachments/assets/0dc86832-7cff-472e-8364-34d79dac43b9" />

## Solution
- Track initialized iframes with WeakSet instead of DOM attributes (prevents hydration issues)
- Use data-theme attribute for CSS theming instead of class manipulation
- Hide iframe content until theme is set to prevent flash

## Changes
- `dark-mode-listener.jsx`: Use WeakSet to track iframes without modifying DOM
- `jsx-render.html`: Simple message listener to set data-theme attribute
- `icon-preview.jsx`: CSS uses data-theme attribute selector for dark mode styles