### PR TITLE
Fix deploy publish expression

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           title: Version Packages (${{ github.ref_name }})
-          publish: yarn run deploy ${{ !endsWith(github.ref_name, '-rc') && format('--tag {0}', github.ref_name) }}
+          publish: yarn run deploy ${{ !endsWith(github.ref_name, '-rc') && format('--tag {0}', github.ref_name) || '' }} # no tag for RC branches.
           createGithubReleases: false
         env:
           NPM_TOKEN: '' # Forces OIDC authentication


### PR DESCRIPTION
### Background

This fixes the command so RC branches run `yarn run deploy` only, while release branches adds the `--tag`
<img width="1530" height="360" alt="image" src="https://github.com/user-attachments/assets/53306d34-51e0-47ac-85f7-3dbab0000ae3" />


### Solution

Fallback to empty string instead of false for RC branches.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
