### PR TITLE
remove extra fields on Discount API

### DIFF
--- a/.changeset/eager-dogs-carry.md
+++ b/.changeset/eager-dogs-carry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Remove unsupported fields for the Discount API. Those fields will be added in a later API.

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
@@ -16,8 +16,6 @@ type DiscountClass = 'product' | 'order' | 'shipping';
 
 type DiscountMethod = 'automatic' | 'code';
 
-type PurchaseType = 'one_time_purchase' | 'subscription' | 'both';
-
 /**
  * The object that exposes the validation with its settings.
  */
@@ -48,20 +46,4 @@ export interface DiscountsApi {
    * A signal that contains the discount method.
    */
   discountMethod: ReadonlySignalLike<DiscountMethod>;
-  /**
-   * A signal that contains the purchase type.
-   */
-  purchaseType: ReadonlySignalLike<PurchaseType>;
-  /**
-   * A function that updates the purchase type.
-   */
-  updatePurchaseType: UpdateSignalFunction<PurchaseType>;
-  /**
-   * A signal that contains the recurring cycle limit for subscriptions purchases.
-   */
-  recurringCycleLimit: ReadonlySignalLike<number | null | undefined>;
-  /**
-   * A function that updates the recurring cycle limit for subscriptions purchases.
-   */
-  updateRecurringCycleLimit: UpdateSignalFunction<number | null | undefined>;
 }


### PR DESCRIPTION
### Background

Removes fields that are not yet supported for discount api 2026-01. Those were not added yet to any release. 

It is based on this comment https://github.com/Shopify/ui-extensions/pull/3641/files#r2662549011
