### PR TITLE
Add back missing limitations to storage api docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/storage-api.doc.ts
@@ -39,7 +39,9 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent: `
 - POS UI extensions can store up to a maximum of 100 entries.
-- Stored extension data is automatically cleared after 30 days of inactivity.
+- The maximum key size is ~1 KB and the maximum value size is ~1 MB.
+- Data persists even when extension targets are disabled or removed.
+- Stored extension data is automatically cleared after 30 days of inactivity. The inactivity timer is reset only by write operations (\`set\`); read operations (\`get\`) do not affect the timer.
 `,
     },
   ],


### PR DESCRIPTION
Part of Part of https://github.com/shop/issues-retail/issues/21459
[Companion shopify-dev PR](https://app.graphite.com/github/pr/Shopify/shopify-dev/65897/Update-POS-UI-Extension-storage-api-limitation-docs)

### Background
Add back missing limitations & add additional detail on inactivity bullet for 2026-01 storage api docs.
