### PR TITLE
docs: fix metafield and metaobject definition intent docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-metafield-definition.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-metafield-definition.js
@@ -2,6 +2,7 @@ const {intents} = useApi(TARGET);
 
 const activity = await intents.invoke('edit:shopify/MetafieldDefinition', {
   value: 'gid://shopify/MetafieldDefinition/123456789',
+  data: {ownerType: 'product'},
 });
 
 const response = await activity.complete;

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-metaobject-definition.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-metaobject-definition.js
@@ -1,7 +1,7 @@
 const {intents} = useApi(TARGET);
 
 const activity = await intents.invoke('edit:shopify/MetaobjectDefinition', {
-  value: 'gid://shopify/MetaobjectDefinition/123456789',
+  data: {type: 'my_metaobject_definition_type'},
 });
 
 const response = await activity.complete;

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
@@ -83,8 +83,8 @@ Where:
 ### Metafield Definition
 | Action | Type | Value | Data |
 |--------|------|-------|------|
-| \`create\` | \`shopify/MetafieldDefinition\` | — | — |
-| \`edit\` | \`shopify/MetafieldDefinition\` | \`gid://shopify/MetafieldDefinition/{id}\` | — |
+| \`create\` | \`shopify/MetafieldDefinition\` | — | { ownerType: 'Product' } |
+| \`edit\` | \`shopify/MetafieldDefinition\` | \`gid://shopify/MetafieldDefinition/{id}\` | { ownerType: 'Product' } |
 
 ### Metaobject
 | Action | Type | Value | Data |
@@ -96,7 +96,7 @@ Where:
 | Action | Type | Value | Data |
 |--------|------|-------|------|
 | \`create\` | \`shopify/MetaobjectDefinition\` | — | — |
-| \`edit\` | \`shopify/MetaobjectDefinition\` | \`gid://shopify/MetaobjectDefinition/{id}\` | — |
+| \`edit\` | \`shopify/MetaobjectDefinition\` | — | { type: 'my_metaobject_definition_type' } |
 
 ### Page
 | Action | Type | Value | Data |


### PR DESCRIPTION
## Description

Updates the documentation for Metafield Definition and Metaobject Definition intents to include the correct data parameters:

- Adds `{ ownerType: 'Product' }` as the data parameter for Metafield Definition create and edit actions
- Replaces the value parameter with a data parameter `{ type: 'my_metaobject_definition_type' }` for Metaobject Definition edit action
- Updates the corresponding example code for editing a Metaobject Definition to use the data parameter instead of the value parameter

## 🎩

- Verify that the updated documentation accurately reflects the expected parameters for these intents
- Confirm that the example code works correctly with the new parameter structure

## Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation