### PR TITLE
Add npm update step in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,9 @@ jobs:
 
       - uses: ./.github/workflows/actions/prepare
 
+      - name: Update npm to 11.7
+        run: npm install -g npm@11.7
+
       - name: Create snapshot
         uses: Shopify/snapit@support-oidc-authentication
         env:
@@ -64,8 +67,8 @@ jobs:
 
       - uses: ./.github/workflows/actions/prepare
 
-      - name: Update npm to latest
-        run: npm install -g npm@latest
+      - name: Update npm to 11.7
+        run: npm install -g npm@11.7
 
       - id: changesets
         name: Create release Pull Request or publish to NPM


### PR DESCRIPTION
Added step to update npm to the latest version before creating a snapshot.

This is needed for OIDC publishing as per https://docs.npmjs.com/trusted-publishers - I pinned to 11.7 to be safe