### PR TITLE
Update Image.d.ts for POS in 2025-10

### DIFF
--- a/.changeset/blue-readers-joke.md
+++ b/.changeset/blue-readers-joke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Adds alt prop to POS Image

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
@@ -12,53 +12,54 @@ import type {ImageProps, Key, Ref} from './components-shared.d.ts';
 
 export type ComponentChildren = any;
 /**
- * The base props for elements without children, providing key, ref, and slot properties.
+ * Used when an element does not have children.
  */
 export interface BaseElementProps<TClass = HTMLElement> {
-  /**
-   * A unique identifier for the element in lists. Used by Preact for efficient rendering and reconciliation.
-   */
   key?: Key;
-  /**
-   * A reference to the underlying DOM element. Commonly used to access the element directly for imperative operations.
-   */
   ref?: Ref<TClass>;
-  /**
-   * The named [slot](/docs/api/polaris/using-polaris-web-components#slots) this element should be placed in when used within a web component.
-   */
   slot?: Lowercase<string>;
 }
 /**
- * The base props for elements with children, extending `BaseElementProps` with children support.
+ * Used when an element has children.
  */
 export interface BaseElementPropsWithChildren<TClass = HTMLElement>
   extends BaseElementProps<TClass> {
-  /**
-   * The child elements to render within this component.
-   */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T &
+  BaseElementPropsWithChildren<T & HTMLElement>;
+export type HtmlElementTagNameProps<T> = T & HTMLElement;
 
 declare const tagName = 's-image';
-export interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit'> {
+export interface ImageJSXProps
+  extends Pick<ImageProps, 'id' | 'objectFit' | 'alt'> {
   /**
-   * Controls the displayed width of the image. Choose based on your layout requirements. For mobile interfaces, consider using `'fill'` with defined container dimensions to ensure consistent image display, as dynamic container heights can cause layout inconsistencies in scrollable views.
+   * The displayed inline width of the image.
    *
-   * - `'auto'` - Displays the image at its natural size. The image will not render until it has loaded, and the aspect ratio will be ignored. Use for images where maintaining original dimensions is important.
-   * - `'fill'` - Makes the image take up 100% of the available inline size. The aspect ratio will be respected and the image will take the necessary space. Use for responsive layouts and flexible image containers.
+   * - `fill`: the image will takes up 100% of the available inline size.
+   * - `auto`: the image will be displayed at its natural size.
+   *
+   * **Mobile surfaces:** Always wrap your image in a box with a set width and height.
+   * ScrollViews on mobile have a dynamic height, which can cause images to appear
+   * inconsistently without defined dimensions.
    *
    * @default 'fill'
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width
    */
   inlineSize?: ImageProps['inlineSize'];
   /**
-   * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are properly formatted and properly formatted.
+   * The image source, which should be a remote URL.
+   *
+   * When the image is loading or no `src` is provided, a placeholder will be rendered.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src
    */
   src?: ImageProps['src'];
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ImageJSXProps;
+    [tagName]: HtmlElementTagNameProps<ImageJSXProps>;
   }
 }
 declare module 'preact' {


### PR DESCRIPTION
### Background
Fixes: https://github.com/shop/issues-retail/issues/21282

Adding in the POS specific detail for image along with the bug of not exposing Alt in the first place

### Solution

1. I ran `BUILD_VERSION=2025-10 pnpm build-extension-components` on  `pos-mobile`, and it exported some files locally. 
2. I manually copied and pasted them here

### 🎩

To run it locally:
- pull this branch down from `ui-extensions`
- and pull this branch from `shopify-dev` : https://github.com/Shopify/shopify-dev/pull/65581

In `shopify-dev,` run `dev server`
Press CTRL-T to open the dev server in a browser. Please note that some rendering errors may occur, if this is the case, either click on ignore if the option is there and try refreshing the browser a couple of times if not an option.

or try this:
https://pr-65581.shopify-dev.shopify.io/docs/api/pos-ui-extensions/latest/polaris-web-components/media-and-visuals/image

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation