### PR TITLE
[Copy edits]: POS UI extensions versions 2025-10

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
@@ -47,19 +47,19 @@ export interface ActionSlots {
  */
 export interface BaseOverlayProps {
   /**
-   * A callback function executed when the overlay begins to appear, immediately after `showOverlay()` is called or the `hidden` property changes to `false`, but before any show animations start. The element may not be visible yet. Use this for initializing overlay content, fetching data needed for display, setting focus on the first interactive element, or tracking analytics events for when users begin viewing the overlay. Avoid layout calculations here as the element may not have final dimensions yet.
+   * Called when the overlay begins to appear, immediately after `showOverlay()` is called or the `hidden` property changes to `false`, but before any show animations start. The element may not be visible yet. Use this for initializing overlay content, fetching data needed for display, setting focus on the first interactive element, or tracking analytics events for when users begin viewing the overlay. Avoid layout calculations here as the element may not have final dimensions yet.
    */
   onShow?: (event: Event) => void;
   /**
-   * A callback function executed after the overlay is fully visible and all show animations have completed. At this point, the overlay is completely rendered with final dimensions and positioning. Use this for operations that require the overlay to be fully displayed, such as focusing specific elements after animations complete, measuring rendered content dimensions, triggering secondary animations, or initializing interactive features that depend on final layout. This is the safest place for DOM measurements and layout-dependent operations.
+   * Called after the overlay is fully visible and all show animations have completed. At this point, the overlay is completely rendered with final dimensions and positioning. Use this for operations that require the overlay to be fully displayed, such as focusing specific elements after animations complete, measuring rendered content dimensions, triggering secondary animations, or initializing interactive features that depend on final layout. This is the safest place for DOM measurements and layout-dependent operations.
    */
   onAfterShow?: (event: Event) => void;
   /**
-   * A callback function executed when the overlay begins to hide, immediately after `hideOverlay()` is called or the `hidden` property changes to `true`, but before any hide animations start. The element is still visible. Use this for cleanup operations, saving overlay state before it disappears, canceling pending requests, or preparing for the post-hide state. This is your last opportunity to interact with the visible overlay before animations begin.
+   * Called when the overlay begins to hide, immediately after `hideOverlay()` is called or the `hidden` property changes to `true`, but before any hide animations start. The element is still visible. Use this for cleanup operations, saving overlay state before it disappears, canceling pending requests, or preparing for the post-hide state. This is your last opportunity to interact with the visible overlay before animations begin.
    */
   onHide?: (event: Event) => void;
   /**
-   * A callback function executed after the overlay is completely hidden and all hide animations have finished. The element is no longer visible or interactive. Use this for final cleanup, focusing the element that triggered the overlay, navigating to another view, freeing resources, or performing operations that should only occur after the overlay is completely dismissed. This is the appropriate place for post-dismissal navigation or state updates that would be jarring if they occurred during animations.
+   * Called after the overlay is completely hidden and all hide animations have finished. The element is no longer visible or interactive. Use this for final cleanup, focusing the element that triggered the overlay, navigating to another view, freeing resources, or performing operations that should only occur after the overlay is completely dismissed. This is the appropriate place for post-dismissal navigation or state updates that would be jarring if they occurred during animations.
    */
   onAfterHide?: (event: Event) => void;
 }
@@ -94,13 +94,13 @@ export interface BaseOverlayMethods {
  */
 export interface FocusEventProps {
   /**
-   * A callback function executed when focus is removed from the element, either by the user moving to another field (tabbing, clicking elsewhere) or programmatically using `blur()`. This event fires before `onChange` for modified fields. The event contains information about which element is receiving focus next (`relatedTarget`). Use this for triggering validation, saving in-progress changes, hiding related UI elements like autocomplete dropdowns, or tracking field interaction analytics. Common pattern: validate and show errors on blur to avoid disrupting users while they're still typing.
+   * Called when focus is removed from the element, either by the user moving to another field (tabbing, clicking elsewhere) or programmatically using `blur()`. This event fires before `onChange` for modified fields. The event contains information about which element is receiving focus next (`relatedTarget`). Use this for triggering validation, saving in-progress changes, hiding related UI elements like autocomplete dropdowns, or tracking field interaction analytics. Common pattern: validate and show errors on blur to avoid disrupting users while they're still typing.
    *
    * Learn more about [blur events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
    */
   onBlur?: (event: FocusEvent) => void;
   /**
-   * A callback function executed when the element receives focus through user interaction (clicking, tabbing) or programmatic methods like `focus()`. This event fires before any input occurs. The event contains information about which element previously had focus (`relatedTarget`). Use this for showing helper text, highlighting the active field, displaying related UI like autocomplete suggestions, preselecting content, or tracking which fields users interact with. Common pattern: clear errors on focus to provide a fresh start when users re-attempt input after validation failure. Learn more about [focus events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
+   * Called when the element receives focus through user interaction (clicking, tabbing) or programmatic methods like `focus()`. This event fires before any input occurs. The event contains information about which element previously had focus (`relatedTarget`). Use this for showing helper text, highlighting the active field, displaying related UI like autocomplete suggestions, preselecting content, or tracking which fields users interact with. Common pattern: clear errors on focus to provide a fresh start when users re-attempt input after validation failure. Learn more about [focus events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
    */
   onFocus?: (event: FocusEvent) => void;
 }
@@ -816,11 +816,11 @@ export interface BannerProps extends GlobalProps, ActionSlots {
    */
   dismissible?: boolean;
   /**
-   * A callback function executed when the user dismisses the banner by clicking the close (X) button. This only fires for user-initiated dismissals through the UI close button, not when the banner is hidden programmatically using the `hidden` property. The callback fires after the user clicks but before hide animations begin. Use this for tracking dismissal metrics, saving user preferences to avoid showing the banner again, performing cleanup when banners are dismissed, or triggering follow-up actions. The banner remains in the DOM after dismissal (just hidden) until re-rendered—to completely remove it, control rendering at the component level based on dismissal state.
+   * Called when the user dismisses the banner by clicking the close (X) button. This only fires for user-initiated dismissals through the UI close button, not when the banner is hidden programmatically using the `hidden` property. The callback fires after the user clicks but before hide animations begin. Use this for tracking dismissal metrics, saving user preferences to avoid showing the banner again, performing cleanup when banners are dismissed, or triggering follow-up actions. The banner remains in the DOM after dismissal (just hidden) until re-rendered—to completely remove it, control rendering at the component level based on dismissal state.
    */
   onDismiss?: (event: Event) => void;
   /**
-   * A callback function executed after the element is fully hidden and all hide animations have completed.
+   * Called after the element is fully hidden and all hide animations have completed.
    *
    * @implementation If implementations animate the hiding of the banner,
    * this event must fire after the banner has fully hidden.
@@ -1246,7 +1246,7 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
    */
   type?: 'submit' | 'button' | 'reset';
   /**
-   * A callback function executed when the element is clicked or activated.
+   * Called when the element is clicked or activated.
    *
    * Learn more about [click events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
    */
@@ -1295,7 +1295,7 @@ export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
    */
   download?: string;
   /**
-   * A callback function executed when the element is clicked or activated.
+   * Called when the element is clicked or activated.
    *
    * Learn more about [click events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
    */
@@ -1402,12 +1402,12 @@ export interface BaseInputProps {
  */
 export interface InputProps extends BaseInputProps {
   /**
-   * A callback function executed when the user has committed a value change, typically triggered when the field loses focus (blur) after the value has been modified. Unlike `onInput`, this fires only once after editing is complete, not during typing. The event contains the finalized value. Use this for validation, saving data, or triggering actions that should occur after the user finishes editing rather than during typing. For controlled components, update the `value` prop in this callback. This is ideal for expensive operations like API calls that shouldn't happen on every keystroke.
+   * Called when the user has committed a value change, typically triggered when the field loses focus (blur) after the value has been modified. Unlike `onInput`, this fires only once after editing is complete, not during typing. The event contains the finalized value. Use this for validation, saving data, or triggering actions that should occur after the user finishes editing rather than during typing. For controlled components, update the `value` prop in this callback. This is ideal for expensive operations like API calls that shouldn't happen on every keystroke.
    * Learn more about [change events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
    */
   onChange?: (event: Event) => void;
   /**
-   * A callback function executed immediately when the user makes any change to the field value. Fires on every keystroke, paste, or other input modification before the field loses focus. The event contains the current field value. Use this for real-time validation, character counting, formatting input as users type, or implementing autocomplete/search-as-you-type features. For controlled components, update the `value` prop in this callback to keep state in sync. Be cautious with expensive operations here as this fires frequently during typing.
+   * Called immediately when the user makes any change to the field value. Fires on every keystroke, paste, or other input modification before the field loses focus. The event contains the current field value. Use this for real-time validation, character counting, formatting input as users type, or implementing autocomplete/search-as-you-type features. For controlled components, update the `value` prop in this callback to keep state in sync. Be cautious with expensive operations here as this fires frequently during typing.
    * Learn more about [input events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
    */
   onInput?: (event: Event) => void;
@@ -1427,12 +1427,12 @@ export interface InputProps extends BaseInputProps {
  */
 export interface MultipleInputProps extends BaseInputProps {
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    * Learn more about [change events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
    */
   onChange?: (event: Event) => void;
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    * Learn more about [input events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
    */
   onInput?: (event: Event) => void;
@@ -1868,7 +1868,7 @@ export interface DatePickerProps
    */
   view?: string;
   /**
-   * A callback function executed when the visible month displayed in the date picker changes, either through user navigation (clicking next/previous month buttons) or programmatic updates to the `view` property. The callback receives the new month as a string in `YYYY-MM` format (for example, `"2024-05"`). Use this to track which month users are viewing, load month-specific data (like availability or pricing), sync the view with external state, or implement custom navigation controls. For controlled date pickers, update the `view` property in this callback to keep the displayed month in sync with your application state. The callback fires after the month has changed but before the new month's dates are fully rendered, making it ideal for triggering data fetches.
+   * Called when the visible month displayed in the date picker changes, either through user navigation (clicking next/previous month buttons) or programmatic updates to the `view` property. The callback receives the new month as a string in `YYYY-MM` format (for example, `"2024-05"`). Use this to track which month users are viewing, load month-specific data (like availability or pricing), sync the view with external state, or implement custom navigation controls. For controlled date pickers, update the `view` property in this callback to keep the displayed month in sync with your application state. The callback fires after the month has changed but before the new month's dates are fully rendered, making it ideal for triggering data fetches.
    */
   onViewChange?: (view: string) => void;
   /**
@@ -1934,11 +1934,11 @@ export interface DatePickerProps
    */
   value?: string;
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: Event) => void;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: Event) => void;
 }
@@ -1961,7 +1961,7 @@ export interface DateFieldProps
     >,
     AutocompleteProps<DateAutocompleteField> {
   /**
-   * A callback function executed when the user enters an invalid value. Fires after change validation fails.
+   * Called when the user enters an invalid value. Fires after change validation fails.
    */
   onInvalid?: (event: Event) => void;
 }
@@ -1997,11 +1997,11 @@ export interface DateSpinnerProps
    */
   value?: string;
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: Event) => void;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed. Date validation occurs when the user finishes editing (on blur), rather than on every keystroke.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed. Date validation occurs when the user finishes editing (on blur), rather than on every keystroke.
    */
   onChange?: (event: Event) => void;
 }
@@ -2323,13 +2323,13 @@ export interface ImageProps extends GlobalProps, BaseImageProps, BorderProps {
    */
   loading?: 'eager' | 'lazy';
   /**
-   * A callback function executed when the image finishes loading successfully and is ready to display. This fires after the browser has downloaded the image data and decoded it, but may fire before the image is actually painted to the screen. Use this for hiding loading indicators, triggering dependent actions that require the image (like image processing), tracking image load metrics, or executing layout operations that depend on image dimensions. For performance tracking, compare timestamps between navigation start and this callback. Note that cached images may trigger this callback synchronously (immediately), so handle both async and sync invocation in your code. This won't fire if the image fails to load—listen to `onError` for failures.
+   * Called when the image finishes loading successfully and is ready to display. This fires after the browser has downloaded the image data and decoded it, but may fire before the image is actually painted to the screen. Use this for hiding loading indicators, triggering dependent actions that require the image (like image processing), tracking image load metrics, or executing layout operations that depend on image dimensions. For performance tracking, compare timestamps between navigation start and this callback. Note that cached images may trigger this callback synchronously (immediately), so handle both async and sync invocation in your code. This won't fire if the image fails to load—listen to `onError` for failures.
    *
    * Learn more about [`onload` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload).
    */
   onLoad?: (event: Event) => void;
   /**
-   * A callback function executed when the image fails to load due to network errors, invalid URLs, unsupported formats, [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) issues, or server errors (for example, 404, 500). The event contains limited error details for security reasons—the browser console provides specific failure reasons. Common operations include displaying fallback images (`event.target.src = 'fallback.jpg'`), showing error messages to users, logging failures for monitoring, hiding broken image icons, or providing alternative content when images are unavailable. A common pattern involves attempting to load a fallback image, and if that fails too, hiding the image container entirely. For critical images like product photos, a placeholder SVG or icon may be shown instead of a broken image indicator. This callback doesn't fire for images that are blocked by browser content policies or ad blockers.
+   * Called when the image fails to load due to network errors, invalid URLs, unsupported formats, [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) issues, or server errors (for example, 404, 500). The event contains limited error details for security reasons—the browser console provides specific failure reasons. Common operations include displaying fallback images (`event.target.src = 'fallback.jpg'`), showing error messages to users, logging failures for monitoring, hiding broken image icons, or providing alternative content when images are unavailable. A common pattern involves attempting to load a fallback image, and if that fails too, hiding the image container entirely. For critical images like product photos, a placeholder SVG or icon may be shown instead of a broken image indicator. This callback doesn't fire for images that are blocked by browser content policies or ad blockers.
    *
    * Learn more about [`onerror` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror).
    */
@@ -2481,7 +2481,7 @@ export interface QRCodeProps extends GlobalProps {
    */
   accessibilityLabel?: string;
   /**
-   * A callback function executed when the resource fails to load.
+   * Called when the resource fails to load.
    */
   onError?: (event: Event) => void;
   /**
@@ -2496,7 +2496,7 @@ export interface QRCodeProps extends GlobalProps {
  */
 export interface ScrollEventProps {
   /**
-   * A callback function executed when scrolling reaches or moves away from any edge of the scrollable container.
+   * Called when scrolling reaches or moves away from any edge of the scrollable container.
    *
    * Provides information about which edges are currently reached:
    * - `inline: 'start'` - at the inline-start edge (typically left in LTR)
@@ -2835,7 +2835,7 @@ export interface TimeFieldProps
       'value' | 'defaultValue' | 'allow' | 'disallow' | 'step'
     > {
   /**
-   * A callback function executed when the user enters an invalid value. Fires after change validation fails.
+   * Called when the user enters an invalid value. Fires after change validation fails.
    */
   onInvalid?: (event: Event) => void;
   /**
@@ -3102,7 +3102,7 @@ interface ButtonJSXProps
    */
   variant?: Extract<ButtonProps['variant'], 'primary' | 'secondary'>;
   /**
-   * A callback function executed when the element is clicked or activated.
+   * Called when the element is clicked or activated.
    */
   onClick?: (event: CallbackEvent<typeof tagName$t>) => void;
   /**
@@ -3301,7 +3301,7 @@ interface TileJSXProps
    */
   disabled?: TileProps['disabled'];
   /**
-   * A callback function executed when the element is clicked or activated.
+   * Called when the element is clicked or activated.
    */
   onClick?: (event: CallbackEvent<typeof tagName$q>) => void;
 }
@@ -3849,11 +3849,11 @@ declare const tagName$k = 's-choice-list';
 interface ChoiceListJSXProps
   extends Pick<ChoiceListProps, 'id' | 'values' | 'multiple'> {
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$k>) => void) | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$k>) => void) | null;
   /**
@@ -3948,19 +3948,19 @@ interface TextFieldJSXProps
     | 'maxLength'
   > {
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$h>) => void) | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$h>) => void) | null;
   /**
-   * A callback function executed when focus is removed from the element.
+   * Called when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$h>) => void) | null;
   /**
-   * A callback function executed when the element receives focus through user interaction or programmatic focus.
+   * Called when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$h>) => void) | null;
   /**
@@ -3986,19 +3986,19 @@ declare const tagName$g = 's-search-field';
 interface SearchFieldJSXProps
   extends Pick<SearchFieldProps, 'id' | 'disabled' | 'placeholder' | 'value'> {
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$g>) => void) | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$g>) => void) | null;
   /**
-   * A callback function executed when focus is removed from the element.
+   * Called when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$g>) => void) | null;
   /**
-   * A callback function executed when the element receives focus through user interaction or programmatic focus.
+   * Called when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$g>) => void) | null;
 }
@@ -4030,19 +4030,19 @@ interface EmailFieldJSXProps
     | 'details'
   > {
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$f>) => void) | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$f>) => void) | null;
   /**
-   * A callback function executed when focus is removed from the element.
+   * Called when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$f>) => void) | null;
   /**
-   * A callback function executed when the element receives focus through user interaction or programmatic focus.
+   * Called when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$f>) => void) | null;
   /**
@@ -4067,7 +4067,7 @@ declare module 'preact' {
 declare const tagName$e = 's-clickable';
 interface ClickableJSXProps extends Pick<ClickableProps, 'id' | 'disabled'> {
   /**
-   * A callback function executed when the element is clicked or activated.
+   * Called when the element is clicked or activated.
    */
   onClick?: (event: CallbackEvent<typeof tagName$e>) => void;
   /**
@@ -4108,15 +4108,15 @@ interface TextAreaJSXProps
    */
   onInput?: ((event: CallbackEvent<typeof tagName$d>) => void) | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$d>) => void) | null;
   /**
-   * A callback function executed when focus is removed from the element.
+   * Called when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$d>) => void) | null;
   /**
-   * A callback function executed when the element receives focus through user interaction or programmatic focus.
+   * Called when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$d>) => void) | null;
   /**
@@ -4202,19 +4202,19 @@ interface NumberFieldJSXProps
    */
   controls?: NumberFieldProps['controls'];
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$c>) => void) | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$c>) => void) | null;
   /**
-   * A callback function executed when focus is removed from the element.
+   * Called when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$c>) => void) | null;
   /**
-   * A callback function executed when the element receives focus through user interaction or programmatic focus.
+   * Called when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$c>) => void) | null;
 }
@@ -4239,19 +4239,19 @@ interface DateFieldJSXProps
     'id' | 'label' | 'details' | 'value' | 'disabled' | 'error'
   > {
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$b>) => void) | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$b>) => void) | null;
   /**
-   * A callback function executed when focus is removed from the element.
+   * Called when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$b>) => void) | null;
   /**
-   * A callback function executed when the element receives focus through user interaction or programmatic focus.
+   * Called when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$b>) => void) | null;
 }
@@ -4272,19 +4272,19 @@ declare module 'preact' {
 declare const tagName$a = 's-date-picker';
 interface DatePickerJSXProps extends Pick<DatePickerProps, 'id' | 'value'> {
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: CallbackEvent<typeof tagName$a>) => void | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: CallbackEvent<typeof tagName$a>) => void | null;
   /**
-   * A callback function executed when focus is removed from the element.
+   * Called when focus is removed from the element.
    */
   onBlur?: (event: CallbackEvent<typeof tagName$a>) => void | null;
   /**
-   * A callback function executed when the element receives focus through user interaction or programmatic focus.
+   * Called when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: (event: CallbackEvent<typeof tagName$a>) => void | null;
 }
@@ -4304,19 +4304,19 @@ declare module 'preact' {
 declare const tagName$9 = 's-date-spinner';
 interface DateSpinnerJSXProps extends Pick<DateSpinnerProps, 'id' | 'value'> {
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: CallbackEvent<typeof tagName$9>) => void | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: CallbackEvent<typeof tagName$9>) => void | null;
   /**
-   * A callback function executed when focus is removed from the element.
+   * Called when focus is removed from the element.
    */
   onBlur?: (event: CallbackEvent<typeof tagName$9>) => void | null;
   /**
-   * A callback function executed when the element receives focus through user interaction or programmatic focus.
+   * Called when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: (event: CallbackEvent<typeof tagName$9>) => void | null;
 }
@@ -4385,19 +4385,19 @@ declare module 'preact' {
 declare const tagName$6 = 's-time-picker';
 interface TimePickerJSXProps extends Pick<TimePickerProps, 'id' | 'value'> {
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: CallbackEvent<typeof tagName$6>) => void | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: CallbackEvent<typeof tagName$6>) => void | null;
   /**
-   * A callback function executed when focus is removed from the element.
+   * Called when focus is removed from the element.
    */
   onBlur?: (event: CallbackEvent<typeof tagName$6>) => void | null;
   /**
-   * A callback function executed when the element receives focus through user interaction or programmatic focus.
+   * Called when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: (event: CallbackEvent<typeof tagName$6>) => void | null;
 }
@@ -4489,19 +4489,19 @@ interface TimeFieldJSXProps
     'id' | 'label' | 'disabled' | 'value' | 'error' | 'details'
   > {
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName$3>) => void) | null;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: ((event: CallbackEvent<typeof tagName$3>) => void) | null;
   /**
-   * A callback function executed when focus is removed from the element.
+   * Called when focus is removed from the element.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName$3>) => void) | null;
   /**
-   * A callback function executed when the element receives focus through user interaction or programmatic focus.
+   * Called when the element receives focus through user interaction or programmatic focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$3>) => void) | null;
 }
@@ -4868,11 +4868,11 @@ interface Choice {
  */
 interface ChoiceListEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$k>) => void;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$k>) => void;
 }
