### PR TITLE
[POS UI extensions 2025-07]: Redefine Storage API subcategory

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -13,7 +13,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'APIs',
   category: 'Target APIs',
-  subCategory: 'Standard APIs',
+  subCategory: 'Platform APIs',
   related: [],
   definitions: [
     {


### PR DESCRIPTION
## This PR: 
- Redefines the Storage API subcategory as Platform APIs versus Standard APIs, in response to Eytan's feedback: https://vault.shopify.io/gsd/reviews/61354
- Relates to https://github.com/Shopify/shopify-dev/pull/65827
- Partially closes https://github.com/Shopify/shopify-dev/issues/65791