### PR TITLE
Add admin.app.intent.render extension target

### DIFF
--- a/.changeset/add-admin-app-intent-render-target.md
+++ b/.changeset/add-admin-app-intent-render-target.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add admin.app.intent.render extension target

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -13,6 +13,7 @@ import type {
   CustomerSegmentTemplateApi,
   CustomerSegmentTemplate,
   StandardApi,
+  StandardRenderingExtensionApi,
 } from './api';
 import {
   ShouldRenderApi,
@@ -22,6 +23,7 @@ import type {BlockExtensionComponents} from './components/BlockExtensionComponen
 import type {ActionExtensionComponents} from './components/ActionExtensionComponents';
 import type {PrintActionExtensionComponents} from './components/PrintActionExtensionComponents';
 import type {FunctionSettingsComponents} from './components/FunctionSettingsComponents';
+import type {StandardComponents} from './components/StandardComponents';
 
 /**
  * Maps extension target identifiers to their corresponding extension types. Each target represents a specific location or context in the Shopify admin where extensions can render or execute. Use these targets to define where your extension appears and what capabilities it has access to.
@@ -646,6 +648,14 @@ export interface ExtensionTargets {
   'admin.app.tools.data': RunnableExtension<
     StandardApi<'admin.app.tools.data'>,
     undefined
+  >;
+
+  /**
+   * Renders an admin extension for handling app intents.
+   */
+  'admin.app.intent.render': RenderExtension<
+    StandardRenderingExtensionApi<'admin.app.intent.render'>,
+    StandardComponents
   >;
 }
 


### PR DESCRIPTION
### Background

Adds a new `admin.app.intent.render` extension target that enables apps to render UI for handling app intents in the admin.

- Part `1 of 2` of closing https://github.com/shop/issues-admin-extensibility/issues/2180 (part 2 will port this PR to `2026-04-rc`)

### Solution

Introduces `admin.app.intent.render` extension target using `RenderExtension<StandardRenderingExtensionApi, StandardComponents>`.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation