### PR TITLE
Add context-specific docs system for Admin vs App Home

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -250,8 +250,34 @@ const templates = {
   }),
 };
 
+const resolveContextualDescription = (entry, isExtensions) => {
+  // Determine the deployment context based on which docs we're building
+  const context = isExtensions ? 'admin' : 'app-home';
+  
+  // If the entry has context-specific overrides, resolve them
+  if (entry.contexts && entry.contexts[context]) {
+    const contextOverride = entry.contexts[context];
+    
+    // Apply context-specific overrides
+    if (contextOverride.description) {
+      entry.description = contextOverride.description;
+    }
+    if (contextOverride.related) {
+      entry.related = contextOverride.related;
+    }
+    
+    // Remove the contexts field from the output
+    delete entry.contexts;
+  }
+  
+  return entry;
+};
+
 const transformJson = async (filePath, isExtensions) => {
   let jsonData = JSON.parse((await fs.readFile(filePath, 'utf8')).toString());
+  
+  // Resolve context-specific descriptions for all entries
+  jsonData = jsonData.map(entry => resolveContextualDescription(entry, isExtensions));
 
   const iconEntry = jsonData.find(
     (entry) => entry.name === 'Icon' && entry.subSections,

--- a/packages/ui-extensions/src/docs/shared/component-definitions.ts
+++ b/packages/ui-extensions/src/docs/shared/component-definitions.ts
@@ -1,4 +1,9 @@
 import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {
+  SharedReferenceEntityTemplateSchema,
+  DeploymentContext,
+} from './docs-type';
+import {resolveContext} from './resolve-context';
 
 const CHECKOUT_PATH =
   '/docs/api/checkout-ui-extensions/latest/using-polaris-components';
@@ -30,6 +35,12 @@ interface ComponentDoc {
   subCategory?: ReferenceEntityTemplateSchema['subCategory'];
   extraContent?: ReferenceEntityTemplateSchema['subSections'];
   extraExamples?: ReferenceEntityTemplateSchema['examples'];
+  /**
+   * Optional deployment context to resolve context-specific descriptions.
+   * When provided along with a SharedReferenceEntityTemplateSchema that has context overrides,
+   * the appropriate context-specific description will be used.
+   */
+  deploymentContext?: DeploymentContext;
 }
 
 function buildDefinitions({
@@ -94,6 +105,35 @@ function buildDefinitions({
   ];
 }
 
+/**
+ * Merges shared component content with context-specific overrides.
+ * Use this when you have a SharedReferenceEntityTemplateSchema with contexts
+ * and want to resolve it for a specific deployment context.
+ *
+ * @param sharedContent - The shared component schema with potential context overrides
+ * @param context - The deployment context to resolve for
+ * @returns The resolved schema without context overrides
+ *
+ * @example
+ * ```ts
+ * import badgeContent from './shared/components/Badge';
+ *
+ * // For admin context
+ * const adminBadge = resolveSharedContent(badgeContent, 'admin');
+ * // Returns Badge schema with admin-specific description
+ *
+ * // For app-home context
+ * const appHomeBadge = resolveSharedContent(badgeContent, 'app-home');
+ * // Returns Badge schema with app-home-specific description
+ * ```
+ */
+export function resolveSharedContent(
+  sharedContent: SharedReferenceEntityTemplateSchema,
+  context: DeploymentContext,
+): Omit<SharedReferenceEntityTemplateSchema, 'contexts'> {
+  return resolveContext(sharedContent, context);
+}
+
 export function createComponentDoc({
   name,
   description,
@@ -110,6 +150,7 @@ export function createComponentDoc({
   bestPractices,
   extraContent = [],
   extraExamples,
+  deploymentContext,
 }: ComponentDoc): ReferenceEntityTemplateSchema {
   const kebabCasedName = name
     .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')

--- a/packages/ui-extensions/src/docs/shared/component-definitions.ts
+++ b/packages/ui-extensions/src/docs/shared/component-definitions.ts
@@ -35,12 +35,6 @@ interface ComponentDoc {
   subCategory?: ReferenceEntityTemplateSchema['subCategory'];
   extraContent?: ReferenceEntityTemplateSchema['subSections'];
   extraExamples?: ReferenceEntityTemplateSchema['examples'];
-  /**
-   * Optional deployment context to resolve context-specific descriptions.
-   * When provided along with a SharedReferenceEntityTemplateSchema that has context overrides,
-   * the appropriate context-specific description will be used.
-   */
-  deploymentContext?: DeploymentContext;
 }
 
 function buildDefinitions({
@@ -150,7 +144,6 @@ export function createComponentDoc({
   bestPractices,
   extraContent = [],
   extraExamples,
-  deploymentContext,
 }: ComponentDoc): ReferenceEntityTemplateSchema {
   const kebabCasedName = name
     .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')

--- a/packages/ui-extensions/src/docs/shared/components/Badge.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Badge.ts
@@ -7,6 +7,16 @@ const data: SharedReferenceEntityTemplateSchema = {
   category: 'Polaris web components',
   subCategory: 'Feedback and status indicators',
   related: [],
+  contexts: {
+    admin: {
+      description:
+        'Michelle woz here. Display status information and system-generated states for resources in the Shopify admin. Use badges to communicate order statuses, fulfillment states, or other resource conditions that merchants need to quickly identify.',
+    },
+    'app-home': {
+      description:
+        'Tim woz here. Highlight important status information and completed actions in your app interface. Use badges to draw attention to notifications, task completion, or other state changes in your app home experience.',
+    },
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/src/docs/shared/docs-type.ts
+++ b/packages/ui-extensions/src/docs/shared/docs-type.ts
@@ -1,4 +1,7 @@
-import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+import type {
+  ReferenceEntityTemplateSchema,
+  LinkType,
+} from '@shopify/generate-docs';
 
 /**
  * Defines the deployment contexts where a component can be used.
@@ -14,7 +17,7 @@ export interface ContextOverride {
   /** Override description for this specific context */
   description?: string;
   /** Override related components for this specific context */
-  related?: string[];
+  related?: LinkType[];
 }
 
 export interface SharedReferenceEntityTemplateSchema

--- a/packages/ui-extensions/src/docs/shared/docs-type.ts
+++ b/packages/ui-extensions/src/docs/shared/docs-type.ts
@@ -1,7 +1,44 @@
 import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
+/**
+ * Defines the deployment contexts where a component can be used.
+ * Each context can have its own description and related components.
+ */
+export type DeploymentContext = 'admin' | 'app-home';
+
+/**
+ * Context-specific overrides for component metadata.
+ * Use this to provide different descriptions or related components for different deployment contexts.
+ */
+export interface ContextOverride {
+  /** Override description for this specific context */
+  description?: string;
+  /** Override related components for this specific context */
+  related?: string[];
+}
+
 export interface SharedReferenceEntityTemplateSchema
   extends Pick<
     ReferenceEntityTemplateSchema,
     'name' | 'description' | 'category' | 'subCategory' | 'related'
-  > {}
+  > {
+  /**
+   * Context-specific overrides for different deployment contexts.
+   * When specified, these values override the base description and related fields.
+   *
+   * @example
+   * ```ts
+   * contexts: {
+   *   'admin': {
+   *     description: 'Admin-specific description...',
+   *     related: ['AdminComponent'],
+   *   },
+   *   'app-home': {
+   *     description: 'App Home-specific description...',
+   *     related: ['AppHomeComponent'],
+   *   }
+   * }
+   * ```
+   */
+  contexts?: Partial<Record<DeploymentContext, ContextOverride>>;
+}

--- a/packages/ui-extensions/src/docs/shared/resolve-context.ts
+++ b/packages/ui-extensions/src/docs/shared/resolve-context.ts
@@ -1,0 +1,78 @@
+import type {
+  SharedReferenceEntityTemplateSchema,
+  DeploymentContext,
+} from './docs-type';
+
+/**
+ * Resolves context-specific content for a shared component schema.
+ *
+ * When a component has context-specific overrides defined, this function
+ * merges the base schema with the appropriate context overrides.
+ *
+ * @param schema - The shared component schema
+ * @param context - The deployment context to resolve for (e.g., 'admin' or 'app-home')
+ * @returns The schema with context-specific overrides applied
+ *
+ * @example
+ * ```ts
+ * import badgeContent from './components/Badge';
+ * import { resolveContext } from './resolve-context';
+ *
+ * // Get admin-specific description
+ * const adminBadge = resolveContext(badgeContent, 'admin');
+ * console.log(adminBadge.description); // Admin-specific description
+ *
+ * // Get app-home-specific description
+ * const appHomeBadge = resolveContext(badgeContent, 'app-home');
+ * console.log(appHomeBadge.description); // App Home-specific description
+ * ```
+ */
+export function resolveContext(
+  schema: SharedReferenceEntityTemplateSchema,
+  context: DeploymentContext,
+): Omit<SharedReferenceEntityTemplateSchema, 'contexts'> {
+  const contextOverride = schema.contexts?.[context];
+
+  if (!contextOverride) {
+    // No context-specific overrides, return base schema without contexts field
+    const {contexts, ...baseSchema} = schema;
+    return baseSchema;
+  }
+
+  // Merge context-specific overrides with base schema
+  const {contexts, ...baseSchema} = schema;
+  return {
+    ...baseSchema,
+    ...(contextOverride.description && {
+      description: contextOverride.description,
+    }),
+    ...(contextOverride.related && {related: contextOverride.related}),
+  };
+}
+
+/**
+ * Type guard to check if a schema has context-specific overrides.
+ *
+ * @param schema - The shared component schema to check
+ * @returns True if the schema has context overrides defined
+ */
+export function hasContextOverrides(
+  schema: SharedReferenceEntityTemplateSchema,
+): boolean {
+  return Boolean(schema.contexts && Object.keys(schema.contexts).length > 0);
+}
+
+/**
+ * Gets all available contexts for a schema.
+ *
+ * @param schema - The shared component schema
+ * @returns Array of deployment contexts that have overrides defined
+ */
+export function getAvailableContexts(
+  schema: SharedReferenceEntityTemplateSchema,
+): DeploymentContext[] {
+  if (!schema.contexts) {
+    return [];
+  }
+  return Object.keys(schema.contexts) as DeploymentContext[];
+}


### PR DESCRIPTION
## This PR: 
- **Prototypes a context-aware docs schema**: Extends `SharedReferenceEntityTemplateSchema` to support a `contexts` field, allowing writers to define different component descriptions for different surfaces, where necessary
- **Integrates context resolution into the build pipeline**: Modifies `build-docs.mjs` to automatically resolve context-specific overrides during doc generation, ensuring Admin UI docs (/docs/api/admin-extensions) and App Home docs (/docs/api/app-home) display appropriate descriptions for each surface
- **Updates the Badge component as an example**: Demonstrates how to define context-specific descriptions

### Tophatting

Check out this branch, and run `yarn docs:admin 2026-01`. This will generate the docs for App Home and Admin UI. Run `dev s` in `shopify-dev` to view the docs. 

You can also review other UI extensions references (like Checkout) to see that it uses the default "shared" description.

<img width="882" height="230" alt="Screenshot 2026-01-29 at 6 16 19 PM" src="https://github.com/user-attachments/assets/76744cd8-311c-48b0-b98c-1e8441137917" />

<img width="885" height="213" alt="Screenshot 2026-01-29 at 6 16 27 PM" src="https://github.com/user-attachments/assets/974c7b29-23c4-4d8c-95dc-1a732bed0619" />

<img width="882" height="184" alt="Screenshot 2026-01-29 at 6 16 32 PM" src="https://github.com/user-attachments/assets/d1e5bda0-8f35-43ae-b410-7fb5c71d1f22" />
