### PR TITLE
Fix snapit workflow

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -23,4 +23,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           build_script: yarn build
-          comment_command: /snapit
+          trigger_comment: /snapit


### PR DESCRIPTION
### Background

Noticed all comments were triggering the [Snapit workflow](https://github.com/Shopify/ui-extensions/actions/workflows/snapit.yml).
Example warning from a [snapit run](https://github.com/Shopify/ui-extensions/actions/runs/19687835011).
> Unexpected input(s) 'comment_command', valid inputs are ['trigger_comment', 'comment_prefix', 'comment_suffix', 'comment_packages', 'comment_is_global', 'cwd', 'branch', 'build_script', 'post_install_script', 'release_branch']

### Solution

Fix to proper `trigger_comment` per https://github.com/Shopify/snapit

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
