### PR TITLE
[Remove redundant types]: POS UI extensions version 2024-07

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Button.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Button.doc.ts
@@ -17,11 +17,6 @@ const data: ReferenceEntityTemplateSchema = {
         'Configure the following properties on the `Button` component.',
       type: 'ButtonProps',
     },
-    {
-      title: 'ButtonType',
-      description: 'Determines the appearance of the button.',
-      type: 'ButtonType',
-    },
   ],
   category: 'UI components',
   subCategory: 'Actions',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Screen.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Screen.doc.ts
@@ -17,16 +17,6 @@ const data: ReferenceEntityTemplateSchema = {
         'Configure the following properties on the `Screen` component.',
       type: 'ScreenProps',
     },
-    {
-      title: 'ScreenPresentationProps',
-      description: '',
-      type: 'ScreenPresentationProps',
-    },
-    {
-      title: 'SecondaryActionProps',
-      description: '',
-      type: 'SecondaryActionProps',
-    },
   ],
   category: 'UI components',
   subCategory: 'Layout and structure',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Section.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Section.doc.ts
@@ -17,11 +17,6 @@ const data: ReferenceEntityTemplateSchema = {
         'Configure the following properties on the `Section` component.',
       type: 'SectionProps',
     },
-    {
-      title: 'SectionHeaderAction',
-      description: '',
-      type: 'SectionHeaderAction',
-    },
   ],
   category: 'UI components',
   subCategory: 'Layout and structure',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Spacing.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Spacing.doc.ts
@@ -10,12 +10,14 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'VerticalSpacing',
-      description: '',
+      description:
+        'The spacing values for controlling vertical space between elements.',
       type: 'VerticalSpacing',
     },
     {
       title: 'HorizontalSpacing',
-      description: '',
+      description:
+        'The spacing values for controlling horizontal space between elements.',
       type: 'HorizontalSpacing',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Text.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Text.doc.ts
@@ -14,16 +14,6 @@ const data: ReferenceEntityTemplateSchema = {
         'Configure the following properties on the `Text` component.',
       type: 'TextProps',
     },
-    {
-      title: 'TextVariant',
-      description: '',
-      type: 'TextVariant',
-    },
-    {
-      title: 'ColorType',
-      description: '',
-      type: 'ColorType',
-    },
   ],
   category: 'UI components',
   subCategory: 'Layout and structure',


### PR DESCRIPTION
## This PR: 
- Removes redundant types that were being referenced twice in the POS UI extensions docs for version 2024-07
- Partially fixes https://github.com/Shopify/shopify-dev/issues/65439
- Relates to [POS pilot bug bash](https://docs.google.com/spreadsheets/d/1Lm8gt_VSAHw7CF6fWsRC-S8XKgK7eiPsrtB2gCTgwok/edit)

### Tophatting

1. In the `ui-extensions` repo, run `yarn docs:point-of-sale 2024-07`.

2. In `shopify-dev`, run a server (`dev server`) with the `templated_refs_v2_m1` feature flag enabled, and review the 2024-07 docs at https://shopify-dev.shop.dev/docs/api/pos-ui-extensions/2024-07