### PR TITLE
Update change set to patch update for alt prop to POS Image

### DIFF
--- a/.changeset/blue-readers-joke.md
+++ b/.changeset/blue-readers-joke.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions': minor
+'@shopify/ui-extensions': patch
 ---
 
 Adds alt prop to POS Image


### PR DESCRIPTION
### Background

This PR updates the change set for this [PR](https://github.com/Shopify/ui-extensions/pull/3600/changes#diff-b0d8b06fd5f46cfbf596896db727ddbb310fb4051b8b8f5b6523ac44dd062d5a). 

We only release `patch` updates for official versions. This changeset was causing the package to bump from 2025.10 to 2025.11 which is not correct.

