### PR TITLE
2025-10 target docs

### DIFF
--- a/packages/ui-extensions/docs/shared/build-docs-type-resolver.mjs
+++ b/packages/ui-extensions/docs/shared/build-docs-type-resolver.mjs
@@ -1,0 +1,399 @@
+/**
+ * Shared type resolver for build-docs-targets-json scripts
+ *
+ * This module provides utilities for parsing TypeScript type definitions
+ * and resolving component types, including handling of:
+ * - String literals: 'ComponentName'
+ * - Type references: TypeName
+ * - Union types: A | B | C
+ * - Exclude types: Exclude<Base, Excluded>
+ * - Array types: (typeof ARRAY)[number]
+ * - @private JSDoc tags for excluding private components
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Creates a type resolver instance for a specific surface
+ * @param {string} sharedTsPath - Path to the shared.ts file for the surface
+ * @returns {Object} Type resolver with methods for resolving types
+ */
+export function createTypeResolver(sharedTsPath) {
+  // Cache for type definitions parsed from shared.ts
+  let typeDefinitionsCache = null;
+  const resolvedTypesCache = {};
+  // Set of type names that are marked with @private JSDoc tag
+  let privateTypesCache = null;
+
+  /**
+   * Parse all type definitions from shared.ts
+   * Returns a map of type name -> type definition string
+   * Also detects @private JSDoc tags to identify private types
+   */
+  function parseTypeDefinitions() {
+    if (typeDefinitionsCache !== null) {
+      return typeDefinitionsCache;
+    }
+
+    typeDefinitionsCache = {};
+    privateTypesCache = new Set();
+
+    try {
+      if (!fs.existsSync(sharedTsPath)) {
+        return typeDefinitionsCache;
+      }
+
+      const content = fs.readFileSync(sharedTsPath, 'utf-8');
+
+      // Parse const arrays (like SUPPORTED_COMPONENTS) - store as resolved arrays
+      const constArrayRegex =
+        /export const (\w+)\s*=\s*\[([\s\S]*?)\]\s*as const/g;
+      let constMatch;
+      while ((constMatch = constArrayRegex.exec(content)) !== null) {
+        const constName = constMatch[1];
+        const arrayContent = constMatch[2];
+        const components = arrayContent.match(/'([^']+)'/g);
+        if (components) {
+          typeDefinitionsCache[constName] = components.map((c) =>
+            c.replace(/'/g, ''),
+          );
+        }
+      }
+
+      // Parse all type definitions: export type TypeName = Definition;
+      // Also check for @private JSDoc comments preceding the type
+      const typeRegex = /export type (\w+)(?:<[^>]+>)?\s*=\s*/g;
+      let match;
+
+      while ((match = typeRegex.exec(content)) !== null) {
+        const typeName = match[1];
+        const startPos = match.index + match[0].length;
+
+        // Check for @private in JSDoc comment before this type definition
+        // Look backwards from the match to find a preceding JSDoc comment
+        const beforeMatch = content.substring(0, match.index);
+        const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+        if (lastJsDocEnd !== -1) {
+          // Check if there's no other code between the JSDoc and this type
+          const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+          if (between === '') {
+            // Find the start of this JSDoc comment
+            const jsDocStart = beforeMatch.lastIndexOf('/**');
+            if (jsDocStart !== -1) {
+              const jsDocContent = beforeMatch.substring(
+                jsDocStart,
+                lastJsDocEnd + 2,
+              );
+              // Check if this JSDoc contains @private tag
+              if (jsDocContent.includes('@private')) {
+                privateTypesCache.add(typeName);
+              }
+            }
+          }
+        }
+
+        // Find the end of the type definition (semicolon at depth 0)
+        let endPos = startPos;
+        let depth = 0;
+        let inString = false;
+
+        for (let i = startPos; i < content.length; i++) {
+          const char = content[i];
+          const prevChar = i > 0 ? content[i - 1] : '';
+
+          if (char === "'" && prevChar !== '\\') {
+            inString = !inString;
+          }
+
+          if (!inString) {
+            if (char === '<' || char === '(' || char === '{' || char === '[') {
+              depth++;
+            } else if (
+              char === '>' ||
+              char === ')' ||
+              char === '}' ||
+              char === ']'
+            ) {
+              depth--;
+            } else if (char === ';' && depth === 0) {
+              endPos = i;
+              break;
+            }
+          }
+        }
+
+        const definition = content.substring(startPos, endPos).trim();
+        typeDefinitionsCache[typeName] = definition;
+      }
+
+      return typeDefinitionsCache;
+    } catch (error) {
+      console.warn('Warning: Failed to parse type definitions:', error.message);
+      return typeDefinitionsCache;
+    }
+  }
+
+  /**
+   * Check if a type is marked as @private
+   */
+  function isPrivateType(typeName) {
+    // Ensure type definitions are parsed (which also populates privateTypesCache)
+    parseTypeDefinitions();
+    return privateTypesCache && privateTypesCache.has(typeName);
+  }
+
+  /**
+   * Get the components from @private types (to exclude them from other types)
+   */
+  function getPrivateComponents() {
+    parseTypeDefinitions();
+    const privateComponents = [];
+    if (privateTypesCache) {
+      for (const typeName of privateTypesCache) {
+        const resolved = resolveTypeInternal(typeName, false); // Don't filter private when getting private components
+        privateComponents.push(...resolved);
+      }
+    }
+    return privateComponents;
+  }
+
+  /**
+   * Internal type resolver - can optionally skip filtering of @private components
+   * @param {string} typeExpr - The type expression to resolve
+   * @param {boolean} filterPrivate - Whether to filter out @private components (default: true)
+   */
+  function resolveTypeInternal(typeExpr, filterPrivate = true) {
+    if (!typeExpr) return [];
+
+    typeExpr = typeExpr.trim();
+
+    // Check cache first (but only for filtered results)
+    const cacheKey = filterPrivate ? typeExpr : `__unfiltered__${typeExpr}`;
+    if (resolvedTypesCache[cacheKey]) {
+      return [...resolvedTypesCache[cacheKey]];
+    }
+
+    const typeDefs = parseTypeDefinitions();
+    let result = [];
+
+    // Handle string literal: 'ComponentName'
+    const stringLiteralMatch = typeExpr.match(/^'([^']+)'$/);
+    if (stringLiteralMatch) {
+      result = [stringLiteralMatch[1]];
+      resolvedTypesCache[cacheKey] = result;
+      return [...result];
+    }
+
+    // IMPORTANT: Check for unions FIRST before other patterns
+    // This ensures we don't match partial patterns within a union
+    if (typeExpr.includes('|')) {
+      const parts = splitByTopLevelPipe(typeExpr);
+      // Only treat as union if we actually got multiple parts
+      if (parts.filter((p) => p.trim()).length > 1) {
+        for (const part of parts) {
+          const trimmed = part.trim();
+          if (trimmed) {
+            result.push(...resolveTypeInternal(trimmed, filterPrivate));
+          }
+        }
+        // Deduplicate
+        result = [...new Set(result)];
+        resolvedTypesCache[cacheKey] = result;
+        return [...result];
+      }
+    }
+
+    // Handle (typeof ARRAY_NAME)[number] - anchored to match entire expression
+    const typeofMatch = typeExpr.match(/^\(typeof (\w+)\)\[number\]$/);
+    if (typeofMatch) {
+      const arrayName = typeofMatch[1];
+      if (Array.isArray(typeDefs[arrayName])) {
+        result = [...typeDefs[arrayName]];
+        resolvedTypesCache[cacheKey] = result;
+        return [...result];
+      }
+    }
+
+    // Handle Exclude<BaseType, ExcludedType>
+    const excludeMatch = typeExpr.match(/^Exclude<(.+)>$/);
+    if (excludeMatch) {
+      const innerContent = excludeMatch[1];
+      const parts = splitByTopLevelComma(innerContent);
+      if (parts.length >= 2) {
+        const baseType = parts[0].trim();
+        const excludedType = parts[1].trim();
+
+        const baseComponents = resolveTypeInternal(baseType, filterPrivate);
+        const excludedComponents = resolveTypeInternal(
+          excludedType,
+          filterPrivate,
+        );
+
+        result = baseComponents.filter((c) => !excludedComponents.includes(c));
+        resolvedTypesCache[cacheKey] = result;
+        return [...result];
+      }
+    }
+
+    // Handle type reference (look up in definitions and resolve recursively)
+    if (/^\w+$/.test(typeExpr)) {
+      // If this type itself is marked @private, return empty (unless we're not filtering)
+      if (filterPrivate && isPrivateType(typeExpr)) {
+        resolvedTypesCache[cacheKey] = [];
+        return [];
+      }
+
+      const definition = typeDefs[typeExpr];
+      if (Array.isArray(definition)) {
+        // It's a pre-resolved array (like SUPPORTED_COMPONENTS)
+        result = [...definition];
+      } else if (typeof definition === 'string') {
+        // Recursively resolve the definition
+        result = resolveTypeInternal(definition, filterPrivate);
+      }
+      resolvedTypesCache[cacheKey] = result;
+      return [...result];
+    }
+
+    // If we can't resolve it, return empty
+    resolvedTypesCache[cacheKey] = result;
+    return [...result];
+  }
+
+  /**
+   * Resolve a type expression to component strings
+   * Automatically excludes components from types marked with @private JSDoc tag
+   * @param {string} typeExpr - The type expression to resolve
+   * @returns {string[]} Array of component names
+   */
+  function resolveType(typeExpr) {
+    // Get result with private components filtered out
+    let result = resolveTypeInternal(typeExpr, true);
+
+    // Also filter out any components that come from @private types
+    const privateComponents = getPrivateComponents();
+    if (privateComponents.length > 0) {
+      result = result.filter((c) => !privateComponents.includes(c));
+    }
+
+    return result;
+  }
+
+  /**
+   * Resolve a type expression WITHOUT filtering @private components
+   * Use this for AllowedComponents<> which explicitly allows private components
+   * @param {string} typeExpr - The type expression to resolve
+   * @returns {string[]} Array of component names
+   */
+  function resolveTypeUnfiltered(typeExpr) {
+    return resolveTypeInternal(typeExpr, false);
+  }
+
+  /**
+   * Get the parsed type definitions (for debugging or advanced use)
+   */
+  function getTypeDefinitions() {
+    return parseTypeDefinitions();
+  }
+
+  /**
+   * Get the set of private type names
+   */
+  function getPrivateTypeNames() {
+    parseTypeDefinitions();
+    return privateTypesCache ? new Set(privateTypesCache) : new Set();
+  }
+
+  return {
+    resolveType,
+    resolveTypeUnfiltered,
+    getTypeDefinitions,
+    getPrivateTypeNames,
+    getPrivateComponents,
+    isPrivateType,
+  };
+}
+
+/**
+ * Split a string by top-level pipe (|) characters, respecting nesting
+ */
+export function splitByTopLevelPipe(str) {
+  const parts = [];
+  let current = '';
+  let depth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<' || char === '(' || char === '{' || char === '[') {
+      depth++;
+      current += char;
+    } else if (char === '>' || char === ')' || char === '}' || char === ']') {
+      depth--;
+      current += char;
+    } else if (char === '|' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+/**
+ * Split a string by top-level comma (,) characters, respecting nesting
+ */
+export function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs-admin-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs-admin-json.mjs
@@ -1,0 +1,639 @@
+const fs = require('fs');
+const path = require('path');
+
+// Configuration for admin surface
+const config = {
+  basePath: path.join(
+    __dirname,
+    '../packages/ui-extensions/src/surfaces/admin',
+  ),
+  outputPath: path.join(
+    __dirname,
+    '../packages/ui-extensions/src/surfaces/admin/generated-targets.json',
+  ),
+  componentTypesPath: 'components',
+  hasComponentTypes: true,
+};
+
+// All components will be populated from StandardComponents
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+// Cache for checkout components
+let checkoutComponentsCache = null;
+
+/**
+ * Parse components from checkout's shared.ts file
+ */
+function parseCheckoutComponents() {
+  // Return cached value if available
+  if (checkoutComponentsCache !== null) {
+    return checkoutComponentsCache;
+  }
+
+  try {
+    // Always look in the checkout surface directory
+    const checkoutBasePath = path.join(
+      __dirname,
+      '../packages/ui-extensions/src/surfaces/checkout',
+    );
+    const sharedPath = path.join(checkoutBasePath, 'shared.ts');
+
+    if (!fs.existsSync(sharedPath)) {
+      checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
+      return checkoutComponentsCache;
+    }
+
+    const content = fs.readFileSync(sharedPath, 'utf-8');
+
+    // Look for SUPPORTED_COMPONENTS array
+    const supportedMatch = content.match(
+      /export const SUPPORTED_COMPONENTS\s*=\s*\[([\s\S]*?)\]\s*as const/,
+    );
+
+    if (supportedMatch) {
+      const arrayContent = supportedMatch[1];
+      // Extract all quoted strings
+      const components = arrayContent.match(/'([^']+)'/g);
+      if (components) {
+        checkoutComponentsCache = components.map((c) => c.replace(/'/g, ''));
+        return checkoutComponentsCache;
+      }
+    }
+
+    checkoutComponentsCache = ['[CheckoutComponentsParseError]'];
+    return checkoutComponentsCache;
+  } catch (error) {
+    checkoutComponentsCache = ['[CheckoutComponentsError]'];
+    return checkoutComponentsCache;
+  }
+}
+
+/**
+ * Parse a string union type from a component file and resolve type references
+ * e.g., export type SmartGridComponents = 'Tile';
+ * or: export type BlockExtensionComponents = StandardComponents | 'AdminBlock';
+ * or: export type StandardComponents = AnyComponent | 'Avatar' | ... (with AnyComponent imported)
+ */
+function parseStringUnionType(filePath, componentTypesMap = {}) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    
+    // Extract all quoted component names from the file (but not from import statements)
+    // Remove import lines first
+    const contentWithoutImports = content.replace(/^import.*?;$/gm, '');
+    const componentNames = contentWithoutImports.match(/'([^']+)'/g);
+    const quotedComponents = componentNames
+      ? componentNames.map((name) => name.replace(/'/g, ''))
+      : [];
+    
+    // Check if the type references other types (like StandardComponents or AnyComponent)
+    // Look for patterns like: StandardComponents | 'OtherComponent'
+    const typeRefPattern = /export type \w+ =\s*([\s\S]*?);/;
+    const typeDefMatch = content.match(typeRefPattern);
+    
+    if (typeDefMatch) {
+      const typeDef = typeDefMatch[1];
+      // Find references to other types (capitalized words that aren't in quotes)
+      const typeRefs = typeDef.match(/\b([A-Z]\w+(?:Components?)?)\b/g);
+      
+      if (typeRefs) {
+        const allComponents = [...quotedComponents];
+        
+        for (const typeRef of typeRefs) {
+          // Check if this is AnyComponent (imported from checkout)
+          if (typeRef === 'AnyComponent') {
+            // Add all checkout components
+            const checkoutComponents = parseCheckoutComponents();
+            allComponents.push(...checkoutComponents);
+          }
+          // If this type reference exists in our map, include its components
+          else if (componentTypesMap[typeRef]) {
+            allComponents.push(...componentTypesMap[typeRef]);
+          }
+        }
+        
+        // Remove duplicates
+        return [...new Set(allComponents)];
+      }
+    }
+    
+    return quotedComponents.length > 0 ? quotedComponents : null;
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from files in the components directory
+ * Uses a two-pass approach:
+ * 1. First pass: Parse all component types that only contain quoted strings
+ * 2. Second pass: Parse types that reference other types (like StandardComponents)
+ */
+function parseComponentTypesFromFiles() {
+  if (!config.hasComponentTypes || !config.componentTypesPath) {
+    return {};
+  }
+
+  const componentsPath = path.join(config.basePath, config.componentTypesPath);
+  const componentTypesMap = {};
+
+  try {
+    // Look for all TypeScript files in the components directory
+    const files = fs.readdirSync(componentsPath);
+    const tsFiles = files.filter(
+      (file) => file.endsWith('.ts') && !file.endsWith('.d.ts'),
+    );
+
+    // First pass: Parse files with only quoted strings
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, {});
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+
+        // If this is StandardComponents, use it as the base
+        if (componentTypeName === 'StandardComponents') {
+          allComponents = components.sort();
+        }
+      }
+    }
+
+    // Second pass: Re-parse files that might reference other types
+    // This allows types like BlockExtensionComponents = StandardComponents | 'AdminBlock'
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, componentTypesMap);
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+      }
+    }
+  } catch (error) {
+    console.error('Error parsing component types:', error.message);
+  }
+
+  return componentTypesMap;
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(config.basePath, 'extension-targets.ts');
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse component type definitions
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'CustomerAccountExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match && match[1].includes('RenderExtension<')) {
+      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    }
+  }
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (apiDefinitionsCache.hasOwnProperty(apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Try to find the API file in the surface's api directory
+  const apiDir = path.join(config.basePath, 'api');
+
+  if (!fs.existsSync(apiDir)) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Convert API name to potential file paths
+  // e.g., StandardApi -> standard-api, CartApi -> cart-api
+  const kebabName = apiName
+    .replace(/Api$/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+  // Try multiple possible locations
+  const possiblePaths = [
+    path.join(apiDir, `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}`, `${kebabName}.ts`),
+    path.join(apiDir, kebabName.replace(/-/g, ''), `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}-api`, `${kebabName}-api.ts`),
+    path.join(apiDir, `${kebabName}-api.ts`),
+    path.join(apiDir, `standard-api`, `standard-api.ts`),
+  ];
+
+  let content = null;
+  for (const apiFilePath of possiblePaths) {
+    try {
+      if (fs.existsSync(apiFilePath)) {
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      }
+    } catch (error) {
+      // Continue to next path
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    let startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const generalMatch = part.match(/(\w+Api)\b/);
+      if (generalMatch) {
+        apiName = generalMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+/**
+ * Parse a TypeScript component type expression
+ * Handles various patterns: type refs, unions, Exclude, AllowedComponents, etc.
+ */
+function parseComponents(componentString, componentTypesMap) {
+  // Normalize whitespace
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
+  const checkoutExceptMatch = componentString.match(/AnyCheckoutComponentExcept<([^>]+)>/);
+  if (checkoutExceptMatch) {
+    const excludedUnion = checkoutExceptMatch[1];
+    // Get all checkout components
+    const allCheckoutComponents = parseCheckoutComponents();
+    // Parse the union of excluded components
+    const excludedComponents = parseUnionOfStrings(excludedUnion);
+    // Filter out the excluded components
+    return allCheckoutComponents.filter((c) => !excludedComponents.includes(c));
+  }
+
+  // Handle Exclude<BaseType, ExcludedComponent>
+  const excludeMatch = componentString.match(/Exclude<(\w+),\s*'([^']+)'>/);
+  if (excludeMatch) {
+    const baseType = excludeMatch[1];
+    const excluded = excludeMatch[2];
+    const baseComponents = resolveComponentType(baseType, componentTypesMap);
+    return baseComponents.filter((c) => c !== excluded);
+  }
+
+  // Handle AllowedComponents<ComponentType>
+  const allowedMatch = componentString.match(/AllowedComponents<([^>]+)>/);
+  if (allowedMatch) {
+    const innerType = allowedMatch[1].trim();
+    return resolveComponentType(innerType, componentTypesMap);
+  }
+
+  // Check if it's a direct type reference
+  const result = resolveComponentType(componentString, componentTypesMap);
+  if (result.length > 0) {
+    return result;
+  }
+
+  // Default to all components if we have them
+  if (allComponents.length > 0) {
+    return allComponents;
+  }
+
+  return ['[Unknown]'];
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Resolve a component type name to a list of component names
+ */
+function resolveComponentType(typeName, componentTypesMap) {
+  typeName = typeName.trim();
+
+  // Check if it's in our component types map
+  if (componentTypesMap[typeName]) {
+    return componentTypesMap[typeName];
+  }
+
+  // Handle special checkout types
+  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyComponent' || typeName === 'AnyThankYouComponent') {
+    return parseCheckoutComponents();
+  }
+
+  // Check if it's a quoted string literal
+  const quotedMatch = typeName.match(/^'([^']+)'$/);
+  if (quotedMatch) {
+    return [quotedMatch[1]];
+  }
+
+  return [];
+}
+
+function createCombinedMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for admin surface');
+  console.log(`📁 Base path: ${config.basePath}`);
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the combined JSON with reverse mappings
+  const combinedJson = createCombinedMapping(targetsJson);
+
+  // Write to output file
+  fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
+
+  console.log('✅ Generated combined targets JSON at:', config.outputPath);
+  
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+  ).length;
+  const componentEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+  ).length;
+  
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(combinedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
@@ -1,0 +1,649 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const EXTENSIONS_API_VERSION = process.argv[2] || 'unstable';
+
+// Configuration for admin surface
+const config = {
+  basePath: path.join(
+    __dirname,
+    '../../../src/surfaces/admin',
+  ),
+  outputPath: path.join(
+    __dirname,
+    `generated/admin_extensions/${EXTENSIONS_API_VERSION}/targets.json`,
+  ),
+  componentTypesPath: 'components',
+  hasComponentTypes: true,
+};
+
+// All components will be populated from StandardComponents
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+// Cache for checkout components
+let checkoutComponentsCache = null;
+
+/**
+ * Parse components from checkout's shared.ts file
+ */
+function parseCheckoutComponents() {
+  // Return cached value if available
+  if (checkoutComponentsCache !== null) {
+    return checkoutComponentsCache;
+  }
+
+  try {
+    // Always look in the checkout surface directory
+    const checkoutBasePath = path.join(
+      __dirname,
+      '../../../src/surfaces/checkout',
+    );
+    const sharedPath = path.join(checkoutBasePath, 'shared.ts');
+
+    if (!fs.existsSync(sharedPath)) {
+      checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
+      return checkoutComponentsCache;
+    }
+
+    const content = fs.readFileSync(sharedPath, 'utf-8');
+
+    // Look for SUPPORTED_COMPONENTS array
+    const supportedMatch = content.match(
+      /export const SUPPORTED_COMPONENTS\s*=\s*\[([\s\S]*?)\]\s*as const/,
+    );
+
+    if (supportedMatch) {
+      const arrayContent = supportedMatch[1];
+      // Extract all quoted strings
+      const components = arrayContent.match(/'([^']+)'/g);
+      if (components) {
+        checkoutComponentsCache = components.map((c) => c.replace(/'/g, ''));
+        return checkoutComponentsCache;
+      }
+    }
+
+    checkoutComponentsCache = ['[CheckoutComponentsParseError]'];
+    return checkoutComponentsCache;
+  } catch (error) {
+    checkoutComponentsCache = ['[CheckoutComponentsError]'];
+    return checkoutComponentsCache;
+  }
+}
+
+/**
+ * Parse a string union type from a component file and resolve type references
+ * e.g., export type SmartGridComponents = 'Tile';
+ * or: export type BlockExtensionComponents = StandardComponents | 'AdminBlock';
+ * or: export type StandardComponents = AnyComponent | 'Avatar' | ... (with AnyComponent imported)
+ */
+function parseStringUnionType(filePath, componentTypesMap = {}) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    
+    // Extract all quoted component names from the file (but not from import statements)
+    // Remove import lines first
+    const contentWithoutImports = content.replace(/^import.*?;$/gm, '');
+    const componentNames = contentWithoutImports.match(/'([^']+)'/g);
+    const quotedComponents = componentNames
+      ? componentNames.map((name) => name.replace(/'/g, ''))
+      : [];
+    
+    // Check if the type references other types (like StandardComponents or AnyComponent)
+    // Look for patterns like: StandardComponents | 'OtherComponent'
+    const typeRefPattern = /export type \w+ =\s*([\s\S]*?);/;
+    const typeDefMatch = content.match(typeRefPattern);
+    
+    if (typeDefMatch) {
+      const typeDef = typeDefMatch[1];
+      // Find references to other types (capitalized words that aren't in quotes)
+      const typeRefs = typeDef.match(/\b([A-Z]\w+(?:Components?)?)\b/g);
+      
+      if (typeRefs) {
+        const allComponents = [...quotedComponents];
+        
+        for (const typeRef of typeRefs) {
+          // Check if this is AnyComponent (imported from checkout)
+          if (typeRef === 'AnyComponent') {
+            // Add all checkout components
+            const checkoutComponents = parseCheckoutComponents();
+            allComponents.push(...checkoutComponents);
+          }
+          // If this type reference exists in our map, include its components
+          else if (componentTypesMap[typeRef]) {
+            allComponents.push(...componentTypesMap[typeRef]);
+          }
+        }
+        
+        // Remove duplicates
+        return [...new Set(allComponents)];
+      }
+    }
+    
+    return quotedComponents.length > 0 ? quotedComponents : null;
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from files in the components directory
+ * Uses a two-pass approach:
+ * 1. First pass: Parse all component types that only contain quoted strings
+ * 2. Second pass: Parse types that reference other types (like StandardComponents)
+ */
+function parseComponentTypesFromFiles() {
+  if (!config.hasComponentTypes || !config.componentTypesPath) {
+    return {};
+  }
+
+  const componentsPath = path.join(config.basePath, config.componentTypesPath);
+  const componentTypesMap = {};
+
+  try {
+    // Look for all TypeScript files in the components directory
+    const files = fs.readdirSync(componentsPath);
+    const tsFiles = files.filter(
+      (file) => file.endsWith('.ts') && !file.endsWith('.d.ts'),
+    );
+
+    // First pass: Parse files with only quoted strings
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, {});
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+
+        // If this is StandardComponents, use it as the base
+        if (componentTypeName === 'StandardComponents') {
+          allComponents = components.sort();
+        }
+      }
+    }
+
+    // Second pass: Re-parse files that might reference other types
+    // This allows types like BlockExtensionComponents = StandardComponents | 'AdminBlock'
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, componentTypesMap);
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+      }
+    }
+  } catch (error) {
+    console.error('Error parsing component types:', error.message);
+  }
+
+  return componentTypesMap;
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(config.basePath, 'extension-targets.ts');
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse component type definitions
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'CustomerAccountExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match && match[1].includes('RenderExtension<')) {
+      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    }
+  }
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (apiDefinitionsCache.hasOwnProperty(apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Try to find the API file in the surface's api directory
+  const apiDir = path.join(config.basePath, 'api');
+
+  if (!fs.existsSync(apiDir)) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Convert API name to potential file paths
+  // e.g., StandardApi -> standard-api, CartApi -> cart-api
+  const kebabName = apiName
+    .replace(/Api$/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+  // Try multiple possible locations
+  const possiblePaths = [
+    path.join(apiDir, `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}`, `${kebabName}.ts`),
+    path.join(apiDir, kebabName.replace(/-/g, ''), `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}-api`, `${kebabName}-api.ts`),
+    path.join(apiDir, `${kebabName}-api.ts`),
+    path.join(apiDir, `standard-api`, `standard-api.ts`),
+  ];
+
+  let content = null;
+  for (const apiFilePath of possiblePaths) {
+    try {
+      if (fs.existsSync(apiFilePath)) {
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      }
+    } catch (error) {
+      // Continue to next path
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    let startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const generalMatch = part.match(/(\w+Api)\b/);
+      if (generalMatch) {
+        apiName = generalMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+/**
+ * Parse a TypeScript component type expression
+ * Handles various patterns: type refs, unions, Exclude, AllowedComponents, etc.
+ */
+function parseComponents(componentString, componentTypesMap) {
+  // Normalize whitespace
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
+  const checkoutExceptMatch = componentString.match(/AnyCheckoutComponentExcept<([^>]+)>/);
+  if (checkoutExceptMatch) {
+    const excludedUnion = checkoutExceptMatch[1];
+    // Get all checkout components
+    const allCheckoutComponents = parseCheckoutComponents();
+    // Parse the union of excluded components
+    const excludedComponents = parseUnionOfStrings(excludedUnion);
+    // Filter out the excluded components
+    return allCheckoutComponents.filter((c) => !excludedComponents.includes(c));
+  }
+
+  // Handle Exclude<BaseType, ExcludedComponent>
+  const excludeMatch = componentString.match(/Exclude<(\w+),\s*'([^']+)'>/);
+  if (excludeMatch) {
+    const baseType = excludeMatch[1];
+    const excluded = excludeMatch[2];
+    const baseComponents = resolveComponentType(baseType, componentTypesMap);
+    return baseComponents.filter((c) => c !== excluded);
+  }
+
+  // Handle AllowedComponents<ComponentType>
+  const allowedMatch = componentString.match(/AllowedComponents<([^>]+)>/);
+  if (allowedMatch) {
+    const innerType = allowedMatch[1].trim();
+    return resolveComponentType(innerType, componentTypesMap);
+  }
+
+  // Check if it's a direct type reference
+  const result = resolveComponentType(componentString, componentTypesMap);
+  if (result.length > 0) {
+    return result;
+  }
+
+  // Default to all components if we have them
+  if (allComponents.length > 0) {
+    return allComponents;
+  }
+
+  return ['[Unknown]'];
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Resolve a component type name to a list of component names
+ */
+function resolveComponentType(typeName, componentTypesMap) {
+  typeName = typeName.trim();
+
+  // Check if it's in our component types map
+  if (componentTypesMap[typeName]) {
+    return componentTypesMap[typeName];
+  }
+
+  // Handle special checkout types
+  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyComponent' || typeName === 'AnyThankYouComponent') {
+    return parseCheckoutComponents();
+  }
+
+  // Check if it's a quoted string literal
+  const quotedMatch = typeName.match(/^'([^']+)'$/);
+  if (quotedMatch) {
+    return [quotedMatch[1]];
+  }
+
+  return [];
+}
+
+function createCombinedMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for admin surface');
+  console.log(`📁 Base path: ${config.basePath}`);
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the combined JSON with reverse mappings
+  const combinedJson = createCombinedMapping(targetsJson);
+
+  // Write to output file
+  const outputDir = path.dirname(config.outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
+
+  console.log('✅ Generated combined targets JSON at:', config.outputPath);
+  
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+  ).length;
+  const componentEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+  ).length;
+  
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(combinedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
@@ -206,7 +206,7 @@ function parseTargetsFile() {
 
   const targets = {};
 
-  // Look for all interfaces that might contain RenderExtension targets
+  // Look for all interfaces that might contain RenderExtension or RunnableExtension targets
   const interfaceNames = [
     'RenderExtensionTargets',
     'OrderStatusExtensionTargets',
@@ -221,8 +221,15 @@ function parseTargetsFile() {
     );
     const match = content.match(regex);
 
-    if (match && match[1].includes('RenderExtension<')) {
-      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    if (match) {
+      // Parse RenderExtension targets (have components)
+      if (match[1].includes('RenderExtension<')) {
+        parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+      }
+      // Parse RunnableExtension targets (no components, like should-render)
+      if (match[1].includes('RunnableExtension<')) {
+        parseRunnableTargetsFromInterfaceBody(match[1], targets);
+      }
     }
   }
 
@@ -292,6 +299,64 @@ function parseTargetsFromInterfaceBody(
 
       targets[targetName] = {
         components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+/**
+ * Parse RunnableExtension targets from an interface body
+ * These targets don't have components (they return data, not UI)
+ */
+function parseRunnableTargetsFromInterfaceBody(interfaceBody, targets) {
+  // Parse each RunnableExtension target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RunnableExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
+    let runnableExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    runnableExtensionContent = runnableExtensionContent
+      .replace(/\/\/[^\n]*/g, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // Split by comma to separate API and Output type
+    const parts = splitByTopLevelComma(runnableExtensionContent);
+
+    if (parts.length >= 1) {
+      const apiString = parts[0].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // RunnableExtension targets don't have components - they return data
+      targets[targetName] = {
+        components: [],
         apis: apis.sort(),
       };
     }

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {
+  createTypeResolver,
+  splitByTopLevelComma,
+} from '../../shared/build-docs-type-resolver.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,10 +13,7 @@ const EXTENSIONS_API_VERSION = process.argv[2] || 'unstable';
 
 // Configuration for admin surface
 const config = {
-  basePath: path.join(
-    __dirname,
-    '../../../src/surfaces/admin',
-  ),
+  basePath: path.join(__dirname, '../../../src/surfaces/admin'),
   outputPath: path.join(
     __dirname,
     `generated/admin_extensions/${EXTENSIONS_API_VERSION}/targets.json`,
@@ -27,11 +28,19 @@ let allComponents = [];
 // Cache for parsed API files to avoid re-reading
 const apiDefinitionsCache = {};
 
-// Cache for checkout components
+// Create type resolver for checkout's shared.ts (to resolve AnyComponent, etc.)
+const checkoutSharedPath = path.join(
+  __dirname,
+  '../../../src/surfaces/checkout/shared.ts',
+);
+const checkoutTypeResolver = createTypeResolver(checkoutSharedPath);
+
+// Cache for checkout components (resolved via type resolver, excluding @private)
 let checkoutComponentsCache = null;
 
 /**
  * Parse components from checkout's shared.ts file
+ * Uses the shared type resolver to properly handle @private types
  */
 function parseCheckoutComponents() {
   // Return cached value if available
@@ -40,36 +49,19 @@ function parseCheckoutComponents() {
   }
 
   try {
-    // Always look in the checkout surface directory
-    const checkoutBasePath = path.join(
-      __dirname,
-      '../../../src/surfaces/checkout',
-    );
-    const sharedPath = path.join(checkoutBasePath, 'shared.ts');
+    // Use the type resolver to get AnyComponent (which excludes @private)
+    checkoutComponentsCache = checkoutTypeResolver.resolveType('AnyComponent');
 
-    if (!fs.existsSync(sharedPath)) {
-      checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
-      return checkoutComponentsCache;
-    }
-
-    const content = fs.readFileSync(sharedPath, 'utf-8');
-
-    // Look for SUPPORTED_COMPONENTS array
-    const supportedMatch = content.match(
-      /export const SUPPORTED_COMPONENTS\s*=\s*\[([\s\S]*?)\]\s*as const/,
-    );
-
-    if (supportedMatch) {
-      const arrayContent = supportedMatch[1];
-      // Extract all quoted strings
-      const components = arrayContent.match(/'([^']+)'/g);
-      if (components) {
-        checkoutComponentsCache = components.map((c) => c.replace(/'/g, ''));
-        return checkoutComponentsCache;
+    if (checkoutComponentsCache.length === 0) {
+      // Fallback: try to get just SUPPORTED_COMPONENTS
+      const typeDefs = checkoutTypeResolver.getTypeDefinitions();
+      if (Array.isArray(typeDefs['SUPPORTED_COMPONENTS'])) {
+        checkoutComponentsCache = [...typeDefs['SUPPORTED_COMPONENTS']];
+      } else {
+        checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
       }
     }
 
-    checkoutComponentsCache = ['[CheckoutComponentsParseError]'];
     return checkoutComponentsCache;
   } catch (error) {
     checkoutComponentsCache = ['[CheckoutComponentsError]'];
@@ -86,7 +78,7 @@ function parseCheckoutComponents() {
 function parseStringUnionType(filePath, componentTypesMap = {}) {
   try {
     const content = fs.readFileSync(filePath, 'utf-8');
-    
+
     // Extract all quoted component names from the file (but not from import statements)
     // Remove import lines first
     const contentWithoutImports = content.replace(/^import.*?;$/gm, '');
@@ -94,20 +86,20 @@ function parseStringUnionType(filePath, componentTypesMap = {}) {
     const quotedComponents = componentNames
       ? componentNames.map((name) => name.replace(/'/g, ''))
       : [];
-    
+
     // Check if the type references other types (like StandardComponents or AnyComponent)
     // Look for patterns like: StandardComponents | 'OtherComponent'
     const typeRefPattern = /export type \w+ =\s*([\s\S]*?);/;
     const typeDefMatch = content.match(typeRefPattern);
-    
+
     if (typeDefMatch) {
       const typeDef = typeDefMatch[1];
       // Find references to other types (capitalized words that aren't in quotes)
       const typeRefs = typeDef.match(/\b([A-Z]\w+(?:Components?)?)\b/g);
-      
+
       if (typeRefs) {
         const allComponents = [...quotedComponents];
-        
+
         for (const typeRef of typeRefs) {
           // Check if this is AnyComponent (imported from checkout)
           if (typeRef === 'AnyComponent') {
@@ -120,12 +112,12 @@ function parseStringUnionType(filePath, componentTypesMap = {}) {
             allComponents.push(...componentTypesMap[typeRef]);
           }
         }
-        
+
         // Remove duplicates
         return [...new Set(allComponents)];
       }
     }
-    
+
     return quotedComponents.length > 0 ? quotedComponents : null;
   } catch (error) {
     console.error(`Error reading component file ${filePath}:`, error.message);
@@ -241,13 +233,43 @@ function parseTargetsFile() {
   return targets;
 }
 
-function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap) {
+function parseTargetsFromInterfaceBody(
+  interfaceBody,
+  targets,
+  componentTypesMap,
+) {
   // Parse each target definition (handle multi-line)
   const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
 
   let match;
   while ((match = targetRegex.exec(interfaceBody)) !== null) {
     const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    // Look backwards from the match to find a preceding JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      // Check if there's no other target between the JSDoc and this target
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      // If the text between JSDoc end and target is empty (or just whitespace), the JSDoc belongs to this target
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          // Skip this target if it's marked @private
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
     let renderExtensionContent = match[2].trim();
 
     // Remove comments before parsing
@@ -274,54 +296,6 @@ function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap
       };
     }
   }
-}
-
-function splitByTopLevelComma(str) {
-  const parts = [];
-  let current = '';
-  let angleDepth = 0;
-  let braceDepth = 0;
-  let parenDepth = 0;
-
-  for (let i = 0; i < str.length; i++) {
-    const char = str[i];
-
-    if (char === '<') {
-      angleDepth++;
-      current += char;
-    } else if (char === '>') {
-      angleDepth--;
-      current += char;
-    } else if (char === '{') {
-      braceDepth++;
-      current += char;
-    } else if (char === '}') {
-      braceDepth--;
-      current += char;
-    } else if (char === '(') {
-      parenDepth++;
-      current += char;
-    } else if (char === ')') {
-      parenDepth--;
-      current += char;
-    } else if (
-      char === ',' &&
-      angleDepth === 0 &&
-      braceDepth === 0 &&
-      parenDepth === 0
-    ) {
-      parts.push(current);
-      current = '';
-    } else {
-      current += char;
-    }
-  }
-
-  if (current) {
-    parts.push(current);
-  }
-
-  return parts;
 }
 
 function getNestedApis(apiName) {
@@ -481,7 +455,9 @@ function parseComponents(componentString, componentTypesMap) {
   componentString = componentString.replace(/\s+/g, ' ').trim();
 
   // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
-  const checkoutExceptMatch = componentString.match(/AnyCheckoutComponentExcept<([^>]+)>/);
+  const checkoutExceptMatch = componentString.match(
+    /AnyCheckoutComponentExcept<([^>]+)>/,
+  );
   if (checkoutExceptMatch) {
     const excludedUnion = checkoutExceptMatch[1];
     // Get all checkout components
@@ -552,7 +528,11 @@ function resolveComponentType(typeName, componentTypesMap) {
   }
 
   // Handle special checkout types
-  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyComponent' || typeName === 'AnyThankYouComponent') {
+  if (
+    typeName === 'AnyCheckoutComponent' ||
+    typeName === 'AnyComponent' ||
+    typeName === 'AnyThankYouComponent'
+  ) {
     return parseCheckoutComponents();
   }
 
@@ -622,21 +602,23 @@ try {
   // Write to output file
   const outputDir = path.dirname(config.outputPath);
   if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true });
+    fs.mkdirSync(outputDir, {recursive: true});
   }
   fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
 
   console.log('✅ Generated combined targets JSON at:', config.outputPath);
-  
+
   // Count the different types of entries
   const targetEntries = Object.keys(targetsJson).length;
   const apiEntries = Object.keys(combinedJson).filter(
-    (key) => combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api'),
   ).length;
   const componentEntries = Object.keys(combinedJson).filter(
-    (key) => combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api'),
   ).length;
-  
+
   console.log('\n📋 Summary:');
   console.log(`  Extension targets: ${targetEntries}`);
   console.log(`  API reverse mappings: ${apiEntries}`);

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -501,6 +501,20 @@ try {
   });
   await generateExtensionsDocs();
   await generateAppBridgeDocs();
+  
+  // Generate targets.json
+  console.log('Generating targets.json...');
+  try {
+    const {execSync} = await import('child_process');
+    execSync(`node ${path.join(docsPath, 'build-docs-targets-json.mjs')} ${EXTENSIONS_API_VERSION}`, {
+      stdio: 'inherit',
+      cwd: rootPath,
+    });
+    console.log('✅ Generated targets.json');
+  } catch (targetsError) {
+    console.warn('Warning: Failed to generate targets.json:', targetsError.message);
+  }
+  
   await copyGeneratedToShopifyDev({
     generatedDocsPath,
     shopifyDevPath,

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-fast.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-fast.sh
@@ -39,6 +39,14 @@ if [ $build_exit -ne 0 ]; then
   exit $build_exit
 fi
 
+# Generate targets.json
+echo "Generating targets.json..."
+node $DOCS_PATH/build-docs-targets-json.mjs $API_VERSION
+targets_exit=$?
+if [ $targets_exit -ne 0 ]; then
+  echo "Warning: Failed to generate targets.json"
+fi
+
 # Copy generated docs to shopify-dev
 copy_generated_docs_to_shopify_dev() {
   if [ -d $SHOPIFY_DEV_PATH ]; then

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
@@ -1,0 +1,529 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const API_VERSION = process.argv[2];
+
+if (!API_VERSION) {
+  console.error('Error: API_VERSION is required.');
+  console.error('Usage: node build-docs-targets-json.mjs <API_VERSION>');
+  console.error('Example: node build-docs-targets-json.mjs 2025-10');
+  process.exit(1);
+}
+
+// Configuration for checkout surface
+const config = {
+  basePath: path.join(
+    __dirname,
+    '../../../src/surfaces/checkout',
+  ),
+  outputPath: path.join(
+    __dirname,
+    `generated/checkout_extensions/${API_VERSION}/targets.json`,
+  ),
+  componentTypesPath: null,
+  hasComponentTypes: false,
+};
+
+// All components will be populated from SUPPORTED_COMPONENTS
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+// Cache for checkout components
+let checkoutComponentsCache = null;
+
+/**
+ * Parse components from checkout's shared.ts file
+ */
+function parseCheckoutComponents() {
+  // Return cached value if available
+  if (checkoutComponentsCache !== null) {
+    return checkoutComponentsCache;
+  }
+
+  try {
+    const sharedPath = path.join(config.basePath, 'shared.ts');
+
+    if (!fs.existsSync(sharedPath)) {
+      checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
+      return checkoutComponentsCache;
+    }
+
+    const content = fs.readFileSync(sharedPath, 'utf-8');
+
+    // Look for SUPPORTED_COMPONENTS array
+    const supportedMatch = content.match(
+      /export const SUPPORTED_COMPONENTS\s*=\s*\[([\s\S]*?)\]\s*as const/,
+    );
+
+    if (supportedMatch) {
+      const arrayContent = supportedMatch[1];
+      // Extract all quoted strings
+      const components = arrayContent.match(/'([^']+)'/g);
+      if (components) {
+        checkoutComponentsCache = components.map((c) => c.replace(/'/g, ''));
+        return checkoutComponentsCache;
+      }
+    }
+
+    checkoutComponentsCache = ['[CheckoutComponentsParseError]'];
+    return checkoutComponentsCache;
+  } catch (error) {
+    checkoutComponentsCache = ['[CheckoutComponentsError]'];
+    return checkoutComponentsCache;
+  }
+}
+
+function parseComponentTypesFromFiles() {
+  // Checkout doesn't have separate component type files
+  return {};
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(config.basePath, 'extension-targets.ts');
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse component type definitions
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'CustomerAccountExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match && match[1].includes('RenderExtension<')) {
+      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    }
+  }
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (apiDefinitionsCache.hasOwnProperty(apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Try to find the API file in the surface's api directory
+  const apiDir = path.join(config.basePath, 'api');
+
+  if (!fs.existsSync(apiDir)) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Convert API name to potential file paths
+  // e.g., StandardApi -> standard-api, CartApi -> cart-api
+  const kebabName = apiName
+    .replace(/Api$/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+  // Try multiple possible locations
+  const possiblePaths = [
+    path.join(apiDir, `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}`, `${kebabName}.ts`),
+    path.join(apiDir, kebabName.replace(/-/g, ''), `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}-api`, `${kebabName}-api.ts`),
+    path.join(apiDir, `${kebabName}-api.ts`),
+    path.join(apiDir, `standard-api`, `standard-api.ts`),
+  ];
+
+  let content = null;
+  for (const apiFilePath of possiblePaths) {
+    try {
+      if (fs.existsSync(apiFilePath)) {
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      }
+    } catch (error) {
+      // Continue to next path
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    let startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const generalMatch = part.match(/(\w+Api)\b/);
+      if (generalMatch) {
+        apiName = generalMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+/**
+ * Parse a TypeScript component type expression
+ * Handles various patterns: type refs, unions, Exclude, AllowedComponents, etc.
+ */
+function parseComponents(componentString, componentTypesMap) {
+  // Normalize whitespace
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
+  const checkoutExceptMatch = componentString.match(/AnyCheckoutComponentExcept<([^>]+)>/);
+  if (checkoutExceptMatch) {
+    const excludedUnion = checkoutExceptMatch[1];
+    // Get all checkout components
+    const allCheckoutComponents = parseCheckoutComponents();
+    // Parse the union of excluded components
+    const excludedComponents = parseUnionOfStrings(excludedUnion);
+    // Filter out the excluded components
+    return allCheckoutComponents.filter((c) => !excludedComponents.includes(c));
+  }
+
+  // Handle Exclude<BaseType, ExcludedComponent>
+  const excludeMatch = componentString.match(/Exclude<(\w+),\s*'([^']+)'>/);
+  if (excludeMatch) {
+    const baseType = excludeMatch[1];
+    const excluded = excludeMatch[2];
+    const baseComponents = resolveComponentType(baseType, componentTypesMap);
+    return baseComponents.filter((c) => c !== excluded);
+  }
+
+  // Handle AllowedComponents<ComponentType>
+  const allowedMatch = componentString.match(/AllowedComponents<([^>]+)>/);
+  if (allowedMatch) {
+    const innerType = allowedMatch[1].trim();
+    return resolveComponentType(innerType, componentTypesMap);
+  }
+
+  // Check if it's a direct type reference
+  const result = resolveComponentType(componentString, componentTypesMap);
+  if (result.length > 0) {
+    return result;
+  }
+
+  // Default to all components if we have them
+  if (allComponents.length > 0) {
+    return allComponents;
+  }
+
+  return ['[Unknown]'];
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Resolve a component type name to a list of component names
+ */
+function resolveComponentType(typeName, componentTypesMap) {
+  typeName = typeName.trim();
+
+  // Check if it's in our component types map
+  if (componentTypesMap[typeName]) {
+    return componentTypesMap[typeName];
+  }
+
+  // Handle special checkout types
+  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyComponent' || typeName === 'AnyThankYouComponent') {
+    return parseCheckoutComponents();
+  }
+
+  // Check if it's a quoted string literal
+  const quotedMatch = typeName.match(/^'([^']+)'$/);
+  if (quotedMatch) {
+    return [quotedMatch[1]];
+  }
+
+  return [];
+}
+
+function createCombinedMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for checkout surface');
+  console.log(`📁 Base path: ${config.basePath}`);
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the combined JSON with reverse mappings
+  const combinedJson = createCombinedMapping(targetsJson);
+
+  // Write to output file
+  const outputDir = path.dirname(config.outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
+
+  console.log('✅ Generated combined targets JSON at:', config.outputPath);
+  
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+  ).length;
+  const componentEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+  ).length;
+  
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(combinedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {
+  createTypeResolver,
+  splitByTopLevelComma,
+} from '../../shared/build-docs-type-resolver.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -16,10 +20,7 @@ if (!API_VERSION) {
 
 // Configuration for checkout surface
 const config = {
-  basePath: path.join(
-    __dirname,
-    '../../../src/surfaces/checkout',
-  ),
+  basePath: path.join(__dirname, '../../../src/surfaces/checkout'),
   outputPath: path.join(
     __dirname,
     `generated/checkout_extensions/${API_VERSION}/targets.json`,
@@ -29,55 +30,19 @@ const config = {
 };
 
 // All components will be populated from SUPPORTED_COMPONENTS
-let allComponents = [];
+const allComponents = [];
 
 // Cache for parsed API files to avoid re-reading
 const apiDefinitionsCache = {};
 
-// Cache for checkout components
-let checkoutComponentsCache = null;
+// Create type resolver for checkout surface
+const sharedTsPath = path.join(config.basePath, 'shared.ts');
+const typeResolver = createTypeResolver(sharedTsPath);
 
-/**
- * Parse components from checkout's shared.ts file
- */
-function parseCheckoutComponents() {
-  // Return cached value if available
-  if (checkoutComponentsCache !== null) {
-    return checkoutComponentsCache;
-  }
-
-  try {
-    const sharedPath = path.join(config.basePath, 'shared.ts');
-
-    if (!fs.existsSync(sharedPath)) {
-      checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
-      return checkoutComponentsCache;
-    }
-
-    const content = fs.readFileSync(sharedPath, 'utf-8');
-
-    // Look for SUPPORTED_COMPONENTS array
-    const supportedMatch = content.match(
-      /export const SUPPORTED_COMPONENTS\s*=\s*\[([\s\S]*?)\]\s*as const/,
-    );
-
-    if (supportedMatch) {
-      const arrayContent = supportedMatch[1];
-      // Extract all quoted strings
-      const components = arrayContent.match(/'([^']+)'/g);
-      if (components) {
-        checkoutComponentsCache = components.map((c) => c.replace(/'/g, ''));
-        return checkoutComponentsCache;
-      }
-    }
-
-    checkoutComponentsCache = ['[CheckoutComponentsParseError]'];
-    return checkoutComponentsCache;
-  } catch (error) {
-    checkoutComponentsCache = ['[CheckoutComponentsError]'];
-    return checkoutComponentsCache;
-  }
-}
+// Expose resolver methods for use in this script
+const resolveType = typeResolver.resolveType;
+const resolveTypeUnfiltered = typeResolver.resolveTypeUnfiltered;
+const getTypeDefinitions = typeResolver.getTypeDefinitions;
 
 function parseComponentTypesFromFiles() {
   // Checkout doesn't have separate component type files
@@ -121,13 +86,43 @@ function parseTargetsFile() {
   return targets;
 }
 
-function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap) {
+function parseTargetsFromInterfaceBody(
+  interfaceBody,
+  targets,
+  componentTypesMap,
+) {
   // Parse each target definition (handle multi-line)
   const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
 
   let match;
   while ((match = targetRegex.exec(interfaceBody)) !== null) {
     const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    // Look backwards from the match to find a preceding JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      // Check if there's no other target between the JSDoc and this target
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      // If the text between JSDoc end and target is empty (or just whitespace), the JSDoc belongs to this target
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          // Skip this target if it's marked @private
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
     let renderExtensionContent = match[2].trim();
 
     // Remove comments before parsing
@@ -154,54 +149,6 @@ function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap
       };
     }
   }
-}
-
-function splitByTopLevelComma(str) {
-  const parts = [];
-  let current = '';
-  let angleDepth = 0;
-  let braceDepth = 0;
-  let parenDepth = 0;
-
-  for (let i = 0; i < str.length; i++) {
-    const char = str[i];
-
-    if (char === '<') {
-      angleDepth++;
-      current += char;
-    } else if (char === '>') {
-      angleDepth--;
-      current += char;
-    } else if (char === '{') {
-      braceDepth++;
-      current += char;
-    } else if (char === '}') {
-      braceDepth--;
-      current += char;
-    } else if (char === '(') {
-      parenDepth++;
-      current += char;
-    } else if (char === ')') {
-      parenDepth--;
-      current += char;
-    } else if (
-      char === ',' &&
-      angleDepth === 0 &&
-      braceDepth === 0 &&
-      parenDepth === 0
-    ) {
-      parts.push(current);
-      current = '';
-    } else {
-      current += char;
-    }
-  }
-
-  if (current) {
-    parts.push(current);
-  }
-
-  return parts;
 }
 
 function getNestedApis(apiName) {
@@ -263,7 +210,7 @@ function getNestedApis(apiName) {
     }
 
     // Find the end position (semicolon at the correct nesting level)
-    let startPos = startMatch.index + startMatch[0].length;
+    const startPos = startMatch.index + startMatch[0].length;
     let endPos = startPos;
     let braceDepth = 0;
     let angleDepth = 0;
@@ -354,42 +301,50 @@ function parseApis(apiString) {
 
 /**
  * Parse a TypeScript component type expression
- * Handles various patterns: type refs, unions, Exclude, AllowedComponents, etc.
+ * Uses the generic resolveType() to handle any type expression dynamically
  */
 function parseComponents(componentString, componentTypesMap) {
   // Normalize whitespace
   componentString = componentString.replace(/\s+/g, ' ').trim();
 
-  // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
-  const checkoutExceptMatch = componentString.match(/AnyCheckoutComponentExcept<([^>]+)>/);
-  if (checkoutExceptMatch) {
-    const excludedUnion = checkoutExceptMatch[1];
-    // Get all checkout components
-    const allCheckoutComponents = parseCheckoutComponents();
-    // Parse the union of excluded components
-    const excludedComponents = parseUnionOfStrings(excludedUnion);
-    // Filter out the excluded components
-    return allCheckoutComponents.filter((c) => !excludedComponents.includes(c));
+  // Handle generic wrapper types like AnyCheckoutComponentExcept<'X' | 'Y'>
+  // These are defined as: type AnyCheckoutComponentExcept<Except> = Exclude<AnyCheckoutComponent, Except>
+  // We need to expand them to their actual Exclude form
+  const genericExceptMatch = componentString.match(/^(\w+Except)<([^>]+)>$/);
+  if (genericExceptMatch) {
+    const genericTypeName = genericExceptMatch[1];
+    const typeArg = genericExceptMatch[2];
+
+    // Look up the generic type definition to find the base type
+    const typeDefs = getTypeDefinitions();
+    const genericDef = typeDefs[genericTypeName];
+
+    if (genericDef) {
+      // Parse the generic definition to extract the base type from Exclude<BaseType, Except>
+      const baseTypeMatch = genericDef.match(/Exclude<(\w+),\s*Except>/);
+      if (baseTypeMatch) {
+        const baseTypeName = baseTypeMatch[1];
+        // Resolve as Exclude<BaseType, typeArg>
+        const baseComponents = resolveType(baseTypeName);
+        const excludedComponents = resolveType(typeArg);
+        return baseComponents.filter((c) => !excludedComponents.includes(c));
+      }
+    }
   }
 
-  // Handle Exclude<BaseType, ExcludedComponent>
-  const excludeMatch = componentString.match(/Exclude<(\w+),\s*'([^']+)'>/);
-  if (excludeMatch) {
-    const baseType = excludeMatch[1];
-    const excluded = excludeMatch[2];
-    const baseComponents = resolveComponentType(baseType, componentTypesMap);
-    return baseComponents.filter((c) => c !== excluded);
-  }
-
-  // Handle AllowedComponents<ComponentType>
+  // Handle AllowedComponents<ComponentType> - it's just an identity wrapper
+  // BUT: AllowedComponents explicitly allows components, so don't filter private
+  // This is how targets like purchase.checkout.chat.render explicitly allow 'Chat'
   const allowedMatch = componentString.match(/AllowedComponents<([^>]+)>/);
   if (allowedMatch) {
     const innerType = allowedMatch[1].trim();
-    return resolveComponentType(innerType, componentTypesMap);
+    // Use unfiltered resolution since AllowedComponents explicitly allows these
+    return resolveTypeUnfiltered(innerType);
   }
 
-  // Check if it's a direct type reference
-  const result = resolveComponentType(componentString, componentTypesMap);
+  // Use the generic resolver for everything else
+  // This handles: type references, Exclude<>, unions, string literals, etc.
+  const result = resolveType(componentString);
   if (result.length > 0) {
     return result;
   }
@@ -400,49 +355,6 @@ function parseComponents(componentString, componentTypesMap) {
   }
 
   return ['[Unknown]'];
-}
-
-/**
- * Parse a union of string literals (e.g., "'Image' | 'Banner'")
- * Returns an array of the string values
- */
-function parseUnionOfStrings(unionString) {
-  const components = [];
-  // Split by | and extract quoted strings
-  const parts = unionString.split('|');
-  for (const part of parts) {
-    const trimmed = part.trim();
-    const match = trimmed.match(/^'([^']+)'$/);
-    if (match) {
-      components.push(match[1]);
-    }
-  }
-  return components;
-}
-
-/**
- * Resolve a component type name to a list of component names
- */
-function resolveComponentType(typeName, componentTypesMap) {
-  typeName = typeName.trim();
-
-  // Check if it's in our component types map
-  if (componentTypesMap[typeName]) {
-    return componentTypesMap[typeName];
-  }
-
-  // Handle special checkout types
-  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyComponent' || typeName === 'AnyThankYouComponent') {
-    return parseCheckoutComponents();
-  }
-
-  // Check if it's a quoted string literal
-  const quotedMatch = typeName.match(/^'([^']+)'$/);
-  if (quotedMatch) {
-    return [quotedMatch[1]];
-  }
-
-  return [];
 }
 
 function createCombinedMapping(targetsJson) {
@@ -502,21 +414,23 @@ try {
   // Write to output file
   const outputDir = path.dirname(config.outputPath);
   if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true });
+    fs.mkdirSync(outputDir, {recursive: true});
   }
   fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
 
   console.log('✅ Generated combined targets JSON at:', config.outputPath);
-  
+
   // Count the different types of entries
   const targetEntries = Object.keys(targetsJson).length;
   const apiEntries = Object.keys(combinedJson).filter(
-    (key) => combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api'),
   ).length;
   const componentEntries = Object.keys(combinedJson).filter(
-    (key) => combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api'),
   ).length;
-  
+
   console.log('\n📋 Summary:');
   console.log(`  Extension targets: ${targetEntries}`);
   console.log(`  API reverse mappings: ${apiEntries}`);

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
@@ -59,9 +59,10 @@ function parseTargetsFile() {
 
   const targets = {};
 
-  // Look for all interfaces that might contain RenderExtension targets
+  // Look for all interfaces that might contain RenderExtension or RunnableExtension targets
   const interfaceNames = [
     'RenderExtensionTargets',
+    'RunnableExtensionTargets',
     'OrderStatusExtensionTargets',
     'CustomerAccountExtensionTargets',
     'ExtensionTargets',
@@ -74,8 +75,15 @@ function parseTargetsFile() {
     );
     const match = content.match(regex);
 
-    if (match && match[1].includes('RenderExtension<')) {
-      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    if (match) {
+      // Parse RenderExtension targets (have components)
+      if (match[1].includes('RenderExtension<')) {
+        parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+      }
+      // Parse RunnableExtension targets (no components, like address-autocomplete)
+      if (match[1].includes('RunnableExtension<')) {
+        parseRunnableTargetsFromInterfaceBody(match[1], targets);
+      }
     }
   }
 
@@ -145,6 +153,64 @@ function parseTargetsFromInterfaceBody(
 
       targets[targetName] = {
         components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+/**
+ * Parse RunnableExtension targets from an interface body
+ * These targets don't have components (they return data, not UI)
+ */
+function parseRunnableTargetsFromInterfaceBody(interfaceBody, targets) {
+  // Parse each RunnableExtension target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RunnableExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
+    let runnableExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    runnableExtensionContent = runnableExtensionContent
+      .replace(/\/\/[^\n]*/g, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // Split by comma to separate API and Output type
+    const parts = splitByTopLevelComma(runnableExtensionContent);
+
+    if (parts.length >= 1) {
+      const apiString = parts[0].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // RunnableExtension targets don't have components - they return data
+      targets[targetName] = {
+        components: [],
         apis: apis.sort(),
       };
     }

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.test.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.test.mjs
@@ -1,0 +1,299 @@
+/**
+ * Test file for build-docs-targets-json.mjs
+ *
+ * This test verifies that component type exclusions work correctly:
+ * - AnyCheckoutComponent should NOT include 'Announcement'
+ * - AnyCheckoutComponentExcept<'Image' | 'Banner'> should NOT include 'Image', 'Banner', or 'Announcement'
+ * - AnyThankYouComponent SHOULD include 'Announcement'
+ * - AllowedComponents<'Chat'> should ONLY include 'Chat'
+ *
+ * Run with: node build-docs-targets-json.test.mjs
+ */
+
+import fs from 'fs';
+import path from 'path';
+import {execSync} from 'child_process';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TEST_VERSION = 'test-version';
+const OUTPUT_PATH = path.join(
+  __dirname,
+  `generated/checkout_extensions/${TEST_VERSION}/targets.json`,
+);
+
+// Test configuration
+const tests = {
+  passed: 0,
+  failed: 0,
+  errors: [],
+};
+
+function assert(condition, message) {
+  if (condition) {
+    tests.passed++;
+    console.log(`  ✅ ${message}`);
+  } else {
+    tests.failed++;
+    tests.errors.push(message);
+    console.log(`  ❌ ${message}`);
+  }
+}
+
+function assertArrayIncludes(array, item, message) {
+  assert(array.includes(item), message);
+}
+
+function assertArrayNotIncludes(array, item, message) {
+  assert(!array.includes(item), message);
+}
+
+// Cleanup function
+function cleanup() {
+  const testDir = path.join(
+    __dirname,
+    `generated/checkout_extensions/${TEST_VERSION}`,
+  );
+  if (fs.existsSync(testDir)) {
+    fs.rmSync(testDir, {recursive: true});
+  }
+}
+
+async function runTests() {
+  console.log('\n🧪 Running checkout build-docs-targets-json.mjs tests\n');
+
+  // Clean up any previous test artifacts
+  cleanup();
+
+  // Generate the targets.json with test version
+  console.log('📦 Generating targets.json...');
+  try {
+    execSync(
+      `node ${path.join(
+        __dirname,
+        'build-docs-targets-json.mjs',
+      )} ${TEST_VERSION}`,
+      {
+        stdio: 'pipe',
+        cwd: path.join(__dirname, '../../..'),
+      },
+    );
+  } catch (error) {
+    console.error('❌ Failed to generate targets.json:', error.message);
+    process.exit(1);
+  }
+
+  // Read the generated JSON
+  if (!fs.existsSync(OUTPUT_PATH)) {
+    console.error(`❌ Output file not found: ${OUTPUT_PATH}`);
+    process.exit(1);
+  }
+
+  const targetsJson = JSON.parse(fs.readFileSync(OUTPUT_PATH, 'utf-8'));
+  console.log('✅ Generated targets.json successfully\n');
+
+  // ============================================
+  // TEST 1: AnyCheckoutComponent targets should NOT include 'Announcement'
+  // ============================================
+  console.log('Test 1: AnyCheckoutComponent should exclude Announcement');
+  console.log('─'.repeat(60));
+
+  // These targets use AnyCheckoutComponent
+  const anyCheckoutComponentTargets = [
+    'purchase.checkout.actions.render-before',
+    'purchase.checkout.cart-line-list.render-after',
+    'purchase.checkout.cart-line-item.render-after',
+    'purchase.checkout.block.render',
+    'purchase.checkout.contact.render-after',
+    'purchase.thank-you.block.render',
+    'purchase.thank-you.footer.render-after',
+  ];
+
+  for (const target of anyCheckoutComponentTargets) {
+    if (targetsJson[target]) {
+      assertArrayNotIncludes(
+        targetsJson[target].components,
+        'Announcement',
+        `${target} should NOT include 'Announcement'`,
+      );
+    } else {
+      console.log(`  ⚠️  Target '${target}' not found in JSON`);
+    }
+  }
+
+  // ============================================
+  // TEST 2: @private targets should NOT be in the output at all
+  // ============================================
+  console.log('\nTest 2: @private targets should be excluded from output');
+  console.log('─'.repeat(60));
+
+  // These targets are marked @private in extension-targets.ts and should NOT appear in targets.json
+  const privateTargets = [
+    'purchase.checkout.gift-card.render',
+    'purchase.checkout.payment-option-item.details.render',
+    'purchase.checkout.payment-option-item.hosted-fields.render-after',
+    'Checkout::PaymentMethod::HostedFields::RenderAfter',
+    'Checkout::PickupPoints::RenderAfter',
+    'Checkout::Dynamic::Render',
+  ];
+
+  for (const target of privateTargets) {
+    if (targetsJson[target]) {
+      tests.failed++;
+      tests.errors.push(
+        `@private target '${target}' should NOT be in output but was found`,
+      );
+      console.log(
+        `  ❌ @private target '${target}' should NOT be in output but was found`,
+      );
+    } else {
+      tests.passed++;
+      console.log(`  ✅ @private target '${target}' correctly excluded`);
+    }
+  }
+
+  // ============================================
+  // TEST 3: AnyThankYouComponent targets SHOULD include 'Announcement'
+  // ============================================
+  console.log('\nTest 3: AnyThankYouComponent should include Announcement');
+  console.log('─'.repeat(60));
+
+  // This target uses AnyThankYouComponent
+  const thankYouAnnouncementTarget = 'purchase.thank-you.announcement.render';
+
+  if (targetsJson[thankYouAnnouncementTarget]) {
+    assertArrayIncludes(
+      targetsJson[thankYouAnnouncementTarget].components,
+      'Announcement',
+      `${thankYouAnnouncementTarget} SHOULD include 'Announcement'`,
+    );
+    // Also verify it has other standard components
+    assertArrayIncludes(
+      targetsJson[thankYouAnnouncementTarget].components,
+      'Banner',
+      `${thankYouAnnouncementTarget} SHOULD include 'Banner'`,
+    );
+    assertArrayIncludes(
+      targetsJson[thankYouAnnouncementTarget].components,
+      'Image',
+      `${thankYouAnnouncementTarget} SHOULD include 'Image'`,
+    );
+  } else {
+    console.log(
+      `  ⚠️  Target '${thankYouAnnouncementTarget}' not found in JSON`,
+    );
+  }
+
+  // ============================================
+  // TEST 4: AllowedComponents<'Chat'> should ONLY have 'Chat'
+  // ============================================
+  console.log('\nTest 4: AllowedComponents<Chat> should only include Chat');
+  console.log('─'.repeat(60));
+
+  const chatTargets = [
+    'purchase.checkout.chat.render',
+    'purchase.thank-you.chat.render',
+  ];
+
+  for (const target of chatTargets) {
+    if (targetsJson[target]) {
+      assert(
+        targetsJson[target].components.length === 1,
+        `${target} should have exactly 1 component`,
+      );
+      assertArrayIncludes(
+        targetsJson[target].components,
+        'Chat',
+        `${target} should include 'Chat'`,
+      );
+    } else {
+      console.log(`  ⚠️  Target '${target}' not found in JSON`);
+    }
+  }
+
+  // ============================================
+  // TEST 5: Verify component counts and differences make sense
+  // ============================================
+  console.log('\nTest 5: Component count and difference verification');
+  console.log('─'.repeat(60));
+
+  // AnyThankYouComponent vs AnyCheckoutComponent:
+  // - AnyThankYouComponent = SUPPORTED_COMPONENTS (has Announcement, no Chat) = 62 components
+  // - AnyCheckoutComponent = SUPPORTED_COMPONENTS minus Announcement (no Chat because @private) = 61 components
+  // Note: Chat is excluded from both because PrivateComponent is marked @private
+  if (
+    targetsJson['purchase.thank-you.announcement.render'] &&
+    targetsJson['purchase.checkout.block.render']
+  ) {
+    const thankYouComponents =
+      targetsJson['purchase.thank-you.announcement.render'].components;
+    const checkoutComponents =
+      targetsJson['purchase.checkout.block.render'].components;
+
+    // AnyThankYouComponent should have Announcement but not Chat (@private)
+    assertArrayIncludes(
+      thankYouComponents,
+      'Announcement',
+      'AnyThankYouComponent should include Announcement',
+    );
+    assertArrayNotIncludes(
+      thankYouComponents,
+      'Chat',
+      'AnyThankYouComponent should NOT include Chat (@private component)',
+    );
+
+    // AnyCheckoutComponent should NOT have Announcement AND should NOT have Chat (@private)
+    assertArrayNotIncludes(
+      checkoutComponents,
+      'Announcement',
+      'AnyCheckoutComponent should NOT include Announcement',
+    );
+    assertArrayNotIncludes(
+      checkoutComponents,
+      'Chat',
+      'AnyCheckoutComponent should NOT include Chat (@private component)',
+    );
+
+    // AnyThankYouComponent should have 1 more component than AnyCheckoutComponent (Announcement)
+    assert(
+      thankYouComponents.length === checkoutComponents.length + 1,
+      `AnyThankYouComponent (${thankYouComponents.length}) should have 1 more component than AnyCheckoutComponent (${checkoutComponents.length})`,
+    );
+  }
+
+  // Note: Gift card target (purchase.checkout.gift-card.render) is @private
+  // so it's excluded from the output. The AnyCheckoutComponentExcept logic
+  // is tested indirectly through the @private exclusion tests above.
+
+  // ============================================
+  // Summary
+  // ============================================
+  console.log(`\n${'═'.repeat(60)}`);
+  console.log('📊 Test Summary');
+  console.log('═'.repeat(60));
+  console.log(`  ✅ Passed: ${tests.passed}`);
+  console.log(`  ❌ Failed: ${tests.failed}`);
+
+  if (tests.failed > 0) {
+    console.log('\n📋 Failed Tests:');
+    tests.errors.forEach((error, i) => {
+      console.log(`  ${i + 1}. ${error}`);
+    });
+  }
+
+  // Cleanup
+  cleanup();
+
+  console.log('\n');
+
+  // Exit with appropriate code
+  process.exit(tests.failed > 0 ? 1 : 0);
+}
+
+runTests().catch((error) => {
+  console.error('Test execution failed:', error);
+  cleanup();
+  process.exit(1);
+});

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-watch.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-watch.sh
@@ -40,6 +40,14 @@ build_docs() {
     return $build_exit
   fi
 
+  # Generate targets.json
+  echo "Generating targets.json..."
+  node $DOCS_PATH/build-docs-targets-json.mjs $API_VERSION
+  targets_exit=$?
+  if [ $targets_exit -ne 0 ]; then
+    echo "Warning: Failed to generate targets.json"
+  fi
+
   # Copy generated docs to shopify-dev
   copy_generated_docs_to_shopify_dev() {
     if [ -d $SHOPIFY_DEV_PATH ]; then

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -95,6 +95,14 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
+# Generate targets.json
+echo "Generating targets.json..."
+node $DOCS_PATH/build-docs-targets-json.mjs $API_VERSION
+targets_exit=$?
+if [ $targets_exit -ne 0 ]; then
+  echo "Warning: Failed to generate targets.json"
+fi
+
 
 copy_generated_docs_to_shopify_dev() {
 # Copy the generated docs to shopify-dev

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
@@ -1,0 +1,646 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const EXTENSIONS_API_VERSION = process.argv[2] || 'unstable';
+
+// Configuration for customer-account surface
+const config = {
+  basePath: path.join(
+    __dirname,
+    '../../../src/surfaces/customer-account',
+  ),
+  outputPath: path.join(
+    __dirname,
+    `generated/customer_account_ui_extensions/${EXTENSIONS_API_VERSION}/targets.json`,
+  ),
+  componentTypesPath: 'components',
+  hasComponentTypes: true,
+};
+
+// All components will be populated from StandardComponents
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+// Cache for checkout components
+let checkoutComponentsCache = null;
+
+/**
+ * Parse components from checkout's shared.ts file
+ */
+function parseCheckoutComponents() {
+  // Return cached value if available
+  if (checkoutComponentsCache !== null) {
+    return checkoutComponentsCache;
+  }
+
+  try {
+    // Always look in the checkout surface directory
+    const checkoutBasePath = path.join(
+      __dirname,
+      '../../../src/surfaces/checkout',
+    );
+    const sharedPath = path.join(checkoutBasePath, 'shared.ts');
+
+    if (!fs.existsSync(sharedPath)) {
+      checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
+      return checkoutComponentsCache;
+    }
+
+    const content = fs.readFileSync(sharedPath, 'utf-8');
+
+    // Look for SUPPORTED_COMPONENTS array
+    const supportedMatch = content.match(
+      /export const SUPPORTED_COMPONENTS\s*=\s*\[([\s\S]*?)\]\s*as const/,
+    );
+
+    if (supportedMatch) {
+      const arrayContent = supportedMatch[1];
+      // Extract all quoted strings
+      const components = arrayContent.match(/'([^']+)'/g);
+      if (components) {
+        checkoutComponentsCache = components.map((c) => c.replace(/'/g, ''));
+        return checkoutComponentsCache;
+      }
+    }
+
+    checkoutComponentsCache = ['[CheckoutComponentsParseError]'];
+    return checkoutComponentsCache;
+  } catch (error) {
+    checkoutComponentsCache = ['[CheckoutComponentsError]'];
+    return checkoutComponentsCache;
+  }
+}
+
+/**
+ * Parse a string union type from a component file and resolve type references
+ * e.g., export type StandardComponents = AnyComponent | 'Avatar' | ... (with AnyComponent imported)
+ */
+function parseStringUnionType(filePath, componentTypesMap = {}) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    
+    // Extract all quoted component names from the file (but not from import statements)
+    // Remove import lines first
+    const contentWithoutImports = content.replace(/^import.*?;$/gm, '');
+    const componentNames = contentWithoutImports.match(/'([^']+)'/g);
+    const quotedComponents = componentNames
+      ? componentNames.map((name) => name.replace(/'/g, ''))
+      : [];
+    
+    // Check if the type references other types (like StandardComponents or AnyComponent)
+    // Look for patterns like: StandardComponents | 'OtherComponent'
+    const typeRefPattern = /export type \w+ =\s*([\s\S]*?);/;
+    const typeDefMatch = content.match(typeRefPattern);
+    
+    if (typeDefMatch) {
+      const typeDef = typeDefMatch[1];
+      // Find references to other types (capitalized words that aren't in quotes)
+      const typeRefs = typeDef.match(/\b([A-Z]\w+(?:Components?)?)\b/g);
+      
+      if (typeRefs) {
+        const allComponents = [...quotedComponents];
+        
+        for (const typeRef of typeRefs) {
+          // Check if this is AnyComponent (imported from checkout)
+          if (typeRef === 'AnyComponent') {
+            // Add all checkout components
+            const checkoutComponents = parseCheckoutComponents();
+            allComponents.push(...checkoutComponents);
+          }
+          // If this type reference exists in our map, include its components
+          else if (componentTypesMap[typeRef]) {
+            allComponents.push(...componentTypesMap[typeRef]);
+          }
+        }
+        
+        // Remove duplicates
+        return [...new Set(allComponents)];
+      }
+    }
+    
+    return quotedComponents.length > 0 ? quotedComponents : null;
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from files in the components directory
+ * Uses a two-pass approach:
+ * 1. First pass: Parse all component types that only contain quoted strings
+ * 2. Second pass: Parse types that reference other types (like StandardComponents)
+ */
+function parseComponentTypesFromFiles() {
+  if (!config.hasComponentTypes || !config.componentTypesPath) {
+    return {};
+  }
+
+  const componentsPath = path.join(config.basePath, config.componentTypesPath);
+  const componentTypesMap = {};
+
+  try {
+    // Look for all TypeScript files in the components directory
+    const files = fs.readdirSync(componentsPath);
+    const tsFiles = files.filter(
+      (file) => file.endsWith('.ts') && !file.endsWith('.d.ts'),
+    );
+
+    // First pass: Parse files with only quoted strings
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, {});
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+
+        // If this is StandardComponents, use it as the base
+        if (componentTypeName === 'StandardComponents') {
+          allComponents = components.sort();
+        }
+      }
+    }
+
+    // Second pass: Re-parse files that might reference other types
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, componentTypesMap);
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+      }
+    }
+  } catch (error) {
+    console.error('Error parsing component types:', error.message);
+  }
+
+  return componentTypesMap;
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(config.basePath, 'extension-targets.ts');
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse component type definitions
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'CustomerAccountExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match && match[1].includes('RenderExtension<')) {
+      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    }
+  }
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (apiDefinitionsCache.hasOwnProperty(apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Try to find the API file in the surface's api directory
+  const apiDir = path.join(config.basePath, 'api');
+
+  if (!fs.existsSync(apiDir)) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Convert API name to potential file paths
+  // e.g., StandardApi -> standard-api, CartApi -> cart-api
+  const kebabName = apiName
+    .replace(/Api$/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+  // Try multiple possible locations
+  const possiblePaths = [
+    path.join(apiDir, `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}`, `${kebabName}.ts`),
+    path.join(apiDir, kebabName.replace(/-/g, ''), `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}-api`, `${kebabName}-api.ts`),
+    path.join(apiDir, `${kebabName}-api.ts`),
+    path.join(apiDir, `standard-api`, `standard-api.ts`),
+  ];
+
+  let content = null;
+  for (const apiFilePath of possiblePaths) {
+    try {
+      if (fs.existsSync(apiFilePath)) {
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      }
+    } catch (error) {
+      // Continue to next path
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    let startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const generalMatch = part.match(/(\w+Api)\b/);
+      if (generalMatch) {
+        apiName = generalMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+/**
+ * Parse a TypeScript component type expression
+ * Handles various patterns: type refs, unions, Exclude, AllowedComponents, etc.
+ */
+function parseComponents(componentString, componentTypesMap) {
+  // Normalize whitespace
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
+  const checkoutExceptMatch = componentString.match(/AnyCheckoutComponentExcept<([^>]+)>/);
+  if (checkoutExceptMatch) {
+    const excludedUnion = checkoutExceptMatch[1];
+    // Get all checkout components
+    const allCheckoutComponents = parseCheckoutComponents();
+    // Parse the union of excluded components
+    const excludedComponents = parseUnionOfStrings(excludedUnion);
+    // Filter out the excluded components
+    return allCheckoutComponents.filter((c) => !excludedComponents.includes(c));
+  }
+
+  // Handle Exclude<BaseType, ExcludedComponent>
+  const excludeMatch = componentString.match(/Exclude<(\w+),\s*'([^']+)'>/);
+  if (excludeMatch) {
+    const baseType = excludeMatch[1];
+    const excluded = excludeMatch[2];
+    const baseComponents = resolveComponentType(baseType, componentTypesMap);
+    return baseComponents.filter((c) => c !== excluded);
+  }
+
+  // Handle AllowedComponents<ComponentType>
+  const allowedMatch = componentString.match(/AllowedComponents<([^>]+)>/);
+  if (allowedMatch) {
+    const innerType = allowedMatch[1].trim();
+    return resolveComponentType(innerType, componentTypesMap);
+  }
+
+  // Check if it's a direct type reference
+  const result = resolveComponentType(componentString, componentTypesMap);
+  if (result.length > 0) {
+    return result;
+  }
+
+  // Default to all components if we have them
+  if (allComponents.length > 0) {
+    return allComponents;
+  }
+
+  return ['[Unknown]'];
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Resolve a component type name to a list of component names
+ */
+function resolveComponentType(typeName, componentTypesMap) {
+  typeName = typeName.trim();
+
+  // Check if it's in our component types map
+  if (componentTypesMap[typeName]) {
+    return componentTypesMap[typeName];
+  }
+
+  // Handle special checkout types
+  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyComponent' || typeName === 'AnyThankYouComponent') {
+    return parseCheckoutComponents();
+  }
+
+  // Check if it's a quoted string literal
+  const quotedMatch = typeName.match(/^'([^']+)'$/);
+  if (quotedMatch) {
+    return [quotedMatch[1]];
+  }
+
+  return [];
+}
+
+function createCombinedMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for customer-account surface');
+  console.log(`📁 Base path: ${config.basePath}`);
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the combined JSON with reverse mappings
+  const combinedJson = createCombinedMapping(targetsJson);
+
+  // Write to output file
+  const outputDir = path.dirname(config.outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
+
+  console.log('✅ Generated combined targets JSON at:', config.outputPath);
+  
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+  ).length;
+  const componentEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+  ).length;
+  
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(combinedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {
+  createTypeResolver,
+  splitByTopLevelComma,
+} from '../../shared/build-docs-type-resolver.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,10 +13,7 @@ const EXTENSIONS_API_VERSION = process.argv[2] || 'unstable';
 
 // Configuration for customer-account surface
 const config = {
-  basePath: path.join(
-    __dirname,
-    '../../../src/surfaces/customer-account',
-  ),
+  basePath: path.join(__dirname, '../../../src/surfaces/customer-account'),
   outputPath: path.join(
     __dirname,
     `generated/customer_account_ui_extensions/${EXTENSIONS_API_VERSION}/targets.json`,
@@ -27,11 +28,19 @@ let allComponents = [];
 // Cache for parsed API files to avoid re-reading
 const apiDefinitionsCache = {};
 
-// Cache for checkout components
+// Create type resolver for checkout's shared.ts (to resolve AnyComponent, etc.)
+const checkoutSharedPath = path.join(
+  __dirname,
+  '../../../src/surfaces/checkout/shared.ts',
+);
+const checkoutTypeResolver = createTypeResolver(checkoutSharedPath);
+
+// Cache for checkout components (resolved via type resolver, excluding @private)
 let checkoutComponentsCache = null;
 
 /**
  * Parse components from checkout's shared.ts file
+ * Uses the shared type resolver to properly handle @private types
  */
 function parseCheckoutComponents() {
   // Return cached value if available
@@ -40,36 +49,21 @@ function parseCheckoutComponents() {
   }
 
   try {
-    // Always look in the checkout surface directory
-    const checkoutBasePath = path.join(
-      __dirname,
-      '../../../src/surfaces/checkout',
-    );
-    const sharedPath = path.join(checkoutBasePath, 'shared.ts');
+    // Use the type resolver to get AnyComponent (which excludes @private)
+    // AnyComponent = SUPPORTED_COMPONENTS + PrivateComponent
+    // But resolveType automatically filters out PrivateComponent because it's @private
+    checkoutComponentsCache = checkoutTypeResolver.resolveType('AnyComponent');
 
-    if (!fs.existsSync(sharedPath)) {
-      checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
-      return checkoutComponentsCache;
-    }
-
-    const content = fs.readFileSync(sharedPath, 'utf-8');
-
-    // Look for SUPPORTED_COMPONENTS array
-    const supportedMatch = content.match(
-      /export const SUPPORTED_COMPONENTS\s*=\s*\[([\s\S]*?)\]\s*as const/,
-    );
-
-    if (supportedMatch) {
-      const arrayContent = supportedMatch[1];
-      // Extract all quoted strings
-      const components = arrayContent.match(/'([^']+)'/g);
-      if (components) {
-        checkoutComponentsCache = components.map((c) => c.replace(/'/g, ''));
-        return checkoutComponentsCache;
+    if (checkoutComponentsCache.length === 0) {
+      // Fallback: try to get just SUPPORTED_COMPONENTS
+      const typeDefs = checkoutTypeResolver.getTypeDefinitions();
+      if (Array.isArray(typeDefs['SUPPORTED_COMPONENTS'])) {
+        checkoutComponentsCache = [...typeDefs['SUPPORTED_COMPONENTS']];
+      } else {
+        checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
       }
     }
 
-    checkoutComponentsCache = ['[CheckoutComponentsParseError]'];
     return checkoutComponentsCache;
   } catch (error) {
     checkoutComponentsCache = ['[CheckoutComponentsError]'];
@@ -84,7 +78,7 @@ function parseCheckoutComponents() {
 function parseStringUnionType(filePath, componentTypesMap = {}) {
   try {
     const content = fs.readFileSync(filePath, 'utf-8');
-    
+
     // Extract all quoted component names from the file (but not from import statements)
     // Remove import lines first
     const contentWithoutImports = content.replace(/^import.*?;$/gm, '');
@@ -92,20 +86,20 @@ function parseStringUnionType(filePath, componentTypesMap = {}) {
     const quotedComponents = componentNames
       ? componentNames.map((name) => name.replace(/'/g, ''))
       : [];
-    
+
     // Check if the type references other types (like StandardComponents or AnyComponent)
     // Look for patterns like: StandardComponents | 'OtherComponent'
     const typeRefPattern = /export type \w+ =\s*([\s\S]*?);/;
     const typeDefMatch = content.match(typeRefPattern);
-    
+
     if (typeDefMatch) {
       const typeDef = typeDefMatch[1];
       // Find references to other types (capitalized words that aren't in quotes)
       const typeRefs = typeDef.match(/\b([A-Z]\w+(?:Components?)?)\b/g);
-      
+
       if (typeRefs) {
         const allComponents = [...quotedComponents];
-        
+
         for (const typeRef of typeRefs) {
           // Check if this is AnyComponent (imported from checkout)
           if (typeRef === 'AnyComponent') {
@@ -118,12 +112,12 @@ function parseStringUnionType(filePath, componentTypesMap = {}) {
             allComponents.push(...componentTypesMap[typeRef]);
           }
         }
-        
+
         // Remove duplicates
         return [...new Set(allComponents)];
       }
     }
-    
+
     return quotedComponents.length > 0 ? quotedComponents : null;
   } catch (error) {
     console.error(`Error reading component file ${filePath}:`, error.message);
@@ -238,13 +232,43 @@ function parseTargetsFile() {
   return targets;
 }
 
-function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap) {
+function parseTargetsFromInterfaceBody(
+  interfaceBody,
+  targets,
+  componentTypesMap,
+) {
   // Parse each target definition (handle multi-line)
   const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
 
   let match;
   while ((match = targetRegex.exec(interfaceBody)) !== null) {
     const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    // Look backwards from the match to find a preceding JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      // Check if there's no other target between the JSDoc and this target
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      // If the text between JSDoc end and target is empty (or just whitespace), the JSDoc belongs to this target
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          // Skip this target if it's marked @private
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
     let renderExtensionContent = match[2].trim();
 
     // Remove comments before parsing
@@ -271,54 +295,6 @@ function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap
       };
     }
   }
-}
-
-function splitByTopLevelComma(str) {
-  const parts = [];
-  let current = '';
-  let angleDepth = 0;
-  let braceDepth = 0;
-  let parenDepth = 0;
-
-  for (let i = 0; i < str.length; i++) {
-    const char = str[i];
-
-    if (char === '<') {
-      angleDepth++;
-      current += char;
-    } else if (char === '>') {
-      angleDepth--;
-      current += char;
-    } else if (char === '{') {
-      braceDepth++;
-      current += char;
-    } else if (char === '}') {
-      braceDepth--;
-      current += char;
-    } else if (char === '(') {
-      parenDepth++;
-      current += char;
-    } else if (char === ')') {
-      parenDepth--;
-      current += char;
-    } else if (
-      char === ',' &&
-      angleDepth === 0 &&
-      braceDepth === 0 &&
-      parenDepth === 0
-    ) {
-      parts.push(current);
-      current = '';
-    } else {
-      current += char;
-    }
-  }
-
-  if (current) {
-    parts.push(current);
-  }
-
-  return parts;
 }
 
 function getNestedApis(apiName) {
@@ -380,7 +356,7 @@ function getNestedApis(apiName) {
     }
 
     // Find the end position (semicolon at the correct nesting level)
-    let startPos = startMatch.index + startMatch[0].length;
+    const startPos = startMatch.index + startMatch[0].length;
     let endPos = startPos;
     let braceDepth = 0;
     let angleDepth = 0;
@@ -478,7 +454,9 @@ function parseComponents(componentString, componentTypesMap) {
   componentString = componentString.replace(/\s+/g, ' ').trim();
 
   // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
-  const checkoutExceptMatch = componentString.match(/AnyCheckoutComponentExcept<([^>]+)>/);
+  const checkoutExceptMatch = componentString.match(
+    /AnyCheckoutComponentExcept<([^>]+)>/,
+  );
   if (checkoutExceptMatch) {
     const excludedUnion = checkoutExceptMatch[1];
     // Get all checkout components
@@ -549,7 +527,11 @@ function resolveComponentType(typeName, componentTypesMap) {
   }
 
   // Handle special checkout types
-  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyComponent' || typeName === 'AnyThankYouComponent') {
+  if (
+    typeName === 'AnyCheckoutComponent' ||
+    typeName === 'AnyComponent' ||
+    typeName === 'AnyThankYouComponent'
+  ) {
     return parseCheckoutComponents();
   }
 
@@ -619,21 +601,23 @@ try {
   // Write to output file
   const outputDir = path.dirname(config.outputPath);
   if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true });
+    fs.mkdirSync(outputDir, {recursive: true});
   }
   fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
 
   console.log('✅ Generated combined targets JSON at:', config.outputPath);
-  
+
   // Count the different types of entries
   const targetEntries = Object.keys(targetsJson).length;
   const apiEntries = Object.keys(combinedJson).filter(
-    (key) => combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api'),
   ).length;
   const componentEntries = Object.keys(combinedJson).filter(
-    (key) => combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api'),
   ).length;
-  
+
   console.log('\n📋 Summary:');
   console.log(`  Extension targets: ${targetEntries}`);
   console.log(`  API reverse mappings: ${apiEntries}`);

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
@@ -103,6 +103,20 @@ try {
     replaceValue: 'any',
   });
   await generateExtensionsDocs();
+  
+  // Generate targets.json
+  console.log('Generating targets.json...');
+  try {
+    const {execSync} = await import('child_process');
+    execSync(`node ${path.join(docsPath, 'build-docs-targets-json.mjs')} ${EXTENSIONS_API_VERSION}`, {
+      stdio: 'inherit',
+      cwd: rootPath,
+    });
+    console.log('✅ Generated targets.json');
+  } catch (targetsError) {
+    console.warn('Warning: Failed to generate targets.json:', targetsError.message);
+  }
+  
   await copyGeneratedToShopifyDev({
     generatedDocsPath,
     shopifyDevPath,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
@@ -1,0 +1,489 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const EXTENSIONS_API_VERSION = process.argv[2];
+
+if (!EXTENSIONS_API_VERSION) {
+  console.error('Error: API_VERSION is required.');
+  console.error('Usage: node build-docs-targets-json.mjs <API_VERSION>');
+  console.error('Example: node build-docs-targets-json.mjs 2024-01');
+  process.exit(1);
+}
+
+// All POS components will be populated from StandardComponents.ts
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+/**
+ * Parse a string union type from a component file
+ * e.g., export type SmartGridComponents = 'Tile';
+ * or multi-line: export type BlockExtensionComponents = 'Badge' | 'Box' | ...;
+ */
+function parseStringUnionType(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    // Extract all quoted component names from the file
+    const componentNames = content.match(/'([^']+)'/g);
+    if (componentNames) {
+      return componentNames.map((name) => name.replace(/'/g, ''));
+    }
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from the separate files in ./components/targets/
+ */
+function parseComponentTypesFromFiles() {
+  const basePath = path.join(
+    __dirname,
+    '../../../src/surfaces/point-of-sale/components/targets',
+  );
+
+  const componentTypesMap = {};
+
+  // Parse SmartGridComponents
+  const smartGridComponents = parseStringUnionType(
+    path.join(basePath, 'SmartGridComponents.ts'),
+  );
+  if (smartGridComponents) {
+    componentTypesMap['SmartGridComponents'] = smartGridComponents;
+  }
+
+  // Parse ActionExtensionComponents
+  const actionComponents = parseStringUnionType(
+    path.join(basePath, 'ActionExtensionComponents.ts'),
+  );
+  if (actionComponents) {
+    componentTypesMap['ActionExtensionComponents'] = actionComponents;
+  }
+
+  // Parse BlockExtensionComponents
+  const blockComponents = parseStringUnionType(
+    path.join(basePath, 'BlockExtensionComponents.ts'),
+  );
+  if (blockComponents) {
+    componentTypesMap['BlockExtensionComponents'] = blockComponents;
+  }
+
+  // Parse ReceiptComponents
+  const receiptComponents = parseStringUnionType(
+    path.join(basePath, 'ReceiptComponents.ts'),
+  );
+  if (receiptComponents) {
+    componentTypesMap['ReceiptComponents'] = receiptComponents;
+  }
+
+  // Parse StandardComponents (for BasicComponents which excludes 'Tile')
+  const standardComponents = parseStringUnionType(
+    path.join(basePath, 'StandardComponents.ts'),
+  );
+  if (standardComponents) {
+    componentTypesMap['StandardComponents'] = standardComponents;
+    // BasicComponents = Exclude<StandardComponents, 'Tile'>
+    componentTypesMap['BasicComponents'] = standardComponents.filter(
+      (c) => c !== 'Tile',
+    );
+    // Update global allComponents
+    allComponents = standardComponents.sort();
+  }
+
+  return componentTypesMap;
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(
+    __dirname,
+    '../../../src/surfaces/point-of-sale/extension-targets.ts',
+  );
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse component type definitions from the separate files
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  // Extract the RenderExtensionTargets interface
+  const interfaceMatch = content.match(
+    /export interface RenderExtensionTargets \{([\s\S]+?)\n\}/,
+  );
+  if (!interfaceMatch) {
+    throw new Error('Could not find RenderExtensionTargets interface');
+  }
+
+  const interfaceBody = interfaceMatch[1];
+
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+  const targets = {};
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing (they can contain commas that break splitting)
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components (but be careful with nested <> brackets)
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+
+  return targets;
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (apiDefinitionsCache.hasOwnProperty(apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Map API names to their file paths (try multiple possible locations)
+  const apiFilePaths = {
+    StandardApi: [
+      './api/standard/standard-api',
+      './render/api/standard/standard-api',
+    ],
+    SmartGridApi: ['./api/smartgrid-api/smartgrid-api'],
+    ActionApi: [
+      './api/action-api/action-api',
+      './render/api/action-api/action-api',
+    ],
+    NavigationApi: [
+      './api/navigation-api/navigation-api',
+      './render/api/navigation-api/navigation-api',
+    ],
+    ScannerApi: [
+      './api/scanner-api/scanner-api',
+      './render/api/scanner-api/scanner-api',
+    ],
+    CartApi: ['./api/cart-api/cart-api', './render/api/cart-api/cart-api'],
+    OrderApi: ['./api/order-api/order-api', './render/api/order-api/order-api'],
+    ConnectivityApi: [
+      './api/connectivity-api/connectivity-api',
+      './render/api/connectivity-api/connectivity-api',
+    ],
+    DeviceApi: [
+      './api/device-api/device-api',
+      './render/api/device-api/device-api',
+    ],
+    LocaleApi: [
+      './api/locale-api/locale-api',
+      './render/api/locale-api/locale-api',
+    ],
+    SessionApi: [
+      './api/session-api/session-api',
+      './render/api/session-api/session-api',
+    ],
+    ToastApi: ['./api/toast-api/toast-api', './render/api/toast-api/toast-api'],
+    ProductSearchApi: [
+      './api/product-search-api/product-search-api',
+      './render/api/product-search-api/product-search-api',
+    ],
+    ActionTargetApi: [
+      './api/action-target-api/action-target-api',
+      './render/api/action-target-api/action-target-api',
+    ],
+    ProductApi: [
+      './api/product-api/product-api',
+      './render/api/product-api/product-api',
+    ],
+    CustomerApi: [
+      './api/customer-api/customer-api',
+      './render/api/customer-api/customer-api',
+    ],
+    DraftOrderApi: [
+      './api/draft-order-api/draft-order-api',
+      './render/api/draft-order-api/draft-order-api',
+    ],
+    PrintApi: ['./api/print-api/print-api', './render/api/print-api/print-api'],
+    StorageApi: ['./api/storage-api/storage-api'],
+    CartLineItemApi: ['./api/cart-line-item-api/cart-line-item-api'],
+    CashDrawerApi: ['./api/cash-drawer-api/cash-drawer-api'],
+    PinPadApi: ['./api/pin-pad-api'],
+  };
+
+  const relativePaths = apiFilePaths[apiName];
+  if (!relativePaths) {
+    // Unknown API, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Try each possible path
+  let content = null;
+
+  for (const relativePath of relativePaths) {
+    const basePath = path.join(
+      __dirname,
+      '../../../src/surfaces/point-of-sale',
+      relativePath,
+    );
+
+    // Try both .ts and .tsx extensions
+    for (const ext of ['.ts', '.tsx']) {
+      try {
+        const apiFilePath = basePath + ext;
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      } catch (error) {
+        // Try next extension
+      }
+    }
+
+    if (content) {
+      break;
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    // We need to capture everything until we find a semicolon that's not inside braces
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    let startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match StandardApi<'...'> or just ApiName
+    let apiName = null;
+
+    if (part.includes('StandardApi')) {
+      apiName = 'StandardApi';
+    } else {
+      // Extract just the type name before any generic parameters
+      const apiMatch = part.match(/^(\w+Api)/);
+      if (apiMatch) {
+        apiName = apiMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+function parseComponents(componentString, componentTypesMap) {
+  // Remove whitespace and newlines
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Check if it directly references one of our parsed component types
+  for (const [typeName, components] of Object.entries(componentTypesMap)) {
+    if (componentString.includes(typeName)) {
+      return components;
+    }
+  }
+
+  // Default to all components if no match
+  return allComponents;
+}
+
+function createReverseMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Generate the JSON
+const targetsJson = parseTargetsFile();
+
+// Create the extended JSON with reverse mappings
+const extendedJson = createReverseMapping(targetsJson);
+
+// Write to output file
+const outputPath = path.join(
+  __dirname,
+  `generated/pos_ui_extensions/${EXTENSIONS_API_VERSION}/targets.json`,
+);
+const outputDir = path.dirname(outputPath);
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}
+fs.writeFileSync(outputPath, JSON.stringify(extendedJson, null, 2));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {splitByTopLevelComma} from '../../shared/build-docs-type-resolver.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -127,6 +128,32 @@ function parseTargetsFile() {
   let match;
   while ((match = targetRegex.exec(interfaceBody)) !== null) {
     const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    // Look backwards from the match to find a preceding JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      // Check if there's no other target between the JSDoc and this target
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      // If the text between JSDoc end and target is empty (or just whitespace), the JSDoc belongs to this target
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          // Skip this target if it's marked @private
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
     let renderExtensionContent = match[2].trim();
 
     // Remove comments before parsing (they can contain commas that break splitting)
@@ -155,54 +182,6 @@ function parseTargetsFile() {
   }
 
   return targets;
-}
-
-function splitByTopLevelComma(str) {
-  const parts = [];
-  let current = '';
-  let angleDepth = 0;
-  let braceDepth = 0;
-  let parenDepth = 0;
-
-  for (let i = 0; i < str.length; i++) {
-    const char = str[i];
-
-    if (char === '<') {
-      angleDepth++;
-      current += char;
-    } else if (char === '>') {
-      angleDepth--;
-      current += char;
-    } else if (char === '{') {
-      braceDepth++;
-      current += char;
-    } else if (char === '}') {
-      braceDepth--;
-      current += char;
-    } else if (char === '(') {
-      parenDepth++;
-      current += char;
-    } else if (char === ')') {
-      parenDepth--;
-      current += char;
-    } else if (
-      char === ',' &&
-      angleDepth === 0 &&
-      braceDepth === 0 &&
-      parenDepth === 0
-    ) {
-      parts.push(current);
-      current = '';
-    } else {
-      current += char;
-    }
-  }
-
-  if (current) {
-    parts.push(current);
-  }
-
-  return parts;
 }
 
 function getNestedApis(apiName) {
@@ -484,6 +463,6 @@ const outputPath = path.join(
 );
 const outputDir = path.dirname(outputPath);
 if (!fs.existsSync(outputDir)) {
-  fs.mkdirSync(outputDir, { recursive: true });
+  fs.mkdirSync(outputDir, {recursive: true});
 }
 fs.writeFileSync(outputPath, JSON.stringify(extendedJson, null, 2));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
@@ -162,6 +162,20 @@ try {
     replaceValue: 'any',
   });
   await generateExtensionsDocs();
+  
+  // Generate targets.json
+  console.log('Generating targets.json...');
+  try {
+    const {execSync} = await import('child_process');
+    execSync(`node ${path.join(docsPath, 'build-docs-targets-json.mjs')} ${EXTENSIONS_API_VERSION}`, {
+      stdio: 'inherit',
+      cwd: rootPath,
+    });
+    console.log('✅ Generated targets.json');
+  } catch (targetsError) {
+    console.warn('Warning: Failed to generate targets.json:', targetsError.message);
+  }
+  
   await copyGeneratedToShopifyDev({
     generatedDocsPath,
     shopifyDevPath,


### PR DESCRIPTION
### Background

Part of: https://github.com/Shopify/temp-project-mover-Archetypically-20260312105649/issues/14

We want to parse target information for the dev docs for each surface.

### Solution

Added scripts for each surface to pull target information from `extension-targets.ts` or `targets.ts` into a format that shopify-dev needs to display that information.

The scripts handle:

- **`@private` JSDoc tags**: Targets marked with `@private` are excluded from the generated output
- **`RunnableExtension` targets**: Included with `components: []` since they don't render UI
- **`Pick<>` and `Omit<>` types**: Correctly resolved to their component lists
- **Union types**: Component types like `AllComponents | OrderRoutingComponents` are correctly merged

Also updated the build-docs.sh script to run the above script to create the targets output in the same place as other docs information for the reference.

### 🎩

Run the docs generation script for the different surfaces and verify that targets.json gets created correctly:

```
# 1. Admin surface
yarn docs:admin 2025-10

# 2. Checkout surface
yarn docs:checkout 2025-10

# 3. Point-of-Sale surface
yarn docs:point-of-sale 2025-10

# 4. Customer account surface
yarn docs:customer-account 2025-10
```

Verify that:

- Targets with `@private` JSDoc tags are NOT included in the output (e.g., `Playground` in admin, `purchase.checkout.gift-card.render` in checkout)
- `RunnableExtension` targets (e.g., `purchase.address-autocomplete.suggest`) have `components: []`
- Component types using `Pick<>` resolve to only the picked components (e.g., `pos.home.tile.render` should have only `['Tile']`)
- Component types using `Omit<>` resolve to all components except the omitted ones

### Checklist

- [x] I have :tophat:'d these changes
