### PR TITLE
Fix `latest` npm release tagging for `2026-01-rc`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,9 @@ jobs:
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
+          # Forces OIDC authentication for raw run commands
+          echo "//registry.npmjs.org/:_authToken=" > "$HOME/.npmrc"
+
           for pkg in $(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | @base64'); do
             _jq() {
               echo ${pkg} | base64 --decode | jq -r ${1}


### PR DESCRIPTION
### Background

See https://github.com/Shopify/ui-extensions/pull/3663

### Solution

Force OIDC for latest dist tag step.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
