### PR TITLE
Fix npm provenance validation during publish

### DIFF
--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -152,6 +152,11 @@
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org/"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shopify/ui-extensions.git",
+    "directory": "packages/ui-extensions"
+  },
   "files": [
     "build",
     "src",


### PR DESCRIPTION
### Background

Fixes error when deploying with OICD.
```
Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/Shopify/ui-extensions" from provenance 
```
<img width="4196" height="1318" alt="image" src="https://github.com/user-attachments/assets/1aa6ada8-2ff9-400f-a6a4-457d3857c3a6" />

### Solution

Add `repository.url` to ui-extensions `package.json` per error.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
