### PR TITLE
[POS UI extensions version 2026-01-rc]: Refine example descriptions, limitations, and links

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -52,7 +52,7 @@ Each extension can only present one modal at a time. Subsequent calls to \`prese
           'present-modal',
         ),
         description:
-          'Present a full-screen modal from menu item actions in detail screens. This example shows how to use `shopify.action.presentModal()` to launch a modal workflow from post-purchase, order details, or other action menu item contexts, enabling complex multi-step operations.',
+          'Present a full-screen modal from menu item actions in detail screens. This example shows how to use `shopify.action.presentModal()` to launch a modal workflow from post-purchase, order details, or other action menu item contexts. With this pattern, you can implement complex, multi-step operations.',
       },
       {
         codeblock: generateJsxCodeBlockForActionApi(
@@ -60,7 +60,7 @@ Each extension can only present one modal at a time. Subsequent calls to \`prese
           'present-modal-tile',
         ),
         description:
-          'Present a full-screen modal from smart grid tiles on the POS home screen. This example demonstrates using `shopify.action.presentModal()` to launch modal workflows from tile interactions, perfect for high-frequency tasks that require additional UI beyond the tile itself.',
+          'Present a full-screen modal from smart grid tiles on the POS home screen. This example demonstrates using `shopify.action.presentModal()` to launch modal workflows from tile interactions. This pattern is perfect for high-frequency tasks that require additional UI beyond the tile itself.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -60,7 +60,7 @@ The \`presentModal()\` method must be called from a user interaction (such as a 
           'present-modal-tile',
         ),
         description:
-          'Present a full-screen modal from smart grid tiles on the POS home screen. This example demonstrates using `shopify.action.presentModal()` to launch modal workflows from tile interactions. This pattern is perfect for high-frequency tasks that require additional UI beyond the tile itself.',
+          'Present a full-screen modal from smart grid tiles on the POS home screen. This example demonstrates using `shopify.action.presentModal()` to launch modal workflows from tile interactions. This pattern is well-suited for high-frequency tasks that require additional UI beyond the tile itself.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -37,7 +37,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-Each extension can only present one modal at a time. Subsequent calls to \`presentModal()\` while a modal is already open may be ignored or replace the current modal.
+The \`presentModal()\` method must be called from a user interaction (such as a button click or tile tap) and can't be invoked programmatically during extension initialization or from background operations.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -63,7 +63,7 @@ const data: ReferenceEntityTemplateSchema = {
           'add-address',
         ),
         description:
-          'Create a new address for the customer associated with the cart. This example demonstrates using `shopify.cart.addAddress()` to add shipping or billing addresses to customer profiles. This streamlines future purchases and enables multiple delivery locations.',
+          'Create a new address for the customer associated with the cart. This example demonstrates using `shopify.cart.addAddress()` to add shipping or billing addresses to customer profiles. This simplifies future purchases and enables multiple delivery locations.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -119,7 +119,7 @@ const data: ReferenceEntityTemplateSchema = {
           'apply-cart-code-discount',
         ),
         description:
-          'Apply a discount code to the cart for automatic discount validation and application. This example demonstrates using `shopify.cart.applyCodeDiscount()` to add discount codes that are validated against Shopify discount rules. This enables seamless promotional code redemption.',
+          'Apply a discount code to the cart for automatic discount validation and application. This example demonstrates using `shopify.cart.applyCodeDiscount()` to add discount codes that are validated against Shopify discount rules. This enables promotional code redemption with automatic validation.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -127,7 +127,7 @@ const data: ReferenceEntityTemplateSchema = {
           'set-line-item-discount',
         ),
         description:
-          'Apply a custom discount to a specific line item in the cart. This example demonstrates using `shopify.cart.setLineItemDiscount()` to add item-level discounts with custom reasons. This is perfect for selective price adjustments or item-specific promotions.',
+          'Apply a custom discount to a specific line item in the cart. This example demonstrates using `shopify.cart.setLineItemDiscount()` to add item-level discounts with custom reasons. This is useful for selective price adjustments or item-specific promotions.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -247,7 +247,7 @@ const data: ReferenceEntityTemplateSchema = {
           'update-default-address',
         ),
         description:
-          'Designate a specific address as the default for the customer. This example demonstrates using `shopify.cart.updateDefaultAddress()` to set the primary shipping or billing address. This streamlines the checkout process for future transactions.',
+          'Designate a specific address as the default for the customer. This example demonstrates using `shopify.cart.updateDefaultAddress()` to set the primary shipping or billing address. This simplifies the checkout process for future transactions.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -56,7 +56,7 @@ const data: ReferenceEntityTemplateSchema = {
           'add-custom-sale',
         ),
         description:
-          'Add a custom item to the cart with manual pricing and details. This example demonstrates using `shopify.cart.addCustomSale()` to create custom line items for services, fees, or items not in the product catalog, providing flexibility for unique sales scenarios.',
+          'Add a custom item to the cart with manual pricing and details. This example demonstrates using `shopify.cart.addCustomSale()` to create custom line items for services, fees, or items not in the product catalog. This provides flexibility for unique sales scenarios.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -64,7 +64,7 @@ const data: ReferenceEntityTemplateSchema = {
           'add-address',
         ),
         description:
-          'Create a new address for the customer associated with the cart. This example demonstrates using `shopify.cart.addAddress()` to add shipping or billing addresses to customer profiles, streamlining future purchases and enabling multiple delivery locations.',
+          'Create a new address for the customer associated with the cart. This example demonstrates using `shopify.cart.addAddress()` to add shipping or billing addresses to customer profiles. This streamlines future purchases and enables multiple delivery locations.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -72,7 +72,7 @@ const data: ReferenceEntityTemplateSchema = {
           'add-line-item',
         ),
         description:
-          'Add a product variant to the cart with specified quantity and optional properties. This example shows how to use `shopify.cart.addLineItem()` to add catalog items to the cart with custom attributes, enabling standard product sales with additional customization.',
+          'Add a product variant to the cart with specified quantity and optional properties. This example shows how to use `shopify.cart.addLineItem()` to add catalog items to the cart with custom attributes. This enables standard product sales with additional customization.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -80,7 +80,7 @@ const data: ReferenceEntityTemplateSchema = {
           'add-line-item-selling-plan',
         ),
         description:
-          'Associate a subscription or selling plan with a line item for recurring purchases. This example shows how to use `shopify.cart.addLineItemSellingPlan()` to add selling plans to items, enabling subscription-based sales and recurring revenue models.',
+          'Associate a subscription or selling plan with a line item for recurring purchases. This example shows how to use `shopify.cart.addLineItemSellingPlan()` to add selling plans to items. This enables subscription-based sales and recurring revenue models.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -88,7 +88,7 @@ const data: ReferenceEntityTemplateSchema = {
           'add-line-item-properties',
         ),
         description:
-          'Attach custom metadata to a specific line item for additional product information. This example shows how to use `shopify.cart.addLineItemProperties()` to add key-value properties to individual items, enabling customization like engraving text, gift messages, or special instructions.',
+          'Attach custom metadata to a specific line item for additional product information. This example shows how to use `shopify.cart.addLineItemProperties()` to add key-value properties to individual items. This enables customization like engraving text, gift messages, or special instructions.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -96,7 +96,7 @@ const data: ReferenceEntityTemplateSchema = {
           'add-cart-properties',
         ),
         description:
-          'Attach custom metadata to the cart for additional order information. This example shows how to use `shopify.cart.addCartProperties()` to add key-value properties that persist through checkout, useful for tracking order sources, preferences, or workflow data.',
+          'Attach custom metadata to the cart for additional order information. This example shows how to use `shopify.cart.addCartProperties()` to add key-value properties that persist through checkout. This is useful for tracking order sources, preferences, or workflow data.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -104,7 +104,7 @@ const data: ReferenceEntityTemplateSchema = {
           'bulk-add-line-item-properties',
         ),
         description:
-          'Attach custom metadata to multiple line items efficiently in a single operation. This example demonstrates using `shopify.cart.bulkAddLineItemProperties()` to add properties to several items simultaneously, improving performance for batch customization operations.',
+          'Attach custom metadata to multiple line items efficiently in a single operation. This example demonstrates using `shopify.cart.bulkAddLineItemProperties()` to add properties to several items simultaneously. This improves performance for batch customization operations.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -112,7 +112,7 @@ const data: ReferenceEntityTemplateSchema = {
           'apply-cart-discount',
         ),
         description:
-          'Apply a custom discount to the entire cart using a fixed amount or percentage. This example shows how to use `shopify.cart.applyCartDiscount()` to add order-level discounts with custom reasons, useful for promotions, loyalty rewards, or staff discounts.',
+          'Apply a custom discount to the entire cart using a fixed amount or percentage. This example shows how to use `shopify.cart.applyCartDiscount()` to add order-level discounts with custom reasons. This is useful for promotions, loyalty rewards, or staff discounts.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -120,7 +120,7 @@ const data: ReferenceEntityTemplateSchema = {
           'apply-cart-code-discount',
         ),
         description:
-          'Apply a discount code to the cart for automatic discount validation and application. This example demonstrates using `shopify.cart.applyCodeDiscount()` to add discount codes that are validated against Shopify discount rules, enabling seamless promotional code redemption.',
+          'Apply a discount code to the cart for automatic discount validation and application. This example demonstrates using `shopify.cart.applyCodeDiscount()` to add discount codes that are validated against Shopify discount rules. This enables seamless promotional code redemption.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -128,7 +128,7 @@ const data: ReferenceEntityTemplateSchema = {
           'set-line-item-discount',
         ),
         description:
-          'Apply a custom discount to a specific line item in the cart. This example demonstrates using `shopify.cart.setLineItemDiscount()` to add item-level discounts with custom reasons, perfect for selective price adjustments or item-specific promotions.',
+          'Apply a custom discount to a specific line item in the cart. This example demonstrates using `shopify.cart.setLineItemDiscount()` to add item-level discounts with custom reasons. This is perfect for selective price adjustments or item-specific promotions.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -136,7 +136,7 @@ const data: ReferenceEntityTemplateSchema = {
           'bulk-set-line-item-discounts',
         ),
         description:
-          'Apply discounts to multiple line items efficiently in a single operation. This example shows how to use `shopify.cart.bulkSetLineItemDiscounts()` to add discounts to several items simultaneously, improving performance for bulk pricing adjustments or category-wide promotions.',
+          'Apply discounts to multiple line items efficiently in a single operation. This example shows how to use `shopify.cart.bulkSetLineItemDiscounts()` to add discounts to several items simultaneously. This improves performance for bulk pricing adjustments or category-wide promotions.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -144,7 +144,7 @@ const data: ReferenceEntityTemplateSchema = {
           'set-customer',
         ),
         description:
-          'Assign a customer to the current cart for personalized pricing and order history. This example demonstrates using `shopify.cart.setCustomer()` to link a customer by ID, enabling customer-specific discounts, loyalty programs, and order tracking.',
+          'Assign a customer to the current cart for personalized pricing and order history. This example demonstrates using `shopify.cart.setCustomer()` to link a customer by ID. This enables customer-specific discounts, loyalty programs, and order tracking.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -152,7 +152,7 @@ const data: ReferenceEntityTemplateSchema = {
           'set-attributed-staff-to-line-item',
         ),
         description:
-          'Associate a specific line item with a staff member for item-level commission tracking. This example shows how to use `shopify.cart.setAttributedStaffToLineItem()` to assign staff members to individual items, enabling granular sales attribution and performance analysis.',
+          'Associate a specific line item with a staff member for item-level commission tracking. This example shows how to use `shopify.cart.setAttributedStaffToLineItem()` to assign staff members to individual items. This enables granular sales attribution and performance analysis.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -160,7 +160,7 @@ const data: ReferenceEntityTemplateSchema = {
           'set-attributed-staff',
         ),
         description:
-          'Associate a staff member with the cart for commission tracking and sales attribution. This example demonstrates using `shopify.cart.setAttributedStaff()` to assign staff members to sales, enabling performance tracking and commission calculations.',
+          'Attribute the cart to a staff member for commission tracking and sales attribution. This example demonstrates using `shopify.cart.setAttributedStaff()` to assign staff members to sales. This enables performance tracking and commission calculations.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -168,7 +168,7 @@ const data: ReferenceEntityTemplateSchema = {
           'check-cart-editable',
         ),
         description:
-          'Verify whether the cart is in an editable state before attempting modifications. This example demonstrates using `shopify.cart.editable` to check if the cart can accept changes, preventing errors and improving user experience by disabling actions when the cart is locked or in an immutable state.',
+          'Verify whether the cart is in an editable state before attempting modifications. This example demonstrates using `shopify.cart.editable` to check if the cart can accept changes. By disabling actions when the cart is locked or in an immutable state, you can prevent errors and improve the user experience.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -176,7 +176,7 @@ const data: ReferenceEntityTemplateSchema = {
           'clear-cart',
         ),
         description:
-          'Remove all line items and reset the cart to an empty state. This example shows how to use `shopify.cart.clear()` to completely clear the cart, useful for starting fresh transactions or implementing cart reset functionality.',
+          'Remove all line items and reset the cart to an empty state. This example shows how to use `shopify.cart.clear()` to completely clear the cart. This is useful for starting fresh transactions or implementing cart reset functionality.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -184,7 +184,7 @@ const data: ReferenceEntityTemplateSchema = {
           'delete-address',
         ),
         description:
-          'Remove a specific address from the customer profile using its unique identifier. This example shows how to use `shopify.cart.deleteAddress()` to delete outdated or incorrect addresses, helping maintain clean customer records.',
+          'Remove a specific address from the customer profile using its unique identifier. This example shows how to use `shopify.cart.deleteAddress()` to delete outdated or incorrect addresses. This helps maintain clean customer records.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -192,7 +192,7 @@ const data: ReferenceEntityTemplateSchema = {
           'remove-line-item-discount',
         ),
         description:
-          'Remove a previously applied discount from a specific line item. This example demonstrates using `shopify.cart.removeLineItemDiscount()` to clear item-level discounts, useful for discount corrections or when promotional conditions are no longer met.',
+          'Remove a previously applied discount from a specific line item. This example demonstrates using `shopify.cart.removeLineItemDiscount()` to clear item-level discounts. This is useful for discount corrections or when promotional conditions are no longer met.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -200,7 +200,7 @@ const data: ReferenceEntityTemplateSchema = {
           'remove-all-discounts',
         ),
         description:
-          'Clear all discounts applied to both the cart and individual line items in a single operation. This example shows how to use `shopify.cart.removeAllDiscounts()` to reset pricing to base values, useful for recalculating totals or canceling promotional offers.',
+          'Clear all discounts applied to both the cart and individual line items in a single operation. This example shows how to use `shopify.cart.removeAllDiscounts()` to reset pricing to base values. This is useful for recalculating totals or canceling promotional offers.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -208,7 +208,7 @@ const data: ReferenceEntityTemplateSchema = {
           'remove-line-item',
         ),
         description:
-          'Remove a specific line item from the cart using its unique identifier. This example demonstrates using `shopify.cart.removeLineItem()` to delete items, useful for implementing remove buttons, cart cleanup, or conditional item removal logic.',
+          'Remove a specific line item from the cart using its unique identifier. This example demonstrates using `shopify.cart.removeLineItem()` to delete items. This is useful for implementing remove buttons, cart cleanup, or conditional item removal logic.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -216,7 +216,7 @@ const data: ReferenceEntityTemplateSchema = {
           'remove-line-item-properties',
         ),
         description:
-          'Delete specific custom properties from a line item by their keys. This example shows how to use `shopify.cart.removeLineItemProperties()` to clear item metadata, useful for removing temporary customization data or outdated property values.',
+          'Delete specific custom properties from a line item by their keys. This example shows how to use `shopify.cart.removeLineItemProperties()` to clear item metadata. This is useful for removing temporary customization data or outdated property values.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -224,7 +224,7 @@ const data: ReferenceEntityTemplateSchema = {
           'remove-cart-properties',
         ),
         description:
-          'Delete specific custom properties from the cart by their keys. This example demonstrates using `shopify.cart.removeCartProperties()` to clear metadata, useful for cleaning up temporary data or removing properties that are no longer needed.',
+          'Delete specific custom properties from the cart by their keys. This example demonstrates using `shopify.cart.removeCartProperties()` to clear metadata. This is useful for cleaning up temporary data or removing properties that are no longer needed.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -232,7 +232,7 @@ const data: ReferenceEntityTemplateSchema = {
           'remove-line-item-selling-plan',
         ),
         description:
-          'Remove the selling plan from a line item to convert it back to a one-time purchase. This example demonstrates using `shopify.cart.removeLineItemSellingPlan()` to clear subscription plans, useful when customers change their mind about recurring orders.',
+          'Remove the selling plan from a line item to convert it back to a one-time purchase. This example demonstrates using `shopify.cart.removeLineItemSellingPlan()` to clear subscription plans. This is useful when customers change their mind about recurring orders.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -240,7 +240,7 @@ const data: ReferenceEntityTemplateSchema = {
           'remove-customer',
         ),
         description:
-          'Disassociate the customer from the current cart for anonymous transactions. This example shows how to use `shopify.cart.removeCustomer()` to clear customer information, reverting to guest checkout pricing and removing customer-specific data from the cart.',
+          'Disassociate the customer from the current cart for anonymous transactions. This example shows how to use `shopify.cart.removeCustomer()` to clear customer information. This reverts to guest checkout pricing and removes customer-specific data from the cart.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -248,7 +248,7 @@ const data: ReferenceEntityTemplateSchema = {
           'update-default-address',
         ),
         description:
-          'Designate a specific address as the default for the customer. This example demonstrates using `shopify.cart.updateDefaultAddress()` to set the primary shipping or billing address, streamlining the checkout process for future transactions.',
+          'Designate a specific address as the default for the customer. This example demonstrates using `shopify.cart.updateDefaultAddress()` to set the primary shipping or billing address. This streamlines the checkout process for future transactions.',
       },
       {
         codeblock: generateJsxCodeBlockForCartApi(
@@ -256,7 +256,7 @@ const data: ReferenceEntityTemplateSchema = {
           'subscribe',
         ),
         description:
-          'Monitor cart state changes in real time using the subscribe method. This example shows how to use `shopify.cart.subscribe()` to receive updates whenever the cart changes, enabling reactive UI updates, validation logic, or analytics tracking based on cart modifications.',
+          'Monitor cart state changes in real time using the subscribe method. This example shows how to use `shopify.cart.subscribe()` to receive updates whenever the cart changes. This enables reactive UI updates, validation logic, or analytics tracking based on cart modifications.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -39,9 +39,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
+- Cart operations can only be performed when the cart is in an editable state—check \`cart.editable\` before attempting modifications.
 - Cart operations may fail due to business rules, inventory constraints, oversell protection, or validation errors—always implement appropriate error handling.
-- Some operations require specific preconditions. For example, customer must be present for address operations and selling plans must be compatible with line items.
-- Selling plan operations are only available for products that support selling plans and may have additional validation requirements.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -39,8 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Cart operations can only be performed when the cart is in an editable state—check \`cart.editable\` before attempting modifications.
-- Cart operations may fail due to business rules, inventory constraints, oversell protection, or validation errors—always implement appropriate error handling.
+Cart operations may fail due to business rules, inventory constraints, oversell protection, or validation errors—always implement appropriate error handling.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
@@ -39,7 +39,6 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- The API provides read-only access to line item data—use the Cart API for modifying line item properties, discounts, selling plans, or other attributes.
 - Line item data reflects the current state and may not include real-time inventory, pricing, or selling plan updates until the cart is refreshed.
 - Selling plan information may be limited during refund or exchange operations where digest values aren't available.
 `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
@@ -55,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
           'id',
         ),
         description:
-          'Access the unique identifier of the current cart line item in line item detail contexts. This example shows how to use `shopify.cartLineItem.id` to retrieve the line item ID, which can be used for modifying the item, applying discounts, or implementing item-specific functionality.',
+          'Access the unique identifier of the current cart line item in line item detail contexts. This example shows how to use `shopify.cartLineItem.id` to retrieve the line item ID. This can be used for modifying the item, applying discounts, or implementing item-specific functionality.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-line-item-api.doc.ts
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         codeblock: generateJsxCodeBlockForCartLineItemApi(
-          'Display the cart line item ID',
+          'Retrieve the cart line item ID',
           'id',
         ),
         description:

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cash-drawer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cash-drawer-api.doc.ts
@@ -59,7 +59,7 @@ const data: ReferenceEntityTemplateSchema = {
           'default.example',
         ),
         description:
-          'Open the cash drawer programmatically for manual cash handling or custom workflows. This example shows how to use `shopify.cashDrawer.open()` to trigger the connected cash drawer hardware, useful for no-sale transactions, manual cash operations, or register management tasks that require direct cash access.',
+          'Open the cash drawer programmatically for manual cash handling or custom workflows. This example shows how to use `shopify.cashDrawer.open()` to trigger the connected cash drawer hardware. This is useful for no-sale transactions, manual cash operations, or register management tasks that require direct cash access.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cash-drawer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cash-drawer-api.doc.ts
@@ -42,9 +42,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- The Cash Drawer API requires compatible cash drawer hardware connected to the POS device through supported peripheral connections (USB, network, or Bluetooth depending on device and hardware model).
-- The API only triggers the drawer opening mechanism and cannot detect whether the drawer is currently open, closed, or physically jammed. Your extension is responsible for any required state tracking.
-- Cash drawer operations are subject to POS hardware capabilities and may not be available on all device configurations. The API will return errors on devices without cash drawer support.
+The API only triggers the drawer opening mechanism and cannot detect whether the drawer is currently open, closed, or physically jammed—your extension is responsible for any required state tracking.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -56,7 +56,7 @@ const data: ReferenceEntityTemplateSchema = {
           'subscribe',
         ),
         description:
-          'Subscribe to connectivity changes to monitor network status in real time. This example demonstrates using `shopify.connectivity.subscribe()` and `shopify.connectivity.connected` to detect when the device goes online or offline, enabling adaptive behavior for offline-capable features or network-dependent operations.',
+          'Subscribe to connectivity changes to monitor network status in real time. This example demonstrates using `shopify.connectivity.subscribe()` and `shopify.connectivity.connected` to detect when the device goes online or offline. This enables adaptive behavior for offline-capable features or network-dependent operations.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -39,9 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- The Connectivity API provides read-only access to connectivity information and can't be used to control or modify network settings on the device.
-- Connectivity status reflects Internet connectivity only and may not indicate the quality or speed of the connection, which could affect API performance.
-- The API monitors general Internet connectivity but doesn't provide specific information about Shopify service availability or API endpoint availability.
+Connectivity status reflects Internet connectivity only and may not indicate the quality or speed of the connection, which could affect API performance.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -35,8 +35,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- The API provides only the customer identifier—use Shopify APIs or external systems to fetch additional customer details like name, email, or purchase history.
-- Customer data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.
+Customer data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -45,7 +45,7 @@ Customer data reflects the current POS session and may not include real-time upd
     examples: [
       {
         codeblock: generateJsxCodeBlockForCustomerApi(
-          'Display the customer ID',
+          'Retrieve the customer ID',
           'id',
         ),
         description:

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
           'id',
         ),
         description:
-          'Access the unique identifier of the current customer in a customer detail context. This example shows how to use `shopify.customer.id` to retrieve the customer ID, which can be used for fetching additional customer data, implementing loyalty features, or building personalized customer experiences.',
+          'Access the unique identifier of the current customer in a customer detail context. This example shows how to use `shopify.customer.id` to retrieve the customer ID. This can be used for fetching additional customer data, implementing loyalty features, or building personalized customer experiences.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -32,14 +32,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Provide device-appropriate experiences:** Design different experiences for tablets versus other devices, leveraging larger screens.
 `,
     },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-Device information queries are asynchronous and may take time to resolve, so always handle the Promise-based responses appropriately in your extension logic.
-`,
-    },
   ],
   related: [],
   examples: {
@@ -68,7 +60,7 @@ Device information queries are asynchronous and may take time to resolve, so alw
           'name',
         ),
         description:
