### PR TITLE
Update docs for `ReadonlySignalLike` 

### DIFF
--- a/packages/ui-extensions/src/shared.ts
+++ b/packages/ui-extensions/src/shared.ts
@@ -944,11 +944,11 @@ export interface GraphQLError {
  */
 export interface ReadonlySignalLike<T> {
   /**
-   * The current value of the locale string in IETF format. For example, `"en-US"`, `"fr-CA"`, or `"de-DE"`. This property provides immediate access to the current locale without requiring subscription setup. Use for one-time locale checks or initial internationalization setup.
+   * The current value of the signal. This property provides immediate access to the current value without requiring subscription setup. Use for one-time value checks or initial setup.
    */
   readonly value: T;
   /**
-   * Subscribes to locale changes and calls the provided function whenever the locale updates. Returns an unsubscribe function to clean up the subscription. Use to automatically update your extension content when merchants change their language settings during POS sessions.
+   * Subscribes to value changes and calls the provided function whenever the value updates. Returns an unsubscribe function to clean up the subscription. Use to automatically react to changes in the signal's value.
    */
   subscribe(fn: (value: T) => void): () => void;
 }


### PR DESCRIPTION
### Background

The current description of properties on `ReadonlySignalLike` isn't generic.

https://pr-66658.shopify-dev.shopify.io/docs/api/admin-extensions/2026-01-rc/api/target-apis/discount-function-settings-api#discounts

<img width="581" height="474" alt="Screenshot 2026-01-08 at 7 59 31 PM" src="https://github.com/user-attachments/assets/89eaa85c-6f82-4184-9143-436bd181606c" />

### Solution

This PR makes the descriptions more generic.