### PR TITLE
Fix build docs script for POS

### DIFF
--- a/packages/ui-extensions/docs/surfaces/build-doc-shared.mjs
+++ b/packages/ui-extensions/docs/surfaces/build-doc-shared.mjs
@@ -3,6 +3,34 @@ import childProcess from 'child_process';
 import fs from 'fs/promises';
 import {existsSync} from 'fs';
 import path from 'path';
+import readline from 'readline/promises';
+import process, {stdin as input, stdout as output} from 'process';
+
+export const resolveShopifyDevPath = async (rootPath) => {
+  const defaultPath = path.resolve(rootPath, '../../../shopify-dev');
+  if (existsSync(defaultPath)) return defaultPath;
+
+  const rl = readline.createInterface({input, output});
+  const answer = (
+    await rl.question(
+      `\n\x1b[33m⚠️  Shopify dev directory not found at:\x1b[0m \x1b[1m${defaultPath}\x1b[0m\n\x1b[32mPlease provide the absolute path to your "shopify-dev" repo:\x1b[0m `,
+    )
+  ).trim();
+  rl.close();
+
+  const shopifyDevPath = answer ? path.resolve(answer) : '';
+  if (!shopifyDevPath || !existsSync(shopifyDevPath)) {
+    throw new Error(
+      `\x1b[31m❌ Error: ${
+        shopifyDevPath
+          ? `shopify-dev directory not found at ${shopifyDevPath}.`
+          : 'Path cannot be empty.'
+      } Check the path and try again!\x1b[0m`,
+    );
+  }
+
+  return shopifyDevPath;
+};
 
 export const replaceFileContent = async ({
   filePaths,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
@@ -8,6 +8,7 @@ import {
   generateFiles,
   copyGeneratedToShopifyDev,
   replaceFileContent,
+  resolveShopifyDevPath,
 } from '../build-doc-shared.mjs';
 
 const EXTENSIONS_API_VERSION = process.argv[2];
@@ -29,7 +30,7 @@ const srcRelativePath = 'src/surfaces/point-of-sale';
 const docsPath = path.join(rootPath, docsRelativePath);
 const srcPath = path.join(rootPath, srcRelativePath);
 const generatedDocsPath = path.join(docsPath, 'generated');
-const shopifyDevPath = path.join(rootPath, '../../../shopify-dev');
+const shopifyDevPath = await resolveShopifyDevPath(rootPath);
 const shopifyDevDBPath = path.join(
   shopifyDevPath,
   'db/data/docs/templated_apis',
@@ -81,7 +82,7 @@ process.on('exit', () => {
     if (existsSync(tempComponentDefs)) {
       require('fs').unlinkSync(tempComponentDefs);
     }
-  } catch (e) {
+  } catch (error) {
     // Ignore cleanup errors on exit
   }
 });


### PR DESCRIPTION
### Background

Fixes assumption of `shopify-dev` folder location.

### Solution

- Prompts if folder not found.
  - Only applied to POS build-docs. Others can adopt if they want.
- Fix lint error on `e`.

### 🎩

<img width="2660" height="552" alt="image" src="https://github.com/user-attachments/assets/b6d158f9-2238-488b-b16a-1deed39a8f59" />

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
