### PR TITLE
Fix rc deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           title: Version Packages (${{ github.ref_name }})
-          publish: yarn run deploy ${{ endsWith(github.ref_name, '-rc') && '' || format('--tag {0}', github.ref_name) }} # RC uses pre mode (no --tag needed), stable publishes with version tag
+          publish: yarn run deploy ${{ !endsWith(github.ref_name, '-rc') && format('--tag {0}', github.ref_name) }}
           createGithubReleases: false
         env:
           NPM_TOKEN: '' # Forces OIDC authentication


### PR DESCRIPTION
### Background
Swap ternary around as '' is falsy
- this makes "rc" branches run as `yarn run deploy` only.
- release branches will run with `--tag`.

<img width="1908" height="414" alt="image" src="https://github.com/user-attachments/assets/3cb1077d-7082-4804-88f9-862f5a8e0a53" />

