### PR TITLE
Fix `latest` npm release tagging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Set 'latest' NPM dist tag
         if: steps.changesets.outputs.published == 'true' && github.ref_name == vars.LATEST_STABLE_VERSION
         env:
+          NPM_TOKEN: '' # Forces OIDC authentication
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           for pkg in $(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | @base64'); do


### PR DESCRIPTION
### Background

Follow up to, https://github.com/Shopify/ui-extensions/pull/3662
Fix `latest` tagging step

### Solution

Force OIDC for latest dist tag step.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
