### PR TITLE
Fix latest npm release tagging for `2025-10`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,9 +48,11 @@ jobs:
       - name: Set 'latest' NPM dist tag
         if: steps.changesets.outputs.published == 'true' && github.ref_name == vars.LATEST_STABLE_VERSION
         env:
-          NPM_TOKEN: '' # Forces OIDC authentication
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
+          # Forces OIDC authentication for raw run commands
+          echo "//registry.npmjs.org/:_authToken=" > ~/.npmrc
+
           for pkg in $(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | @base64'); do
             _jq() {
               echo ${pkg} | base64 --decode | jq -r ${1}


### PR DESCRIPTION
### Background

Follow up from, https://github.com/Shopify/ui-extensions/pull/3663

### Solution

Force OIDC for latest dist tag step.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
