### PR TITLE
[Docs] Update Text component docs: Add warning about nesting Icon/Badge

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -42,6 +42,7 @@ const data: ReferenceEntityTemplateSchema = {
 - **Apply appropriate tones:** Use \`success\` for positive outcomes, \`warning\` or \`critical\` for alerts, \`info\` for helpful context, \`auto\` for neutral content.
 - **Balance color intensity:** Use \`strong\` for emphasis, \`base\` for readability, \`subdued\` for secondary info.
 - **Nest for mixed formatting:** Nest \`Text\` components when you need multiple styles within one text block.
+- **Use Stack for icons and badges:** When combining text with icons or badges, use Stack with direction="inline" instead of nesting components inside Text.
 `,
     },
     {
@@ -50,6 +51,8 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent: `
 Complex rich text formatting isn't supported—use multiple \`Text\` components or nested text elements for varied formatting needs.
+
+Nesting Icon or Badge components inside Text isn't supported due to React Native alignment limitations—use Stack with direction="inline" and alignItems="center" instead to properly align icons and badges with text.
 `,
     },
   ],


### PR DESCRIPTION
### Background

**Issue:** [#21094](https://github.com/Shopify/ui-extensions/issues/21094)

Developers have been intuitively nesting `<s-icon>` and `<s-badge>` components inside `<s-text>`, expecting them to align with the text baseline. However, this causes visible vertical misalignment (originally reported in #19011).

**Root cause:** React Native's `Text` component fundamentally does not support baseline alignment for nested `View` components. Since `Icon` renders as an SVG `View` and `Badge` renders as `HStack→Box→Badge`, they float without proper vertical positioning when nested inside `Text`.

### Solution

Updated the Text component documentation to prevent this common mistake by:

1. **Best Practices section** - Added guidance to use `Stack` with `direction="inline"` when combining text with icons or badges, rather than nesting components inside `Text`

2. **Limitations section** - Added clear explanation of the React Native alignment limitation with nested `Icon`/`Badge` components, including the recommended `Stack` alternative pattern

This is a documentation-only change that guides developers toward the correct pattern without requiring code changes or impacting performance.