@@ -4920,19 +4920,19 @@ interface Clickable {
  */
 interface DateFieldEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$b>) => void;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$b>) => void;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   blur?: (event: CallbackEvent<typeof tagName$b>) => void;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   focus?: (event: CallbackEvent<typeof tagName$b>) => void;
 }
@@ -4971,19 +4971,19 @@ interface DateField {
  */
 interface DatePickerEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$a>) => void | null;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$a>) => void | null;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   blur?: (event: CallbackEvent<typeof tagName$a>) => void | null;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   focus?: (event: CallbackEvent<typeof tagName$a>) => void | null;
 }
@@ -5006,19 +5006,19 @@ interface DatePicker {
  */
 interface DateSpinnerEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$9>) => void | null;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$9>) => void | null;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   blur?: (event: CallbackEvent<typeof tagName$9>) => void | null;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   focus?: (event: CallbackEvent<typeof tagName$9>) => void | null;
 }
@@ -5056,19 +5056,19 @@ interface Divider {
  */
 interface EmailFieldEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$f>) => void;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$f>) => void;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   blur?: (event: CallbackEvent<typeof tagName$f>) => void;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   focus?: (event: CallbackEvent<typeof tagName$f>) => void;
 }
@@ -5242,19 +5242,19 @@ interface Modal {
  */
 interface NumberFieldEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$c>) => void;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$c>) => void;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   blur?: (event: CallbackEvent<typeof tagName$c>) => void;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   focus?: (event: CallbackEvent<typeof tagName$c>) => void;
 }
@@ -5507,19 +5507,19 @@ interface ScrollBox {
  */
 interface SearchFieldEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$g>) => void;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$g>) => void;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   blur?: (event: CallbackEvent<typeof tagName$g>) => void;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   focus?: (event: CallbackEvent<typeof tagName$g>) => void;
 }
@@ -5756,19 +5756,19 @@ interface Text {
  */
 interface TextAreaEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$d>) => void;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$d>) => void;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   blur?: (event: CallbackEvent<typeof tagName$d>) => void;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   focus?: (event: CallbackEvent<typeof tagName$d>) => void;
 }
@@ -5839,19 +5839,19 @@ interface TextArea {
  */
 interface TextFieldEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$h>) => void;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$h>) => void;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   blur?: (event: CallbackEvent<typeof tagName$h>) => void;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   focus?: (event: CallbackEvent<typeof tagName$h>) => void;
 }
@@ -5958,19 +5958,19 @@ interface Tile {
  */
 interface TimeFieldEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$3>) => void;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$3>) => void;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   blur?: (event: CallbackEvent<typeof tagName$3>) => void;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   focus?: (event: CallbackEvent<typeof tagName$3>) => void;
 }
