### PR TITLE
Add renderMode object to PickupLocationItemApi

### DIFF
--- a/.changeset/stale-vans-nail.md
+++ b/.changeset/stale-vans-nail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Adds shared RenderMode type. Adds renderMode field to pickup-location-item. Updates shipping-option to use shared RenderMode type.

--- a/packages/ui-extensions/src/surfaces/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout.ts
@@ -84,6 +84,7 @@ export type {
   ValidationError,
   MailingAddress,
   ShippingAddress,
+  RenderMode,
 } from './checkout/api/shared';
 
 export type {SubscribableSignalLike} from './checkout/shared';
@@ -148,10 +149,7 @@ export type {CartLineItemApi} from './checkout/api/cart-line/cart-line-item';
 export type {PickupLocationListApi} from './checkout/api/pickup/pickup-location-list';
 export type {PickupPointListApi} from './checkout/api/pickup/pickup-point-list';
 export type {PickupLocationItemApi} from './checkout/api/pickup/pickup-location-item';
-export type {
-  ShippingOptionItemApi,
-  ShippingOptionItemRenderMode,
-} from './checkout/api/shipping/shipping-option-item';
+export type {ShippingOptionItemApi} from './checkout/api/shipping/shipping-option-item';
 export type {
   ShippingOptionListApi,
   DeliveryGroupList,

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
@@ -1,5 +1,6 @@
 import type {SubscribableSignalLike} from '../../shared';
 import type {PickupLocationOption} from '../standard/standard';
+import type {RenderMode} from '../shared';
 
 export interface PickupLocationItemApi {
   /**
@@ -11,4 +12,9 @@ export interface PickupLocationItemApi {
    * Whether the pickup location is currently selected.
    */
   isTargetSelected: SubscribableSignalLike<boolean>;
+
+  /**
+   * The render mode of the pickup location option.
+   */
+  renderMode: RenderMode;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
@@ -148,3 +148,10 @@ export interface ShippingAddress extends MailingAddress {
    */
   oneTimeUse?: boolean;
 }
+
+export interface RenderMode {
+  /**
+   * Whether the extension is rendered in an overlay.
+   */
+  overlay: boolean;
+}

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
@@ -1,5 +1,6 @@
 import type {SubscribableSignalLike} from '../../shared';
 import type {ShippingOption} from '../standard/standard';
+import type {RenderMode} from '../shared';
 
 export interface ShippingOptionItemApi {
   /**
@@ -15,15 +16,5 @@ export interface ShippingOptionItemApi {
   /**
    * The render mode of the shipping option.
    */
-  renderMode: ShippingOptionItemRenderMode;
-}
-
-/**
- * The render mode of a shipping option.
- */
-export interface ShippingOptionItemRenderMode {
-  /**
-   * Whether the shipping option is rendered in an overlay.
-   */
-  overlay: boolean;
+  renderMode: RenderMode;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/preact/pickup-location-option-target.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/preact/pickup-location-option-target.ts
@@ -1,6 +1,7 @@
 import {useMemo} from 'preact/hooks';
 
 import type {PickupLocationOption} from '../api/standard/standard';
+import type {RenderMode} from '../api/shared';
 
 import {ExtensionHasNoTargetError} from './errors';
 import {useApi} from './api';
@@ -14,6 +15,7 @@ import {useSubscription} from './subscription';
 export function usePickupLocationOptionTarget(): {
   pickupLocationOptionTarget: PickupLocationOption;
   isTargetSelected: boolean;
+  renderMode: RenderMode;
 } {
   const api =
     useApi<'purchase.checkout.pickup-location-option-item.render-after'>();
@@ -26,13 +28,15 @@ export function usePickupLocationOptionTarget(): {
 
   const pickupLocationOptionTarget = useSubscription(api.target);
   const isTargetSelected = useSubscription(api.isTargetSelected);
+  const renderMode = api.renderMode;
 
   const pickupLocationOption = useMemo(() => {
     return {
       pickupLocationOptionTarget,
       isTargetSelected,
+      renderMode,
     };
-  }, [pickupLocationOptionTarget, isTargetSelected]);
+  }, [pickupLocationOptionTarget, isTargetSelected, renderMode]);
 
   return pickupLocationOption;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/preact/shipping-option-target.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/preact/shipping-option-target.ts
@@ -1,7 +1,7 @@
 import {useMemo} from 'preact/hooks';
 
 import type {ShippingOption} from '../api/standard/standard';
-import type {ShippingOptionItemRenderMode} from '../api/shipping/shipping-option-item';
+import type {RenderMode} from '../api/shared';
 
 import {useApi} from './api';
 import {ExtensionHasNoTargetError} from './errors';
@@ -16,7 +16,7 @@ import {useSubscription} from './subscription';
 export function useShippingOptionTarget(): {
   shippingOptionTarget: ShippingOption;
   isTargetSelected: boolean;
-  renderMode: ShippingOptionItemRenderMode;
+  renderMode: RenderMode;
 } {
   const api = useApi<
     | 'purchase.checkout.shipping-option-item.render-after'

--- a/packages/ui-extensions/src/surfaces/checkout/preact/tests/pickup-location-option-target.test.tsx
+++ b/packages/ui-extensions/src/surfaces/checkout/preact/tests/pickup-location-option-target.test.tsx
@@ -59,6 +59,7 @@ describe('usePickupLocationOptionTarget', () => {
     setupGlobalShopifyMock<typeof target>({
       extension: createMockExtension(target),
       target: createMockSubscribableSignalLike(pickupLocationOption),
+      renderMode: {overlay: false},
     });
 
     expect(() => {
@@ -77,6 +78,7 @@ describe('usePickupLocationOptionTarget', () => {
       extension: createMockExtension(target),
       target: createMockSubscribableSignalLike(pickupLocationOption),
       isTargetSelected: createMockSubscribableSignalLike(true),
+      renderMode: {overlay: false},
     });
 
     const {value} = mount.hook(() => usePickupLocationOptionTarget());
@@ -84,6 +86,7 @@ describe('usePickupLocationOptionTarget', () => {
     expect(value).toStrictEqual({
       pickupLocationOptionTarget: pickupLocationOption,
       isTargetSelected: true,
+      renderMode: {overlay: false},
     });
   });
 });


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-checkout/issues/9641
Closes https://github.com/shop/issues-checkout/issues/10513

Changes to the Delivery section through the delivery redesign experiment have created 2 locations for the [pickup-location-option-item-render-after](https://shopify.dev/docs/api/checkout-ui-extensions/latest/targets/local-pickup/purchase-checkout-pickup-location-option-item-render-after) target to render extensions, one of them being in a modal. We need a way to inform the extensions that are being rendered in this target that they are currently in a modal (or not).  
  
implementation in checkout-web can be found in this draft [PR stack]([https://app.graphite.com/github/pr/shop/world/330702/[Checkout-Redesign]-pass-isInModal-to-PickupLocationItemApiOptions](https://app.graphite.com/github/pr/shop/world/330702/%5BCheckout-Redesign%5D-pass-isInModal-to-PickupLocationItemApiOptions))

<details>
<summary>Screenshots</summary>

### Inline

<img width="400" height="450" alt="Screenshot 2025-12-19 at 11 31 18 AM" src="https://github.com/user-attachments/assets/edcee4da-b286-441e-bab8-4303d83b331c" />

### In modal

<img width="400" height="400" alt="Screenshot 2025-12-19 at 11 27 40 AM" src="https://github.com/user-attachments/assets/182dfa06-d5fd-41d2-a42f-f95ff06142e6" />

</details>

### Solution

Extend the same pattern we use for [shipping-option-item-render-after](https://shopify.dev/docs/api/checkout-ui-extensions/latest/targets/shipping/purchase-checkout-shipping-option-item-render-after) by exposing the `renderMode` object on PickupLocationItemApi

Create a new shared `RenderMode` type to be used in shipping-option-item + pickup-location-item

Update shipping-option-item to use the new shared type. 

```javascript
// shared.ts
export interface RenderMode {
  overlay: boolean;
}

PickupLocationItemApi
{
  isTargetSelected: ...
  target: ...
  renderMode: RenderMode
}

ShippingOptionItemApi
{
  isTargetSelected: ...
  target: ...
  renderMode: RenderMode
}

```

### 🎩

- Create or using an existing checkout UI extension. ([docs for generating an extension](https://shopify.dev/docs/api/shopify-cli/app/app-generate-extension))
- Update the @shopify/ui-extensions package within your extension with the npm snapshot and run `npm install`

```
"@shopify/ui-extensions": "0.0.0-snapshot-20260113163731" 
```

- Import the usePickupLocationOptionTarget hook into your extension
- Ensure that the `overlay` property is available

```
import { usePickupLocationOptionTarget } from "@shopify/ui-extensions/checkout/preact";

const renderingInModal = pickupLocationOptionTarget.renderMode.overlay; 
```

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation