### PR TITLE
[2025-10] Update Buyer Journey API docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
@@ -39,6 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
         To block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/configuration#block-progress) capability in your extension's configuration.
         If you do, then you're expected to inform the buyer why navigation was blocked, either by passing validation errors to the checkout UI or rendering the errors in your extension.
         \`useBuyerJourneyIntercept()\` should be called at the top level of the extension, not within an embedded or child component, to avoid errors should the child component get destroyed.
+        It is good practice to show a warning in the checkout editor when the merchant has not given permission for your extension to block checkout progress.
       `,
       type: 'UseBuyerJourneyInterceptGeneratedType',
     },

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/extension-banner.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/extension-banner.example.tsx
@@ -2,7 +2,11 @@ import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useState} from 'preact/hooks';
 
-import {useBuyerJourneyIntercept} from '@shopify/ui-extensions/checkout/preact';
+import {
+  useBuyerJourneyIntercept,
+  useExtensionEditor,
+  useExtensionCapability,
+} from '@shopify/ui-extensions/checkout/preact';
 
 export default function extension() {
   render(<Extension />, document.body);
@@ -11,6 +15,9 @@ export default function extension() {
 function Extension() {
   const [showError, setShowError] =
     useState(false);
+  const editorType = useExtensionEditor()?.type;
+  const blockProgressGranted =
+    useExtensionCapability('block_progress');
 
   useBuyerJourneyIntercept(
     ({canBlockProgress}) => {
@@ -34,9 +41,25 @@ function Extension() {
     },
   );
 
-  return showError ? (
-    <s-banner tone="critical">
-      This item has a limit of one per customer.
-    </s-banner>
-  ) : null;
+  return (
+    <>
+      {editorType === 'checkout' &&
+      !blockProgressGranted ? (
+        <s-banner
+          tone="warning"
+          heading="This app may be misconfigured"
+        >
+          To allow this app to block checkout,
+          enable this behavior in "Checkout
+          behavior" settings.
+        </s-banner>
+      ) : null}
+      {showError ? (
+        <s-banner tone="critical">
+          This item has a limit of one per
+          customer.
+        </s-banner>
+      ) : null}
+    </>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/page-level-error.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/page-level-error.example.tsx
@@ -1,13 +1,21 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-import {useBuyerJourneyIntercept} from '@shopify/ui-extensions/checkout/preact';
+import {
+  useBuyerJourneyIntercept,
+  useExtensionEditor,
+  useExtensionCapability,
+} from '@shopify/ui-extensions/checkout/preact';
 
 export default function extension() {
   render(<Extension />, document.body);
 }
 
 function Extension() {
+  const editorType = useExtensionEditor()?.type;
+  const blockProgressGranted =
+    useExtensionCapability('block_progress');
+
   useBuyerJourneyIntercept(
     ({canBlockProgress}) => {
       return canBlockProgress &&
@@ -32,5 +40,19 @@ function Extension() {
     },
   );
 
-  return null;
+  return (
+    <>
+      {editorType === 'checkout' &&
+      !blockProgressGranted ? (
+        <s-banner
+          tone="warning"
+          heading="This app may be misconfigured"
+        >
+          To allow this app to block checkout,
+          enable this behavior in "Checkout
+          behavior" settings.
+        </s-banner>
+      ) : null}
+    </>
+  );
 }

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/target-native-field.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/buyer-journey-intercept/target-native-field.example.tsx
@@ -1,13 +1,21 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-import {useBuyerJourneyIntercept} from '@shopify/ui-extensions/checkout/preact';
+import {
+  useBuyerJourneyIntercept,
+  useExtensionEditor,
+  useExtensionCapability,
+} from '@shopify/ui-extensions/checkout/preact';
 
 export default function extension() {
   render(<Extension />, document.body);
 }
 
 function Extension() {
+  const editorType = useExtensionEditor()?.type;
+  const blockProgressGranted =
+    useExtensionCapability('block_progress');
+
   useBuyerJourneyIntercept(
     ({canBlockProgress}) => {
       return canBlockProgress &&
@@ -39,5 +47,19 @@ function Extension() {
     },
   );
 
-  return null;
+  return (
+    <>
+      {editorType === 'checkout' &&
+      !blockProgressGranted ? (
+        <s-banner
+          tone="warning"
+          heading="This app may be misconfigured"
+        >
+          To allow this app to block checkout,
+          enable this behavior in "Checkout
+          behavior" settings.
+        </s-banner>
+      ) : null}
+    </>
+  );
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -418,6 +418,9 @@ export interface BuyerJourney {
    *
    * If you do, then you're expected to inform the buyer why navigation was blocked,
    * either by passing validation errors to the checkout UI or rendering the errors in your extension.
+   *
+   * It is good practice to show a warning in the checkout editor when the merchant has not given permission for your extension
+   * to block checkout progress.
    */
   intercept(interceptor: Interceptor): Promise<() => void>;
 

--- a/packages/ui-extensions/src/surfaces/checkout/preact/buyer-journey.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/preact/buyer-journey.ts
@@ -45,6 +45,9 @@ export function useBuyerJourneyCompleted<
  *
  * `useBuyerJourneyIntercept()` should be called at the top level of the extension,
  * not within an embedded or child component, to avoid errors should the child component get destroyed.
+ *
+ * It is good practice to show a warning in the checkout editor when the merchant has not given permission for your extension
+ * to block checkout progress.
  */
 export function useBuyerJourneyIntercept<
   Target extends RenderExtensionTarget = RenderExtensionTarget,


### PR DESCRIPTION
### Background

Update `2025-10` Buyer Journey API docs with guidance and examples to show a warning banner in the Checkout and Accounts editor when "block progress" has not been granted to the extension by the merchant.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
