### PR TITLE
Add RegisterName to DeviceApi

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
@@ -4,6 +4,9 @@ export interface DeviceApiContent {
    */
   name: string;
   /**
+    A short, unique identifier for the device, assigned by Shopify.   */
+  registerName: string;
+  /**
    * Retrieves the unique string identifier for the device. Returns a promise that resolves to the device ID. Use for device-specific data storage, analytics tracking, or implementing device-based permissions and configurations.
    * Note: While Shopify POS attempts to maintain a stable identifier, it is not guaranteed to be permanent and may change.
    */


### PR DESCRIPTION
### Background

Contributes to https://github.com/shop/issues-retail/issues/21042

### Solution

Add RegisterName to deviceApi, so that the point of sale device identifier / handle is exposed to app developer.

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
