### PR TITLE
Fix latest npm release tagging for `2025-10`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy
 
 on:
+  workflow_dispatch: # temporary for manual deployment
   push:
     branches:
       # Stable version branches
@@ -46,7 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 
       - name: Set 'latest' NPM dist tag
-        if: steps.changesets.outputs.published == 'true' && github.ref_name == vars.LATEST_STABLE_VERSION
+        if: (steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch') && github.ref_name == vars.LATEST_STABLE_VERSION
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           # Forces OIDC authentication for raw run commands
-          echo "//registry.npmjs.org/:_authToken=" > ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=" > "$HOME/.npmrc"
 
           for pkg in $(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | @base64'); do
             _jq() {


### PR DESCRIPTION
### Background

Follow up from, https://github.com/Shopify/ui-extensions/pull/3668

### Solution

Force OIDC for latest dist tag step. Add temporary Run for deploy workflow, will remove after fix.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
