### PR TITLE
[2025-07] Update Buyer Journey API docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
@@ -39,6 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
         To block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/configuration#block-progress) capability in your extension's configuration.
         If you do, then you're expected to inform the buyer why navigation was blocked, either by passing validation errors to the checkout UI or rendering the errors in your extension.
         \`useBuyerJourneyIntercept()\` should be called at the top level of the extension, not within an embedded or child component, to avoid errors should the child component get destroyed.
+        It is good practice to show a warning in the checkout editor when the merchant has not given permission for your extension to block checkout progress.
       `,
       type: 'UseBuyerJourneyInterceptGeneratedType',
     },

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/extension-banner.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/extension-banner.example.ts
@@ -5,14 +5,48 @@ import {
 
 export default extension(
   'purchase.checkout.cart-line-item.render-after',
-  (root, {buyerJourney, target}) => {
-    const banner = root.createComponent(Banner);
+  (root, {buyerJourney, extension, target}) => {
+    const orderLimitBanner =
+      root.createComponent(Banner);
+    const configBanner = root.createComponent(
+      Banner,
+      {
+        status: 'warning',
+        title: 'This app may be misconfigured',
+      },
+      `To allow this app to block checkout, enable this behavior in "Checkout behavior" settings.`,
+    );
 
     let quantity = target.current.quantity;
+    let blockProgressGranted =
+      extension.capabilities.current.find(
+        (capability) =>
+          capability === 'block_progress',
+      );
+    const editorType = extension.editor.type;
 
     target?.subscribe((newTarget) => {
       quantity = newTarget.quantity;
     });
+
+    extension.capabilities.subscribe(
+      (newCapabilities) => {
+        blockProgressGranted =
+          newCapabilities.find(
+            (capability) =>
+              capability === 'block_progress',
+          );
+
+        if (
+          editorType === 'checkout' &&
+          !blockProgressGranted
+        ) {
+          root.appendChild(configBanner);
+        } else {
+          root.removeChild(configBanner);
+        }
+      },
+    );
 
     buyerJourney.intercept(
       ({canBlockProgress}) => {
@@ -22,17 +56,21 @@ export default extension(
               reason: 'limited stock',
               perform: (result) => {
                 if (result.behavior === 'block') {
-                  banner.appendChild(
+                  orderLimitBanner.appendChild(
                     'This item has a limit of one per customer.',
                   );
-                  root.appendChild(banner);
+                  root.appendChild(
+                    orderLimitBanner,
+                  );
                 }
               },
             }
           : {
               behavior: 'allow',
               perform: () => {
-                root.removeChild(banner);
+                root.removeChild(
+                  orderLimitBanner,
+                );
               },
             };
       },

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/extension-banner.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/extension-banner.example.tsx
@@ -4,6 +4,8 @@ import {
   Banner,
   useBuyerJourneyIntercept,
   useCartLineTarget,
+  useExtensionCapability,
+  useExtensionEditor,
 } from '@shopify/ui-extensions-react/checkout';
 
 export default reactExtension(
@@ -15,6 +17,9 @@ function Extension() {
   const [showError, setShowError] =
     useState(false);
   const {quantity} = useCartLineTarget();
+  const editorType = useExtensionEditor()?.type;
+  const blockProgressGranted =
+    useExtensionCapability('block_progress');
 
   useBuyerJourneyIntercept(
     ({canBlockProgress}) => {
@@ -37,9 +42,25 @@ function Extension() {
     },
   );
 
-  return showError ? (
-    <Banner>
-      This item has a limit of one per customer.
-    </Banner>
-  ) : null;
+  return (
+    <>
+      {editorType === 'checkout' &&
+      !blockProgressGranted ? (
+        <Banner
+          status="warning"
+          title="This app may be misconfigured"
+        >
+          To allow this app to block checkout,
+          enable this behavior in "Checkout
+          behavior" settings.
+        </Banner>
+      ) : null}
+      {showError ? (
+        <Banner>
+          This item has a limit of one per
+          customer.
+        </Banner>
+      ) : null}
+    </>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/page-level-error.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/page-level-error.example.ts
@@ -1,12 +1,52 @@
-import {extension} from '@shopify/ui-extensions/checkout';
+import {
+  extension,
+  Banner,
+} from '@shopify/ui-extensions/checkout';
 
 export default extension(
   'purchase.checkout.delivery-address.render-before',
-  (root, {buyerJourney, shippingAddress}) => {
+  (
+    root,
+    {buyerJourney, extension, shippingAddress},
+  ) => {
+    const banner = root.createComponent(
+      Banner,
+      {
+        status: 'warning',
+        title: 'This app may be misconfigured',
+      },
+      `To allow this app to block checkout, enable this behavior in "Checkout behavior" settings.`,
+    );
+    const editorType = extension.editor.type;
+
     let address = shippingAddress?.current;
     shippingAddress?.subscribe((newAddress) => {
       address = newAddress;
     });
+
+    let blockProgressGranted =
+      extension.capabilities.current.find(
+        (capability) =>
+          capability === 'block_progress',
+      );
+    extension.capabilities.subscribe(
+      (newCapabilities) => {
+        blockProgressGranted =
+          newCapabilities.find(
+            (capability) =>
+              capability === 'block_progress',
+          );
+
+        if (
+          editorType === 'checkout' &&
+          !blockProgressGranted
+        ) {
+          root.appendChild(banner);
+        } else {
+          root.removeChild(banner);
+        }
+      },
+    );
 
     buyerJourney.intercept(
       ({canBlockProgress}) => {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/page-level-error.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/page-level-error.example.tsx
@@ -1,6 +1,9 @@
 import {
   reactExtension,
+  Banner,
   useBuyerJourneyIntercept,
+  useExtensionCapability,
+  useExtensionEditor,
   useShippingAddress,
 } from '@shopify/ui-extensions-react/checkout';
 
@@ -11,6 +14,9 @@ export default reactExtension(
 
 function Extension() {
   const address = useShippingAddress();
+  const editorType = useExtensionEditor()?.type;
+  const blockProgressGranted =
+    useExtensionCapability('block_progress');
 
   useBuyerJourneyIntercept(
     ({canBlockProgress}) => {
@@ -34,5 +40,15 @@ function Extension() {
     },
   );
 
-  return null;
+  return editorType === 'checkout' &&
+    !blockProgressGranted ? (
+    <Banner
+      status="warning"
+      title="This app may be misconfigured"
+    >
+      To allow this app to block checkout, enable
+      this behavior in "Checkout behavior"
+      settings.
+    </Banner>
+  ) : null;
 }

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/target-native-field.example.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/target-native-field.example.ts
@@ -1,12 +1,52 @@
-import {extension} from '@shopify/ui-extensions/checkout';
+import {
+  extension,
+  Banner,
+} from '@shopify/ui-extensions/checkout';
 
 export default extension(
   'purchase.checkout.delivery-address.render-before',
-  (root, {buyerJourney, shippingAddress}) => {
+  (
+    root,
+    {buyerJourney, extension, shippingAddress},
+  ) => {
+    const banner = root.createComponent(
+      Banner,
+      {
+        status: 'warning',
+        title: 'This app may be misconfigured',
+      },
+      `To allow this app to block checkout, enable this behavior in "Checkout behavior" settings.`,
+    );
+    const editorType = extension.editor.type;
+
     let address = shippingAddress?.current;
     shippingAddress?.subscribe((newAddress) => {
       address = newAddress;
     });
+
+    let blockProgressGranted =
+      extension.capabilities.current.find(
+        (capability) =>
+          capability === 'block_progress',
+      );
+    extension.capabilities.subscribe(
+      (newCapabilities) => {
+        blockProgressGranted =
+          newCapabilities.find(
+            (capability) =>
+              capability === 'block_progress',
+          );
+
+        if (
+          editorType === 'checkout' &&
+          !blockProgressGranted
+        ) {
+          root.appendChild(banner);
+        } else {
+          root.removeChild(banner);
+        }
+      },
+    );
 
     buyerJourney.intercept(
       ({canBlockProgress}) => {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/target-native-field.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/target-native-field.example.tsx
@@ -1,6 +1,9 @@
 import {
   reactExtension,
+  Banner,
   useBuyerJourneyIntercept,
+  useExtensionCapability,
+  useExtensionEditor,
   useShippingAddress,
 } from '@shopify/ui-extensions-react/checkout';
 
@@ -11,6 +14,9 @@ export default reactExtension(
 
 function Extension() {
   const address = useShippingAddress();
+  const editorType = useExtensionEditor()?.type;
+  const blockProgressGranted =
+    useExtensionCapability('block_progress');
 
   useBuyerJourneyIntercept(
     ({canBlockProgress}) => {
@@ -41,5 +47,15 @@ function Extension() {
     },
   );
 
-  return null;
+  return editorType === 'checkout' &&
+    !blockProgressGranted ? (
+    <Banner
+      status="warning"
+      title="This app may be misconfigured"
+    >
+      To allow this app to block checkout, enable
+      this behavior in "Checkout behavior"
+      settings.
+    </Banner>
+  ) : null;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -415,6 +415,9 @@ export interface BuyerJourney {
    *
    * If you do, then you're expected to inform the buyer why navigation was blocked,
    * either by passing validation errors to the checkout UI or rendering the errors in your extension.
+   *
+   * It is good practice to show a warning in the checkout editor when the merchant has not given permission for your extension
+   * to block checkout progress.
    */
   intercept(interceptor: Interceptor): Promise<() => void>;
 


### PR DESCRIPTION
### Background

Update `2025-07` Buyer Journey API docs with guidance and examples to show a warning banner in the Checkout and Accounts editor when "block progress" has not been granted to the extension by the merchant.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
