### PR TITLE
Use latest version of snapit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm install -g npm@11.7
 
       - name: Create snapshot
-        uses: Shopify/snapit@support-oidc-authentication
+        uses: Shopify/snapit@v0.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           NPM_TOKEN: ''


### PR DESCRIPTION
### Background

The deploy workflow was using `Shopify/snapit@support-oidc-authentication` (a branch reference) for snapshot releases. The snapit action has now released v0.1.0 which includes OIDC authentication support as a stable feature.

### Solution

Updated `Shopify/snapit@support-oidc-authentication` → `Shopify/snapit@v0.1.0`

Using a tagged release instead of a branch reference provides:
- Stability: Branch references can change unexpectedly
- Reproducibility: Pinned versions ensure consistent behavior
- Security: Tagged releases are reviewed and intentional

The workflow already has npm 11.7 installed (line 43-44), which satisfies the v0.1.0 requirement of npm CLI 11.5.2+ for OIDC authentication.

### 🎩

- Verified v0.1.0 is the latest release on https://github.com/Shopify/snapit/releases
- No functional changes expected - same OIDC auth behavior, just pinned to a release

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation