### PR TITLE
Improve component documentation descriptions for clarity and consistency

### DIFF
--- a/packages/ui-extensions/src/docs/shared/components/Avatar.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Avatar.ts
@@ -3,7 +3,7 @@ import {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Avatar',
   description:
-    'Show a user’s profile image or initials in a compact, visual element.',
+    'Identifies individuals or businesses by showing their profile image or initials.',
   category: 'Polaris web components',
   subCategory: 'Media',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ButtonGroup.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ButtonGroup.ts
@@ -2,7 +2,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'ButtonGroup',
-  description: 'Displays multiple buttons in a layout.',
+  description:
+    'Groups related actions together in a consistent layout, making secondary actions visible alongside primary ones.',
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Checkbox.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Checkbox.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Checkbox',
   description:
-    'Give users a clear way to make selections, such as agreeing to terms or choosing multiple items from a list.',
+    'Gives users a clear way to make selections, such as agreeing to terms or choosing multiple items from a list.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'ChoiceList',
   description:
-    'Present multiple options to users, allowing either single selections with radio buttons or multiple selections with checkboxes.',
+    'Presents multiple options to users, allowing either single selections with radio buttons or multiple selections with checkboxes.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ClickableChip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ClickableChip.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'ClickableChip',
   description:
-    'Interactive button used to categorize or highlight content attributes. They are often displayed near the content they classify, enhancing discoverability by allowing users to identify items with similar properties.',
+    'Creates interactive filters or tags that can be clicked, removed, or configured as links to navigate to related content.',
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ColorField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ColorField.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'ColorField',
   description:
-    'Allow users to select a color with a color picker or as a text input.',
+    'Allows users to select a color with a color picker or as a text input.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ColorPicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ColorPicker.ts
@@ -2,7 +2,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'ColorPicker',
-  description: 'Allow users to select a color from a color palette.',
+  description: 'Allows users to select a color from a color palette.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/DateField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DateField.ts
@@ -2,7 +2,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'DateField',
-  description: 'Allow users to select a specific date with a date picker.',
+  description: 'Allows users to select a specific date with a date picker.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
@@ -2,7 +2,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'DatePicker',
-  description: 'Allow users to select a specific date or date range.',
+  description: 'Allows users to select a specific date or date range.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Divider.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Divider.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Divider',
   description:
-    'Create clear visual separation between elements in your user interface.',
+    'Separates elements inside sections and visually groups related content in forms and lists.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Grid.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Grid.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Grid',
   description:
-    'Organizes content into a grid-like layout with columns and rows, consistent alignment, and spacing. Creates responsive layouts following the CSS grid layout pattern.',
+    'Organizes content into a grid-like layout with columns and rows, consistent alignment, and spacing. Creates responsive layouts following the [CSS grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout) pattern.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Grid.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Grid.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Grid',
   description:
-    'Use `s-grid` to organize your content in a matrix of rows and columns and make responsive layouts for pages. Grid follows the same pattern as the [CSS grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout).',
+    'Organizes content into a grid-like layout with columns and rows, consistent alignment, and spacing. Creates responsive layouts following the CSS grid layout pattern.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Link.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Link.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Link',
   description:
-    'Makes text interactive, allowing users to navigate to other pages or perform specific actions. Supports standard URLs, custom protocols, and navigation within Shopify or app pages.',
+    'Makes text interactive for navigation to other pages, internal app routes, or external URLs. For actions, use buttons instead.',
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Menu.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Menu.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Menu',
   description:
-    'Use Menu to display a list of actions that can be performed on a resource.',
+    'Presents a set of actions or selectable options in a dropdown menu, organized into logical groupings.',
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Modal.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Modal.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Modal',
   description:
-    'Displays content in an overlay. Use to create a distraction-free experience such as a confirmation dialog or a settings panel.',
+    'Displays content in an overlay to focus on a specific task, complete a flow that needs dedicated attention, or confirm a significant action.',
   category: 'Polaris web components',
   subCategory: 'Overlays',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Page.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Page.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Page',
   description:
-    ' Use `s-page` as the main container for placing content in your app. Page comes with preset layouts and automatically adds spacing between elements.',
+    'Serves as the main container for placing content in your app with preset layouts and automatic spacing between elements.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Paragraph',
   description:
-    'Displays text content in a block format while grouping elements with the same style. Icons and other inline elements automatically adopt the paragraph's tone.',
+    "Displays text content in a block format while grouping elements with the same style. Icons and other inline elements automatically adopt the paragraph's tone.",
   category: 'Polaris web components',
   subCategory: 'Titles and text',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Paragraph',
   description:
-    'Displays a block of text and can contain inline elements such as buttons, links, or emphasized text. Use to present standalone blocks of content as opposed to inline text.',
+    'Displays text content in a block format while grouping elements with the same style. Icons and other inline elements automatically adopt the paragraph's tone.',
   category: 'Polaris web components',
   subCategory: 'Titles and text',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Popover.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Popover.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Popover',
   description:
-    'Popovers are used to display content in an overlay that can be triggered by a button.',
+    'Displays secondary information and related actions in an overlay triggered by a button.',
   category: 'Polaris web components',
   subCategory: 'Overlays',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Table.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Table.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Table',
   description:
-    'Display data clearly in rows and columns, helping users view, analyze, and compare information. Automatically renders as a list on small screens and a table on large ones.',
+    'Displays data clearly in rows and columns, helping users view, analyze, and compare information. Automatically renders as a list on small screens and a table on large ones.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Thumbnail.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Thumbnail.ts
@@ -3,7 +3,7 @@ import {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Thumbnail',
   description:
-    'Display a small preview image representing content, products, or media.',
+    'Identifies items visually in lists, tables, or cards by showing a small preview image.',
   category: 'Polaris web components',
   subCategory: 'Media',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Tooltip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Tooltip.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Tooltip',
   description:
-    'Displays helpful information in a small overlay when users hover or focus on an element. Use to provide additional context without cluttering the interface.',
+    'Displays non-essential context in a small overlay on hover or focus. Useful for icon-only buttons or showing keyboard shortcuts.',
   category: 'Polaris web components',
   subCategory: 'Overlays',
   related: [],


### PR DESCRIPTION
## Summary

- Improved descriptions for 20 Polaris web components to be more task-oriented and actionable
- Standardized verb tense to third person present ("Allows", "Displays", "Presents") for consistency
- Aligned descriptions with "useful for" and "best practices" documentation patterns

## Changes

Updated description fields in the following component documentation files:

**Forms:** Checkbox, ChoiceList, ColorField, ColorPicker, DateField, DatePicker
**Actions:** ButtonGroup, ClickableChip, Link, Menu
**Structure:** Divider, Grid, Page, Table
**Overlays:** Modal, Popover, Tooltip
**Media:** Avatar, Thumbnail
**Titles and text:** Paragraph

## Motivation

Component descriptions should clearly communicate what each component does and when to use it, helping developers quickly identify the right component for their use case.

## Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation