### PR TITLE
Test snapit OIDC authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: ./.github/workflows/actions/prepare
 
       - name: Create snapshot
-        uses: Shopify/snapit@main
+        uses: Shopify/snapit@support-oidc-authentication
         env:
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           NPM_TOKEN: ''


### PR DESCRIPTION
## Summary

- Points snapit action to `Shopify/snapit@support-oidc-authentication` branch to test OIDC support

## Why this PR must be merged to test

GitHub Actions `issue_comment` events (which trigger `/snapit`) always run workflows from the **default branch**, not from the PR branch. This means commenting `/snapit` on this PR will use the workflow from `2025-10`, which still points to `Shopify/snapit@main`.

To test the OIDC-enabled snapit branch, this PR must be merged first.

## Risk assessment

**Low risk:**
- If OIDC works → success, then we merge the snapit PR and update this repo to point back to `@main`
- If OIDC fails → the publish fails (no packages are published incorrectly), and we revert this change

## Test plan

1. Merge this PR
2. Open a new PR with a changeset
3. Comment `/snapit` on that PR to verify OIDC authentication works

## References

- Prior PR: https://github.com/Shopify/ui-extensions/pull/3712
- Snapit PR: https://github.com/Shopify/snapit/pull/52
- Snapit Issue: https://github.com/Shopify/snapit/issues/50
- Blocking Issue: https://github.com/shop/issues-admin-extensibility/issues/2137

🤖 Generated with [Claude Code](https://claude.ai/code)