### PR TITLE
Fix snapit workflow input name

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -23,4 +23,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           build_script: yarn build
-          trigger_comment: /snapit
+          comment_command: /snapit


### PR DESCRIPTION
## Summary
- Fix the `/snapit` command which was silently failing

## Problem
The snapit action's `action.yml` was updated to rename `comment_command` to `trigger_comment` ([snapit PR #32](https://github.com/Shopify/snapit/pull/32)), but the source code still reads `comment_command`:

```javascript
const commentCommand = core.getInput('comment_command');
```

This means when we pass `trigger_comment: /snapit`, the code reads an empty value and silently exits without processing any `/snapit` comments.

## Solution
Use `comment_command` which is the actual input name the code reads.

## Test plan
- [ ] Merge this PR
- [ ] Comment `/snapit` on another PR and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## References

- https://github.com/Shopify/snapit/pull/32
- https://github.com/Shopify/ui-extensions/pull/3706
- https://github.com/shop/issues-admin-extensibility/issues/2128
- https://github.com/shop/issues-admin-extensibility/issues/2126