-          'Access the friendly name of the current POS device. This example shows how to use `shopify.device.name` to retrieve the device name configured in POS settings. This is useful for device identification, multi-device workflows, or displaying location-specific information.',
+          'Retrieve the name of the current POS device. This example shows how to use `shopify.device.name` to get the device name configured in POS settings. This is useful for device identification, multi-device workflows, or displaying location-specific information.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -56,7 +56,7 @@ Device information queries are asynchronous and may take time to resolve, so alw
       },
       {
         codeblock: generateJsxCodeBlockForDeviceApi(
-          'Display the device ID',
+          'Retrieve the device ID',
           'device-id',
         ),
         description:
@@ -64,7 +64,7 @@ Device information queries are asynchronous and may take time to resolve, so alw
       },
       {
         codeblock: generateJsxCodeBlockForDeviceApi(
-          'Display the device name',
+          'Retrieve the device name',
           'name',
         ),
         description:

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -54,7 +54,7 @@ const data: ReferenceEntityTemplateSchema = {
           'tablet',
         ),
         description:
-          'Check if the POS device is running on tablet hardware to adapt your UI accordingly. This example shows how to use `shopify.device.isTablet()` to determine the device form factor, enabling responsive layouts and touch-optimized interfaces for tablet devices versus traditional POS terminals.',
+          'Check if the POS device is running on tablet hardware to adapt your UI accordingly. This example shows how to use `shopify.device.isTablet()` to determine the device form factor. This enables responsive layouts and touch-optimized interfaces for tablet devices versus traditional POS terminals.',
       },
       {
         codeblock: generateJsxCodeBlockForDeviceApi(
@@ -62,7 +62,7 @@ const data: ReferenceEntityTemplateSchema = {
           'device-id',
         ),
         description:
-          'Access the unique identifier of the current POS device. This example demonstrates using `shopify.device.id` to retrieve the device ID, enabling device-specific configurations, analytics tracking, or multi-device coordination features.',
+          'Access the unique identifier of the current POS device. This example demonstrates using `shopify.device.id` to retrieve the device ID. This enables device-specific configurations, analytics tracking, or multi-device coordination features.',
       },
       {
         codeblock: generateJsxCodeBlockForDeviceApi(
@@ -70,7 +70,7 @@ const data: ReferenceEntityTemplateSchema = {
           'name',
         ),
         description:
-          'Access the friendly name of the current POS device. This example shows how to use `shopify.device.name` to retrieve the device name configured in POS settings, useful for device identification, multi-device workflows, or displaying location-specific information.',
+          'Access the friendly name of the current POS device. This example shows how to use `shopify.device.name` to retrieve the device name configured in POS settings. This is useful for device identification, multi-device workflows, or displaying location-specific information.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -37,9 +37,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Device information queries are asynchronous and may take time to resolve, so always handle the Promise-based responses appropriately in your extension logic.
-- The Device API provides read-only access to device information and can't be used to modify device settings or capabilities.
-- Device type detection is limited to basic form factor identification (tablet vs. non-tablet) and doesn't provide detailed hardware specifications or capabilities.
+Device information queries are asynchronous and may take time to resolve, so always handle the Promise-based responses appropriately in your extension logic.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         codeblock: generateJsxCodeBlockForDraftOrderApi(
-          'Display the draft order ID',
+          'Retrieve a draft order ID',
           'id',
         ),
         description:

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
           'id',
         ),
         description:
-          'Access the unique identifier of the current draft order in a draft order detail context. This example shows how to use `shopify.draftOrder.id` to retrieve the draft order ID, which can be used for fetching additional order data, implementing custom workflows, or building draft order-specific features.',
+          'Access the unique identifier of the current draft order in a draft order detail context. This example shows how to use `shopify.draftOrder.id` to retrieve the draft order ID. This can be used for fetching additional order data, implementing custom workflows, or building draft order-specific features.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
@@ -51,8 +51,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- The API provides only basic draft order information—use Shopify APIs or external systems to fetch additional draft order details like line items, totals, or timestamps.
-- Draft order data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.
+Draft order data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -32,14 +32,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Provide fallback handling:** Implement fallback behavior for unsupported locales, defaulting to a supported language like English.
 `,
     },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-Locale changes are detected through the subscription mechanism, but the API doesn't provide historical locale information or change timestamps.
-`,
-    },
   ],
   related: [],
   examples: {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -54,7 +54,7 @@ const data: ReferenceEntityTemplateSchema = {
           'subscribe',
         ),
         description:
-          "Subscribe to locale changes to monitor the merchant's language settings in real time. This example shows how to use `shopify.locale.subscribe()` and `shopify.locale.ianaCode` to detect when the merchant changes their language preference, enabling dynamic content localization and internationalized user experiences.",
+          "Subscribe to locale changes to monitor the merchant's language settings in real time. This example shows how to use `shopify.locale.subscribe()` and `shopify.locale.ianaCode` to detect when the merchant changes their language preference. This enables dynamic content localization and internationalized user experiences.",
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -37,9 +37,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- The Locale API provides read-only access to locale information and can't be used to change the merchant's locale settings, which must be configured through POS system settings.
-- Locale changes are detected through the subscription mechanism, but the API doesn't provide historical locale information or change timestamps.
-- The locale format follows IETF standards, but the specific locales available depend on POS system configuration and may vary between different Shopify POS installations.
+Locale changes are detected through the subscription mechanism, but the API doesn't provide historical locale information or change timestamps.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -46,7 +46,6 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - The Navigation API is only available in action (modal) targets and can't be used in action (menu item), block, or tile targets that don't support multi-screen navigation.
 - Navigation state is limited to serializable data and can't contain functions, complex objects, or circular references.
-- The API follows web platform standards but operates within the POS modal context, so some web navigation behaviors may differ from standard browser navigation.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -61,7 +61,7 @@ const data: ReferenceEntityTemplateSchema = {
           'two-screen',
         ),
         description:
-          'Create multi-screen workflows within your extension using web-standard navigation. This example demonstrates using `navigation.navigate()` to move between different screens in your modal interface, enabling complex multi-step processes with proper navigation history management.',
+          'Create multi-screen workflows within your extension using web-standard navigation. This example demonstrates using `navigation.navigate()` to move between different screens in your modal interface. This enables complex multi-step processes with proper navigation history management.',
       },
       {
         codeblock: generateJsxCodeBlockForNavigationApi(
@@ -69,7 +69,7 @@ const data: ReferenceEntityTemplateSchema = {
           'native-screen',
         ),
         description:
-          'Navigate to native POS screens from your extension using deep link URIs. This example shows how to use `navigation.navigate()` with POS screen URIs to transition to core POS functionality like cart, product details, or order screens, enabling seamless integration between your extension and native POS features.',
+          'Navigate to native POS screens from your extension using deep link URIs. This example shows how to use `navigation.navigate()` with POS screen URIs to transition to core POS functionality like cart, product details, or order screens. This enables seamless integration between your extension and native POS features.',
       },
       {
         codeblock: generateJsxCodeBlockForNavigationApi(
@@ -77,7 +77,7 @@ const data: ReferenceEntityTemplateSchema = {
           'state-params',
         ),
         description:
-          'Share data between screens using navigation state parameters. This example demonstrates using the `state` option in `navigation.navigate()` to pass data when navigating, enabling screens to receive context and maintain workflow continuity across navigation transitions.',
+          'Share data between screens using navigation state parameters. This example demonstrates using the `state` option in `navigation.navigate()` to pass data when navigating. This enables screens to receive context and maintain workflow continuity across navigation transitions.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -68,7 +68,7 @@ const data: ReferenceEntityTemplateSchema = {
           'native-screen',
         ),
         description:
-          'Navigate to native POS screens from your extension using deep link URIs. This example shows how to use `navigation.navigate()` with POS screen URIs to transition to core POS functionality like cart, product details, or order screens. This enables seamless integration between your extension and native POS features.',
+          'Navigate to native POS screens from your extension using deep link URIs. This example shows how to use `navigation.navigate()` with POS screen URIs to transition to core POS functionality like cart, product details, or order screens. This enables direct transitions between your extension and native POS features.',
       },
       {
         codeblock: generateJsxCodeBlockForNavigationApi(

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -48,7 +48,7 @@ Order data reflects the current POS session and may not include real-time update
     examples: [
       {
         codeblock: generateJsxCodeBlockForOrderApi(
-          'Display the order ID',
+          'Retrieve an order ID',
           'id',
         ),
         description:

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -35,8 +35,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- The API provides only basic order information—use Shopify APIs or external systems to fetch additional order details like line items, totals, or fulfillment status.
-- Order data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.
+Order data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -53,7 +53,7 @@ const data: ReferenceEntityTemplateSchema = {
           'id',
         ),
         description:
-          'Access the unique identifier of the current order in an order detail action context. This example shows how to use `shopify.order.id` to retrieve the order ID, which can be used for fetching additional order data, tracking, or implementing order-specific functionality and post-purchase workflows.',
+          'Access the unique identifier of the current order in an order detail action context. This example shows how to use `shopify.order.id` to retrieve the order ID. This can be used for fetching additional order data, tracking, or implementing order-specific functionality and post-purchase workflows.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
@@ -37,9 +37,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
+- PIN length must be between 4 and 10 digits. The \`minPinLength\` and \`maxPinLength\` options must be set within this range.
 - PIN validation must be handled through the \`onSubmit\` callback and should be performed securely on your backend service rather than in client-side extension code.
 - The PinPad API displays a modal interface that takes over the entire screen until PIN entry is complete or the modal is dismissed.
-- PIN data is provided as an array of numbers and must be handled securely, following appropriate data protection and privacy practices.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
@@ -37,9 +37,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- PIN length must be between 4 and 10 digits. The \`minPinLength\` and \`maxPinLength\` options must be set within this range.
-- PIN validation must be handled through the \`onSubmit\` callback and should be performed securely on your backend service rather than in client-side extension code.
-- The PinPad API displays a modal interface that takes over the entire screen until PIN entry is complete or the modal is dismissed.
+PIN validation must be handled through the \`onSubmit\` callback and should be performed securely on your backend service rather than in client-side extension code.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/pinpad-api.doc.ts
@@ -54,7 +54,7 @@ const data: ReferenceEntityTemplateSchema = {
           'validation',
         ),
         description:
-          'Present a secure PIN pad interface to collect and validate user PINs for authentication or verification. This example shows how to use `shopify.pinPad.show()` to display a PIN entry modal with customizable options, handle the entered PIN securely, and process the result for secure authentication workflows.',
+          'Present a secure PIN pad interface to collect and validate user PINs for authentication or verification. This example shows how to use `shopify.pinPad.show()` to display a PIN entry modal with customizable options. By handling the entered PIN securely and processing the result, you can implement secure authentication workflows.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
@@ -61,7 +61,7 @@ PDF printing on Android devices requires downloading the file and using an exter
       },
       {
         codeblock: generateJsxCodeBlockForPrintApi(
-          'Print from a remote URL',
+          'Print a document from a remote URL',
           'print-full-url',
         ),
         description:
@@ -69,7 +69,7 @@ PDF printing on Android devices requires downloading the file and using an exter
       },
       {
         codeblock: generateJsxCodeBlockForPrintApi(
-          'Print using a relative file path',
+          'Print a document using a relative file path',
           'print-relative',
         ),
         description:

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
@@ -59,7 +59,7 @@ const data: ReferenceEntityTemplateSchema = {
           'print',
         ),
         description:
-          'Trigger the native print dialog from a smart grid tile action. This example shows how to use `shopify.print()` to print a document specified by a relative path, allowing quick printing of receipts, labels, or reports directly from the POS home screen.',
+          'Trigger the native print dialog from a smart grid tile action. This example shows how to use `shopify.print()` to print a document specified by a relative path. This allows quick printing of receipts, labels, or reports directly from the POS home screen.',
       },
       {
         codeblock: generateJsxCodeBlockForPrintApi(
@@ -67,7 +67,7 @@ const data: ReferenceEntityTemplateSchema = {
           'print-full-url',
         ),
         description:
-          'Print documents hosted on external servers using full URLs. This example shows how to use `shopify.print()` with a complete URL to print remotely hosted documents, enabling dynamic content generation or printing from external services.',
+          'Print documents hosted on external servers using full URLs. This example shows how to use `shopify.print()` with a complete URL to print remotely hosted documents. This enables dynamic content generation or printing from external services.',
       },
       {
         codeblock: generateJsxCodeBlockForPrintApi(
@@ -75,7 +75,7 @@ const data: ReferenceEntityTemplateSchema = {
           'print-relative',
         ),
         description:
-          'Print documents using relative paths within your extension bundle. This example demonstrates using `shopify.print()` with a relative path to reference HTML, text, image, or PDF files included in your extension, making it easy to print pre-defined templates or documents.',
+          'Print documents using relative paths within your extension bundle. This example demonstrates using `shopify.print()` with a relative path to reference HTML, text, image, or PDF files included in your extension. This makes it easy to print pre-defined templates or documents.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
@@ -42,9 +42,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- PDF printing on Android devices requires downloading the file and using an external application, which may interrupt the user workflow.
-- Print operations depend on device printer connectivity and configuration, which may not be available in all POS setups.
-- Document formatting and appearance may vary depending on the printer type, paper size, and device capabilities.
+PDF printing on Android devices requires downloading the file and using an external application, which may interrupt the user workflow.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -29,7 +29,7 @@ const data: ReferenceEntityTemplateSchema = {
           'id',
         ),
         description:
-          'Access the unique identifier of the current product in a product detail action context. This example shows how to use `shopify.product.id` to retrieve the product ID, which can be used for fetching additional product data, analytics, or implementing product-specific features and workflows.',
+          'Access the unique identifier of the current product in a product detail action context. This example shows how to use `shopify.product.id` to retrieve the product ID. This can be used for fetching additional product data, analytics, or implementing product-specific features and workflows.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -25,7 +25,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         codeblock: generateJsxCodeBlockForProductApi(
-          'Display the product ID',
+          'Retrieve a product ID',
           'id',
         ),
         description:

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -49,8 +49,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- The API provides only basic product identifiers—use Shopify APIs or external systems to fetch additional product details like title, description, pricing, or inventory levels.
-- Product data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.
+Product data reflects the current POS session and may not include real-time updates from other channels until the session is refreshed.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -41,7 +41,6 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - Product search results are limited to products available on the current POS device and may not include the complete shop catalog if products aren't synced locally.
 - Bulk operations (\`fetchProductsWithIds\` and \`fetchProductVariantsWithIds\`) are limited to 50 items maximum, with additional IDs automatically removed from requests.
-- Search functionality depends on local product data synchronization and may not reflect real-time inventory or pricing changes until the next sync.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -56,7 +56,7 @@ const data: ReferenceEntityTemplateSchema = {
           'fetch-product-with-id',
         ),
         description:
-          'Retrieve detailed information for a specific product using its ID. This example demonstrates using `shopify.productSearch.fetchById()` to get complete product data including variants, pricing, and inventory information for a single product.',
+          'Fetch a single product by ID. This example demonstrates using `shopify.productSearch.fetchById()` to get complete product data including variants, pricing, and inventory information for a single product.',
       },
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(
@@ -64,7 +64,7 @@ const data: ReferenceEntityTemplateSchema = {
           'fetch-product-variant-with-id',
         ),
         description:
-          'Retrieve detailed information for a specific product variant using its ID. This example demonstrates using `shopify.productSearch.fetchVariantById()` to get variant-specific data including pricing, inventory, and options for a particular variant.',
+          'Fetch a single variant by ID. This example demonstrates using `shopify.productSearch.fetchVariantById()` to get variant-specific data including pricing, inventory, and options for a particular variant.',
       },
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(
@@ -72,7 +72,7 @@ const data: ReferenceEntityTemplateSchema = {
           'fetch-products-with-ids',
         ),
         description:
-          'Retrieve detailed information for multiple products in a single request using their IDs. This example shows how to use `shopify.productSearch.fetchByIds()` to efficiently fetch data for multiple products at once, improving performance when displaying product lists or related items.',
+          'Fetch multiple products by IDs. This example shows how to use `shopify.productSearch.fetchByIds()` to efficiently fetch data for multiple products in a single request. This improves performance when displaying product lists or related items.',
       },
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(
@@ -80,7 +80,7 @@ const data: ReferenceEntityTemplateSchema = {
           'fetch-product-variants-with-ids',
         ),
         description:
-          'Retrieve detailed information for multiple product variants in a single request using their IDs. This example shows how to use `shopify.productSearch.fetchVariantsByIds()` to efficiently fetch data for multiple variants at once, useful for displaying variant lists or comparisons.',
+          'Fetch multiple variants by IDs. This example shows how to use `shopify.productSearch.fetchVariantsByIds()` to efficiently fetch data for multiple variants in a single request. This is useful for displaying variant lists or comparisons.',
       },
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(
@@ -88,7 +88,7 @@ const data: ReferenceEntityTemplateSchema = {
           'fetch-paginated-product-variants-with-product-id',
         ),
         description:
-          'Retrieve product variants with pagination support for products with many variants. This example demonstrates using `shopify.productSearch.fetchVariantsByProductId()` with pagination parameters to load variants page by page, improving performance and user experience for products with large variant catalogs.',
+          'Fetch paginated variants for a product. This example demonstrates using `shopify.productSearch.fetchVariantsByProductId()` with pagination parameters to load variants page by page. This improves performance and user experience for products with large variant catalogs.',
       },
       {
         codeblock: generateJsxCodeBlockForProductSearchApi(
@@ -96,7 +96,7 @@ const data: ReferenceEntityTemplateSchema = {
           'search-products',
         ),
         description:
-          'Search for products using text queries with real-time results. This example shows how to use `shopify.productSearch.search()` to perform text-based product searches with pagination support, allowing users to find products by name, SKU, or other searchable attributes.',
+          'Search for products using a search bar. This example shows how to use `shopify.productSearch.search()` to perform text-based product searches with pagination support. This allows users to find products by name, SKU, or other searchable attributes.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -31,6 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
 - **Validate scanned data:** Validate before processing and handle invalid codes, unsupported formats, or errors.
 - **Provide clear feedback:** Show success confirmations, error messages, and guidance when scans fail.
 - **Adapt to available sources:** Check available scanner sources and provide alternatives when preferred methods aren't available.
+- **Handle scan data processing:** Scan data processing is reactive and requires proper subscription management to avoid memory leaks or unexpected behavior when components unmount.
 `,
     },
     {
@@ -38,8 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- The Scanner API is only available in action (modal) targets where scanning functionality is supported and can't be used in other targets.
-- Scan data processing is reactive and requires proper subscription management to avoid memory leaks or unexpected behavior when components unmount.
+The Scanner API is only available in action (modal) targets where scanning functionality is supported and can't be used in other targets.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -39,7 +39,6 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent: `
 - The Scanner API is only available in action (modal) targets where scanning functionality is supported and can't be used in other targets.
-- Scanning availability depends on device hardware capabilities and may vary between different POS devices and configurations.
 - Scan data processing is reactive and requires proper subscription management to avoid memory leaks or unexpected behavior when components unmount.
 `,
     },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -55,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
           'conditional-scanner-example',
         ),
         description:
-          'Subscribe to scan events and adapt behavior based on the scanner source. This example shows how to use `shopify.scanner.subscribe()` to receive scan events and check `shopify.scanner.source` to determine which scanner type was used (camera, external scanner, or embedded hardware), allowing you to customize handling based on the scanning method.',
+          'Subscribe to scan events and adapt behavior based on the scanner source. This example shows how to use `shopify.scanner.subscribe()` to receive scan events and check `shopify.scanner.source` to determine which scanner type was used (camera, external scanner, or embedded hardware). By identifying the scanner type, you can customize handling based on the scanning method.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -54,7 +54,7 @@ const data: ReferenceEntityTemplateSchema = {
           'token',
         ),
         description:
-          'Retrieve current session information and generate secure authentication tokens for backend API calls. This example shows how to access shop details, user information, and location data through `shopify.session`, and use `shopify.session.getSessionToken()` to generate tokens for authenticated requests to your backend services.',
+          'Access session data and generate authentication tokens. This example shows how to access shop details, user information, and location data through `shopify.session`, and use `shopify.session.getSessionToken()` to generate tokens for authenticated requests to your backend services.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -37,8 +37,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Session tokens are only available when the authenticated user has proper app permissions enabled. Staff members who are pinned in but not authenticated can't generate tokens.
-- Session data is read-only and can't be modified through the API. Changes to shop settings, locations, or staff assignments require POS application updates.
+- Session tokens are only available when the authenticated user has proper app permissions enabled—staff members who are pinned in but not authenticated can't generate tokens.
 - Session tokens should only be used for communication with your app's configured backend service and can't be used for direct Shopify API calls from the client side.
 `,
     },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Design consistent key naming:** Use hierarchical names like \`settings.user.theme\` or \`cache.products.${id}\` to organize data.
+- **Design consistent key naming:** Use hierarchical names like \`settings.user.theme\` or \`cache.products.\${id}\` to organize data.
 - **Validate retrieved data:** Check structure and types after \`get()\` since data may be outdated. Provide defaults and handle missing properties.
 - **Plan for data evolution:** Include version fields and implement migration logic to handle schema updates between versions.
 - **Keep sensitive data out:** Never store passwords, API keys, or sensitive information. Use Session API for secure backend communication.
@@ -56,7 +56,7 @@ const data: ReferenceEntityTemplateSchema = {
           'clear',
         ),
         description:
-          'Remove all stored data for your extension from persistent storage. This example demonstrates using `shopify.storage.clear()` to delete all key-value pairs stored by your extension, useful for reset functionality or clearing user preferences.',
+          'Remove all stored data for your extension from persistent storage. This example demonstrates using `shopify.storage.clear()` to delete all key-value pairs stored by your extension. This is useful for reset functionality or clearing user preferences.',
       },
       {
         codeblock: generateJsxCodeBlockForStorageApi(
@@ -64,7 +64,7 @@ const data: ReferenceEntityTemplateSchema = {
           'delete',
         ),
         description:
-          'Delete a specific value from storage using its key. This example shows how to use `shopify.storage.delete()` to remove a stored item, permanently clearing the data associated with that key while leaving other stored values intact.',
+          'Delete a specific value from storage using its key. This example shows how to use `shopify.storage.delete()` to remove a stored item. This permanently clears the data associated with that key while leaving other stored values intact.',
       },
       {
         codeblock: generateJsxCodeBlockForStorageApi(
@@ -72,7 +72,7 @@ const data: ReferenceEntityTemplateSchema = {
           'entries',
         ),
         description:
-          'Fetch all key-value pairs stored by your extension. This example shows how to use `shopify.storage.entries()` to retrieve an array of all stored items, useful for displaying saved data, performing bulk operations, or exporting stored information.',
+          'Fetch all key-value pairs stored by your extension. This example shows how to use `shopify.storage.entries()` to retrieve an array of all stored items. This is useful for displaying saved data, performing bulk operations, or exporting stored information.',
       },
       {
         codeblock: generateJsxCodeBlockForStorageApi(
@@ -80,7 +80,7 @@ const data: ReferenceEntityTemplateSchema = {
           'get',
         ),
         description:
-          'Read a stored value using its key from persistent storage. This example shows how to use `shopify.storage.get()` to retrieve a previously saved value, which returns the stored data with automatic JSON deserialization or undefined if the key does not exist.',
+          'Read a stored value using its key from persistent storage. This example shows how to use `shopify.storage.get()` to retrieve a previously saved value. This returns the stored data with automatic JSON deserialization or undefined if the key does not exist.',
       },
       {
         codeblock: generateJsxCodeBlockForStorageApi(
@@ -88,7 +88,7 @@ const data: ReferenceEntityTemplateSchema = {
           'set',
         ),
         description:
-          'Store a value in persistent storage using a key-value pair. This example demonstrates using `shopify.storage.set()` to save data that will persist across user sessions, device restarts, and extension reloads, with automatic JSON serialization of the value.',
+          'Store a value in persistent storage using a key-value pair. This example demonstrates using `shopify.storage.set()` to save data that persists across user sessions, device restarts, and extension reloads. The value is automatically JSON serialized.',
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -39,8 +39,6 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent: `
 - POS UI extensions can store up to a maximum of 100 entries.
-- The maximum key size is ~1 KB and the maximum value size is ~1 MB.
-- Data persists even when extension targets are disabled or removed.
 - Stored extension data is automatically cleared after 30 days of inactivity.
 `,
     },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -30,6 +30,7 @@ const data: ReferenceEntityTemplateSchema = {
 - **Use appropriate timing:** Choose durations that give users enough time to read without keeping visible too long.
 - **Provide meaningful feedback:** Use toasts to confirm actions, explain errors, or communicate status changes.
 - **Avoid overuse:** Reserve for important feedback. Don't show multiple toasts simultaneously.
+- **Handle multiple toast messages:** Multiple toast messages may overlap or interfere with each other if shown in rapid succession. Consider queuing or spacing out notifications appropriately.
 `,
     },
     {
@@ -37,8 +38,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Multiple toast messages may overlap or interfere with each other if shown in rapid succession. Consider queuing or spacing out notifications appropriately.
-- Toast content is limited to plain text and can't include rich formatting, links, or interactive elements.
+Toast content is limited to plain text and can't include rich formatting, links, or interactive elements.
 `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -37,7 +37,6 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Toast messages are temporary and can't be made persistent. For important information that users need to reference later, consider using other UI components or storage mechanisms.
 - Multiple toast messages may overlap or interfere with each other if shown in rapid succession. Consider queuing or spacing out notifications appropriately.
 - Toast content is limited to plain text and can't include rich formatting, links, or interactive elements.
 `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -54,7 +54,7 @@ const data: ReferenceEntityTemplateSchema = {
           'show',
         ),
         description:
-          "Show a temporary notification message to provide user feedback. This example demonstrates using `shopify.toast.show()` to display a brief, non-intrusive message that automatically disappears after a specified duration, useful for confirmations, status updates, or success messages that don't require user interaction.",
+          "Display a toast notification from a tile. This example demonstrates using `shopify.toast.show()` to display a brief, non-intrusive message that automatically disappears after a specified duration. This is useful for confirmations, status updates, or success messages that don't require user interaction.",
       },
     ],
   },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -3,8 +3,9 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Badge',
   description:
-    'The `Badge` component uses color and text to communicate status information for orders, products, customers, and other business data. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes within your POS interface.' +
-    '\n\nThe component automatically adjusts its appearance based on the specified `tone` property, ensuring consistent visual communication across the POS interface. Badges support different sizes and can display text, numbers, or status indicators, making them versatile for representing everything from order counts to inventory alerts in a compact, scannable format.',
+    "The `Badge` component uses color and text to communicate status information for orders, products, customers, and other business data. Badges aren't interactive elements; they display information but don't respond to user interactions like clicks or taps. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes within your POS interface. " +
+    '\n\nThe component automatically adjusts its appearance based on the specified `tone` property, ensuring consistent visual communication across the POS interface. The component relies on the tone system for semantic meaning, so using custom styling with badges may not clearly convey meaning to merchants.' +
+    '\n\nBadges support different sizes and can display text, numbers, or status indicators. This makes them versatile for representing everything from order counts to inventory alerts in a compact, scannable format.',
   thumbnail: 'badge-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -49,10 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Badges aren't interactive elements—they display information but don't respond to user interactions like clicks or taps.
-- The component relies on the tone system for semantic meaning, so custom styling may not convey the same semantic benefits.
-- Very long text content may be truncated or cause layout issues depending on the container and screen size.
-`,
+Very long text content may be truncated or cause layout issues depending on the container and screen size.`,
     },
   ],
   related: [],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -4,7 +4,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Banner',
   description:
     'The `Banner` component highlights important information or required actions prominently within the POS interface. Use banners to communicate critical updates, warnings, informational messages, or success notifications that require merchant attention in a persistent but non-interruptive way.' +
