### PR TITLE
Update POS storage api limitations doc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -81,7 +81,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
-      sectionContent: `\n- POS UI extensions can store up to a maximum of 100 entries.\n- The maximum key size is ~1 KB and the maximum value size is ~1 MB.\n- Data persists even when extension targets are disabled or removed.\n- Stored extension data is automatically cleared after 30 days of inactivity.\n`,
+      sectionContent: `\n- POS UI extensions can store up to a maximum of 100 entries.\n- The maximum key size is ~1 KB and the maximum value size is ~1 MB.\n- Data persists even when extension targets are disabled or removed.\n- Stored extension data is automatically cleared after 30 days of inactivity. The inactivity timer is reset only by write operations (\`set\`); read operations (\`get\`) do not affect the timer.\n`,
     },
   ],
 };


### PR DESCRIPTION
Part of https://github.com/shop/issues-retail/issues/21459
[Companion shopify-dev PR](https://app.graphite.com/github/pr/Shopify/shopify-dev/65897/Update-POS-UI-Extension-storage-api-limitation-docs)

### Background

Add back missing limitations & add additional detail on inactivity bullet for 2025-07 storage api docs.
