### PR TITLE
[POS UI extensions 2025-07]: Rename `ProductSearch API` to `Product Search API`

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -7,7 +7,7 @@ const generateCodeBlockForProductSearchApi = (
 ) => generateCodeBlock(title, 'product-search-api', fileName);
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'ProductSearch API',
+  name: 'Product Search API',
   description:
     'The Product Search API provides access to POS native product search functionality, allowing you to search for products, fetch product details, and retrieve product variants with pagination support and flexible sorting options. The API enables both text-based search and direct product lookups by ID.',
   isVisualComponent: false,


### PR DESCRIPTION
## This PR:
- Renames `ProductSearch API` to `Product Search API` in the POS UI extensions version 2025-07
- Relates to https://github.com/Shopify/shopify-dev/pull/65542