-    '\n\nThe component provides persistent visibility for important messages while remaining non-intrusive to the main workflow, with support for dismissible and non-dismissible states. It includes automatic color coding based on message severity and integrates with the POS design system to maintain visual consistency across different alert types and use cases.',
+    '\n\nThe component provides persistent visibility for important messages while remaining non-intrusive to the main workflow, with support for dismissible and non-dismissible states. It includes automatic color coding based on message severity and integrates with the POS design system to maintain visual consistency across different alert types and use cases.' +
+    "\n\nThe `Banner` component only accepts a `heading` property for text content and doesn't support body content. You can't place `<s-text>` or other text elements inside the banner as children.",
   thumbnail: 'banner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -50,14 +51,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Make non-critical banners dismissible:** Allow dismissal for non-critical information. Keep critical alerts non-dismissible until resolved.
 - **Include clear actions:** If action is needed, use the primaryAction slot to provide clear next steps.
 - **Use for persistent messages:** Use banners for messages that need to persist. For temporary notifications, consider toast notifications.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- The \`Banner\` component only accepts a \`heading\` property for text content and doesn't support body content. You can't place \`<s-text>\` or other text elements inside the banner as children.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -49,7 +49,6 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Box is a layout container and doesn't provide interactive functionality—use it in combination with interactive components like [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) for user interactions.
 - Padding values are limited to the predefined design system scale—custom pixel values for padding aren't supported to maintain design consistency.
 - Box doesn't provide scrolling capabilities for overflow content—use [\`ScrollBox\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/scrollbox) when content might exceed container dimensions.
 `,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -49,9 +49,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Box is a layout container and doesn't provide interactive functionality—use it in combination with interactive components like \`Button\` or \`Clickable\` for user interactions.
+- Box is a layout container and doesn't provide interactive functionality—use it in combination with interactive components like [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) for user interactions.
 - Padding values are limited to the predefined design system scale—custom pixel values for padding aren't supported to maintain design consistency.
-- Box doesn't provide scrolling capabilities for overflow content—use \`ScrollBox\` when content might exceed container dimensions.
+- Box doesn't provide scrolling capabilities for overflow content—use [\`ScrollBox\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/scrollbox) when content might exceed container dimensions.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -3,9 +3,10 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
-    'The `Box` component displays a generic container with consistent spacing and styling. Use it to apply padding, to nest and group other components, or as the foundation for building structured layouts.' +
-    '\n\nThe component provides granular control over spacing through padding properties and sizing through width/height properties, serving as a building block for precise layouts. It simplifies the creation of containers with consistent spacing by using design system tokens, ensuring visual consistency and reducing the need for custom CSS in most layout scenarios.' +
-    '\n\n`Box` components provide shorthand properties for common padding patterns like equal padding on all sides or symmetric horizontal/vertical padding, reducing verbose property specifications for simpler layouts.',
+    "The `Box` component displays a generic container with consistent spacing and styling. Use it to apply padding, to nest and group other components, or as the foundation for building structured layouts. Box doesn't provide interactive functionality. For user interaction, use boxes in combination with interactive components like [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable)." +
+    "\n\nThe component provides granular control over spacing through padding properties and sizing through width/height properties, serving as a building block for precise layouts. It simplifies the creation of containers with consistent spacing by using design system tokens, ensuring visual consistency and reducing the need for custom CSS in most layout scenarios. To maintain consistency, `Box` only supports predefined design system scales. Custom pixel values for padding aren't supported." +
+    '\n\n`Box` components provide shorthand properties for common padding patterns like equal padding on all sides or symmetric horizontal/vertical padding, reducing verbose property specifications for simpler layouts.' +
+    "\n\n`Box` doesn't provide scrolling capabilities for overflow content. When content exceeds the container dimensions, use [`ScrollBox`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/scrollbox) instead.",
   thumbnail: 'box-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -42,15 +43,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Use design system padding:** Use predefined padding keywords (\`small\`, \`base\`, \`large\`) for consistency.
 - **Use directional padding for asymmetry:** Use \`paddingInline\` and \`paddingBlock\` when different spacing is needed on different sides.
 - **Understand block vs inline:** \`block\` refers to content flow direction (usually vertical), \`inline\` to text direction (usually horizontal).
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- Padding values are limited to the predefined design system scale—custom pixel values for padding aren't supported to maintain design consistency.
-- Box doesn't provide scrolling capabilities for overflow content—use [\`ScrollBox\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/scrollbox) when content might exceed container dimensions.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -3,8 +3,10 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
-    'The `Button` component triggers actions or events, such as opening dialogs or navigating to other pages. Use `Button` to let merchants perform specific tasks or initiate interactions throughout the POS interface.' +
-    '\n\nButtons provide clear calls-to-action that guide merchants through workflows, enable form submissions, and trigger important operations. They support various visual styles, tones, and interaction patterns to communicate intent and hierarchy within the interface.',
+    'The `Button` component triggers actions or events, such as opening dialogs or navigating to other pages. Use `Button` to let merchants perform specific tasks or to initiate interactions throughout the POS interface.' +
+    "\n\n Button content must be plain text. If you nest components inside a button, the button extracts and displays only the text content from those components. For example, placing an `s-icon` inside a button won't display the icon, only its text content. Use of nested interactive components within buttons isn't supported." +
+    '\n\nButtons provide clear calls-to-action that guide merchants through workflows, enable form submissions, and trigger important operations. They support various visual styles, tones, and interaction patterns to communicate intent and hierarchy within the interface.' +
+    "\n\nLoading states replace all button content with a spinner. Custom loading indicators or partial content updates aren't supported.",
   thumbnail: 'button-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -49,16 +51,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Show loading states:** Set \`loading\` to \`true\` during async operations to prevent duplicate submissions.
 - **Use command system for component control:** Use \`commandFor\` and \`command\` to control modals and overlays declaratively.
 - **Structure hierarchies clearly:** Group related actions together. Separate destructive actions to prevent accidental activation.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- Button content must be plain text. If you nest components inside a button, the button extracts and displays only the text content from those components. For example, placing an \`s-icon\` inside a button won't display the icon—only any text content will be rendered. HTML, markdown, or rich text formatting isn't supported.
-- Loading states replace all button content with a spinner. Custom loading indicators or partial content updates aren't supported.
-- Complex button layouts or nested interactive components within buttons aren't supported.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -4,8 +4,9 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'ChoiceList',
   description:
     'The `ChoiceList` component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options in forms or filtering interfaces.' +
-    '\n\nThe component supports both single and multiple selection modes with clear visual indicators for selected states and proper checkbox or radio button semantics. It includes features like select all/none functionality for multiple selection across various configuration and filtering scenarios.' +
-    '\n\n`ChoiceList` components maintain selection state across navigation and form resets, with proper visual indication of indeterminate states when some but not all options in a group are selected.',
+    '\n\nThe component supports both single and multiple selection modes with clear visual indicators for selected states and proper checkbox or radio button semantics, although the actual appearance may vary based on the POS platform and screen size. It includes features like select all/none functionality for multiple selection across various configuration and filtering scenarios.' +
+    '\n\n`ChoiceList` components maintain selection state across navigation and form resets, with proper visual indication of indeterminate states when some but not all options in a group are selected. Within `ChoiceList`, use only `Choice` components as children.' +
+    "\n\n`ChoiceList` doesn't automatically filter or update content based on selections. You must implement the logic to respond to selection changes.",
   thumbnail: 'choicelist-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -60,10 +61,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`ChoiceList\` requires choice components as children—other component types can't be used as options within the choice list.
-- The component provides the selection interface but doesn't automatically filter or update content based on selections—you must implement the logic to respond to selection changes.
-- Visual variants have different presentations across devices and contexts—the actual appearance may vary based on the POS platform and screen size.
-`,
+\`ChoiceList\` component types other than Choice can't be used as options within the choice list.`,
     },
   ],
   related: [],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -61,7 +61,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-\`ChoiceList\` component types other than Choice can't be used as options within the choice list.`,
+\`ChoiceList\` component types other than \`Choice\` can't be used as options within the choice list.`,
     },
   ],
   related: [],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -4,7 +4,9 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
     'The `Clickable` component makes any content interactive to user interactions. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.' +
-    "\n\nThis component provides a flexible way to wrap any content and make it respond to user interactions. Unlike buttons, it doesn't impose visual styling, allowing you to create custom interactive elements that match your design requirements while ensuring proper event handling.",
+    "\n\nThis component provides a flexible way to wrap any content and make it respond to user interactions. Unlike buttons, it doesn't impose visual styling, allowing you to create custom interactive elements that match your design requirements while ensuring proper event handling." +
+    "\n\n`Clickable` provides built-in `onClick` feedback, but because it doesn't impose visual styling, you must implement focus indicators and other visual cues yourself." +
+    '\n\nWhen disabled, child elements can still receive focus and be interacted with. Be careful when using nested interactive elements within `Clickable` components to avoid event propagation conflicts and unexpected user experiences.',
   thumbnail: 'clickable-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -54,10 +56,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`Clickable\` components don't provide built-in visual styling. While the component provides built-in \`onClick\` feedback, you must implement focus indicators and other visual cues yourself.
-- When disabled, child elements can still receive focus and be interacted with, which may create unexpected user experiences if not handled properly.
-- Complex nested interactive elements within clickables may cause event propagation conflicts.
-- The component doesn't automatically provide keyboard navigation support beyond basic click functionality.
+The component doesn't automatically provide keyboard navigation support beyond basic click functionality.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -5,7 +5,8 @@ const data: ReferenceEntityTemplateSchema = {
   description:
     'The `DateField` component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
     '\n\n`DateField` components support both manual text entry and picker selection, giving merchants flexibility to choose their preferred input method based on personal preference and specific date entry scenarios.' +
-    '\n\nFor visual calendar-based selection, consider [`DatePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker). For space-constrained layouts with scrolling date selection, use [`DateSpinner`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner).',
+    '\n\nFor visual calendar-based selection, consider [`DatePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker). For space-constrained layouts with scrolling date selection, use [`DateSpinner`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner).' +
+    '\n\n> **Note:** `DateField` accepts date values in ISO 8601 format (`YYYY-MM-DD`)—other date formats require conversion before setting the value property.',
   thumbnail: 'date-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -55,9 +56,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`DateField\` accepts date values in ISO 8601 format (\`YYYY-MM-DD\`)—other date formats require conversion before setting the value property.
-- Validation occurs when the user finishes editing rather than on every keystroke—invalid dates are only flagged after blur, which may delay error feedback.
-- The component provides text-based date input—for calendar-style date selection, use the [\`DatePicker\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) component which offers visual date selection interface.
+Validation occurs when the user finishes editing rather than on every keystroke—invalid dates are only flagged after blur, which may delay error feedback.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -5,7 +5,7 @@ const data: ReferenceEntityTemplateSchema = {
   description:
     'The `DateField` component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
     '\n\n`DateField` components support both manual text entry and picker selection, giving merchants flexibility to choose their preferred input method based on personal preference and specific date entry scenarios.' +
-    '\n\nFor visual calendar-based selection, consider `DatePicker`. For space-constrained layouts with scrolling date selection, use `DateSpinner`.',
+    '\n\nFor visual calendar-based selection, consider [`DatePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker). For space-constrained layouts with scrolling date selection, use [`DateSpinner`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner).',
   thumbnail: 'date-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -45,7 +45,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for direct text input:** Use \`DateField\` when users know the exact date and can type it efficiently. Use \`DatePicker\` for calendar selection or \`DateSpinner\` for space-constrained layouts.
+- **Choose for direct text input:** Use \`DateField\` when users know the exact date and can type it efficiently. Use [\`DatePicker\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) for calendar selection or [\`DateSpinner\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) for space-constrained layouts.
 - **Explain date constraints:** Use \`details\` to clarify requirements like "Select a date within the next 30 days" or "Must be a future date."
 - **Write actionable error messages:** Provide clear validation messages for invalid dates that help users correct their input.
 `,
@@ -57,7 +57,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - \`DateField\` accepts date values in ISO 8601 format (\`YYYY-MM-DD\`)—other date formats require conversion before setting the value property.
 - Validation occurs when the user finishes editing rather than on every keystroke—invalid dates are only flagged after blur, which may delay error feedback.
-- The component provides text-based date input—for calendar-style date selection, use the \`DatePicker\` component which offers visual date selection interface.
+- The component provides text-based date input—for calendar-style date selection, use the [\`DatePicker\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) component which offers visual date selection interface.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -4,9 +4,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DateField',
   description:
     'The `DateField` component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
-    '\n\n`DateField` components support both manual text entry and picker selection, giving merchants flexibility to choose their preferred input method based on personal preference and specific date entry scenarios.' +
-    '\n\nFor visual calendar-based selection, consider [`DatePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker). For space-constrained layouts with scrolling date selection, use [`DateSpinner`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner).' +
-    '\n\n> **Note:** `DateField` accepts date values in ISO 8601 format (`YYYY-MM-DD`)—other date formats require conversion before setting the value property.',
+    '\n\n`DateField` accepts values in ISO 8601 format (`YYYY-MM-DD`). Other date formats require conversion before setting the value property. Validation of the entered date occurs when the user finishes editing, rather than on every keystroke, so invalid dates are flagged after blur. This can delay error feedback, so consider this in your design.' +
+    '\n\n`DateField` components support manual text entry. For visual calendar-based selection, consider using [`DatePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) or [`DateSpinner`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) components.',
   thumbnail: 'date-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -49,14 +48,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Choose for direct text input:** Use \`DateField\` when users know the exact date and can type it efficiently. Use [\`DatePicker\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) for calendar selection or [\`DateSpinner\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) for space-constrained layouts.
 - **Explain date constraints:** Use \`details\` to clarify requirements like "Select a date within the next 30 days" or "Must be a future date."
 - **Write actionable error messages:** Provide clear validation messages for invalid dates that help users correct their input.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-Validation occurs when the user finishes editing rather than on every keystroke—invalid dates are only flagged after blur, which may delay error feedback.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -4,7 +4,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DatePicker',
   description:
     'The `DatePicker` component allows merchants to select a specific date using a calendar-like picker interface. Use it to provide visual date selection with an intuitive calendar view for improved user experience.' +
-    '\n\n`DatePicker` offers a calendar-based alternative to [spinner-style pickers](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) when visual calendar context is beneficial. The calendar interface allows merchants to see dates in context of the full month, making it easier to select dates relative to specific days of the week or to visualize date ranges within a month view.',
+    '\n\n`DatePicker` offers a calendar-based alternative to [spinner-style pickers](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) when visual calendar context is beneficial. The calendar interface allows merchants to see dates in context of the full month, making it easier to select dates relative to specific days of the week or to visualize date ranges within a month view.' +
+    '\n\n`DatePicker` requires you to manage state externally by updating the `value` property in response to change events. The component automatically adapts its selection mode based on the format you provide—single dates, multiple dates, or date ranges are all supported through the `value` property format alone. Be sure to validate date formats before setting them, as invalid values will result in no date being selected.',
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -46,16 +47,6 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - **Choose for calendar-based selection:** Use \`DatePicker\` when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use [\`DateSpinner\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) for tight spaces or [\`DateField\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datefield) when users know the exact date.
 - **Provide adequate space:** Ensure sufficient spacing around the picker to avoid interfering with on-screen keyboards or other interactive elements.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- \`DatePicker\` provides the calendar interface but requires external state management for the selected value—you must update the \`value\` property in response to change events.
-- The component supports single dates, multiple dates, and date ranges through value format alone—the selection mode is inferred from the \`value\` property format rather than an explicit property.
-- Invalid date values result in no date being selected—the component doesn't provide specific error feedback, so you must validate date formats before setting the \`value\` property.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -5,7 +5,8 @@ const data: ReferenceEntityTemplateSchema = {
   description:
     'The `DatePicker` component allows merchants to select a specific date using a calendar-like picker interface. Use it to provide visual date selection with an intuitive calendar view for improved user experience.' +
     '\n\n`DatePicker` offers a calendar-based alternative to [spinner-style pickers](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) when visual calendar context is beneficial. The calendar interface allows merchants to see dates in context of the full month, making it easier to select dates relative to specific days of the week or to visualize date ranges within a month view.' +
-    '\n\n`DatePicker` requires you to manage state externally by updating the `value` property in response to change events. The component automatically adapts its selection mode based on the format you provide—single dates, multiple dates, or date ranges are all supported through the `value` property format alone. Be sure to validate date formats before setting them, as invalid values will result in no date being selected.',
+    '\n\nThe component supports single dates, multiple dates, and date ranges. This is achieved through value format alone—the selection mode is inferred from the `value` property format rather than an explicit property.' +
+    "\n\n`DatePicker` provides the calendar interface but requires external state management for the selected value. You must update the `value` property in response to change events. Invalid date values result in no date being selected. The component doesn't provide specific error feedback, so you must validate date formats before setting the `value` property.",
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DatePicker',
   description:
     'The `DatePicker` component allows merchants to select a specific date using a calendar-like picker interface. Use it to provide visual date selection with an intuitive calendar view for improved user experience.' +
-    '\n\n`DatePicker` offers a calendar-based alternative to spinner-style pickers when visual calendar context is beneficial. The calendar interface allows merchants to see dates in context of the full month, making it easier to select dates relative to specific days of the week or to visualize date ranges within a month view.',
+    '\n\n`DatePicker` offers a calendar-based alternative to [spinner-style pickers](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) when visual calendar context is beneficial. The calendar interface allows merchants to see dates in context of the full month, making it easier to select dates relative to specific days of the week or to visualize date ranges within a month view.',
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for calendar-based selection:** Use \`DatePicker\` when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use \`DateSpinner\` for tight spaces or \`DateField\` when users know the exact date.
+- **Choose for calendar-based selection:** Use \`DatePicker\` when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use [\`DateSpinner\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) for tight spaces or [\`DateField\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datefield) when users know the exact date.
 - **Provide adequate space:** Ensure sufficient spacing around the picker to avoid interfering with on-screen keyboards or other interactive elements.
 `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -4,8 +4,9 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DateSpinner',
   description:
     'The `DateSpinner` component enables merchants to select a specific date using a spinner interface with scrollable columns for month, day, and year. Use it to provide compact date selection in constrained spaces.' +
+    '\n\n`DateSpinner` uses ISO 8601 date format (`YYYY-MM-DD`) only. Other date formats require conversion before setting the value property.' +
     '\n\n`DateSpinner` offers an alternative to [calendar-style pickers](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) when space is limited or when users prefer scrolling through date values. The spinner interface allows merchants to select dates by scrolling through separate columns for month, day, and year, providing a compact and intuitive way to select dates in constrained layouts.' +
-    '\n\n> **Note:** `DateSpinner` uses ISO 8601 date format (`YYYY-MM-DD`) only—other date formats require conversion before setting the value property.',
+    "\n\n`DateSpinner` doesn't include field labels, help text, or error messaging. Combine the component with other UI elements or text components to provide complete form field experiences.",
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -48,14 +49,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Use for space-constrained layouts:** Choose \`DateSpinner\` for narrow layouts or split-screen interfaces where a calendar view would be impractical.
 - **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, [\`DatePicker\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) provides faster navigation.
 - **Provide interaction cues:** Consider labels or instructions to help first-time users understand the scrollable column interface.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-\`DateSpinner\` doesn't include field labels, help text, or error messaging—combine with other UI elements or text components to provide complete form field experiences.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DateSpinner',
   description:
     'The `DateSpinner` component enables merchants to select a specific date using a spinner interface with scrollable columns for month, day, and year. Use it to provide compact date selection in constrained spaces.' +
-    '\n\n`DateSpinner` offers an alternative to calendar-style pickers when space is limited or when users prefer scrolling through date values. The spinner interface allows merchants to select dates by scrolling through separate columns for month, day, and year, providing a compact and intuitive way to select dates in constrained layouts.',
+    '\n\n`DateSpinner` offers an alternative to [calendar-style pickers](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) when space is limited or when users prefer scrolling through date values. The spinner interface allows merchants to select dates by scrolling through separate columns for month, day, and year, providing a compact and intuitive way to select dates in constrained layouts.',
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -45,7 +45,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent: `
 - **Use for space-constrained layouts:** Choose \`DateSpinner\` for narrow layouts or split-screen interfaces where a calendar view would be impractical.
-- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, \`DatePicker\` provides faster navigation.
+- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, [\`DatePicker\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) provides faster navigation.
 - **Provide interaction cues:** Consider labels or instructions to help first-time users understand the scrollable column interface.
 `,
     },
@@ -55,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent: `
 - \`DateSpinner\` uses ISO 8601 date format (\`YYYY-MM-DD\`) only—other date formats require conversion before setting the value property.
-- The component provides spinner-based date selection exclusively—for calendar-style visual selection with month context, use the \`DatePicker\` component instead.
+- The component provides spinner-based date selection exclusively—for calendar-style visual selection with month context, use the [\`DatePicker\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) component instead.
 - \`DateSpinner\` doesn't include field labels, help text, or error messaging—combine with other UI elements or text components to provide complete form field experiences.
 `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -4,7 +4,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DateSpinner',
   description:
     'The `DateSpinner` component enables merchants to select a specific date using a spinner interface with scrollable columns for month, day, and year. Use it to provide compact date selection in constrained spaces.' +
-    '\n\n`DateSpinner` offers an alternative to [calendar-style pickers](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) when space is limited or when users prefer scrolling through date values. The spinner interface allows merchants to select dates by scrolling through separate columns for month, day, and year, providing a compact and intuitive way to select dates in constrained layouts.',
+    '\n\n`DateSpinner` offers an alternative to [calendar-style pickers](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) when space is limited or when users prefer scrolling through date values. The spinner interface allows merchants to select dates by scrolling through separate columns for month, day, and year, providing a compact and intuitive way to select dates in constrained layouts.' +
+    '\n\n> **Note:** `DateSpinner` uses ISO 8601 date format (`YYYY-MM-DD`) only—other date formats require conversion before setting the value property.',
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -54,9 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`DateSpinner\` uses ISO 8601 date format (\`YYYY-MM-DD\`) only—other date formats require conversion before setting the value property.
-- The component provides spinner-based date selection exclusively—for calendar-style visual selection with month context, use the [\`DatePicker\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) component instead.
-- \`DateSpinner\` doesn't include field labels, help text, or error messaging—combine with other UI elements or text components to provide complete form field experiences.
+\`DateSpinner\` doesn't include field labels, help text, or error messaging—combine with other UI elements or text components to provide complete form field experiences.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -5,7 +5,8 @@ const data: ReferenceEntityTemplateSchema = {
   description:
     'The `Divider` component creates a visual separation between content sections. Use dividers to organize information and improve content hierarchy by providing clear section boundaries.' +
     '\n\nThe component renders a subtle horizontal line that follows design system specifications for color and thickness, maintaining visual consistency across the interface. It provides a clean way to separate content groups without adding significant visual weight, helping merchants scan and understand interface structure through strategic content segmentation.' +
-    '\n\n`Divider` components support both full-width and inset dividers with configurable margins, allowing precise control over visual separation without adding custom CSS for common divider placement patterns.',
+    "\n\nTo maintain consistency with the native POS styling, The component doesn't support custom styling beyond the available direction property. Other visual properties are controlled by the POS design system." +
+    "\n\n`Divider` components support both full-width and inset dividers with configurable margins, allowing precise control over visual separation without adding custom CSS for common divider placement patterns. Dividers don't automatically adjust spacing around themselves. Ensure your design uses appropriate margins and padding to achieve proper visual separation.",
   thumbnail: 'divider-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -41,16 +42,6 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - **Choose appropriate direction:** Use \`inline\` (horizontal) for most content separation. Use \`block\` (vertical) for columns or sidebar boundaries.
 - **Avoid overuse:** Use dividers strategically. In dense interfaces, consider whitespace or typography hierarchy instead.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- \`Divider\` is a purely visual component and doesn't provide interactive functionality—it serves only to create visual separation between content areas.
-- The component doesn't support custom styling beyond the available direction property—color, thickness, and other visual properties are controlled by the POS design system.
-- Dividers don't automatically adjust spacing around themselves—you must manage appropriate margins and padding in surrounding content to achieve proper visual separation.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -63,7 +63,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - \`EmailField\` provides the input interface but doesn't perform automatic email validation—you must implement validation logic and use the \`error\` property to display validation results.
 - The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display, so you must manually check for empty values and set errors accordingly.
-- The \`accessory\` slot supports only \`Button\` and \`Clickable\` components—other component types can't be used in the accessory slot.
+- The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components—other component types can't be used in the accessory slot.
 `,
     },
   ],
