### PR TITLE
Add intents to customer account extension api

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/intents.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/intents.doc.ts
@@ -4,21 +4,14 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Intents',
   overviewPreviewDescription:
     'The API for invoking Shopify intents to request workflows.',
-  description: `Entry point for Shopify intents. Intents pair an \`action\` (verb) with a resource \`type\` and optional \`value\` and \`data\` to request a workflow.`,
+  description: `The Intents API provides a way to invoke existing customer account workflows for managing buyer information.`,
   isVisualComponent: false,
   category: 'APIs',
   type: 'API',
-  definitions: [
-    {
-      title: 'Intents',
-      description: 'Intents API for invoking Shopify workflows.',
-      type: 'Intents',
-    },
-  ],
   defaultExample: {
     description: '',
     codeblock: {
-      title: 'Extension.jsx',
+      title: 'Replace payment method',
       tabs: [
         {
           code: '../examples/apis/intents.example.jsx',
@@ -26,6 +19,80 @@ const data: ReferenceEntityTemplateSchema = {
         },
       ],
     },
+  },
+  definitions: [
+    {
+      title: 'invoke',
+      description: `The \`invoke\` API is a function that accepts either a string query or an options object describing the intent to invoke and returns a Promise that resolves to an activity handle for the workflow.
+
+## Intent Format
+
+Intents are invoked using a string query format: \`\${action}:\${type},\${value}\`
+
+Where:
+- \`action\` - The operation to perform (\`create\`, \`edit\` or \`open\`)
+- \`type\` - The resource type (e.g., \`shopify/SubscriptionContract\`)
+- \`value\` - The resource identifier
+
+## Supported Resources
+
+### Subscription Contract
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`open\` | \`shopify/SubscriptionContract\` | \`gid://shopify/SubscriptionContract/{id}\` | \`{ field: 'paymentMethod' }\` |`,
+      type: 'Intents',
+    },
+    {
+      title: 'IntentAction',
+      description: `Supported actions that can be performed on resources.
+- \`create\`: Opens a creation workflow for a new resource
+- \`edit\`: Opens an editing workflow for an existing resource (requires \`value\` parameter)
+- \`open\`: Opens a workflow for an existing resource (requires \`value\` parameter)`,
+      type: 'IntentAction',
+    },
+    {
+      title: 'IntentQuery',
+      description: `Structured description of an intent to invoke. Use this object form when programmatically composing an intent at runtime.`,
+      type: 'IntentQuery',
+    },
+    {
+      title: 'IntentQueryOptions',
+      description: `Options for invoking intents when using the query string format.`,
+      type: 'IntentQueryOptions',
+    },
+    {
+      title: 'IntentActivity',
+      description: `Activity handle for tracking intent workflow progress.`,
+      type: 'IntentActivity',
+    },
+    {
+      title: 'IntentResponse',
+      description: `Response object returned when the intent workflow completes.`,
+      type: 'IntentResponse',
+    },
+  ],
+  examples: {
+    description: 'Intents for each Shopify resource type',
+    exampleGroups: [
+      {
+        title: 'Subscription Contract',
+        examples: [
+          {
+            description:
+              'Replace the payment method on an active subscription contract. Opens a modal with vaulted cards.',
+            codeblock: {
+              title: 'Replace payment method',
+              tabs: [
+                {
+                  code: '../examples/apis/intents.example.jsx',
+                  language: 'jsx',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
   },
   related: [],
 };

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/intents.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/intents.doc.ts
@@ -25,7 +25,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'invoke',
       description: `The \`invoke\` API is a function that accepts either a string query or an options object describing the intent to invoke and returns a Promise that resolves to an activity handle for the workflow.
 
-## Intent Format
+## Intent format
 
 Intents are invoked using a string query format: \`\${action}:\${type},\${value}\`
 
@@ -34,9 +34,9 @@ Where:
 - \`type\` - The resource type (e.g., \`shopify/SubscriptionContract\`)
 - \`value\` - The resource identifier
 
-## Supported Resources
+## Supported resources
 
-### Subscription Contract
+### Subscription contract
 | Action | Type | Value | Data |
 |--------|------|-------|------|
 | \`open\` | \`shopify/SubscriptionContract\` | \`gid://shopify/SubscriptionContract/{id}\` | \`{ field: 'paymentMethod' }\` |`,

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/intents.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/intents.doc.ts
@@ -1,0 +1,33 @@
+import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Intents',
+  overviewPreviewDescription:
+    'The API for invoking Shopify intents to request workflows.',
+  description: `Entry point for Shopify intents. Intents pair an \`action\` (verb) with a resource \`type\` and optional \`value\` and \`data\` to request a workflow.`,
+  isVisualComponent: false,
+  category: 'APIs',
+  type: 'API',
+  definitions: [
+    {
+      title: 'Intents',
+      description: 'Intents API for invoking Shopify workflows.',
+      type: 'Intents',
+    },
+  ],
+  defaultExample: {
+    description: '',
+    codeblock: {
+      title: 'Extension.jsx',
+      tabs: [
+        {
+          code: '../examples/apis/intents.example.jsx',
+          language: 'jsx',
+        },
+      ],
+    },
+  },
+  related: [],
+};
+
+export default data;

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/intents.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/intents.doc.ts
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     description: '',
     codeblock: {
-      title: 'Replace payment method',
+      title: 'Replace payment method with object syntax',
       tabs: [
         {
           code: '../examples/apis/intents.example.jsx',
@@ -46,7 +46,6 @@ Where:
       title: 'IntentAction',
       description: `Supported actions that can be performed on resources.
 - \`create\`: Opens a creation workflow for a new resource
-- \`edit\`: Opens an editing workflow for an existing resource (requires \`value\` parameter)
 - \`open\`: Opens a workflow for an existing resource (requires \`value\` parameter)`,
       type: 'IntentAction',
     },
@@ -73,24 +72,19 @@ Where:
   ],
   examples: {
     description: 'Intents for each Shopify resource type',
-    exampleGroups: [
+    examples: [
       {
-        title: 'Subscription Contract',
-        examples: [
-          {
-            description:
-              'Replace the payment method on an active subscription contract. Opens a modal with vaulted cards.',
-            codeblock: {
-              title: 'Replace payment method',
-              tabs: [
-                {
-                  code: '../examples/apis/intents.example.jsx',
-                  language: 'jsx',
-                },
-              ],
+        description:
+          'Replace the payment method on an active subscription contract. Opens a modal with vaulted cards.',
+        codeblock: {
+          title: 'Replace payment method with string syntax',
+          tabs: [
+            {
+              code: '../examples/apis/intents.string.example.jsx',
+              language: 'jsx',
             },
-          },
-        ],
+          ],
+        },
       },
     ],
   },

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/intents.example.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/intents.example.jsx
@@ -1,0 +1,35 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  async function handleReplacePaymentMethod() {
+    const activity = await intents.invoke({
+      action: 'open',
+      type: 'shopify/SubscriptionContract',
+      value:
+        'gid://shopify/SubscriptionContract/123',
+      data: {field: 'paymentMethod'},
+    });
+
+    const response = await activity.complete;
+
+    if (response.code === 'ok') {
+      console.log(
+        'Intent completed successfully',
+        response.data,
+      );
+    }
+  }
+
+  return (
+    <s-button
+      onClick={handleReplacePaymentMethod}
+    >
+      Edit subscription payment method
+    </s-button>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/intents.string.example.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/apis/intents.string.example.jsx
@@ -8,13 +8,7 @@ export default async () => {
 function Extension() {
   async function handleReplacePaymentMethod() {
     const activity = await shopify.intents.invoke(
-      {
-        action: 'open',
-        type: 'shopify/SubscriptionContract',
-        value:
-          'gid://shopify/SubscriptionContract/123',
-        data: {field: 'paymentMethod'},
-      },
+      'open:shopify/SubscriptionContract,gid://shopify/SubscriptionContract/123?field=paymentMethod',
     );
 
     const response = await activity.complete;

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -757,7 +757,7 @@ export interface IntentActivity {
 export interface Intents {
   /**
    * Invoke an intent using the object or URL syntax.
-   * 
+   *
    * Object format: `{action, type, value?, data?}`
    *
    * @param query - Structured intent description, including `action` and `type`.

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -634,7 +634,7 @@ export interface ToastApi {
  */
 export interface IntentQueryOptions {
   /**
-   * The resource identifier for edit actions (e.g., 'gid://shopify/SubscriptionContract/123').
+   * The resource identifier for edit actions (e.g. `gid://shopify/SubscriptionContract/123`).
    */
   value?: string;
   /**
@@ -667,12 +667,12 @@ export interface IntentQuery extends IntentQueryOptions {
   /**
    * Verb describing the operation to perform on the target resource.
    *
-   * Common values include `'create'` and `'open'`. The set of
+   * Common values include `create` and `open`. The set of
    * allowed verbs is intent-specific; unknown verbs will fail validation.
    */
   action: IntentAction;
   /**
-   * The resource type (e.g., 'shopify/SubscriptionContract').
+   * The resource type (e.g. `shopify/SubscriptionContract`).
    */
   type: string;
 }
@@ -756,7 +756,9 @@ export interface IntentActivity {
  */
 export interface Intents {
   /**
-   * Invoke an intent using the object syntax.
+   * Invoke an intent using the object or URL syntax.
+   * 
+   * Object format: `{action, type, value?, data?}`
    *
    * @param query - Structured intent description, including `action` and `type`.
    * @returns A promise for an {@link IntentActivity} that completes with an
@@ -776,9 +778,7 @@ export interface Intents {
    */
   invoke(query: IntentQuery): Promise<IntentActivity>;
   /**
-   * Invoke an intent using the URL syntax.
-   *
-   * URL format: `action:type[,value][?params]`.
+   * URL format: `action:type[,value][?params]`
    *
    * @param intentURL - Intent in URL form
    * @param options - Optional supplemental inputs such as `value` or `data`.

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -624,3 +624,185 @@ export interface ToastApiResult {
 export interface ToastApi {
   show: (content: string) => Promise<ToastApiResult>;
 }
+
+/**
+ * Options for URL-based invocations.
+ *
+ * When invoking via URL syntax, `action` and `type` are parsed from the
+ * string. This companion type captures the remaining optional fields that can
+ * be provided alongside the URL.
+ */
+export interface IntentQueryOptions {
+  /**
+   * The resource identifier for edit actions (e.g., 'gid://shopify/SubscriptionContract/123').
+   */
+  value?: string;
+  /**
+   * Optional input payload passed to the intent.
+   *
+   * Used to seed forms or supply parameters. The accepted shape is
+   * intent-specific. For example:
+   * - Replacing a payment method on a subscription contract requires
+   *   { field: 'paymentMethod' }
+   */
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Allowed actions that can be performed by an intent.
+ *
+ * Common actions include:
+ * - `'create'`: Initiate creation of a new resource.
+ * - `'open'`: Modify an existing resource.
+ */
+export type IntentAction = 'create' | 'open' | string;
+
+/**
+ * Structured description of an intent to invoke.
+ *
+ * Use this object form when programmatically composing an intent at runtime.
+ * It pairs an action (verb) with a resource type and optional inputs.
+ */
+export interface IntentQuery extends IntentQueryOptions {
+  /**
+   * Verb describing the operation to perform on the target resource.
+   *
+   * Common values include `'create'` and `'open'`. The set of
+   * allowed verbs is intent-specific; unknown verbs will fail validation.
+   */
+  action: IntentAction;
+  /**
+   * The resource type (e.g., 'shopify/SubscriptionContract').
+   */
+  type: string;
+}
+
+/**
+ * Successful intent completion.
+ *
+ * - `code` is always `'ok'`
+ * - `data` contains the output payload
+ */
+export interface SuccessIntentResponse {
+  code: 'ok';
+  /**
+   * Validated output payload produced by the workflow.
+   *
+   * The shape is intent-specific. Consumers should narrow by `code === 'ok'` before accessing.
+   */
+  data: Record<string, unknown>;
+}
+
+/**
+ * Failed intent completion.
+ *
+ * - `code` is always `'error'`
+ * - `message` summarizes the failure
+ * - `issues` optionally provides structured details for validation or
+ *   field-specific problems following the Standard Schema convention
+ *
+ */
+export interface ErrorIntentResponse {
+  code?: 'error';
+  message?: string;
+  issues?: {
+    /**
+     * The path to the field with the issue.
+     */
+    path?: string[];
+    /**
+     * The error message for the issue.
+     */
+    message?: string;
+  }[];
+}
+
+/**
+ * User dismissed or closed the workflow without completing it.
+ *
+ * Distinct from `error`: no failure occurred, the activity was simply
+ * abandoned by the user.
+ */
+export interface ClosedIntentResponse {
+  code: 'closed';
+}
+
+/**
+ * Result of an intent activity.
+ *
+ * Discriminated union representing all possible completion outcomes for an
+ * invoked intent.
+ */
+export type IntentResponse =
+  | SuccessIntentResponse
+  | ErrorIntentResponse
+  | ClosedIntentResponse;
+
+/**
+ * Activity handle for tracking intent workflow progress.
+ */
+export interface IntentActivity {
+  /**
+   * A Promise that resolves when the intent workflow completes, returning the response.
+   */
+  complete: Promise<IntentResponse>;
+}
+
+/**
+ * Entry point for Shopify intents.
+ *
+ * Intents pair an `action` (verb) with a resource `type` and optional `value`
+ * and `data` to request a workflow.
+ */
+export interface Intents {
+  /**
+   * Invoke an intent using the object syntax.
+   *
+   * @param query - Structured intent description, including `action` and `type`.
+   * @returns A promise for an {@link IntentActivity} that completes with an
+   *          {@link IntentResponse}.
+   *
+   * @example
+   * ```javascript
+   * const activity = await shopify.intents.invoke(
+   *   {
+   *     action: 'open',
+   *     type: 'shopify/SubscriptionContract',
+   *     value: 'gid://shopify/SubscriptionContract/69372608568',
+   *     data: { field: 'paymentMethod' },
+   *   }
+   * );
+   * ```
+   */
+  invoke(query: IntentQuery): Promise<IntentActivity>;
+  /**
+   * Invoke an intent using the URL syntax.
+   *
+   * URL format: `action:type[,value][?params]`.
+   *
+   * @param intentURL - Intent in URL form
+   * @param options - Optional supplemental inputs such as `value` or `data`.
+   * @returns A promise for an {@link IntentActivity} that completes with an
+   *          {@link IntentResponse}.
+   *
+   * @example
+   * ```javascript
+   * // Using query string syntax
+   * const activity = await shopify.intents.invoke('open:shopify/SubscriptionContract,gid://shopify/SubscriptionContract/69372608568?field=paymentMethod');
+   *
+   * // Or using a query string and options
+   * const activity = await shopify.intents.invoke(
+   *   'open:shopify/SubscriptionContract',
+   *   {
+   *    value: 'gid://shopify/SubscriptionContract/69372608568',
+   *    data: { field: 'paymentMethod' },
+   *   }
+   * );
+   * const response = await activity.complete;
+   * ```
+   */
+  invoke(
+    intentURL: string,
+    options?: IntentQueryOptions,
+  ): Promise<IntentActivity>;
+}

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -12,6 +12,7 @@ import {
   CustomerPrivacy,
   ApplyTrackingConsentChangeType,
   ToastApi,
+  Intents,
   SubscribableSignalLike,
 } from '../shared';
 
@@ -86,6 +87,14 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * > Note: Requires to [connect a third-party domain](https://help.shopify.com/en/manual/domains/add-a-domain/connecting-domains/connect-domain-customer-account) to Shopify for your customer account pages.
    */
   analytics: Analytics;
+
+  /**
+   * Entry point for Shopify intents.
+   *
+   * Intents pair an `action` (verb) with a resource `type` and optional `value`
+   * and `data` to request a workflow.
+   */
+  intents: Intents;
 
   /**
    * The settings matching the settings definition written in the


### PR DESCRIPTION
### Background

Closes https://github.com/shop/issues-extensions-api/issues/18

### Solution

Add type support for intents on the customer account extension Standard API.

### 🎩

See https://github.com/Shopify/shopify-dev/pull/67158 for testing instructions.