### PR TITLE
Remove children slot from DropZone docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
@@ -18,11 +18,6 @@ const data: AdminReferenceEntityTemplateSchema = {
         'Learn more about [registering events](/docs/api/app-home/using-polaris-components#event-handling).',
       type: 'DropZoneEvents',
     },
-    {
-      title: 'Slots',
-      description: '',
-      type: 'DropZoneSlots',
-    },
   ],
   defaultExample: {
     codeblock: {


### PR DESCRIPTION
### Background

Children isn't an aligned slot for DropZone. This should be removed as a supported slot.

### Solution

Removed the children slot from the DropZone component docs.

### 🎩

Run the following in `ui-extensions` repo:

```
yarn docs:admin 2025-10
```

Then run `shopify-dev` locally and visit [the DropZone page](https://shopify-dev.shop.dev/docs/api/app-home/polaris-web-components/forms/dropzone).

Ensure the "Slots' section is removed.

<img width="3248" height="2120" alt="18-46-mqyyp-qjirx" src="https://github.com/user-attachments/assets/ea1f67ba-59da-4687-821f-a8d1aae33d64" />


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