@@ -74,7 +74,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Add action buttons to the email field using the accessory slot for quick actions like clearing input or verifying email addresses. This example shows how to use `s-button` and `s-clickable` components in the accessory slot, providing inline functionality within the email input context.',
+          'Add action buttons to the email field using the accessory slot for quick actions like clearing input or verifying email addresses. This example shows how to use [`s-button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [`s-clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the email input context.',
         codeblock: {
           title: 'Add accessory buttons',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'EmailField',
   description:
-    'The `EmailField` component captures email address input from customers with built-in validation. Use it to collect email information in forms, customer profiles, or contact workflows.' +
-    '\n\nThe component includes built-in email format validation using standard email patterns to ensure data quality. It provides real-time feedback on invalid entries and supports features like autocomplete and keyboard optimization for email input, helping merchants quickly capture valid customer contact information during checkout or registration workflows.' +
+    'The `EmailField` component captures email address input from customers. Use it to collect email information in forms, customer profiles, or contact workflows.' +
+    "\n\n`EmailField` provides the input interface but doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results." +
     '\n\n`EmailField` components integrate with browser autocomplete features to speed up email entry by suggesting previously used addresses, significantly reducing typing time during customer registration workflows.',
   thumbnail: 'email-field-thumbnail.png',
   isVisualComponent: true,
@@ -61,9 +61,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`EmailField\` provides the input interface but doesn't perform automatic email validation—you must implement validation logic and use the \`error\` property to display validation results.
-- The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display, so you must manually check for empty values and set errors accordingly.
-- The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components—other component types can't be used in the accessory slot.
+The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components—other component types can't be used in the accessory slot.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -3,9 +3,9 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
-    'The `Heading` component renders hierarchical titles to communicate the structure and organization of page content. Heading levels adjust automatically based on nesting within parent Section components, ensuring a meaningful page outline.' +
+    'The `Heading` component renders hierarchical titles to communicate the structure and organization of page content. Heading levels adjust automatically based on nesting within parent [`Section`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.' +
     '\n\nUse headings to create clear information hierarchy and help users navigate complex interfaces efficiently.' +
-    '\n\n`Heading` components provide consistent typographic scaling that maintains visual hierarchy while ensuring headings remain readable at all levels, even when deeply nested within multiple `Section` components.',
+    '\n\n`Heading` components provide consistent typographic scaling that maintains visual hierarchy while ensuring headings remain readable at all levels, even when deeply nested within multiple [`Section`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components.',
   thumbnail: 'heading-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -49,7 +49,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Heading levels are automatically determined by nesting within \`Section\` components—manual heading level control is not available to ensure consistent document structure.
+- Heading levels are automatically determined by nesting within [\`Section\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components—manual heading level control is not available to ensure consistent document structure.
 - The component doesn't support rich text formatting within the heading content—use plain text or simple inline elements for heading content.
 - Visual styling is controlled by the POS design system and heading level—custom typography styles beyond the available properties aren't supported.
 `,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -51,7 +51,6 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - Heading levels are automatically determined by nesting within [\`Section\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components—manual heading level control is not available to ensure consistent document structure.
 - The component doesn't support rich text formatting within the heading content—use plain text or simple inline elements for heading content.
-- Visual styling is controlled by the POS design system and heading level—custom typography styles beyond the available properties aren't supported.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -3,9 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
-    'The `Heading` component renders hierarchical titles to communicate the structure and organization of page content. Heading levels adjust automatically based on nesting within parent [`Section`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.' +
-    '\n\nUse headings to create clear information hierarchy and help users navigate complex interfaces efficiently.' +
-    '\n\n`Heading` components provide consistent typographic scaling that maintains visual hierarchy while ensuring headings remain readable at all levels, even when deeply nested within multiple [`Section`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components.',
+    "The `Heading` component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces. Heading levels adjust automatically based on nesting within parent [`Section`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline. Use plain text or simple inline elements only for heading content; rich text format isn't supported." +
+    '\n\nThe styling of `Heading` components is controlled by the POS design system. This provides consistent typographic scaling that maintains visual hierarchy while ensuring headings remain readable at all levels, even when deeply nested within multiple [`Section`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components. ',
   thumbnail: 'heading-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -42,15 +41,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Create logical hierarchy:** Start with higher-level headings for main sections, nested headings for subsections. Nested sections automatically adjust heading levels.
 - **Write specific headings:** Avoid generic terms like "Details." Use specific descriptions like "Customer Contact Information" or "Transaction Summary."
 - **Keep text concise:** Headings don't truncate, so keep them brief enough to display across different screen sizes.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- Heading levels are automatically determined by nesting within [\`Section\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components—manual heading level control is not available to ensure consistent document structure.
-- The component doesn't support rich text formatting within the heading content—use plain text or simple inline elements for heading content.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -4,8 +4,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
     'The `Icon` component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories consistently. Use icons to enhance navigation or provide visual context alongside text in POS interfaces.' +
-    '\n\nIcons help merchants quickly understand interface elements and actions without relying solely on text labels. Icons are optimized for readability at standard sizes and automatically scale to maintain visual consistency across different screen densities and device types.' +
-    "\n\nIcons are purely decorative and don't support click events or interactive behaviors—wrap them in [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components for interactive functionality.",
+    "\n\n To use icons to create interactive UI elements, wrap them in [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components. Icons on their behave purely as images and don't support click events or interactive behaviors." +
+    "\n\n To maintain a consistent visual apperance, icon styling is controlled by the POS design system. Custom styling and external icon libraries aren't supported. Icons are optimized for readability at standard sizes and automatically scale to maintain visual consistency across different screen densities and device types.",
   thumbnail: 'icon-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -44,14 +44,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Apply tones for meaning:** Use \`critical\` for destructive actions, \`warning\` for cautions, \`success\` for confirmations, \`auto\` or \`neutral\` for general elements.
 - **Pair with text for clarity:** Consider adding text labels, especially for complex or uncommon actions.
 - **Use color for hierarchy:** Use \`subdued\` for secondary elements, \`base\` for standard visibility, \`strong\` for emphasis.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-The available icon set is predefined and limited to POS-specific symbols—custom icons or external icon libraries aren't supported.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -4,7 +4,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
     'The `Icon` component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories consistently. Use icons to enhance navigation or provide visual context alongside text in POS interfaces.' +
-    '\n\nIcons help merchants quickly understand interface elements and actions without relying solely on text labels. Icons are optimized for readability at standard sizes and automatically scale to maintain visual consistency across different screen densities and device types.',
+    '\n\nIcons help merchants quickly understand interface elements and actions without relying solely on text labels. Icons are optimized for readability at standard sizes and automatically scale to maintain visual consistency across different screen densities and device types.' +
+    "\n\nIcons are purely decorative and don't support click events or interactive behaviors—wrap them in [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components for interactive functionality.",
   thumbnail: 'icon-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -50,9 +51,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Icons are purely decorative and don't support click events or interactive behaviors—wrap them in [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components for interactive functionality.
-- The available icon set is predefined and limited to POS-specific symbols—custom icons or external icon libraries aren't supported.
-- Icon appearance and styling are controlled by the POS design system—custom colors, styles, or modifications beyond the provided properties are not available.
+The available icon set is predefined and limited to POS-specific symbols—custom icons or external icon libraries aren't supported.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Icons are purely decorative and don't support click events or interactive behaviors—wrap them in \`Button\` or \`Clickable\` components for interactive functionality.
+- Icons are purely decorative and don't support click events or interactive behaviors—wrap them in [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components for interactive functionality.
 - The available icon set is predefined and limited to POS-specific symbols—custom icons or external icon libraries aren't supported.
 - Icon appearance and styling are controlled by the POS design system—custom colors, styles, or modifications beyond the provided properties are not available.
 `,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
-    'The `Image` component adds visual content to the POS interface and allows you to customize the presentation of visuals. Use images to showcase products, illustrate concepts, provide visual context, or support user tasks and interactions in POS workflows.' +
+    'The `Image` component adds visual content to the POS interface and allows you to customize the presentation of visuals. Use images to showcase products, illustrate concepts, provide visual context, or support user tasks and interactions in POS workflows. Images are display-only components. For interactive functionality, wrap them in [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components.' +
     '\n\nImages enhance the user experience by providing immediate visual recognition and reducing cognitive load.' +
     '\n\n`Image` components handle loading errors gracefully with fallback options and provides placeholder states to maintain layout stability during image loading on slower network connections. The component implements lazy loading for images outside the viewport, improving initial page load performance while ensuring smooth scrolling as merchants navigate through product catalogs or image-heavy interfaces.',
   thumbnail: 'image-thumbnail.png',
@@ -41,6 +41,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - **Choose appropriate sizing:** Use \`inlineSize="fill"\` for responsive layouts. Use \`inlineSize="auto"\` to maintain natural dimensions.
 - **Select object fit behavior:** Use \`objectFit="contain"\` to show the complete image. Use \`objectFit="cover"\` to fill the container, accepting cropping.
+- **Implement error handling and loading states:** Image loading and caching behavior depends on the browser and network conditions—implement proper error handling and loading states for better user experience.
 `,
     },
     {
@@ -48,9 +49,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Images are display-only components and don't support click events or interactive behaviors—wrap them in [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components for interactive functionality.
-- Image loading and caching behavior depends on the browser and network conditions—implement proper error handling and loading states for better user experience.
-- Large images can impact performance—ensure proper optimization and compression for better loading times.
+Large images can impact performance—ensure proper optimization and compression for better loading times.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -48,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Images are display-only components and don't support click events or interactive behaviors—wrap them in \`Button\` or \`Clickable\` components for interactive functionality.
+- Images are display-only components and don't support click events or interactive behaviors—wrap them in [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components for interactive functionality.
 - Image loading and caching behavior depends on the browser and network conditions—implement proper error handling and loading states for better user experience.
 - Large images can impact performance—ensure proper optimization and compression for better loading times.
 `,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -4,7 +4,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Modal',
   description:
     'The `Modal` component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.' +
-    '\n\nModals block interaction with the underlying interface until the merchant resolves the modal content. The component maintains focus within the modal boundary and returns focus to the trigger element on close, ensuring keyboard navigation remains predictable throughout the modal lifecycle.',
+    '\n\nModals block interaction with the underlying interface until the merchant resolves the modal content. The component maintains focus within the modal boundary and returns focus to the trigger element on close, ensuring keyboard navigation remains predictable throughout the modal lifecycle.' +
+    "\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through events and commands.",
   thumbnail: 'modal-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -62,8 +63,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Multiple modals can't be displayed simultaneously—showing a new modal while another is visible may cause unexpected behavior or poor user experience.
-- Modal visibility and lifecycle must be managed programmatically through events and commands—they don't automatically handle state management or persistence.
+Multiple modals can't be displayed simultaneously—showing a new modal while another is visible may cause unexpected behavior or poor user experience.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -4,8 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'NumberField',
   description:
     "The `NumberField` component captures numeric input. Use it to collect quantity, price, or other numeric information with optional `stepper` control. Stepper controls restrict which properties are available—`label`, `details`, `placeholder`, `error`, `required`, and `inputMode` aren't supported. Choose your control type based on which properties your implementation requires." +
-    '\n\nThe component includes built-in number validation, optional min/max constraints, and step increments to ensure accurate numeric data entry. It supports various number formats including integers and decimals, with validation feedback to prevent entry errors during high-volume retail operations.' +
-    "\n\nThe `required` property adds semantic meaning only—it doesn't trigger automatic error display or prevent invalid submissions without additional validation logic.",
+    '\n\nThe component includes built-in number validation, optional min/max constraints, and step increments to ensure accurate numeric data entry. It supports various number formats including integers and decimals, with validation feedback to prevent entry errors during high-volume retail operations.',
   thumbnail: 'number-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -3,8 +3,9 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'NumberField',
   description:
-    'The `NumberField` component captures numeric input with built-in validation. Use it to collect quantity, price, or other numeric information with optional `stepper` controls.' +
-    '\n\nThe component includes built-in number validation, optional min/max constraints, and step increments to ensure accurate numeric data entry. It supports various number formats including integers and decimals, with validation feedback to prevent entry errors during high-volume retail operations.',
+    "The `NumberField` component captures numeric input. Use it to collect quantity, price, or other numeric information with optional `stepper` control. Stepper controls restrict which properties are available—`label`, `details`, `placeholder`, `error`, `required`, and `inputMode` aren't supported. Choose your control type based on which properties your implementation requires." +
+    '\n\nThe component includes built-in number validation, optional min/max constraints, and step increments to ensure accurate numeric data entry. It supports various number formats including integers and decimals, with validation feedback to prevent entry errors during high-volume retail operations.' +
+    "\n\nThe `required` property adds semantic meaning only—it doesn't trigger automatic error display or prevent invalid submissions without additional validation logic.",
   thumbnail: 'number-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -53,16 +54,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Choose appropriate controls:** Use \`stepper\` for quantities or small adjustments. Use \`none\` for prices or large values where steppers are impractical.
 - **Select the right input mode:** Use \`decimal\` for prices and measurements. Use \`numeric\` for quantities and counts.
 - **Explain constraints in details:** Use \`details\` to clarify valid ranges or formatting, like "Enter a quantity between 1 and 999."
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- \`NumberField\` provides numeric input but doesn't enforce \`min\`/\`max\` constraints for keyboard input—you must implement validation logic to enforce bounds and display appropriate errors.
-- Stepper controls restrict which properties are available—\`label\`, \`details\`, \`placeholder\`, \`error\`, \`required\`, and \`inputMode\` aren't supported. Choose your control type based on which properties your implementation requires.
-- The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display or prevent invalid submissions without additional validation logic.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Page',
   description:
-    'The `Page` component serves as the main container for app content with preset layouts and heading controls. Use it to structure full-screen views with consistent navigation and content organization.' +
-    '\n\nThe component provides a complete page structure with built-in header, sidebar, and action bar layouts that follow POS design patterns. It manages heading hierarchy, spacing, and responsive behavior automatically, allowing you to focus on content rather than layout mechanics while ensuring consistent page structures across extensions.' +
+    "The `Page` component serves as the main container for app content with preset layouts and heading controls. Use it to structure full-screen views with consistent navigation and content organization. `Page` is designed for full-screen modal interfaces and isn't suitable for inline content or partial page layouts within existing POS screens." +
+    '\n\nThe component provides a complete page structure with built-in header, sidebar, and action bar layouts that follow POS design patterns. It manages heading hierarchy, spacing, and responsive behavior automatically, allowing you to focus on content rather than layout mechanics while ensuring consistent page structures across extensions. To maintain consistency, page layout and styling are controlled by the POS design system, so custom styling is limited to the provided slots and properties.' +
     '\n\n`Page` components handle safe area insets automatically for devices with notches or rounded corners, ensuring content remains visible and interactive without manual padding adjustments for different device shapes.',
   thumbnail: 'page-thumbnail.png',
   isVisualComponent: true,
@@ -55,9 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- The secondary-actions slot supports only a single button element—multiple actions in the action bar aren't supported and should be handled within the main content area.
-- Page layout and styling are controlled by the POS design system—custom page-level styling beyond the provided slots and properties is not available.
-- The component is designed for full-screen modal interfaces—it's not suitable for inline content or partial page layouts within existing POS screens.
+The secondary-actions slot supports only a single button element. Multiple actions in the action bar aren't supported and should be handled within the main content area.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'PosBlock',
   description:
     'The `PosBlock` component creates a container to place content with an action button. Use it to display structured content within POS block targets.' +
-    '\n\nThe component provides a standardized layout specifically designed for content blocks within POS detail views, with consistent padding, spacing, and optional action buttons. It integrates with the native POS design language, ensuring extension content feels cohesive with the core POS interface while maintaining clear content boundaries.' +
+    "\n\nThe component provides a standardized layout specifically designed for content blocks within POS detail views, with consistent padding, spacing, and optional action buttons. It integrates with the native POS design language, ensuring extension content feels cohesive with the core POS interface while maintaining clear content boundaries. Custom styling beyond content organization isn't supported." +
     '\n\n`PosBlock` components provide consistent interaction patterns for action buttons across different block types, ensuring merchants can predict button behavior and location regardless of the specific POS context.',
   thumbnail: 'pos-block-thumbnail.png',
   isVisualComponent: true,
@@ -53,16 +53,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - **Provide descriptive headings:** If you don't specify a heading, the system uses your extension's description, so ensure it's meaningful and concise.
 - **Place important actions in secondary-actions slot:** Include only the most relevant actions directly related to your block's content.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- \`PosBlock\` is designed specifically for block targets—it can't be used in modal or action (menu item) targets.
-- The component's visual styling is controlled by the POS design system—custom styling beyond content organization isn't supported.
-- Only one secondary action element is recommended to maintain clean, focused interfaces that don't overwhelm the existing POS workflow.
+- **Limit secondary actions:** To maintain clean, focused interfaces that don't overwhelm the existing POS workflow, use only one secondary action element in each block.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -43,16 +43,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Use for appropriate content:** Reserve \`ScrollBox\` for long lists or dynamic content that genuinely needs scrolling, not short content that fits within available space.
 `,
     },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- \`ScrollBox\` automatically manage overflow behavior—manual overflow control beyond the component's built-in scrolling isn't available.
-- Scroll behavior and styling are controlled by the POS design system—custom scroll bar styling or scroll physics modifications aren't supported.
-- The component is optimized for touch-based scrolling in POS environments—complex scroll interactions or nested scrolling scenarios may not perform optimally.
-`,
-    },
   ],
   related: [],
 };

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -58,7 +58,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - \`SearchField\` provides a search input field with visual styling and clear functionality—additional search features like filters, sorting, search history, or search buttons require custom implementation.
 - The component handles text input and basic interaction events—complex search workflows with multiple steps or advanced state management require additional components or custom logic.
-- \`SearchField\` is optimized for inline search and filtering—displaying search results requires using other components like \`Stack\`, \`Section\`, or custom layout components to present filtered content.
+- \`SearchField\` is optimized for inline search and filtering—displaying search results requires using other components like [\`Stack\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/stack), [\`Section\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section), or custom layout components to present filtered content.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -5,7 +5,8 @@ const data: ReferenceEntityTemplateSchema = {
   description:
     'The `SearchField` component captures search terms using a single-line input field. Use it to enable search and filtering within POS interfaces.' +
     '\n\nThe component includes built-in debouncing to optimize performance during real-time search operations and supports features like autocomplete suggestions and search history. It provides clear visual feedback for search states including loading, results found, and no results, helping merchants quickly locate products, customers, or orders in large catalogs.' +
-    '\n\n`SearchField` components clear search queries with a single tap on the clear button while maintaining search history for quick access to recent searches, balancing convenience with data management.',
+    '\n\n`SearchField` components clear search queries with a single tap on the clear button while maintaining search history for quick access to recent searches, balancing convenience with data management.' +
+    '\n\n`SearchField` is optimized for inline search and filtering. For additional search features like sorting and search history use a custom implementation.',
   thumbnail: 'search-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -49,16 +50,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Follow placeholder pattern:** Use "Search {items}" format like "Search products" or "Search customers" to clarify scope.
 - **Choose the right event:** Use \`input\` for real-time filtering as users type. Use \`change\` for expensive operations that should wait until typing completes.
 - **Handle empty values:** When the field is cleared, reset filters or show all items appropriately.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- \`SearchField\` provides a search input field with visual styling and clear functionality—additional search features like filters, sorting, search history, or search buttons require custom implementation.
-- The component handles text input and basic interaction events—complex search workflows with multiple steps or advanced state management require additional components or custom logic.
-- \`SearchField\` is optimized for inline search and filtering—displaying search results requires using other components like [\`Stack\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/stack), [\`Section\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section), or custom layout components to present filtered content.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -4,7 +4,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Section',
   description:
     'The `Section` component groups related content into clearly-defined thematic areas. Sections have contextual heading levels to maintain a meaningful page structure.' +
-    '\n\nUse sections to organize content logically and provide clear navigation landmarks. The component manages heading levels to ensure nested sections maintain proper semantic structure.',
+    '\n\nUse sections to organize content logically and provide clear navigation landmarks. The component manages heading levels automatically to ensure nested sections maintain proper semantic structure.' +
+    "\n\nTo maintain clean, focused interfaces that don't overwhelm users, only one secondary action button is supported for each section.",
   thumbnail: 'section-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -47,16 +48,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Write descriptive headings:** Provide clear heading text that represents the section's content.
 - **Let heading levels adjust automatically:** Nested sections automatically adjust heading levels for proper semantic structure.
 - **Place relevant secondary actions:** Use the secondary-actions slot for actions that apply to the entire section, like "Edit Settings" or "Add Item."
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- Section heading levels are automatically determined by nesting depth—manual heading level control is not available to ensure consistent document structure.
-- Only one secondary action button is supported per section to maintain clean, focused interfaces that don't overwhelm users.
-- The component's visual styling and spacing are controlled by the POS design system—custom section styling beyond content organization is not supported.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -5,7 +5,8 @@ const data: ReferenceEntityTemplateSchema = {
   description:
     'The `Stack` component organizes elements horizontally or vertically along the block or inline axis. Use it to structure layouts, group related components, or control spacing between elements with flexible alignment options.' +
     '\n\nThe component simplifies layout creation by automatically managing spacing between child elements through gap properties, eliminating the need for manual margin management. It supports both horizontal and vertical arrangements, flexible alignment options, and wrapping behavior, making it the foundation for building consistent, responsive layouts throughout POS extensions.' +
-    '\n\n`Stack` components support responsive gap values that automatically adjust spacing based on screen size, ensuring layouts remain visually balanced and maintain proper element separation across different devices.',
+    "\n\nThe spacing of `Stack` components' gap values automatically adjust based on screen size. This ensures layouts remain visually balanced and maintain proper element separation across different devices." +
+    '\n\nComplex grid-like layouts may require multiple nested `Stack` components or alternative layout approaches for optimal results.',
   thumbnail: 'stack-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -44,16 +45,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Apply alignment properties:** Use \`justifyContent\` for main axis distribution, \`alignItems\` for cross axis positioning, \`alignContent\` for extra space distribution.
 - **Avoid percentages on mobile:** Don't use percentage-based sizing within scrollable containers on mobile surfaces.
 - **Use gap for spacing control:** Use \`gap\` for uniform spacing, \`rowGap\` for block axis, \`columnGap\` for inline axis.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- Wrapping behavior is determined by direction—inline stacks wrap content while block stacks don't, which may not suit all layout requirements.
-- Percentage-based sizing should be avoided on mobile surfaces within scrollable containers due to unexpected behavior.
-- Complex grid-like layouts may require multiple nested \`Stack\` components or alternative layout approaches for optimal results.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -51,8 +51,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Text styling is controlled by the POS design system through the provided properties—custom font families, sizes, or styling beyond the available options aren't supported.
-- Complex rich text formatting isn't supported—use multiple \`Text\` components or nested text elements for varied formatting needs.
+Complex rich text formatting isn't supported—use multiple \`Text\` components or nested text elements for varied formatting needs.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -62,7 +62,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - \`TextArea\` provides multi-line text input but doesn't include rich text formatting capabilities—complex formatting like bold, italic, or lists requires alternative solutions or plain text representations.
 - The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display or validation, so you must implement validation logic manually.
-- The \`accessory\` slot supports only \`Button\` and \`Clickable\` components—other component types can't be used for field accessories.
+- The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components—other component types can't be used for field accessories.
 `,
     },
   ],
