### PR TITLE
Update Toast API docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -7,7 +7,7 @@ const generateJsxCodeBlockForToastApi = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Toast API',
   description:
-    "The Toast API provides temporary notification functionality for POS UI extensions, allowing you to display brief, non-intrusive messages to users for feedback, confirmations, and status updates that automatically disappear after a specified duration. Toast messages appear as overlay notifications that don't interrupt the user's workflow.",
+    "The Toast API provides temporary notification functionality for POS UI extensions, allowing you to display brief, non-intrusive messages to users for feedback, confirmations, and status updates that automatically disappear. Toast messages appear as overlay notifications that don't interrupt the user's workflow.",
   isVisualComponent: false,
   type: 'APIs',
   definitions: [
@@ -27,7 +27,6 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent: `
 - **Write clear, concise messages:** Keep content brief since toasts disappear automatically.
-- **Use appropriate timing:** Choose durations that give users enough time to read without keeping visible too long.
 - **Provide meaningful feedback:** Use toasts to confirm actions, explain errors, or communicate status changes.
 - **Avoid overuse:** Reserve for important feedback. Don't show multiple toasts simultaneously.
 - **Handle multiple toast messages:** Multiple toast messages may overlap or interfere with each other if shown in rapid succession. Consider queuing or spacing out notifications appropriately.
@@ -53,7 +52,7 @@ Toast content is limited to plain text and can't include rich formatting, links,
           'show',
         ),
         description:
-          "Display a toast notification from a tile. This example demonstrates using `shopify.toast.show()` to display a brief, non-intrusive message that automatically disappears after a specified duration. This is useful for confirmations, status updates, or success messages that don't require user interaction.",
+          "Display a toast notification from a tile. This example demonstrates using `shopify.toast.show()` to display a brief, non-intrusive message that automatically disappears. This is useful for confirmations, status updates, or success messages that don't require user interaction.",
       },
     ],
   },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -73,11 +73,7 @@ export type {
 
 export type {StorageApi} from './api/storage-api/storage-api';
 
-export type {
-  ShowToastOptions,
-  ToastApiContent,
-  ToastApi,
-} from './api/toast-api/toast-api';
+export type {ToastApiContent, ToastApi} from './api/toast-api/toast-api';
 
 // Type exports
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
@@ -1,21 +1,10 @@
-/**
- * Specifies configuration options for displaying toast notifications. Controls the duration and display behavior of temporary notification messages.
- */
-export interface ShowToastOptions {
-  /**
-   * The duration in milliseconds that the toast message should remain visible before automatically dismissing. If not specified, the toast will use the default system duration. Use shorter durations for simple confirmations and longer durations for important messages that users need time to read.
-   */
-  duration?: number;
-}
-
 export interface ToastApiContent {
   /**
    * Displays a toast notification with the specified text content. The message appears as a temporary overlay that automatically dismisses after the specified duration. Use for providing immediate user feedback, confirming actions, or communicating status updates without interrupting the user's workflow.
    *
    * @param content The text content to display.
-   * @param options An object containing ShowToastOptions.
    */
-  show: (content: string, options?: ShowToastOptions) => void;
+  show: (content: string) => void;
 }
 
 /**


### PR DESCRIPTION
Remove the `duration` option, as it is no longer in use by POS. Partially resolves https://github.com/shop/issues-retail/issues/21718