### PR TITLE
Fix npm provenance validation during publish for `2025-07`

### DIFF
--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -85,6 +85,11 @@
     "react-reconciler": "0.29.0",
     "react-test-renderer": "^18.2.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shopify/ui-extensions.git",
+    "directory": "packages/ui-extensions"
+  },
   "files": [
     "build",
     "src",


### PR DESCRIPTION
### Background

Fixes error when deploying with OICD for `2025-07`. Follow up to, https://github.com/Shopify/ui-extensions/pull/3691
https://github.com/Shopify/ui-extensions/actions/runs/20380788212/job/58570496872

### Solution

Add to `ui-extensions-react` as well.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