@@ -73,7 +73,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Add action buttons to the text area using the accessory slot for quick actions like clearing text or formatting content. This example shows how to use `s-button` and `s-clickable` components in the accessory slot, providing inline functionality within the multi-line input context.',
+          'Add action buttons to the text area using the accessory slot for quick actions like clearing text or formatting content. This example shows how to use [`s-button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [`s-clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the multi-line input context.',
         codeblock: {
           title: 'Add accessory buttons',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextArea',
   description:
-    'The `TextArea` component captures longer text content with a multi-line, resizable text input area. Use it to collect descriptions, notes, comments, or other extended text input in forms and data entry workflows.' +
+    'The `TextArea` component captures plain text content with a multi-line, resizable text input area. Use it to collect descriptions, notes, comments, or other extended text input in forms and data entry workflows.' +
     '\n\nThe component provides a multi-line text input area that accommodates longer content. It supports validation and multi-line formatting, making it ideal for capturing detailed information such as order notes, product descriptions, or customer feedback that requires more than single-line input.',
   thumbnail: 'text-area-thumbnail.png',
   isVisualComponent: true,
@@ -60,9 +60,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`TextArea\` provides multi-line text input but doesn't include rich text formatting capabilities—complex formatting like bold, italic, or lists requires alternative solutions or plain text representations.
-- The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display or validation, so you must implement validation logic manually.
-- The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components—other component types can't be used for field accessories.
+The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components. Other component types can't be used for field accessories.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextField',
   description:
-    'The `TextField` component captures single-line text input. Use it to collect short, free-form information in forms and data entry workflows.' +
+    'The `TextField` component captures single-line text input. Use it to collect short, free-form information in forms and data entry workflows. For multi-line text entry, use the [`TextArea`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textarea) component.' +
     '\n\nThe component supports various input configurations including placeholders, character limits, and validation. It includes built-in support for labels, helper text, and error states to guide merchants through data entry, ensuring accurate and efficient information capture across different retail scenarios.',
   thumbnail: 'text-field-thumbnail.png',
   isVisualComponent: true,
@@ -60,9 +60,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`TextField\` provides single-line text input only—multi-line text entry requires the [\`TextArea\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textarea) component.
-- The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display or validation, so you must implement validation logic manually.
-- The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.
+The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Use for single-line text input:** Choose \`TextField\` for short values like names, titles, or identifiers. For multi-line content, use \`TextArea\`.
+- **Use for single-line text input:** Choose \`TextField\` for short values like names, titles, or identifiers. For multi-line content, use [\`TextArea\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textarea).
 - **Show character limit feedback:** When approaching \`maxLength\`, display remaining characters in the \`details\` text.
 - **Write descriptive labels:** Use specific labels like "Product Name" or "Reference Code" rather than generic terms.
 `,
@@ -60,9 +60,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`TextField\` provides single-line text input only—multi-line text entry requires the \`TextArea\` component.
+- \`TextField\` provides single-line text input only—multi-line text entry requires the [\`TextArea\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textarea) component.
 - The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display or validation, so you must implement validation logic manually.
-- The \`accessory\` slot supports only \`Button\` and \`Clickable\` components with text content only—other component types or complex layouts can't be used for field accessories.
+- The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.
 `,
     },
   ],
@@ -73,7 +73,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use `s-button` and `s-clickable` components with text content in the accessory slot, enabling inline actions without leaving the input context.',
+          'Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use [`s-button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [`s-clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components with text content in the accessory slot, enabling inline actions without leaving the input context.',
         codeblock: {
           title: 'Add accessory buttons',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -4,7 +4,9 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Tile',
   description:
     'The `Tile` component displays interactive buttons for the POS smart grid that allow merchants to complete actions quickly. Tiles serve as customizable shortcuts that provide contextual information and enable merchants to quickly access workflows, actions, and information from the smart grid.' +
-    '\n\nTiles are dynamic components that can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They support tap interactions, visual feedback, and can display contextual information through titles, subtitles, and badge values.',
+    '\n\nTiles are dynamic components that can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They support tap interactions, visual feedback, and can display contextual information through titles, subtitles, and badge values.' +
+    "\n\nTo maintain a consistent visual experience, tile size and layout are determined by the smart grid system, and custom icons and images aren't supported." +
+    '\n\nEach POS UI extension can only render one `Tile` component for each [home screen tile target](/docs/api/pos-ui-extensions/2026-01-rc/targets/home-screen#home-screen-tile-).',
   thumbnail: 'tile-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -55,12 +57,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Each POS UI extension can only render one \`Tile\` component per tile target.
-- The \`itemCount\` property only accepts numeric values—string or text badges aren't supported.
-- Custom icons, images, or visual styling beyond the built-in \`tone\` property aren't supported.
-- Tile size and layout are determined by the smart grid system and can't be customized.
-- The \`Tile\` component supports click and long press interactions only. Swipe, drag, and other gestures aren't supported.
-- The \`heading\` and \`subheading\` properties must be plain strings—HTML, markdown, or rich text formatting isn't supported.
+The \`Tile\` component supports click and long press interactions only. Swipe, drag, and other gestures aren't supported.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -55,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent: `
 - \`TimeField\` accepts time values in 24-hour \`HH:mm:ss\` format only—12-hour times or other formats require conversion before setting the value property.
-- The component provides text-based time input—for visual time selection with clock or spinner interfaces, use the \`TimePicker\` component which offers interactive time selection.
+- The component provides text-based time input—for visual time selection with clock or spinner interfaces, use the [\`TimePicker\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timepicker) component which offers interactive time selection.
 - Validation occurs when the user finishes editing rather than on every keystroke—invalid times are only flagged after blur, which may delay error feedback.
 `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -4,8 +4,9 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'TimeField',
   description:
     'The `TimeField` component captures time input with a consistent interface for time selection and validation. Use it to collect time information in scheduling, booking, or data entry workflows.' +
-    '\n\nThe component supports both 12-hour and 24-hour time formats based on locale settings, with built-in validation to ensure valid time entries. It includes features like time picker integration, keyboard shortcuts, and formatted display to streamline time entry for scheduling, appointment booking, and time-sensitive operations in retail environments.' +
-    '\n\n`TimeField` components respects merchant locale settings for default time format preferences while allowing manual override for specific use cases that require alternative formats.',
+    '\n\nThe component supports both 12-hour and 24-hour time formats based on locale settings. It includes features like time picker integration, keyboard shortcuts, and formatted display to streamline time entry for scheduling, appointment booking, and time-sensitive operations in retail environments.' +
+    '\n\n`TimeField` components respects merchant locale settings for default time format preferences while allowing manual override for specific use cases that require alternative formats.' +
+    '\n\n`TimeField` provides only text-based time input. For visual time selection with clock or spinner interfaces, use the [`TimePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timepicker) component which offers interactive time selection.',
   thumbnail: 'time-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -47,16 +48,6 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - **Use correct format:** Always use \`HH:mm:ss\` format with leading zeros (like \`"09:05:00"\` not \`"9:5:0"\`).
 - **Explain time constraints:** Use \`details\` to clarify requirements like "Business hours only (09:00-17:00)" or "Must be a future time."
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- \`TimeField\` accepts time values in 24-hour \`HH:mm:ss\` format only—12-hour times or other formats require conversion before setting the value property.
-- The component provides text-based time input—for visual time selection with clock or spinner interfaces, use the [\`TimePicker\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timepicker) component which offers interactive time selection.
-- Validation occurs when the user finishes editing rather than on every keystroke—invalid times are only flagged after blur, which may delay error feedback.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'TimePicker',
   description:
     'The `TimePicker` component allows merchants to select a specific time using an interactive picker interface. Use it to provide visual time selection for improved user experience and reduced input errors.' +
-    '\n\n`TimePicker` offers a more visual and touch-friendly alternative to text-based time input, making time selection faster and more accurate. The picker interface provides an intuitive way to select hours and minutes through an interactive interface.',
+    '\n\n`TimePicker` offers a more visual and touch-friendly alternative to [text-based time input](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timefield), making time selection faster and more accurate. The picker interface provides an intuitive way to select hours and minutes through an interactive interface.',
   thumbnail: 'time-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for visual time selection:** Use \`TimePicker\` when users benefit from a visual picker interface. Use \`TimeField\` when users know the exact time.
+- **Choose for visual time selection:** Use \`TimePicker\` when users benefit from a visual picker interface. Use [\`TimeField\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timefield) when users know the exact time.
 - **Use correct format:** Always use \`HH:mm:ss\` format with leading zeros. The internal format is always 24-hour regardless of UI presentation.
 - **Validate before setting values:** Invalid values reset to empty string. Implement validation to show appropriate error messages.
 `,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimePicker',
   description:
-    'The `TimePicker` component allows merchants to select a specific time using an interactive picker interface. Use it to provide visual time selection for improved user experience and reduced input errors.' +
-    '\n\n`TimePicker` offers a more visual and touch-friendly alternative to [text-based time input](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timefield), making time selection faster and more accurate. The picker interface provides an intuitive way to select hours and minutes through an interactive interface.',
+    'The `TimePicker` component allows merchants to select a specific time using an interactive picker interface. This offers a more visual and touch-friendly alternative to [text-based time input](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timefield), making time selection faster and more accurate.' +
+    '\n\n`TimePicker` provides the picker interface but requires external state management for the selected value. You must manage the selected time value in your application state and update it using the `onChange` callback.',
   thumbnail: 'time-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -47,16 +47,6 @@ const data: ReferenceEntityTemplateSchema = {
 - **Choose for visual time selection:** Use \`TimePicker\` when users benefit from a visual picker interface. Use [\`TimeField\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timefield) when users know the exact time.
 - **Use correct format:** Always use \`HH:mm:ss\` format with leading zeros. The internal format is always 24-hour regardless of UI presentation.
 - **Validate before setting values:** Invalid values reset to empty string. Implement validation to show appropriate error messages.
-`,
-    },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-- \`TimePicker\` provides the picker interface but requires external state management for the selected value—you must update the value property in response to change events.
-- The component uses 24-hour \`HH:mm:ss\` format internally—display formatting for 12-hour time or locale-specific formats requires additional formatting logic in your application.
-- Invalid time values result in an empty string without specific error feedback—you must validate time formats before setting the value property to provide meaningful error messages to users.
 `,
     },
   ],


### PR DESCRIPTION
## This PR: 
- Integrates Tim Trevor's feedback on the following:
  - Refines API example descriptions to avoid long sentences (>30 words), and the participial phrase
  - Removes certain API limitations that shouldn't be called out at that level, using a "Limitations framework"
- Adds some links to cross-reference component docs
- Closes https://github.com/Shopify/shopify-dev/issues/65493
  
### Limitations framework 
  
- **Limitations are constraints developers must work around**: I only documented restrictions that require developers to handle edge cases, implement fallbacks, or design around boundaries (like size limits, availability restrictions, or failure conditions).
- **Limitations are not product descriptions**: I removed statements that simply describe how the product is designed to work, its intended scope, or its normal operating requirements (like "requires hardware" or "provides read-only access").
- **Limitations highlight what can go wrong or fail**: I focued on technical boundaries where operations can fail, data can be stale, or functionality is conditionally available, rather than explaining the product's standard behavior or architecture.

### Tophatting

1. In the `ui-extensions` repo, run `yarn docs:point-of-sale 2026-01-rc`.
2. In `shopify-dev`, run a server (`dev server`) with the `templated_refs_v2_m1` feature flag enabled, and review the 2026-01 release candidate docs at https://shopify-dev.shop.dev/docs/api/pos-ui-extensions/2026-01-rc
