### PR TITLE
Update API and add observables for discount function settings

### DIFF
--- a/.changeset/wet-cycles-punch.md
+++ b/.changeset/wet-cycles-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added subscribable discounts api. Update the type for `data.id` to string to fix a previously incorrect type.

--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -952,3 +952,38 @@ export interface ReadonlySignalLike<T> {
    */
   subscribe(fn: (value: T) => void): () => void;
 }
+
+/**
+ * A result type that indicates the success or failure of an operation.
+ */
+type Result<T> =
+  | {success: true; value: T}
+  | {success: false; errors: ValidationError[]};
+
+/**
+ * A validation error object that is returned when an operation fails.
+ */
+interface ValidationError {
+  type: 'error';
+  /**
+   * A message describing the error.
+   */
+  message: string;
+  /**
+   * A code identifier for the error.
+   */
+  code: string;
+  /**
+   * Field-level validation issues
+   */
+  issues?: {
+    message: string;
+    path: string[];
+  }[];
+}
+
+/**
+ * A function that updates a signal and returns a result indicating success or failure.
+ * The function is typically used alongisde a ReadonlySignalLike object.
+ */
+export type UpdateSignalFunction<T> = (value: T) => Result<T>;

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -18,6 +18,12 @@ const data: ReferenceEntityTemplateSchema = {
         'The object exposed to the extension that contains the discount function settings.',
       type: 'DiscountFunctionSettingsData',
     },
+    {
+      title: 'discounts',
+      description:
+        'The reactive API for managing discount function configuration.',
+      type: 'DiscountsApi',
+    },
   ],
   category: 'API',
   subCategory: 'Target APIs',

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.ts
@@ -2,7 +2,7 @@ import type {BlockExtensionApi} from '../block/block';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
 import {ApplyMetafieldChange} from './metafields';
-import {DiscountFunctionSettingsData} from './launch-options';
+import {DiscountFunctionSettingsData, DiscountsApi} from './launch-options';
 
 export interface DiscountFunctionSettingsApi<
   ExtensionTarget extends AnyExtensionTarget,
@@ -12,4 +12,5 @@ export interface DiscountFunctionSettingsApi<
    */
   applyMetafieldChange: ApplyMetafieldChange;
   data: DiscountFunctionSettingsData;
+  discounts: DiscountsApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
@@ -1,3 +1,8 @@
+import type {
+  ReadonlySignalLike,
+  UpdateSignalFunction,
+} from '../../../../shared';
+
 interface Metafield {
   description?: string;
   id: string;
@@ -7,23 +12,56 @@ interface Metafield {
   type: string;
 }
 
-export enum DiscountClass {
-  Product = 'PRODUCT',
-  Order = 'ORDER',
-  Shipping = 'SHIPPING',
-}
+type DiscountClass = 'product' | 'order' | 'shipping';
 
-interface Discount {
-  /**
-   * the discount's gid
-   */
-  id: string;
-}
+type DiscountMethod = 'automatic' | 'code';
+
+type PurchaseType = 'one_time_purchase' | 'subscription' | 'both';
 
 /**
  * The object that exposes the validation with its settings.
  */
 export interface DiscountFunctionSettingsData {
-  id: Discount;
+  /**
+   * The unique identifier for the discount.
+   */
+  id: string;
+  /**
+   * The discount metafields.
+   */
   metafields: Metafield[];
+}
+
+/**
+ * Reactive Api for managing discount function configuration.
+ */
+export interface DiscountsApi {
+  /**
+   * A signal that contains the discount classes.
+   */
+  discountClasses: ReadonlySignalLike<DiscountClass[]>;
+  /**
+   * A function that updates the discount classes.
+   */
+  updateDiscountClasses: UpdateSignalFunction<DiscountClass[]>;
+  /**
+   * A signal that contains the discount method.
+   */
+  discountMethod: ReadonlySignalLike<DiscountMethod>;
+  /**
+   * A signal that contains the purchase type.
+   */
+  purchaseType: ReadonlySignalLike<PurchaseType>;
+  /**
+   * A function that updates the purchase type.
+   */
+  updatePurchaseType: UpdateSignalFunction<PurchaseType>;
+  /**
+   * A signal that contains the recurring cycle limit for subscriptions purchases.
+   */
+  recurringCycleLimit: ReadonlySignalLike<number | null | undefined>;
+  /**
+   * A function that updates the recurring cycle limit for subscriptions purchases.
+   */
+  updateRecurringCycleLimit: UpdateSignalFunction<number | null | undefined>;
 }


### PR DESCRIPTION
### Background

Related to https://github.com/Shopify/ui-api-design/pull/1332

Adds a subscribable API for Discounts Functions Settings extension target. 

- PurchaseType
- DiscountMethod (readonly)
- DiscountClasses
- RecurringCycleLimit