@@ -6009,19 +6009,19 @@ interface TimeField {
  */
 interface TimePickerEvents {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   input?: (event: CallbackEvent<typeof tagName$6>) => void | null;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   change?: (event: CallbackEvent<typeof tagName$6>) => void | null;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   blur?: (event: CallbackEvent<typeof tagName$6>) => void | null;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   focus?: (event: CallbackEvent<typeof tagName$6>) => void | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
@@ -749,7 +749,7 @@ export interface BadgeProps extends GlobalProps {
    */
   children?: ComponentChildren;
   /**
-   * The semantic tone of the badge, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * The semantic tone of the badge, based on the intention of the information being conveyed. Affects color and styling to communicate meaning. Badges rely on the tone system for semantic meaning, so using custom styling may not clearly convey meaning to merchants.
    *
    * @default 'auto'
    */
@@ -781,7 +781,7 @@ export interface BadgeProps extends GlobalProps {
 }
 export interface BannerProps extends GlobalProps, ActionSlots {
   /**
-   * The title text displayed prominently at the top of the banner. Should be concise and clearly communicate the main message or purpose of the banner.
+   * The title text displayed prominently at the top of the banner. This is the only property for text content—body text content isn't supported. You can't place `<s-text>` or other text elements as children.
    *
    * @default ''
    */
@@ -1252,13 +1252,13 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
    */
   onClick?: (event: Event) => void;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
   disabled?: boolean;
   /**
-   * Indicates whether the button action is currently in progress. When `true`, displays a loading spinner or progress indicator and prevents additional clicks to avoid duplicate submissions. The button remains visually enabled but unresponsive to interaction. Set to `true` when starting an async operation (for example, API call, navigation) and back to `false` when the operation completes or fails. This provides user feedback during long-running operations and prevents race conditions from multiple rapid clicks.
+   * Indicates whether the button action is currently in progress. When `true`, replaces all button content with a loading spinner and prevents additional clicks to avoid duplicate submissions. The button remains visually enabled but unresponsive to interaction. Set to `true` when starting an async operation (for example, API call, navigation) and back to `false` when the operation completes or fails. This provides user feedback during long-running operations and prevents race conditions from multiple rapid clicks. Custom loading indicators or partial content updates aren't supported.
    *
    * @default false
    */
@@ -1341,7 +1341,7 @@ export interface ButtonProps extends GlobalProps, BaseClickableProps {
    */
   accessibilityLabel?: string;
   /**
-   * The child elements to render within this component.
+   * The child elements to render within this component. Button content must be plain text.
    */
   children?: ComponentChildren;
   /**
@@ -1391,7 +1391,7 @@ export interface BaseInputProps {
    */
   name?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction. When `true`, the field can't receive focus, be edited, or be interacted with. Disabled fields are visually dimmed, excluded from form submission, and announced as disabled to screen readers. Use when a field is temporarily unavailable due to application state, permissions, or dependencies on other fields.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -1586,7 +1586,7 @@ export interface BaseSelectableProps {
    */
   accessibilityLabel?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -1667,11 +1667,11 @@ export interface ChoiceListProps
    */
   multiple?: boolean;
   /**
-   * The child elements to render within this component.
+   * The child elements to render within this component. Within `ChoiceList`, use only `Choice` components as children. Other component types can't be used as options within the choice list.
    */
   children?: ComponentChildren;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -1700,7 +1700,7 @@ export interface ClickableProps
    */
   loading?: BaseClickableProps['loading'];
   /**
-   * Whether the element is disabled, preventing any user interaction.
+   * Whether the element is disabled, preventing user interaction. Use when temporarily unavailable due to application state, permissions, or dependencies. Child elements can still receive focus and be interacted with.
    */
   disabled?: BaseClickableProps['disabled'];
   /**
@@ -1928,7 +1928,7 @@ export interface DatePickerProps
    */
   defaultValue?: string;
   /**
-   * The currently selected date value in ISO date format (YYYY-MM-DD, for example, `"2024-05-15"`). An empty string means no date is selected. For date ranges, use comma-separated dates (for example, `"2024-05-15,2024-05-20"`).
+   * The currently selected date value in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (`YYYY-MM-DD`, for example, `"2024-05-15"`). An empty string means no date is selected. For date ranges, use comma-separated dates (for example, `"2024-05-15,2024-05-20"`). Other date formats require conversion before setting this property. The selection mode (`type` property) is inferred from the value format: single date for one value, multiple dates for comma-separated values without a range, and range for two comma-separated dates when `type` is set to 'range'.
    *
    * @default ""
    */
@@ -1952,7 +1952,6 @@ export interface DateFieldProps
       DatePickerProps,
       | 'view'
       | 'defaultView'
-      | 'value'
       | 'defaultValue'
       | 'allow'
       | 'disallow'
@@ -2002,7 +2001,7 @@ export interface DateSpinnerProps
    */
   onInput?: (event: Event) => void;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed. Date validation occurs when the user finishes editing (on blur), rather than on every keystroke.
    */
   onChange?: (event: Event) => void;
 }
@@ -2189,7 +2188,7 @@ export interface HeadingProps
     AccessibilityVisibilityProps,
     BlockTypographyProps {
   /**
-   * The child elements to render within this component.
+   * The child elements to render within this component. Use plain text or simple inline elements only for heading content. Rich text format isn't supported.
    */
   children?: ComponentChildren;
   /**
@@ -3296,7 +3295,7 @@ interface TileJSXProps
     'heading' | 'id' | 'itemCount' | 'tone' | 'subheading'
   > {
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -3812,15 +3811,15 @@ declare module 'preact' {
 declare const tagName$l = 's-badge';
 interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
   /**
-   * Determines the visual appearance and semantic meaning of the badge. Available options:
+   * Determines the visual appearance and semantic meaning of the badge. Badges rely on the tone system for semantic meaning, so using custom styling may not clearly convey meaning to merchants. Available options:
    *
-   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context. Use when you want the system to determine the most appropriate styling.
-   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis. Use for general status updates and standard information.
-   * - `'info'` - Blue styling for informational content and neutral updates. Use for informational content that provides helpful context.
-   * - `'success'` - Green styling for positive states, completed actions, and successful operations. Use for positive outcomes and successful processes.
-   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent. Use for potential issues that require awareness.
-   * - `'warning'` - Orange styling for important notices that require merchant awareness. Use for situations that need attention but aren't critical.
-   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action. Use for urgent issues that need immediate merchant attention.
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
+   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis.
+   * - `'info'` - Blue styling for informational content and neutral updates.
+   * - `'success'` - Green styling for positive states, completed actions, and successful operations.
+   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent.
+   * - `'warning'` - Orange styling for important notices that require merchant awareness.
+   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action.
    *
    * @default 'auto'
    */
@@ -4609,15 +4608,15 @@ export type {
 
 interface Badge {
   /**
-   * Determines the visual appearance and semantic meaning of the badge. Available options:
+   * Determines the visual appearance and semantic meaning of the badge. Badges rely on the tone system for semantic meaning, so using custom styling may not clearly convey meaning to merchants. Available options:
    *
-   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context. Use when you want the system to determine the most appropriate styling.
-   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis. Use for general status updates and standard information.
-   * - `'info'` - Blue styling for informational content and neutral updates. Use for informational content that provides helpful context.
-   * - `'success'` - Green styling for positive states, completed actions, and successful operations. Use for positive outcomes and successful processes.
-   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent. Use for potential issues that require awareness.
-   * - `'warning'` - Orange styling for important notices that require merchant awareness. Use for situations that need attention but aren't critical.
-   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action. Use for urgent issues that need immediate merchant attention.
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
+   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis.
+   * - `'info'` - Blue styling for informational content and neutral updates.
+   * - `'success'` - Green styling for positive states, completed actions, and successful operations.
+   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent.
+   * - `'warning'` - Orange styling for important notices that require merchant awareness.
+   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action.
    *
    * @default 'auto'
    */
@@ -4665,7 +4664,7 @@ interface Banner {
    */
   tone?: 'auto' | 'info' | 'success' | 'warning' | 'critical';
   /**
-   * The title text displayed prominently at the top of the banner. Should be concise and clearly communicate the main message or purpose of the banner.
+   * The title text displayed prominently at the top of the banner. This is the only property for text content—body text content isn't supported. You can't place `<s-text>` or other text elements as children.
    *
    * @default ''
    */
@@ -4823,7 +4822,7 @@ interface Button {
    */
   id?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -4847,11 +4846,11 @@ interface Choice {
    */
   id?: string;
   /**
-   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   * The unique value associated with this choice option. This value is used to identify the option and gets submitted with forms when selected. Use meaningful values like `"small"`, `"medium"`, or `"large"` rather than display text.
    */
   value?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -4911,7 +4910,7 @@ interface Clickable {
    */
   id?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    */
   disabled?: boolean;
 }
@@ -4944,7 +4943,7 @@ interface DateField {
    */
   id?: string;
   /**
-   * The content to use as the field label that describes the time information being requested.
+   * The content to use as the field label that describes the date information being requested.
    */
   label?: string;
   /**
@@ -4952,11 +4951,11 @@ interface DateField {
    */
   details?: string;
   /**
-   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   * The currently selected date value in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (`YYYY-MM-DD`, for example, `"2024-05-15"`). An empty string means no date is selected. Other date formats require conversion before setting this property. Validation occurs when the user finishes editing (on blur), rather than on every keystroke, so invalid dates are flagged after completing entry.
    */
   value?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -4995,7 +4994,7 @@ interface DatePicker {
    */
   id?: string;
   /**
-   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   * The currently selected date value in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (`YYYY-MM-DD`, for example, `"2024-05-15"`). An empty string means no date is selected. Other date formats require conversion before setting this property. Validation occurs when the user finishes editing (on blur), rather than on every keystroke, so invalid dates are flagged after completing entry.
    *
    * @default ""
    */
@@ -5030,7 +5029,7 @@ interface DateSpinner {
    */
   id?: string;
   /**
-   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   * The currently selected date value in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (`YYYY-MM-DD`, for example, `"2024-05-15"`). An empty string means no date is selected. Other date formats require conversion before setting this property. Validation occurs when the user finishes editing (on blur), rather than on every keystroke, so invalid dates are flagged after completing entry.
    *
    * @default ""
    */
@@ -5090,11 +5089,11 @@ interface EmailField {
    */
   id?: string;
   /**
-   * The content to use as the field label that describes the time information being requested.
+   * The content to use as the field label that describes the email information being requested.
    */
   label?: string;
   /**
-   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   * The current email address entered in the field. An empty string means no email is entered.
    */
   value?: string;
   /**
@@ -5102,7 +5101,7 @@ interface EmailField {
    */
   placeholder?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -5272,7 +5271,7 @@ interface NumberFieldSlots {
 
 interface NumberField {
   /**
-   * The content to use as the field label that describes the time information being requested.
+   * The content to use as the field label that describes the numeric information being requested.
    */
   label?: string;
   /**
@@ -5319,11 +5318,11 @@ interface NumberField {
    */
   id?: string;
   /**
-   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   * The current numeric value entered in the field. An empty string means no value is entered.
    */
   value?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -5531,7 +5530,7 @@ interface SearchField {
    */
   id?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -5541,7 +5540,7 @@ interface SearchField {
    */
   placeholder?: string;
   /**
-   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   * The current search query text entered in the field. An empty string means no search query is entered.
    */
   value?: string;
 }
@@ -5790,7 +5789,7 @@ interface TextArea {
    */
   id?: string;
   /**
-   * The content to use as the field label that describes the time information being requested.
+   * The content to use as the field label that describes the text information being requested.
    */
   label?: string;
   /**
@@ -5798,7 +5797,7 @@ interface TextArea {
    */
   details?: string;
   /**
-   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   * The current text content entered in the field. An empty string means no text is entered.
    */
   value?: string;
   /**
@@ -5806,7 +5805,7 @@ interface TextArea {
    */
   placeholder?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -5873,7 +5872,7 @@ interface TextField {
    */
   id?: string;
   /**
-   * The content to use as the field label that describes the time information being requested.
+   * The content to use as the field label that describes the text information being requested.
    */
   label?: string;
   /**
@@ -5881,7 +5880,7 @@ interface TextField {
    */
   details?: string;
   /**
-   * The current selected value in 24-hour format. An empty string means no time is selected. The value must be in `HH:mm:ss` format with leading zeros (for example, `"00:00:00"`, `"09:05:00"`, `"23:59:00"`, `"14:03:30"`). This follows the [HTML time input value format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#value), which is always 24-hour with leading zeros regardless of UI presentation.
+   * The current text content entered in the field. An empty string means no text is entered.
    */
   value?: string;
   /**
@@ -5889,7 +5888,7 @@ interface TextField {
    */
   placeholder?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -5921,7 +5920,7 @@ interface TileEvents {
 
 interface Tile {
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -5986,7 +5985,7 @@ interface TimeField {
    */
   label?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge.d.ts
@@ -43,14 +43,14 @@ export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
 declare const tagName = 's-badge';
 export interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
   /**
-   * Determines the visual appearance and semantic meaning of the badge. Available options:
-   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context. Typically applied when you want the system to determine the most appropriate styling.
-   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis. Commonly used for general status updates and standard information.
-   * - `'info'` - Blue styling for informational content and neutral updates. Commonly used for informational content that provides helpful context.
-   * - `'success'` - Green styling for positive states, completed actions, and successful operations. Commonly used for positive outcomes and successful processes.
-   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent. Commonly used for potential issues that require awareness.
-   * - `'warning'` - Orange styling for important notices that require merchant awareness. Commonly used for situations that need attention but aren't critical.
-   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action. Commonly used for urgent issues that need immediate merchant attention.
+   * Determines the visual appearance and semantic meaning of the badge. Badges rely on the tone system for semantic meaning, so using custom styling may not clearly convey meaning to merchants. Available options:
+   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
+   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis.
+   * - `'info'` - Blue styling for informational content and neutral updates.
+   * - `'success'` - Green styling for positive states, completed actions, and successful operations.
+   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent.
+   * - `'warning'` - Orange styling for important notices that require merchant awareness.
+   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action.
    *
    * @default 'auto'
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -3,9 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Badge',
   description:
-    "The `Badge` component uses color and text to communicate status information for orders, products, customers, and other business data. Badges aren't interactive elements; they display information but don't respond to user interactions like clicks or taps. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes within your POS interface. " +
-    '\n\nThe component automatically adjusts its appearance based on the specified `tone` property, ensuring consistent visual communication across the POS interface. The component relies on the tone system for semantic meaning, so using custom styling with badges may not clearly convey meaning to merchants.' +
-    '\n\nBadges support different sizes and can display text, numbers, or status indicators. This makes them versatile for representing everything from order counts to inventory alerts in a compact, scannable format.',
+    'The `Badge` component uses color and text to communicate status information for orders, products, customers, and other business data. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes.' +
+    "\n\nBadges aren't interactive elements. They display information but don't respond to user interactions like clicks or taps.",
   thumbnail: 'badge-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -3,9 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Banner',
   description:
-    'The `Banner` component highlights important information or required actions prominently within the POS interface. Use banners to communicate critical updates, warnings, informational messages, or success notifications that require merchant attention in a persistent but non-interruptive way.' +
-    '\n\nThe component provides persistent visibility for important messages while remaining non-intrusive to the main workflow, with support for dismissible and non-dismissible states. It includes automatic color coding based on message severity and integrates with the POS design system to maintain visual consistency across different alert types and use cases.' +
-    "\n\nThe `Banner` component only accepts a `heading` property for text content and doesn't support body content. You can't place `<s-text>` or other text elements inside the banner as children.",
+    'The `Banner` component highlights important information or required actions. Use banners to communicate critical updates, warnings, informational messages, or success notifications that require merchant attention.' +
+    '\n\nBanners provide persistent visibility with support for dismissible and non-dismissible states.',
   thumbnail: 'banner-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -3,10 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
-    "The `Box` component displays a generic container with consistent spacing and styling. Use it to apply padding, to nest and group other components, or as the foundation for building structured layouts. Box doesn't provide interactive functionality. For user interaction, use boxes in combination with interactive components like [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable)." +
-    "\n\nThe component provides granular control over spacing through padding properties and sizing through width/height properties, serving as a building block for precise layouts. It simplifies the creation of containers with consistent spacing by using design system tokens, ensuring visual consistency and reducing the need for custom CSS in most layout scenarios. To maintain consistency, `Box` only supports predefined design system scales. Custom pixel values for padding aren't supported." +
-    '\n\n`Box` components provide shorthand properties for common padding patterns like equal padding on all sides or symmetric horizontal/vertical padding, reducing verbose property specifications for simpler layouts.' +
-    "\n\n`Box` doesn't provide scrolling capabilities for overflow content. When content exceeds the container dimensions, use [`ScrollBox`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/layout-and-structure/scrollbox) instead.",
+    'The `Box` component provides a container for layout and visual styling. Use it to apply padding, borders, and background colors, or to nest and group other components.' +
+    '\n\nFor user interaction, use `Box` in combination with interactive components like [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable). For scrollable content, use [`ScrollBox`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/scrollbox).',
   thumbnail: 'box-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -22,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'box-default.png',
     description:
-      'Create flexible layouts using the `Box` component with configurable spacing, borders, and background colors. This example demonstrates a basic box container with padding and styling.',
+      'Create layouts using a `Box` component. This example demonstrates a basic box container with padding and styling.',
     codeblock: {
       title: 'Create a container with a box',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
     'The `Box` component provides a container for layout and visual styling. Use it to apply padding, borders, and background colors, or to nest and group other components.' +
-    '\n\nFor user interaction, use `Box` in combination with interactive components like [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable). For scrollable content, use [`ScrollBox`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/scrollbox).',
+    '\n\nFor user interaction, use `Box` in combination with interactive components like [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable). For scrollable content, use [`ScrollBox`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/layout-and-structure/scrollbox).',
   thumbnail: 'box-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -4,9 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
     'The `Button` component triggers actions or events, such as opening dialogs or navigating to other pages. Use `Button` to let merchants perform specific tasks or to initiate interactions throughout the POS interface.' +
-    "\n\n Button content must be plain text. If you nest components inside a button, the button extracts and displays only the text content from those components. For example, placing an `s-icon` inside a button won't display the icon, only its text content. Use of nested interactive components within buttons isn't supported." +
-    '\n\nButtons provide clear calls-to-action that guide merchants through workflows, enable form submissions, and trigger important operations. They support various visual styles, tones, and interaction patterns to communicate intent and hierarchy within the interface.' +
-    "\n\nLoading states replace all button content with a spinner. Custom loading indicators or partial content updates aren't supported.",
+    '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy within the interface.',
   thumbnail: 'button-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList.d.ts
@@ -77,11 +77,11 @@ declare const tagName = 's-choice-list';
 export interface ChoiceListJSXProps
   extends Pick<ChoiceListProps, 'id' | 'values' | 'multiple'> {
   /**
-   * A callback function executed when the user changes a choice. Fires simultaneously with `onChange`.
+   * Called when the user changes a choice. Fires simultaneously with `onChange`.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed when the user changes a choice. Fires simultaneously with `onInput`.
+   * Called when the user changes a choice. Fires simultaneously with `onInput`.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'ChoiceList',
   description:
-    'The `ChoiceList` component presents multiple options for selection. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
-    '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes.',
+    'The `ChoiceList` component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
+    '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It offers multiple layout variants including list, inline, block, and grid formats to suit different space constraints and visual requirements.',
   thumbnail: 'choicelist-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -3,10 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'ChoiceList',
   description:
-    'The `ChoiceList` component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options in forms or filtering interfaces.' +
-    '\n\nThe component supports both single and multiple selection modes with clear visual indicators for selected states and proper checkbox or radio button semantics, although the actual appearance may vary based on the POS platform and screen size. It includes features like select all/none functionality for multiple selection across various configuration and filtering scenarios.' +
-    '\n\n`ChoiceList` components maintain selection state across navigation and form resets, with proper visual indication of indeterminate states when some but not all options in a group are selected. Within `ChoiceList`, use only `Choice` components as children.' +
-    "\n\n`ChoiceList` doesn't automatically filter or update content based on selections. You must implement the logic to respond to selection changes.",
+    'The `ChoiceList` component presents multiple options for selection. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
+    '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes.',
   thumbnail: 'choicelist-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -35,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'choicelist-default.png',
     description:
-      'Present multiple options for single or multiple selections using a `ChoiceList` component. This example shows a basic choice list with radio button semantics for single selection.',
+      'Present options using a `ChoiceList` component. This example shows a basic choice list for single selection.',
     codeblock: {
       title: 'Create a choice list for selections',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -3,10 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
-    'The `Clickable` component makes any content interactive to user interactions. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.' +
-    "\n\nThis component provides a flexible way to wrap any content and make it respond to user interactions. Unlike buttons, it doesn't impose visual styling, allowing you to create custom interactive elements that match your design requirements while ensuring proper event handling." +
-    "\n\n`Clickable` provides built-in `onClick` feedback, but because it doesn't impose visual styling, you must implement focus indicators and other visual cues yourself." +
-    '\n\nWhen disabled, child elements can still receive focus and be interacted with. Be careful when using nested interactive elements within `Clickable` components to avoid event propagation conflicts and unexpected user experiences.',
+    'The `Clickable` component makes any content interactive. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.' +
+    "\n\nUnlike the [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) component, `Clickable` doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
   thumbnail: 'clickable-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
     'The `Clickable` component makes any content interactive. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.' +
-    "\n\nUnlike the [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) component, `Clickable` doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
+    "\n\nUnlike the [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) component, `Clickable` doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
   thumbnail: 'clickable-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField.d.ts
@@ -80,19 +80,19 @@ export interface DateFieldJSXProps
     'id' | 'label' | 'details' | 'value' | 'disabled' | 'error'
   > {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DateField',
   description:
     'The `DateField` component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
-    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [`DatePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) or [`DateSpinner`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) components.',
+    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [`DatePicker`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) or [`DateSpinner`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) components.',
   thumbnail: 'date-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -4,8 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DateField',
   description:
     'The `DateField` component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
-    '\n\n`DateField` accepts values in ISO 8601 format (`YYYY-MM-DD`). Other date formats require conversion before setting the value property. Validation of the entered date occurs when the user finishes editing, rather than on every keystroke, so invalid dates are flagged after blur. This can delay error feedback, so consider this in your design.' +
-    '\n\n`DateField` components support manual text entry. For visual calendar-based selection, consider using [`DatePicker`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) or [`DateSpinner`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) components.',
+    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [`DatePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) or [`DateSpinner`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) components.',
   thumbnail: 'date-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker.d.ts
@@ -77,19 +77,19 @@ declare const tagName = 's-date-picker';
 export interface DatePickerJSXProps
   extends Pick<DatePickerProps, 'id' | 'value'> {
   /**
-   * A callback function executed when the user selects a date from the picker.
+   * Called when the user selects a date from the picker.
    */
   onInput?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * A callback function executed when the user selects a date from the picker that is different from the current value.
+   * Called when the user selects a date from the picker that is different from the current value.
    */
   onChange?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * A callback function executed when the date picker is dismissed or closed.
+   * Called when the date picker is dismissed or closed.
    */
   onBlur?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * A callback function executed when the date picker is revealed or opened.
+   * Called when the date picker is revealed or opened.
    */
   onFocus?: (event: CallbackEvent<typeof tagName>) => void | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DatePicker',
   description:
     'The `DatePicker` component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
-    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, use [`DateSpinner`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner). For exact date entry, use [`DateField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield).',
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, consider using [`DateSpinner`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) instead. For text date entry, use [`DateField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield).',
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -3,10 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DatePicker',
   description:
-    'The `DatePicker` component allows merchants to select a specific date using a calendar-like picker interface. Use it to provide visual date selection with an intuitive calendar view for improved user experience.' +
-    '\n\n`DatePicker` offers a calendar-based alternative to [spinner-style pickers](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) when visual calendar context is beneficial. The calendar interface allows merchants to see dates in context of the full month, making it easier to select dates relative to specific days of the week or to visualize date ranges within a month view.' +
-    '\n\nThe component supports single dates, multiple dates, and date ranges. This is achieved through value format alone—the selection mode is inferred from the `value` property format rather than an explicit property.' +
-    "\n\n`DatePicker` provides the calendar interface but requires external state management for the selected value. You must update the `value` property in response to change events. Invalid date values result in no date being selected. The component doesn't provide specific error feedback, so you must validate date formats before setting the `value` property.",
+    'The `DatePicker` component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, use [`DateSpinner`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner). For exact date entry, use [`DateField`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datefield).',
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DatePicker',
   description:
     'The `DatePicker` component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
-    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, use [`DateSpinner`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner). For exact date entry, use [`DateField`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datefield).',
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, use [`DateSpinner`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner). For exact date entry, use [`DateField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield).',
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner.d.ts
@@ -77,19 +77,19 @@ declare const tagName = 's-date-spinner';
 export interface DateSpinnerJSXProps
   extends Pick<DateSpinnerProps, 'id' | 'value'> {
   /**
-   * A callback function executed when the user makes a selection in the spinner.
+   * Called when the user makes a selection in the spinner.
    */
   onInput?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * A callback function executed when the value changes. Only called when a different value is selected.
+   * Called when the value changes. Only called when a different value is selected.
    */
   onChange?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * A callback function executed when the date spinner is dismissed or closed.
+   * Called when the date spinner is dismissed or closed.
    */
   onBlur?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * A callback function executed when the date spinner is revealed or opened.
+   * Called when the date spinner is revealed or opened.
    */
   onFocus?: (event: CallbackEvent<typeof tagName>) => void | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -3,10 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DateSpinner',
   description:
-    'The `DateSpinner` component enables merchants to select a specific date using a spinner interface with scrollable columns for month, day, and year. Use it to provide compact date selection in constrained spaces.' +
-    '\n\n`DateSpinner` uses ISO 8601 date format (`YYYY-MM-DD`) only. Other date formats require conversion before setting the value property.' +
-    '\n\n`DateSpinner` offers an alternative to [calendar-style pickers](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) when space is limited or when users prefer scrolling through date values. The spinner interface allows merchants to select dates by scrolling through separate columns for month, day, and year, providing a compact and intuitive way to select dates in constrained layouts.' +
-    "\n\n`DateSpinner` doesn't include field labels, help text, or error messaging. Combine the component with other UI elements or text components to provide complete form field experiences.",
+    'The `DateSpinner` component enables merchants to select dates using a spinner interface with scrollable columns for month, day, and year. Use it for compact date selection in space-constrained layouts or when selecting dates close to the current date.' +
+    '\n\nFor visual calendar context, use [`DatePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker). For exact date entry, use [`DateField`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datefield).',
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DateSpinner',
   description:
     'The `DateSpinner` component enables merchants to select dates using a spinner interface with scrollable columns for month, day, and year. Use it for compact date selection in space-constrained layouts or when selecting dates close to the current date.' +
-    '\n\nFor visual calendar context, use [`DatePicker`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker). For exact date entry, use [`DateField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield).',
+    '\n\nFor visual calendar context, consider using [`DatePicker`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) instead. For text date entry, use [`DateField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield).',
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'DateSpinner',
   description:
     'The `DateSpinner` component enables merchants to select dates using a spinner interface with scrollable columns for month, day, and year. Use it for compact date selection in space-constrained layouts or when selecting dates close to the current date.' +
-    '\n\nFor visual calendar context, use [`DatePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker). For exact date entry, use [`DateField`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datefield).',
+    '\n\nFor visual calendar context, use [`DatePicker`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker). For exact date entry, use [`DateField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield).',
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Divider',
   description:
-    'The `Divider` component creates visual separation between content sections. Use it to organize information and improve content hierarchy.',
+    'The `Divider` component creates visual separation between content sections by rendering a horizontal or vertical line. Use it to organize information and improve content hierarchy.',
   thumbnail: 'divider-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -3,10 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Divider',
   description:
-    'The `Divider` component creates a visual separation between content sections. Use dividers to organize information and improve content hierarchy by providing clear section boundaries.' +
-    '\n\nThe component renders a subtle horizontal line that follows design system specifications for color and thickness, maintaining visual consistency across the interface. It provides a clean way to separate content groups without adding significant visual weight, helping merchants scan and understand interface structure through strategic content segmentation.' +
-    "\n\nTo maintain consistency with the native POS styling, The component doesn't support custom styling beyond the available direction property. Other visual properties are controlled by the POS design system." +
-    "\n\n`Divider` components support both full-width and inset dividers with configurable margins, allowing precise control over visual separation without adding custom CSS for common divider placement patterns. Dividers don't automatically adjust spacing around themselves. Ensure your design uses appropriate margins and padding to achieve proper visual separation.",
+    'The `Divider` component creates visual separation between content sections. Use it to organize information and improve content hierarchy.',
   thumbnail: 'divider-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -23,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'divider-default.png',
     description:
-      'Create visual separation between content sections using a `Divider` component. This example shows a horizontal divider that provides clear section boundaries.',
+      'Separate content sections using a `Divider` component. This example shows a basic horizontal divider.',
     codeblock: {
       title: 'Separate content sections with a divider',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField.d.ts
@@ -93,19 +93,19 @@ export interface EmailFieldJSXProps
     | 'details'
   > {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -3,9 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'EmailField',
   description:
-    'The `EmailField` component captures email address input from customers. Use it to collect email information in forms, customer profiles, or contact workflows.' +
-    "\n\n`EmailField` provides the input interface but doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results." +
-    '\n\n`EmailField` components integrate with browser autocomplete features to speed up email entry by suggesting previously used addresses, significantly reducing typing time during customer registration workflows.',
+    'The `EmailField` component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
+    "\n\n`EmailField` doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results.",
   thumbnail: 'email-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -34,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'email-field-default.png',
     description:
-      'Capture email address input using an `EmailField` component with built-in email validation. This example shows a basic email field with label and automatic format validation.',
+      'Capture email address input using an `EmailField` component. This example shows a basic email field with a label for collecting email information.',
     codeblock: {
       title: 'Capture email addresses with an email field',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
     'The `Heading` component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces.' +
-    '\n\nHeading levels adjust automatically based on nesting within parent [`Section`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.',
+    '\n\nHeading levels adjust automatically based on nesting within parent [`Section`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.',
   thumbnail: 'heading-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
-    "The `Heading` component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces. Heading levels adjust automatically based on nesting within parent [`Section`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline. Use plain text or simple inline elements only for heading content; rich text format isn't supported." +
-    '\n\nThe styling of `Heading` components is controlled by the POS design system. This provides consistent typographic scaling that maintains visual hierarchy while ensuring headings remain readable at all levels, even when deeply nested within multiple [`Section`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/layout-and-structure/section) components. ',
+    'The `Heading` component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces.' +
+    '\n\nHeading levels adjust automatically based on nesting within parent [`Section`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.',
   thumbnail: 'heading-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
     'The `Icon` component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories. Use icons to enhance navigation or provide visual context alongside text.' +
-    '\n\nFor interactive icons, wrap them in [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components.',
+    '\n\nFor interactive icons, wrap them in [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components.',
   thumbnail: 'icon-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -3,9 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
-    'The `Icon` component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories consistently. Use icons to enhance navigation or provide visual context alongside text in POS interfaces.' +
-    "\n\n To use icons to create interactive UI elements, wrap them in [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components. Icons on their behave purely as images and don't support click events or interactive behaviors." +
-    "\n\n To maintain a consistent visual apperance, icon styling is controlled by the POS design system. Custom styling and external icon libraries aren't supported. Icons are optimized for readability at standard sizes and automatically scale to maintain visual consistency across different screen densities and device types.",
+    'The `Icon` component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories. Use icons to enhance navigation or provide visual context alongside text.' +
+    '\n\nFor interactive icons, wrap them in [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components.',
   thumbnail: 'icon-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -3,9 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
-    'The `Image` component adds visual content to the POS interface and allows you to customize the presentation of visuals. Use images to showcase products, illustrate concepts, provide visual context, or support user tasks and interactions in POS workflows. Images are display-only components. For interactive functionality, wrap them in [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components.' +
-    '\n\nImages enhance the user experience by providing immediate visual recognition and reducing cognitive load.' +
-    '\n\n`Image` components handle loading errors gracefully with fallback options and provides placeholder states to maintain layout stability during image loading on slower network connections. The component implements lazy loading for images outside the viewport, improving initial page load performance while ensuring smooth scrolling as merchants navigate through product catalogs or image-heavy interfaces.',
+    'The `Image` component displays visual content. Use images to showcase products, illustrate concepts, or provide visual context in POS workflows.' +
+    '\n\nImages are display-only components. For interactive functionality, wrap them in [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components.',
   thumbnail: 'image-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
     'The `Image` component displays visual content. Use images to showcase products, illustrate concepts, or provide visual context in POS workflows.' +
-    '\n\nImages are display-only components. For interactive functionality, wrap them in [`Button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components.',
+    '\n\nImages are display-only components. For interactive functionality, wrap them in [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components.',
   thumbnail: 'image-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -4,8 +4,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Modal',
   description:
     'The `Modal` component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.' +
-    '\n\nModals block interaction with the underlying interface until the merchant resolves the modal content. The component maintains focus within the modal boundary and returns focus to the trigger element on close, ensuring keyboard navigation remains predictable throughout the modal lifecycle.' +
-    "\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through events and commands.",
+    '\n\nModals block interaction with the underlying interface until the merchant resolves the modal content.' +
+    "\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through [events](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/feedback-and-status-indicators/modal#events).",
   thumbnail: 'modal-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -5,7 +5,7 @@ const data: ReferenceEntityTemplateSchema = {
   description:
     'The `Modal` component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.' +
     '\n\nModals block interaction with the underlying interface until the merchant resolves the modal content.' +
-    "\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through [events](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/feedback-and-status-indicators/modal#events).",
+    "\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through [events](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/feedback-and-status-indicators/modal#events).",
   thumbnail: 'modal-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'NumberField',
   description:
-    "The `NumberField` component captures numeric input. Use it to collect quantity, price, or other numeric information with optional `stepper` control. Stepper controls restrict which properties are available—`label`, `details`, `placeholder`, `error`, `required`, and `inputMode` aren't supported. Choose your control type based on which properties your implementation requires." +
-    '\n\nThe component includes built-in number validation, optional min/max constraints, and step increments to ensure accurate numeric data entry. It supports various number formats including integers and decimals, with validation feedback to prevent entry errors during high-volume retail operations.',
+    'The `NumberField` component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
+    '\n\nThe component supports optional stepper controls, min/max constraints, and step increments for guided numeric entry.',
   thumbnail: 'number-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'number-field-default.png',
     description:
-      'Capture numeric input using a `NumberField` component with built-in validation and optional stepper controls. This example shows a basic number field with label and numeric validation.',
+      'Capture numeric input using a `NumberField` component. This example shows a basic number field with a label for collecting numeric values.',
     codeblock: {
       title: 'Capture numeric input with a number field',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -3,9 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Page',
   description:
-    "The `Page` component serves as the main container for app content with preset layouts and heading controls. Use it to structure full-screen views with consistent navigation and content organization. `Page` is designed for full-screen modal interfaces and isn't suitable for inline content or partial page layouts within existing POS screens." +
-    '\n\nThe component provides a complete page structure with built-in header, sidebar, and action bar layouts that follow POS design patterns. It manages heading hierarchy, spacing, and responsive behavior automatically, allowing you to focus on content rather than layout mechanics while ensuring consistent page structures across extensions. To maintain consistency, page layout and styling are controlled by the POS design system, so custom styling is limited to the provided slots and properties.' +
-    '\n\n`Page` components handle safe area insets automatically for devices with notches or rounded corners, ensuring content remains visible and interactive without manual padding adjustments for different device shapes.',
+    'The `Page` component serves as the main container for app content with preset layouts and heading controls. Use it to structure full-screen views with consistent navigation and content organization.' +
+    "\n\n`Page` is designed for full-screen modal interfaces and isn't suitable for inline content or partial page layouts within existing POS screens.",
   thumbnail: 'page-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -55,7 +54,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-The secondary-actions slot supports only a single button element. Multiple actions in the action bar aren't supported and should be handled within the main content area.
+The \`secondary-actions\` slot supports only a single button element. Multiple actions in the action bar aren't supported and should be handled within the main content area.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -4,8 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'PosBlock',
   description:
     'The `PosBlock` component creates a container to place content with an action button. Use it to display structured content within POS block targets.' +
-    "\n\nThe component provides a standardized layout specifically designed for content blocks within POS detail views, with consistent padding, spacing, and optional action buttons. It integrates with the native POS design language, ensuring extension content feels cohesive with the core POS interface while maintaining clear content boundaries. Custom styling beyond content organization isn't supported." +
-    '\n\n`PosBlock` components provide consistent interaction patterns for action buttons across different block types, ensuring merchants can predict button behavior and location regardless of the specific POS context.',
+    '\n\nThe component provides a standardized layout specifically designed for content blocks within POS detail views, with consistent padding, spacing, and optional action buttons.',
   thumbnail: 'pos-block-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -4,8 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'ScrollBox',
   description:
     'The `ScrollBox` component creates a scrollable area for content that exceeds container bounds. Use it to display large amounts of content within constrained spaces while maintaining usability.' +
-    '\n\nThe component creates a defined scrollable area with customizable dimensions and scroll behavior, essential for constraining content height in modal dialogs and constrained layouts. It provides touch-optimized scrolling for POS devices with visual scroll indicators.' +
-    '\n\n`ScrollBox` components provide scrollbar styling that matches the design system while ensuring sufficient contrast for visibility, with automatic thickness adjustments for touch-based scrolling versus mouse-based scrolling.',
+    '\n\nThe component creates a defined scrollable area with customizable dimensions and scroll behavior.',
   thumbnail: 'scrollbox-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField.d.ts
@@ -77,19 +77,19 @@ declare const tagName = 's-search-field';
 export interface SearchFieldJSXProps
   extends Pick<SearchFieldProps, 'id' | 'disabled' | 'placeholder' | 'value'> {
   /**
-   * A callback function executed when the user changes the value in the field.
+   * Called when the user changes the value in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed when the field loses focus after the user changes the value in the field.
+   * Called when the field loses focus after the user changes the value in the field.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed when the field loses focus.
+   * Called when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed when the field is focused.
+   * Called when the field is focused.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -3,10 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'SearchField',
   description:
-    'The `SearchField` component captures search terms using a single-line input field. Use it to enable search and filtering within POS interfaces.' +
-    '\n\nThe component includes built-in debouncing to optimize performance during real-time search operations and supports features like autocomplete suggestions and search history. It provides clear visual feedback for search states including loading, results found, and no results, helping merchants quickly locate products, customers, or orders in large catalogs.' +
-    '\n\n`SearchField` components clear search queries with a single tap on the clear button while maintaining search history for quick access to recent searches, balancing convenience with data management.' +
-    '\n\n`SearchField` is optimized for inline search and filtering. For additional search features like sorting and search history use a custom implementation.',
+    'The `SearchField` component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers.',
   thumbnail: 'search-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -29,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'search-field-default.png',
     description:
-      'Enable search functionality using a `SearchField` component with built-in debouncing. This example shows a basic search field with placeholder text.',
+      'Enable search functionality using a `SearchField` component. This example shows a basic search field with placeholder text.',
     codeblock: {
       title: 'Enable search with a search field',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -3,9 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Section',
   description:
-    'The `Section` component groups related content into clearly-defined thematic areas. Sections have contextual heading levels to maintain a meaningful page structure.' +
-    '\n\nUse sections to organize content logically and provide clear navigation landmarks. The component manages heading levels automatically to ensure nested sections maintain proper semantic structure.' +
-    "\n\nTo maintain clean, focused interfaces that don't overwhelm users, only one secondary action button is supported for each section.",
+    'The `Section` component groups related content into clearly-defined thematic areas. Use it to organize content and provide clear navigation landmarks.' +
+    '\n\nThe component manages heading levels automatically, ensuring nested sections maintain proper semantic structure.',
   thumbnail: 'section-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -28,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'section-default.png',
     description:
-      'Group related content using a `Section` component with automatic heading level management. This example shows a basic section with a heading and content area.',
+      'Group related content using a `Section` component. This example shows a basic section with a heading and content area.',
     codeblock: {
       title: 'Group related content into sections',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Section',
   description:
     'The `Section` component groups related content into clearly-defined thematic areas. Use it to organize content and provide clear navigation landmarks.' +
-    '\n\nThe component manages heading levels automatically, ensuring nested sections maintain proper semantic structure.',
+    '\n\nThe component manages heading levels automatically, ensuring nested sections maintain proper semantic structure. Only one secondary action button is supported for each section.',
   thumbnail: 'section-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -3,10 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
-    'The `Stack` component organizes elements horizontally or vertically along the block or inline axis. Use it to structure layouts, group related components, or control spacing between elements with flexible alignment options.' +
-    '\n\nThe component simplifies layout creation by automatically managing spacing between child elements through gap properties, eliminating the need for manual margin management. It supports both horizontal and vertical arrangements, flexible alignment options, and wrapping behavior, making it the foundation for building consistent, responsive layouts throughout POS extensions.' +
-    "\n\nThe spacing of `Stack` components' gap values automatically adjust based on screen size. This ensures layouts remain visually balanced and maintain proper element separation across different devices." +
-    '\n\nComplex grid-like layouts may require multiple nested `Stack` components or alternative layout approaches for optimal results.',
+    'The `Stack` component organizes elements along the block (vertical) or inline (horizontal) axis. Use it to structure layouts and control spacing between elements.' +
+    '\n\nThe component automatically manages spacing through gap properties and supports flexible alignment and wrapping behavior. Complex grid-like layouts may require multiple nested `Stack` components or alternative layout approaches.',
   thumbnail: 'stack-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -23,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'stack-default.png',
     description:
-      'Organize elements horizontally or vertically using a `Stack` component with automatic spacing. This example shows a basic stack with gap spacing between child elements.',
+      'Organize elements using a `Stack` component. This example shows a basic stack with spacing between child elements.',
     codeblock: {
       title: 'Organize elements with a stack',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -4,8 +4,6 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Text',
   description:
     'The `Text` component displays text with specific visual styles or tones. Use it to present content with appropriate emphasis, hierarchy, or tone while maintaining semantic meaning.' +
-    '\n\nText provides flexible styling options that integrate with the POS design system while ensuring proper contrast and readability across different contexts.' +
-    '\n\nThe component automatically adjusts line length for optimal readability based on container width, preventing overly long lines that reduce reading speed and comprehension in wider layouts.' +
     '\n\nText on mobile surfaces is blockish, rather than inline.',
   thumbnail: 'text-thumbnail.png',
   isVisualComponent: true,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'TextArea',
   description:
     'The `TextArea` component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
-    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [`TextField`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textfield).',
+    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [`TextField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/textfield).',
   thumbnail: 'text-area-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextArea',
   description:
-    'The `TextArea` component captures plain text content with a multi-line, resizable text input area. Use it to collect descriptions, notes, comments, or other extended text input in forms and data entry workflows.' +
-    '\n\nThe component provides a multi-line text input area that accommodates longer content. It supports validation and multi-line formatting, making it ideal for capturing detailed information such as order notes, product descriptions, or customer feedback that requires more than single-line input.',
+    'The `TextArea` component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
+    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [`TextField`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textfield).',
   thumbnail: 'text-area-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'text-area-default.png',
     description:
-      'Capture multi-line text input using a `TextArea` component with resizable height. This example shows a basic text area with label for longer content entry.',
+      'Capture multi-line text input using a `TextArea` component. This example shows a basic text area with a label for extended content.',
     codeblock: {
       title: 'Capture multi-line text with a text area',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'TextField',
   description:
     'The `TextField` component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
-    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [`TextArea`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textarea) component.',
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [`TextArea`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/textarea) component.',
   thumbnail: 'text-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextField',
   description:
-    'The `TextField` component captures single-line text input. Use it to collect short, free-form information in forms and data entry workflows. For multi-line text entry, use the [`TextArea`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/textarea) component.' +
-    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. It includes built-in support for labels, helper text, and error states to guide merchants through data entry, ensuring accurate and efficient information capture across different retail scenarios.',
+    'The `TextField` component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [`TextArea`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textarea) component.',
   thumbnail: 'text-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -5,7 +5,7 @@ const data: ReferenceEntityTemplateSchema = {
   description:
     'The `Tile` component displays interactive buttons for the POS smart grid. Use tiles as customizable shortcuts that allow merchants to quickly access workflows, actions, and information from the smart grid.' +
     '\n\nTiles can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They can display contextual information through titles, subtitles, and badge values.' +
-    '\n\nEach POS UI extension can only render one `Tile` component for each [home screen tile target](/docs/api/pos-ui-extensions/2026-01-rc/targets/home-screen#home-screen-tile-).',
+    '\n\nEach POS UI extension can only render one `Tile` component for each [home screen tile target](/docs/api/pos-ui-extensions/2025-10/targets/home-screen#home-screen-tile-).',
   thumbnail: 'tile-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -3,10 +3,9 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Tile',
   description:
-    'The `Tile` component displays interactive buttons for the POS smart grid that allow merchants to complete actions quickly. Tiles serve as customizable shortcuts that provide contextual information and enable merchants to quickly access workflows, actions, and information from the smart grid.' +
-    '\n\nTiles are dynamic components that can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They support tap interactions, visual feedback, and can display contextual information through titles, subtitles, and badge values.' +
-    "\n\nTo maintain a consistent visual experience, tile size and layout are determined by the smart grid system, and custom icons and images aren't supported." +
-    '\n\nEach POS UI extension can only render one `Tile` component for each [home screen tile target](/docs/api/pos-ui-extensions/2025-10/targets/home-screen#home-screen-tile-).',
+    'The `Tile` component displays interactive buttons for the POS smart grid. Use tiles as customizable shortcuts that allow merchants to quickly access workflows, actions, and information from the smart grid.' +
+    '\n\nTiles can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They can display contextual information through titles, subtitles, and badge values.' +
+    '\n\nEach POS UI extension can only render one `Tile` component for each [home screen tile target](/docs/api/pos-ui-extensions/2026-01-rc/targets/home-screen#home-screen-tile-).',
   thumbnail: 'tile-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField.d.ts
@@ -80,19 +80,19 @@ export interface TimeFieldJSXProps
     'id' | 'label' | 'disabled' | 'value' | 'error' | 'details'
   > {
   /**
-   * A callback function executed when the user makes any changes in the field.
+   * Called when the user makes any changes in the field.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed after editing completes, typically on blur.
+   * Called after editing completes, typically on blur.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed when the element loses focus.
+   * Called when the element loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function executed when the element receives focus.
+   * Called when the element receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'TimeField',
   description:
     'The `TimeField` component captures time input through direct text entry. Use it when merchants know the exact time they want to enter or for quick time data entry.' +
-    '\n\nFor visual time selection with clock or spinner interfaces, use [`TimePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timepicker).',
+    '\n\nFor visual time selection with clock or spinner interfaces, use [`TimePicker`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/timepicker).',
   thumbnail: 'time-field-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -3,10 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimeField',
   description:
-    'The `TimeField` component captures time input with a consistent interface for time selection and validation. Use it to collect time information in scheduling, booking, or data entry workflows.' +
-    '\n\nThe component supports both 12-hour and 24-hour time formats based on locale settings. It includes features like time picker integration, keyboard shortcuts, and formatted display to streamline time entry for scheduling, appointment booking, and time-sensitive operations in retail environments.' +
-    '\n\n`TimeField` components respects merchant locale settings for default time format preferences while allowing manual override for specific use cases that require alternative formats.' +
-    '\n\n`TimeField` provides only text-based time input. For visual time selection with clock or spinner interfaces, use the [`TimePicker`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/timepicker) component which offers interactive time selection.',
+    'The `TimeField` component captures time input through direct text entry. Use it when merchants know the exact time they want to enter or for quick time data entry.' +
+    '\n\nFor visual time selection with clock or spinner interfaces, use [`TimePicker`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timepicker).',
   thumbnail: 'time-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -29,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'time-field-default.png',
     description:
-      'Capture time input using a `TimeField` component with locale-aware formatting. This example shows a basic time field with label and time validation.',
+      'Capture time input using a `TimeField` component. This example shows a basic time field with a label for time entry.',
     codeblock: {
       title: 'Capture time input with a time field',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker.d.ts
@@ -77,19 +77,19 @@ declare const tagName = 's-time-picker';
 export interface TimePickerJSXProps
   extends Pick<TimePickerProps, 'id' | 'value'> {
   /**
-   * A callback function executed when the user selects a time from the picker.
+   * Called when the user selects a time from the picker.
    */
   onInput?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * A callback function executed when the user selects a time from the picker that is different from the current value.
+   * Called when the user selects a time from the picker that is different from the current value.
    */
   onChange?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * A callback function executed when the time picker is dismissed or closed.
+   * Called when the time picker is dismissed or closed.
    */
   onBlur?: (event: CallbackEvent<typeof tagName>) => void | null;
   /**
-   * A callback function executed when the time picker is revealed or opened.
+   * Called when the time picker is revealed or opened.
    */
   onFocus?: (event: CallbackEvent<typeof tagName>) => void | null;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'TimePicker',
   description:
     'The `TimePicker` component allows merchants to select times using an interactive picker interface. Use it when merchants benefit from visual time selection rather than typing exact times.' +
-    '\n\nFor direct text entry when merchants know the exact time, use [`TimeField`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timefield).',
+    '\n\nFor direct text entry when merchants know the exact time, use [`TimeField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/timefield).',
   thumbnail: 'time-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimePicker',
   description:
-    'The `TimePicker` component allows merchants to select a specific time using an interactive picker interface. This offers a more visual and touch-friendly alternative to [text-based time input](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/timefield), making time selection faster and more accurate.' +
-    '\n\n`TimePicker` provides the picker interface but requires external state management for the selected value. You must manage the selected time value in your application state and update it using the `onChange` callback.',
+    'The `TimePicker` component allows merchants to select times using an interactive picker interface. Use it when merchants benefit from visual time selection rather than typing exact times.' +
+    '\n\nFor direct text entry when merchants know the exact time, use [`TimeField`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timefield).',
   thumbnail: 'time-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'time-spinner-default.png',
     description:
-      'Enable visual time selection using a `TimePicker` component with an interactive picker interface. This example shows a basic time picker for selecting hours and minutes.',
+      'Select times using a `TimePicker` component. This example shows a basic time picker for selecting hours and minutes.',
     codeblock: {
       title: 'Select times with a time picker',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
@@ -745,7 +745,7 @@ export interface BadgeProps extends GlobalProps {
    */
   children?: ComponentChildren;
   /**
-   * The semantic tone of the badge, based on the intention of the information being conveyed. Affects color and styling to communicate meaning.
+   * The semantic tone of the badge, based on the intention of the information being conveyed. Badges rely on the tone system for semantic meaning, so using custom styling may not clearly convey meaning to merchants.
    *
    * @default 'auto'
    */
@@ -777,7 +777,7 @@ export interface BadgeProps extends GlobalProps {
 }
 export interface BannerProps extends GlobalProps, ActionSlots {
   /**
-   * The title text displayed prominently at the top of the banner, summarizing the banner's main message in a single, scannable line. This heading is typically concise (3-8 words) and immediately communicates the banner's purpose or key information without requiring users to read the full banner content. The heading appears before the banner's child content and uses emphasized typography to catch attention. When omitted, the banner displays only its child content and actions without a title. Clear, action-oriented or informative headings tell users what they need to know at a glance (for example, "Order placed successfully", "Action required", "New feature available", "Connection lost"). The heading's visual style adapts to the banner's `tone` property for semantic consistency.
+   * The title text displayed prominently at the top of the banner. This is the only property for text content—body text content isn't supported. You can't place `<s-text>` or other text elements as children.
    *
    * @default ''
    */
@@ -1245,13 +1245,13 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
    */
   onClick?: (event: Event) => void;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
   disabled?: boolean;
   /**
-   * Indicates whether the button action is currently in progress. When `true`, displays a loading spinner or progress indicator and prevents additional clicks to avoid duplicate submissions. The button remains visually enabled but unresponsive to interaction. Set to `true` when starting an async operation (for example, API call, navigation) and back to `false` when the operation completes or fails. This provides user feedback during long-running operations and prevents race conditions from multiple rapid clicks.
+   * Indicates whether the button action is currently in progress. When `true`, replaces all button content with a loading spinner and prevents additional clicks to avoid duplicate submissions. The button remains visually enabled but unresponsive to interaction. Set to `true` when starting an async operation (for example, API call, navigation) and back to `false` when the operation completes or fails. This provides user feedback during long-running operations and prevents race conditions from multiple rapid clicks. Custom loading indicators or partial content updates aren't supported.
    *
    * @default false
    */
@@ -1330,7 +1330,7 @@ export interface ButtonProps extends GlobalProps, BaseClickableProps {
    */
   accessibilityLabel?: string;
   /**
-   * The child elements to render within this component.
+   * The child elements to render within this component. Button content must be plain text.
    */
   children?: ComponentChildren;
   /**
@@ -1572,7 +1572,7 @@ export interface BaseSelectableProps {
    */
   accessibilityLabel?: string;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -1653,11 +1653,11 @@ export interface ChoiceListProps
    */
   multiple?: boolean;
   /**
-   * The child elements to render within this component.
+   * The child elements to render within this component. Within `ChoiceList`, use only `Choice` components as children. Other component types can't be used as options within the choice list.
    */
   children?: ComponentChildren;
   /**
-   * Whether the field is disabled, preventing any user interaction.
+   * Whether the field is disabled, preventing user interaction. Use when the field is temporarily unavailable due to application state, permissions, or dependencies.
    *
    * @default false
    */
@@ -1686,7 +1686,7 @@ export interface ClickableProps
    */
   loading?: BaseClickableProps['loading'];
   /**
-   * Whether the element is disabled, preventing any user interaction.
+   * Whether the element is disabled, preventing user interaction. Use when temporarily unavailable due to application state, permissions, or dependencies. Child elements can still receive focus and be interacted with.
    */
   disabled?: BaseClickableProps['disabled'];
   /**
@@ -1914,7 +1914,7 @@ export interface DatePickerProps
    */
   defaultValue?: string;
   /**
-   * The currently selected date value in ISO date format (YYYY-MM-DD, for example, `"2024-05-15"`). An empty string means no date is selected. For date ranges, use comma-separated dates (for example, `"2024-05-15,2024-05-20"`).
+   * The currently selected date value in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (`YYYY-MM-DD`, for example, `"2024-05-15"`). An empty string means no date is selected. For date ranges, use comma-separated dates (for example, `"2024-05-15,2024-05-20"`). Other date formats require conversion before setting this property. The selection mode (`type` property) is inferred from the value format: single date for one value, multiple dates for comma-separated values without a range, and range for two comma-separated dates when `type` is set to 'range'.
    *
    * @default ""
    */
@@ -1991,7 +1991,7 @@ export interface DateSpinnerProps
    */
   onInput?: (event: Event) => void;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed. Date validation occurs when the user finishes editing (on blur), rather than on every keystroke.
    */
   onChange?: (event: Event) => void;
 }
@@ -2172,7 +2172,7 @@ export interface HeadingProps
     AccessibilityVisibilityProps,
     BlockTypographyProps {
   /**
-   * The child elements to render within this component.
+   * The child elements to render within this component. Use plain text or simple inline elements only for heading content. Rich text format isn't supported.
    */
   children?: ComponentChildren;
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
@@ -45,19 +45,19 @@ export interface ActionSlots {
  */
 export interface BaseOverlayProps {
   /**
-   * A callback function executed when the overlay begins to appear, immediately after `showOverlay()` is called or the `hidden` property changes to `false`, but before any show animations start. The element may not be visible yet. Common operations include initializing overlay content, fetching data needed for display, setting focus on the first interactive element, or tracking analytics events. Layout calculations should be avoided here as the element may not have final dimensions yet.
+   * Called when the overlay begins to appear, immediately after `showOverlay()` is called or the `hidden` property changes to `false`, but before any show animations start. The element may not be visible yet. Common operations include initializing overlay content, fetching data needed for display, setting focus on the first interactive element, or tracking analytics events. Layout calculations should be avoided here as the element may not have final dimensions yet.
    */
   onShow?: (event: Event) => void;
   /**
-   * A callback function executed after the overlay is fully visible and all show animations have completed. At this point, the overlay is completely rendered with final dimensions and positioning. Common operations include focusing specific elements after animations complete, measuring rendered content dimensions, triggering secondary animations, or initializing interactive features that depend on final layout. This is the safest point for DOM measurements and layout-dependent operations.
+   * Called after the overlay is fully visible and all show animations have completed. At this point, the overlay is completely rendered with final dimensions and positioning. Common operations include focusing specific elements after animations complete, measuring rendered content dimensions, triggering secondary animations, or initializing interactive features that depend on final layout. This is the safest point for DOM measurements and layout-dependent operations.
    */
   onAfterShow?: (event: Event) => void;
   /**
-   * A callback function executed when the overlay begins to hide, immediately after `hideOverlay()` is called or the `hidden` property changes to `true`, but before any hide animations start. The element is still visible. Common operations include cleanup tasks, saving overlay state before it disappears, canceling pending requests, or preparing for the post-hide state. This is the last opportunity to interact with the visible overlay before animations begin.
+   * Called when the overlay begins to hide, immediately after `hideOverlay()` is called or the `hidden` property changes to `true`, but before any hide animations start. The element is still visible. Common operations include cleanup tasks, saving overlay state before it disappears, canceling pending requests, or preparing for the post-hide state. This is the last opportunity to interact with the visible overlay before animations begin.
    */
   onHide?: (event: Event) => void;
   /**
-   * A callback function executed after the overlay is completely hidden and all hide animations have finished. The element is no longer visible or interactive. Common operations include final cleanup, focusing the element that triggered the overlay, navigating to another view, freeing resources, or performing operations that should only occur after the overlay is completely dismissed. Post-dismissal navigation or state updates that would be jarring during animations are appropriate here.
+   * Called after the overlay is completely hidden and all hide animations have finished. The element is no longer visible or interactive. Common operations include final cleanup, focusing the element that triggered the overlay, navigating to another view, freeing resources, or performing operations that should only occur after the overlay is completely dismissed. Post-dismissal navigation or state updates that would be jarring during animations are appropriate here.
    */
   onAfterHide?: (event: Event) => void;
 }
@@ -92,11 +92,11 @@ export interface BaseOverlayMethods {
  */
 export interface FocusEventProps {
   /**
-   * A callback function executed when focus is removed from the element, either by the user moving to another field (tabbing, clicking elsewhere) or programmatically using `blur()`. This event fires before `onChange` for modified fields. The event contains information about which element is receiving focus next (`relatedTarget`). Common operations include triggering validation, saving in-progress changes, hiding related UI elements like autocomplete dropdowns, or tracking field interaction analytics. A common pattern is validating and showing errors on blur to avoid disrupting users while they're still typing. Learn more about [blur events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
+   * Called when focus is removed from the element, either by the user moving to another field (tabbing, clicking elsewhere) or programmatically using `blur()`. This event fires before `onChange` for modified fields. The event contains information about which element is receiving focus next (`relatedTarget`). Common operations include triggering validation, saving in-progress changes, hiding related UI elements like autocomplete dropdowns, or tracking field interaction analytics. A common pattern is validating and showing errors on blur to avoid disrupting users while they're still typing. Learn more about [blur events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
    */
   onBlur?: (event: FocusEvent) => void;
   /**
-   * A callback function executed when the element receives focus through user interaction (clicking, tabbing) or programmatic methods like `focus()`. This event fires before any input occurs. The event contains information about which element previously had focus (`relatedTarget`). Common operations include showing helper text, highlighting the active field, displaying related UI like autocomplete suggestions, preselecting content, or tracking which fields users interact with. A common pattern is clearing errors on focus to provide a fresh start when users re-attempt input after validation failure. Learn more about [focus events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
+   * Called when the element receives focus through user interaction (clicking, tabbing) or programmatic methods like `focus()`. This event fires before any input occurs. The event contains information about which element previously had focus (`relatedTarget`). Common operations include showing helper text, highlighting the active field, displaying related UI like autocomplete suggestions, preselecting content, or tracking which fields users interact with. A common pattern is clearing errors on focus to provide a fresh start when users re-attempt input after validation failure. Learn more about [focus events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
    */
   onFocus?: (event: FocusEvent) => void;
 }
@@ -812,11 +812,11 @@ export interface BannerProps extends GlobalProps, ActionSlots {
    */
   dismissible?: boolean;
   /**
-   * A callback function executed when the user dismisses the banner by clicking the close (X) button. This only fires for user-initiated dismissals through the UI close button, not when the banner is hidden programmatically using the `hidden` property. The callback fires after the user clicks but before hide animations begin. Common operations include tracking dismissal metrics, saving user preferences to avoid showing the banner again, performing cleanup when banners are dismissed, or triggering follow-up actions. The banner remains in the DOM after dismissal (just hidden) until re-rendered—complete removal requires controlling rendering at the component level based on dismissal state.
+   * Called when the user dismisses the banner by clicking the close (X) button. This only fires for user-initiated dismissals through the UI close button, not when the banner is hidden programmatically using the `hidden` property. The callback fires after the user clicks but before hide animations begin. Common operations include tracking dismissal metrics, saving user preferences to avoid showing the banner again, performing cleanup when banners are dismissed, or triggering follow-up actions. The banner remains in the DOM after dismissal (just hidden) until re-rendered—complete removal requires controlling rendering at the component level based on dismissal state.
    */
   onDismiss?: (event: Event) => void;
   /**
-   * A callback function executed after the element is fully hidden and all hide animations have completed.
+   * Called after the element is fully hidden and all hide animations have completed.
    *
    * @implementation If implementations animate the hiding of the banner,
    * this event must fire after the banner has fully hidden.
@@ -1241,7 +1241,7 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
    */
   type?: 'submit' | 'button' | 'reset';
   /**
-   * A callback function executed when the element is clicked or activated. Learn more about [click events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
+   * Called when the element is clicked or activated. Learn more about [click events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
    */
   onClick?: (event: Event) => void;
   /**
@@ -1288,7 +1288,7 @@ export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
    */
   download?: string;
   /**
-   * A callback function executed when the element is clicked or activated. Learn more about [click events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
+   * Called when the element is clicked or activated. Learn more about [click events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
    */
   onClick?: (event: Event) => void;
 }
@@ -1392,11 +1392,11 @@ export interface BaseInputProps {
  */
 export interface InputProps extends BaseInputProps {
   /**
-   * A callback function executed when the user has committed a value change, typically triggered when the field loses focus (blur) after the value has been modified. Unlike `onInput`, this fires only once after editing is complete, not during typing. The event contains the finalized value. Common operations include validation, saving data, or triggering actions that should occur after the user finishes editing rather than during typing. For controlled components, the `value` prop should be updated in this callback. This is ideal for expensive operations like API calls that shouldn't happen on every keystroke. Learn more about [change events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   * Called when the user has committed a value change, typically triggered when the field loses focus (blur) after the value has been modified. Unlike `onInput`, this fires only once after editing is complete, not during typing. The event contains the finalized value. Common operations include validation, saving data, or triggering actions that should occur after the user finishes editing rather than during typing. For controlled components, the `value` prop should be updated in this callback. This is ideal for expensive operations like API calls that shouldn't happen on every keystroke. Learn more about [change events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
    */
   onChange?: (event: Event) => void;
   /**
-   * A callback function executed immediately when the user makes any change to the field value. Fires on every keystroke, paste, or other input modification before the field loses focus. The event contains the current field value. Common operations include real-time validation, character counting, formatting input as users type, or implementing autocomplete/search-as-you-type features. For controlled components, the `value` prop should be updated in this callback to keep state in sync. Expensive operations should be avoided here as this fires frequently during typing. Learn more about [input events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   * Called immediately when the user makes any change to the field value. Fires on every keystroke, paste, or other input modification before the field loses focus. The event contains the current field value. Common operations include real-time validation, character counting, formatting input as users type, or implementing autocomplete/search-as-you-type features. For controlled components, the `value` prop should be updated in this callback to keep state in sync. Expensive operations should be avoided here as this fires frequently during typing. Learn more about [input events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
    */
   onInput?: (event: Event) => void;
   /**
@@ -1415,11 +1415,11 @@ export interface InputProps extends BaseInputProps {
  */
 export interface MultipleInputProps extends BaseInputProps {
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed. Learn more about [change events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed. Learn more about [change events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
    */
   onChange?: (event: Event) => void;
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction. Learn more about [input events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction. Learn more about [input events on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
    */
   onInput?: (event: Event) => void;
   /**
@@ -1854,7 +1854,7 @@ export interface DatePickerProps
    */
   view?: string;
   /**
-   * A callback function executed when the visible month displayed in the date picker changes, either through user navigation (clicking next/previous month buttons) or programmatic updates to the `view` property. The callback receives the new month as a string in `YYYY-MM` format (for example, `"2024-05"`). Common operations include tracking which month users are viewing, loading month-specific data (like availability or pricing), syncing the view with external state, or implementing custom navigation controls. For controlled date pickers, the `view` property should be updated in this callback to keep the displayed month in sync with application state. The callback fires after the month has changed but before the new month's dates are fully rendered, making it well-suited for triggering data fetches.
+   * Called when the visible month displayed in the date picker changes, either through user navigation (clicking next/previous month buttons) or programmatic updates to the `view` property. The callback receives the new month as a string in `YYYY-MM` format (for example, `"2024-05"`). Common operations include tracking which month users are viewing, loading month-specific data (like availability or pricing), syncing the view with external state, or implementing custom navigation controls. For controlled date pickers, the `view` property should be updated in this callback to keep the displayed month in sync with application state. The callback fires after the month has changed but before the new month's dates are fully rendered, making it well-suited for triggering data fetches.
    */
   onViewChange?: (view: string) => void;
   /**
@@ -1920,11 +1920,11 @@ export interface DatePickerProps
    */
   value?: string;
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: Event) => void;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed.
    */
   onChange?: (event: Event) => void;
 }
@@ -1948,7 +1948,7 @@ export interface DateFieldProps
     >,
     AutocompleteProps<DateAutocompleteField> {
   /**
-   * A callback function executed when the user enters an invalid value. Fires after change validation fails.
+   * Called when the user enters an invalid value. Fires after change validation fails.
    */
   onInvalid?: (event: Event) => void;
 }
@@ -1987,11 +1987,11 @@ export interface DateSpinnerProps
    */
   value?: string;
   /**
-   * A callback function executed when the user makes any change to the field value. Fires on each keystroke or interaction.
+   * Called when the user makes any change to the field value. Fires on each keystroke or interaction.
    */
   onInput?: (event: Event) => void;
   /**
-   * A callback function executed when the user has finished editing the field, typically triggered on blur after the value has changed. Date validation occurs when the user finishes editing (on blur), rather than on every keystroke.
+   * Called when the user has finished editing the field, typically triggered on blur after the value has changed. Date validation occurs when the user finishes editing (on blur), rather than on every keystroke.
    */
   onChange?: (event: Event) => void;
 }
@@ -2304,11 +2304,11 @@ export interface ImageProps extends GlobalProps, BaseImageProps, BorderProps {
    */
   loading?: 'eager' | 'lazy';
   /**
-   * A callback function executed when the image finishes loading successfully and is ready to display. This fires after the browser has downloaded the image data and decoded it, but may fire before the image is actually painted to the screen. Common operations include hiding loading indicators, triggering dependent actions that require the image (like image processing), tracking image load metrics, or executing layout operations that depend on image dimensions. For performance tracking, timestamps between navigation start and this callback can be compared. Cached images may trigger this callback synchronously (immediately), so both async and sync invocation should be handled in code. This won't fire if the image fails to load—`onError` fires for failures. Learn more about [`onload` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload).
+   * Called when the image finishes loading successfully and is ready to display. This fires after the browser has downloaded the image data and decoded it, but may fire before the image is actually painted to the screen. Common operations include hiding loading indicators, triggering dependent actions that require the image (like image processing), tracking image load metrics, or executing layout operations that depend on image dimensions. For performance tracking, timestamps between navigation start and this callback can be compared. Cached images may trigger this callback synchronously (immediately), so both async and sync invocation should be handled in code. This won't fire if the image fails to load—`onError` fires for failures. Learn more about [`onload` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload).
    */
   onLoad?: (event: Event) => void;
   /**
-   * A callback function executed when the image fails to load due to network errors, invalid URLs, unsupported formats, [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) issues, or server errors (for example, 404, 500). The event contains limited error details for security reasons—the browser console provides specific failure reasons. Common operations include displaying fallback images (`event.target.src = 'fallback.jpg'`), showing error messages to users, logging failures for monitoring, hiding broken image icons, or providing alternative content when images are unavailable. A common pattern involves attempting to load a fallback image, and if that fails too, hiding the image container entirely. For critical images like product photos, a placeholder SVG or icon may be shown instead of a broken image indicator. This callback doesn't fire for images that are blocked by browser content policies or ad blockers. Learn more about [`onerror` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror).
+   * Called when the image fails to load due to network errors, invalid URLs, unsupported formats, [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) issues, or server errors (for example, 404, 500). The event contains limited error details for security reasons—the browser console provides specific failure reasons. Common operations include displaying fallback images (`event.target.src = 'fallback.jpg'`), showing error messages to users, logging failures for monitoring, hiding broken image icons, or providing alternative content when images are unavailable. A common pattern involves attempting to load a fallback image, and if that fails too, hiding the image container entirely. For critical images like product photos, a placeholder SVG or icon may be shown instead of a broken image indicator. This callback doesn't fire for images that are blocked by browser content policies or ad blockers. Learn more about [`onerror` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror).
    */
   onError?: (event: Event) => void;
 }
@@ -2458,7 +2458,7 @@ export interface QRCodeProps extends GlobalProps {
    */
   accessibilityLabel?: string;
   /**
-   * A callback function executed when the resource fails to load.
+   * Called when the resource fails to load.
    */
   onError?: (event: Event) => void;
   /**
@@ -2473,7 +2473,7 @@ export interface QRCodeProps extends GlobalProps {
  */
 export interface ScrollEventProps {
   /**
-   * A callback function executed when scrolling reaches or moves away from any edge of the scrollable container.
+   * Called when scrolling reaches or moves away from any edge of the scrollable container.
    *
    * Provides information about which edges are currently reached:
    * - `inline: 'start'` - at the inline-start edge (typically left in LTR)
@@ -2799,7 +2799,7 @@ export interface TimeFieldProps
       'value' | 'defaultValue' | 'allow' | 'disallow' | 'step'
     > {
   /**
-   * A callback function executed when the user enters an invalid value. Fires after change validation fails.
+   * Called when the user enters an invalid value. Fires after change validation fails.
    */
   onInvalid?: (event: Event) => void;
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/pin-pad.ts
@@ -35,7 +35,7 @@ export interface PinPadActionType {
    */
   label: string;
   /**
-   * A callback function executed when the action button is clicked. Can return the PIN digits directly as an array of numbers, or return a Promise that resolves to the PIN array. Use for implementing custom PIN retrieval logic or validation workflows.
+   * Called when the action button is clicked. Can return the PIN digits directly as an array of numbers, or return a Promise that resolves to the PIN array. Use for implementing custom PIN retrieval logic or validation workflows.
    */
   onClick: () => Promise<number[]> | number[];
 }


### PR DESCRIPTION
## This PR: 
- Revises component descriptions in the 2025-10 version to remove duplicative content and information that relates to broad POS functionality
- Moves prop-specific information to prop descriptions, and fixes some inaccurate descriptions
- Makes some minor edits to example descriptions
- Revises repetitive "A callback function..." descriptions 
- Partially fixes https://github.com/Shopify/shopify-dev/issues/65439
- Relates to [POS pilot bug bash](https://docs.google.com/spreadsheets/d/1Lm8gt_VSAHw7CF6fWsRC-S8XKgK7eiPsrtB2gCTgwok/edit)

### Tophatting

1. In the `ui-extensions` repo, run `yarn docs:point-of-sale 2025-10`.

2. In `shopify-dev`, run a server (`dev server`) with the `templated_refs_v2_m1` feature flag enabled, and review the 2025-10 docs at https://shopify-dev.shop.dev/docs/api/pos-ui-extensions/2025-10