### PR TITLE
Will include the ChoiceList > Compose rich choice content example in 2026-01

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -93,6 +93,19 @@ const data: ReferenceEntityTemplateSchema = {
           ],
         },
       },
+      {
+        description:
+          'Compose rich choice content by nesting other components within `Choice` elements. This example demonstrates combining images, text, and layout components to create visually enhanced choice options with descriptions and supporting images.',
+        codeblock: {
+          title: 'Compose rich choice content',
+          tabs: [
+            {
+              code: './examples/composed-choices.jsx',
+              language: 'jsx',
+            },
+          ],
+        },
+      },
     ],
   },
 };

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/examples/composed-choices.jsx
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/examples/composed-choices.jsx
@@ -1,0 +1,35 @@
+<s-choice-list>
+  {/* Composed choice with image and text */}
+  <s-choice value="option1">
+    <s-stack gap="small-200" alignItems="center" direction="inline">
+      <s-box blockSize="40px" inlineSize="40px">
+        <s-image src="https://placehold.co/60x60" inlineSize="fill" objectFit="cover" />
+      </s-box>
+      <s-box>
+        <s-text>Option 1</s-text>
+        <s-text type="small" color="subdued">
+          Additional details for option 1
+        </s-text>
+      </s-box>
+    </s-stack>
+  </s-choice>
+
+  {/* Composed choice with nested text */}
+  <s-choice value="option2">
+    <s-text type="strong">
+      Option 2
+      <s-text type="small" color="subdued">
+        Additional details for option 2
+      </s-text>
+    </s-text>
+  </s-choice>
+
+  {/* Mix of text and composed elements */}
+  <s-choice value="option3" disabled>
+    Option 3
+    <s-text type="small" color="subdued">
+      (disabled)
+    </s-text>
+    <s-text type="strong">Additional details for option 3</s-text>
+  </s-choice>
+</s-choice-list>


### PR DESCRIPTION
### Background

This PR adds the example to the ChoiceList component documentation to `2026-01` as well (note: It is already present in `2025-10` but is missing in `2026-01)

### 🎩

- Verify that the "Compose rich choice content" example in present in 2026-01.
- Tophat link: https://pr-66384.shopify-dev.shopify.io/ 

### Checklist

- [x] I have 🎩'd these changes
- [x] I have updated relevant documentation

---

![image.png](https://app.graphite.com/user-attachments/assets/1495461b-37d0-4917-bc51-a3540e9993f2.png)