### PR TITLE
Removed slot references and examples from 2026-01 docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -16,12 +16,6 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'EmailField',
     },
     {
-      title: 'Slots',
-      description:
-        'The `EmailField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
-      type: 'EmailFieldSlots',
-    },
-    {
       title: 'Events',
       description:
         'The `EmailField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
@@ -55,33 +49,11 @@ const data: ReferenceEntityTemplateSchema = {
 - **Write actionable error messages:** Provide clear validation messages like "Please enter a valid email address" that help users correct their input.
 `,
     },
-    {
-      type: 'Generic',
-      anchorLink: 'limitations',
-      title: 'Limitations',
-      sectionContent: `
-The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components—other component types can't be used in the accessory slot.
-`,
-    },
   ],
   related: [],
   examples: {
-    description:
-      'Learn how to add accessory buttons and handle email input events.',
+    description: 'Learn how to handle email input events.',
     examples: [
-      {
-        description:
-          'Add action buttons to the email field using the accessory slot for quick actions like clearing input or verifying email addresses. This example shows how to use [`s-button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [`s-clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the email input context.',
-        codeblock: {
-          title: 'Add accessory buttons',
-          tabs: [
-            {
-              code: './examples/accessory-slot.jsx',
-              language: 'jsx',
-            },
-          ],
-        },
-      },
       {
         description:
           'Subscribe to email input events to respond when merchants enter email addresses. This example demonstrates handling `onChange`, `onInput`, `onFocus`, and `onBlur` events for real-time email validation, duplicate checking, or autosave functionality.',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/examples/accessory-slot.jsx
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/examples/accessory-slot.jsx
@@ -1,9 +1,0 @@
-<s-email-field
-  label="Newsletter signup"
-  placeholder="Enter email address"
-  value="customer@example.com"
->
-  <s-button slot="accessory" onClick={() => console.log('Subscribe')}>
-    Subscribe
-  </s-button>
-</s-email-field>;


### PR DESCRIPTION
Fixes [#21545](https://github.com/shop/issues-retail/issues/21545)

### Background

This PR removes the accessory slot feature from the EmailField component documentation and examples.

### Solution

The changes include:

- Removing the "Slots" section from the component documentation
- Removing the "Limitations" section that described constraints for the accessory slot
- Updating the examples description to focus only on handling email input events
- Deleting the `accessory-slot.jsx` example file that demonstrated how to use buttons in the accessory slot

### 🎩

- Before change (Original): https://shopify.dev/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/emailfield
- After change: https://pr-65965.shopify-dev.shopify.io/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/emailfield

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation

---

**Screenshots**:

![image.png](https://app.graphite.com/user-attachments/assets/1c3ad09a-ac77-4345-bc58-0671d92cc97e.png)