### PR TITLE
Fix rc tag publish script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           title: Version Packages (${{ github.ref_name }})
-          publish: yarn run deploy --tag ${{ endsWith(github.ref_name, '-rc') && 'rc' || github.ref_name }} # RC publishes as `rc` tag, stable publishes as the version number
+          publish: yarn run deploy ${{ endsWith(github.ref_name, '-rc') && '' || format('--tag {0}', github.ref_name) }} # RC uses pre mode (no --tag needed), stable publishes with version tag
           createGithubReleases: false
         env:
           NPM_TOKEN: '' # Forces OIDC authentication


### PR DESCRIPTION
### Background

`yarn run deply --tag rc` doesn't work in pre-mode. Remove `--tag` flag on RC branch as pre mode handles it automatically - this is how it was done [before](https://github.com/Shopify/ui-extensions/blob/092a4ca01de14740d99fe183b55c7bd85bc6ee4a/.github/workflows/deploy-rc.yml#L26)

<img width="1430" height="310" alt="image" src="https://github.com/user-attachments/assets/e8d20b8e-af83-413c-92de-9f7d564d570a" />
