### PR TITLE
Fix to `minor` changeset for PR #3603

### DIFF
--- a/.changeset/old-geese-smoke.md
+++ b/.changeset/old-geese-smoke.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions': major
+'@shopify/ui-extensions': minor
 ---
 
 Remove accessory slot from TextArea component


### PR DESCRIPTION
### Background

Fix `rc` release. Major changeset makes `2026-01-rc` incorrectly become `@shopify/ui-extensions@2027.0.0-rc.4`

### Solution

Update to `minor` changeset.

### 🎩

N/A. Already done in origin PR.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
