### PR TITLE
[v.2025-10] Add registerName to device-api

### DIFF
--- a/.changeset/serious-keys-trade.md
+++ b/.changeset/serious-keys-trade.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add registerName field to the Device Api

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
@@ -4,6 +4,10 @@ export interface DeviceApiContent {
    */
   name: string;
   /**
+   * A short, unique identifier for the device, assigned by Shopify.
+   */
+  registerName: string;
+  /**
    * Retrieves the unique string identifier for the device. Returns a promise that resolves to the device ID. Use for device-specific data storage, analytics tracking, or implementing device-based permissions and configurations.
    */
   getDeviceId(): Promise<string>;


### PR DESCRIPTION
### Background
fixes https://github.com/shop/issues-retail/issues/21042
Also back ported to versions [2026-01-rc](https://github.com/Shopify/ui-extensions/pull/3738) and [2025-07](https://github.com/Shopify/ui-extensions/pull/3736)

StoreLink our compliance partner in Spain and France, requires to registerName aka device -> identifier/handle to be exposed by the api.

### Solution

Added RegisterName to Device Api

### 🎩

- ...

### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
