### PR TITLE
Add admin.app.tools.data extension target

### DIFF
--- a/.changeset/add-admin-tools-data-target.md
+++ b/.changeset/add-admin-tools-data-target.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add admin.app.tools.data extension target

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -12,6 +12,7 @@ import type {
   DiscountFunctionSettingsApi,
   CustomerSegmentTemplateApi,
   CustomerSegmentTemplate,
+  StandardApi,
 } from './api';
 import {
   ShouldRenderApi,
@@ -724,6 +725,14 @@ export interface ExtensionTargets {
   'admin.product-index.selection-print-action.should-render': RunnableExtension<
     ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,
     ShouldRenderOutput
+  >;
+
+  /**
+   * Provides tools data for the admin tools functionality.
+   */
+  'admin.app.tools.data': RunnableExtension<
+    StandardApi<'admin.app.tools.data'>,
+    undefined
   >;
 }
 


### PR DESCRIPTION
  ### Background

  Adds a new `admin.app.tools.data` extension target that enables apps to provide tool results for the admin tools functionality.

> [!NOTE]
> This PR is a port of #3706, which was merged into `2025-10` branch, to `2026-01-rc`.

  ### Solution

  Introduces `admin.app.tools.data` extension target using `RunnableExtension<StandardApi, undefined>`.

  ### Checklist

  - [ ] I have :tophat:'d these changes
  - [ ] I have updated relevant documentation

  ## References

  - https://github.com/shop/issues-admin-extensibility/issues/2133
  - https://github.com/shop/issues-admin-extensibility/issues/2126
  - https://github.com/shop/issues-admin-extensibility/issues/2128
  - https://github.com/Shopify/extensions-templates/pull/356