### PR TITLE
Fix snapit: remove changeset pre exit from build script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           NPM_TOKEN: ''
           NPM_CONFIG_PROVENANCE: true
         with:
-          build_script: yarn build && yarn changeset pre exit
+          build_script: yarn build
           comment_command: /snapit
 
   changesets:


### PR DESCRIPTION
## Summary
Fix the `/snapit` command which fails with:
```
🦋  error `changeset pre exit` can only be run when in pre mode
```

## Problem
The build script was set to:
```yaml
build_script: yarn build && yarn changeset pre exit
```

The `changeset pre exit` command fails on stable branches (like `2025-10`) because they are not in pre-release mode.

## Context: Pre-release Mode in Changesets

Changesets has a "pre-release mode" for publishing RC/alpha/beta versions:

- **Enter pre mode:** `changeset pre enter rc` → creates `.changeset/pre.json`
- **Exit pre mode:** `changeset pre exit` → removes `pre.json`, returns to stable releases

### How ui-extensions uses this:

| Branch | Has `pre.json`? | Publishes versions like |
|--------|-----------------|------------------------|
| `2025-10-rc` | ✅ Yes | `2025.10.0-rc.0`, `2025.10.0-rc.1` |
| `2025-10` (stable) | ❌ No | `2025.10.0`, `2025.10.1` |

### Why `pre exit` was added (incorrect assumption)

Someone likely thought snapit needed to exit pre mode before publishing snapshots. But **snapit doesn't use pre-release mode** - it uses a completely different `--snapshot` flag:

```bash
changeset version --snapshot  # Creates 0.0.0-snapshot-20260107...
```

This works independently of whether the repo is in pre mode or not.

### Why it fails

Running `changeset pre exit` on a branch that isn't in pre mode (no `pre.json`) causes the error:
```
🦋  error `changeset pre exit` can only be run when in pre mode
```

## Reference: How other repos do it

The **extensibility** repo uses snapit successfully without `pre exit`:

```yaml
# Shopify/extensibility/.github/workflows/snapit.yml
- name: Create snapshots for public packages
  uses: Shopify/snapit@v0.0.14
  with:
    build_script: pnpm build  # No "changeset pre exit"
```

- Uses pinned version `@v0.0.14` (not `@main`)
- Simple build script: just `pnpm build`
- No `pre.json` in their repo either
- Works fine ✅

## Solution
Remove the unnecessary `&& yarn changeset pre exit` from the build script. Snapit doesn't need it.

## Test plan
- [x] Merge this PR
- [ ] Comment `/snapit` on PR #3706 and verify it publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## References

- https://github.com/changesets/changesets/blob/main/docs/prereleases.md