### PR TITLE
2024-07 target docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
@@ -270,6 +270,49 @@ function parseComponentTypesFromFiles() {
   return componentTypesMap;
 }
 
+/**
+ * Parse inline component type definitions from extension-targets.ts
+ * Handles types like: type AllComponents = AnyComponentBuilder<Omit<Components, ...>>
+ */
+function parseInlineComponentTypes(content, componentTypesMap) {
+  // Match type definitions like: type TypeName = AnyComponentBuilder<...>
+  const typeDefRegex = /type\s+(\w+)\s*=\s*(AnyComponentBuilder<[\s\S]*?>)\s*;/g;
+  
+  let match;
+  while ((match = typeDefRegex.exec(content)) !== null) {
+    const typeName = match[1];
+    const typeDefinition = match[2];
+    
+    // Handle AnyComponentBuilder<Pick<Components, 'Comp1' | 'Comp2'>>
+    const pickMatch = typeDefinition.match(/AnyComponentBuilder<\s*Pick<\s*Components\s*,\s*([\s\S]+?)>\s*>/);
+    if (pickMatch) {
+      const pickedUnion = pickMatch[1].trim();
+      const pickedComponents = parseUnionOfStrings(pickedUnion);
+      componentTypesMap[typeName] = pickedComponents;
+      console.log(`Parsed ${typeName} (Pick): ${pickedComponents.length} components`);
+      continue;
+    }
+    
+    // Handle AnyComponentBuilder<Omit<Components, 'Comp1' | 'Comp2'>>
+    const omitMatch = typeDefinition.match(/AnyComponentBuilder<\s*Omit<\s*Components\s*,\s*([\s\S]+?)>\s*>/);
+    if (omitMatch) {
+      const omittedUnion = omitMatch[1].trim();
+      const omittedComponents = parseUnionOfStrings(omittedUnion);
+      if (allComponents.length > 0) {
+        componentTypesMap[typeName] = allComponents.filter((c) => !omittedComponents.includes(c));
+        console.log(`Parsed ${typeName} (Omit): ${componentTypesMap[typeName].length} components`);
+      }
+      continue;
+    }
+    
+    // Handle plain AnyComponentBuilder<Components>
+    if (typeDefinition.match(/AnyComponentBuilder<\s*Components\s*>/)) {
+      componentTypesMap[typeName] = allComponents.length > 0 ? [...allComponents] : [];
+      console.log(`Parsed ${typeName} (All): ${componentTypesMap[typeName].length} components`);
+    }
+  }
+}
+
 function parseTargetsFile() {
   console.log('Starting parseTargetsFile...');
   const targetsFilePath = path.join(config.basePath, 'extension-targets.ts');
@@ -292,6 +335,10 @@ function parseTargetsFile() {
   const componentTypesMap = parseComponentTypesFromFiles();
   console.log(`Found ${Object.keys(componentTypesMap).length} component type mappings`);
 
+  // Also parse inline component types from extension-targets.ts
+  parseInlineComponentTypes(content, componentTypesMap);
+  console.log(`After inline parsing: ${Object.keys(componentTypesMap).length} component type mappings`);
+
   const targets = {};
 
   // Look for all interfaces that might contain RenderExtension targets
@@ -310,9 +357,17 @@ function parseTargetsFile() {
     );
     const match = content.match(regex);
 
-    if (match && match[1].includes('RenderExtension<')) {
-      console.log(`Parsing targets from ${interfaceName}...`);
-      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    if (match) {
+      // Handle RenderExtension targets
+      if (match[1].includes('RenderExtension<')) {
+        console.log(`Parsing RenderExtension targets from ${interfaceName}...`);
+        parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+      }
+      // Handle RunnableExtension targets (like should-render)
+      if (match[1].includes('RunnableExtension<')) {
+        console.log(`Parsing RunnableExtension targets from ${interfaceName}...`);
+        parseRunnableTargetsFromInterfaceBody(match[1], targets);
+      }
     }
   }
 
@@ -334,6 +389,22 @@ function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap
     const targetName = match[1];
     let renderExtensionContent = match[2].trim();
 
+    // Check for @private JSDoc comment before this target
+    const beforeMatch = interfaceBody.slice(0, match.index);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+    if (lastJsDocEnd !== -1) {
+      const jsDocStart = beforeMatch.lastIndexOf('/**', lastJsDocEnd);
+      if (jsDocStart !== -1) {
+        const betweenJsDocAndMatch = beforeMatch.slice(lastJsDocEnd);
+        if (!betweenJsDocAndMatch.includes("': RenderExtension<")) {
+          const jsDocContent = beforeMatch.slice(jsDocStart, lastJsDocEnd + 2);
+          if (jsDocContent.includes('@private')) {
+            continue; // Skip private targets
+          }
+        }
+      }
+    }
+
     // Remove comments before parsing
     renderExtensionContent = renderExtensionContent
       .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
@@ -354,6 +425,55 @@ function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap
 
       targets[targetName] = {
         components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+/**
+ * Parse RunnableExtension targets from interface body
+ * RunnableExtension targets don't render UI, so they have components: []
+ */
+function parseRunnableTargetsFromInterfaceBody(interfaceBody, targets) {
+  const targetRegex = /'([^']+)':\s*RunnableExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let runnableContent = match[2].trim();
+
+    // Check for @private JSDoc comment before this target
+    const beforeMatch = interfaceBody.slice(0, match.index);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+    if (lastJsDocEnd !== -1) {
+      const jsDocStart = beforeMatch.lastIndexOf('/**', lastJsDocEnd);
+      if (jsDocStart !== -1) {
+        const betweenJsDocAndMatch = beforeMatch.slice(lastJsDocEnd);
+        if (!betweenJsDocAndMatch.includes("': RunnableExtension<")) {
+          const jsDocContent = beforeMatch.slice(jsDocStart, lastJsDocEnd + 2);
+          if (jsDocContent.includes('@private')) {
+            continue; // Skip private targets
+          }
+        }
+      }
+    }
+
+    // Remove comments
+    runnableContent = runnableContent
+      .replace(/\/\/[^\n]*/g, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // RunnableExtension has API type and return type, parse APIs
+    const parts = splitByTopLevelComma(runnableContent);
+    
+    if (parts.length >= 1) {
+      const apiString = parts[0].trim();
+      const apis = parseApis(apiString);
+
+      // RunnableExtension targets don't render components
+      targets[targetName] = {
+        components: [],
         apis: apis.sort(),
       };
     }
@@ -621,6 +741,22 @@ function parseComponents(componentString, componentTypesMap) {
   if (allowedMatch) {
     const innerType = allowedMatch[1].trim();
     return resolveComponentType(innerType, componentTypesMap);
+  }
+
+  // Handle union types like: AllComponents | OrderRoutingComponents
+  // Check if it's a union of type references (not string literals)
+  if (componentString.includes('|') && !componentString.includes('<')) {
+    const unionParts = componentString.split('|').map(s => s.trim());
+    const allUnionComponents = new Set();
+    
+    for (const part of unionParts) {
+      const partComponents = resolveComponentType(part, componentTypesMap);
+      partComponents.forEach(c => allUnionComponents.add(c));
+    }
+    
+    if (allUnionComponents.size > 0) {
+      return Array.from(allUnionComponents);
+    }
   }
 
   // Check if it's a direct type reference

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
@@ -1,0 +1,764 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+console.log('✅ Module loaded, starting script...');
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const EXTENSIONS_API_VERSION = process.argv[2] || 'unstable';
+
+// Configuration for admin surface
+const config = {
+  basePath: path.join(
+    __dirname,
+    '../../../src/surfaces/admin',
+  ),
+  outputPath: path.join(
+    __dirname,
+    'generated/targets.json',
+  ),
+  componentTypesPath: 'components',
+  hasComponentTypes: true,
+};
+
+// All components will be populated from StandardComponents
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+// Cache for checkout components
+let checkoutComponentsCache = null;
+
+/**
+ * Parse components from checkout's shared.ts file
+ */
+function parseCheckoutComponents() {
+  // Return cached value if available
+  if (checkoutComponentsCache !== null) {
+    return checkoutComponentsCache;
+  }
+
+  try {
+    // Always look in the checkout surface directory
+    const checkoutBasePath = path.join(
+      __dirname,
+      '../../../src/surfaces/checkout',
+    );
+    const sharedPath = path.join(checkoutBasePath, 'shared.ts');
+    const componentsPath = path.join(checkoutBasePath, 'components.ts');
+
+    // First try to parse from shared.ts (legacy format with SUPPORTED_COMPONENTS)
+    if (fs.existsSync(sharedPath)) {
+      const content = fs.readFileSync(sharedPath, 'utf-8');
+
+      // Look for SUPPORTED_COMPONENTS array
+      const supportedMatch = content.match(
+        /export const SUPPORTED_COMPONENTS\s*=\s*\[([\s\S]*?)\]\s*as const/,
+      );
+
+      if (supportedMatch) {
+        const arrayContent = supportedMatch[1];
+        // Extract all quoted strings
+        const components = arrayContent.match(/'([^']+)'/g);
+        if (components) {
+          checkoutComponentsCache = components.map((c) => c.replace(/'/g, ''));
+          return checkoutComponentsCache;
+        }
+      }
+    }
+
+    // If SUPPORTED_COMPONENTS not found, try to parse from components.ts
+    if (fs.existsSync(componentsPath)) {
+      const content = fs.readFileSync(componentsPath, 'utf-8');
+      
+      // Match export statements like: export {ComponentName} from './components/ComponentName/ComponentName';
+      const exportMatches = content.matchAll(/export\s*\{\s*(\w+)\s*\}\s*from/g);
+      const components = [];
+      
+      for (const match of exportMatches) {
+        const componentName = match[1];
+        // Filter out Props types and other exports
+        if (!componentName.endsWith('Props') && 
+            !componentName.includes('Type') &&
+            componentName.charAt(0) === componentName.charAt(0).toUpperCase()) {
+          components.push(componentName);
+        }
+      }
+      
+      if (components.length > 0) {
+        checkoutComponentsCache = components;
+        return checkoutComponentsCache;
+      }
+    }
+
+    if (!fs.existsSync(sharedPath) && !fs.existsSync(componentsPath)) {
+      checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
+      return checkoutComponentsCache;
+    }
+
+    checkoutComponentsCache = ['[CheckoutComponentsParseError]'];
+    return checkoutComponentsCache;
+  } catch (error) {
+    console.error('Error parsing checkout components:', error);
+    checkoutComponentsCache = ['[CheckoutComponentsError]'];
+    return checkoutComponentsCache;
+  }
+}
+
+/**
+ * Parse components from the local components.ts file
+ */
+function parseLocalComponents() {
+  try {
+    const componentsPath = path.join(config.basePath, 'components.ts');
+
+    if (!fs.existsSync(componentsPath)) {
+      console.warn('components.ts not found at:', componentsPath);
+      return [];
+    }
+
+    const content = fs.readFileSync(componentsPath, 'utf-8');
+    
+    // Match export statements like: export {ComponentName} from './components/ComponentName/ComponentName';
+    const exportMatches = content.matchAll(/export\s*\{\s*(\w+)\s*\}\s*from/g);
+    const components = [];
+    
+    for (const match of exportMatches) {
+      const componentName = match[1];
+      // Filter out Props types and other exports
+      if (!componentName.endsWith('Props') && 
+          !componentName.includes('Type') &&
+          componentName.charAt(0) === componentName.charAt(0).toUpperCase()) {
+        components.push(componentName);
+      }
+    }
+    
+    return components;
+  } catch (error) {
+    console.error('Error parsing local components:', error);
+    return [];
+  }
+}
+
+/**
+ * Parse a string union type from a component file and resolve type references
+ * e.g., export type SmartGridComponents = 'Tile';
+ * or: export type BlockExtensionComponents = StandardComponents | 'AdminBlock';
+ * or: export type StandardComponents = AnyComponent | 'Avatar' | ... (with AnyComponent imported)
+ */
+function parseStringUnionType(filePath, componentTypesMap = {}) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    
+    // Extract all quoted component names from the file (but not from import statements)
+    // Remove import lines first
+    const contentWithoutImports = content.replace(/^import.*?;$/gm, '');
+    const componentNames = contentWithoutImports.match(/'([^']+)'/g);
+    const quotedComponents = componentNames
+      ? componentNames.map((name) => name.replace(/'/g, ''))
+      : [];
+    
+    // Check if the type references other types (like StandardComponents or AnyComponent)
+    // Look for patterns like: StandardComponents | 'OtherComponent'
+    const typeRefPattern = /export type \w+ =\s*([\s\S]*?);/;
+    const typeDefMatch = content.match(typeRefPattern);
+    
+    if (typeDefMatch) {
+      const typeDef = typeDefMatch[1];
+      // Find references to other types (capitalized words that aren't in quotes)
+      const typeRefs = typeDef.match(/\b([A-Z]\w+(?:Components?)?)\b/g);
+      
+      if (typeRefs) {
+        const allComponents = [...quotedComponents];
+        
+        for (const typeRef of typeRefs) {
+          // Check if this is AnyComponent (imported from checkout)
+          if (typeRef === 'AnyComponent') {
+            // Add all checkout components
+            const checkoutComponents = parseCheckoutComponents();
+            allComponents.push(...checkoutComponents);
+          }
+          // If this type reference exists in our map, include its components
+          else if (componentTypesMap[typeRef]) {
+            allComponents.push(...componentTypesMap[typeRef]);
+          }
+        }
+        
+        // Remove duplicates
+        return [...new Set(allComponents)];
+      }
+    }
+    
+    return quotedComponents.length > 0 ? quotedComponents : null;
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from files in the components directory
+ * Uses a two-pass approach:
+ * 1. First pass: Parse all component types that only contain quoted strings
+ * 2. Second pass: Parse types that reference other types (like StandardComponents)
+ */
+function parseComponentTypesFromFiles() {
+  if (!config.hasComponentTypes || !config.componentTypesPath) {
+    return {};
+  }
+
+  const componentsPath = path.join(config.basePath, config.componentTypesPath);
+  const componentTypesMap = {};
+
+  try {
+    // Look for all TypeScript files in the components directory
+    const files = fs.readdirSync(componentsPath);
+    const tsFiles = files.filter(
+      (file) => file.endsWith('.ts') && !file.endsWith('.d.ts'),
+    );
+
+    // First pass: Parse files with only quoted strings
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, {});
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+
+        // If this is StandardComponents, use it as the base
+        if (componentTypeName === 'StandardComponents') {
+          allComponents = components.sort();
+        }
+      }
+    }
+
+    // Second pass: Re-parse files that might reference other types
+    // This allows types like BlockExtensionComponents = StandardComponents | 'AdminBlock'
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, componentTypesMap);
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+      }
+    }
+  } catch (error) {
+    console.error('Error parsing component types:', error.message);
+  }
+
+  return componentTypesMap;
+}
+
+function parseTargetsFile() {
+  console.log('Starting parseTargetsFile...');
+  const targetsFilePath = path.join(config.basePath, 'extension-targets.ts');
+
+  console.log('Reading targets file:', targetsFilePath);
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse and populate allComponents from the local components.ts file
+  if (allComponents.length === 0) {
+    console.log('Parsing local components...');
+    const localComponents = parseLocalComponents();
+    console.log(`Found ${localComponents.length} local components`);
+    if (localComponents.length > 0) {
+      allComponents = localComponents.sort();
+    }
+  }
+
+  // Parse component type definitions
+  console.log('Parsing component types from files...');
+  const componentTypesMap = parseComponentTypesFromFiles();
+  console.log(`Found ${Object.keys(componentTypesMap).length} component type mappings`);
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'CustomerAccountExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  console.log('Looking for interface targets...');
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match && match[1].includes('RenderExtension<')) {
+      console.log(`Parsing targets from ${interfaceName}...`);
+      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    }
+  }
+
+  console.log(`Found ${Object.keys(targets).length} targets total`);
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (apiDefinitionsCache.hasOwnProperty(apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Try to find the API file in the surface's api directory
+  const apiDir = path.join(config.basePath, 'api');
+
+  if (!fs.existsSync(apiDir)) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Convert API name to potential file paths
+  // e.g., StandardApi -> standard-api, CartApi -> cart-api
+  const kebabName = apiName
+    .replace(/Api$/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+  // Try multiple possible locations
+  const possiblePaths = [
+    path.join(apiDir, `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}`, `${kebabName}.ts`),
+    path.join(apiDir, kebabName.replace(/-/g, ''), `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}-api`, `${kebabName}-api.ts`),
+    path.join(apiDir, `${kebabName}-api.ts`),
+    path.join(apiDir, `standard-api`, `standard-api.ts`),
+  ];
+
+  let content = null;
+  for (const apiFilePath of possiblePaths) {
+    try {
+      if (fs.existsSync(apiFilePath)) {
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      }
+    } catch (error) {
+      // Continue to next path
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    let startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const generalMatch = part.match(/(\w+Api)\b/);
+      if (generalMatch) {
+        apiName = generalMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+/**
+ * Parse a TypeScript component type expression
+ * Handles various patterns: type refs, unions, Exclude, AllowedComponents, etc.
+ */
+function parseComponents(componentString, componentTypesMap) {
+  // Normalize whitespace
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyComponentBuilder<Pick<Components, 'Comp1' | 'Comp2'>>
+  const pickMatch = componentString.match(/AnyComponentBuilder<\s*Pick<\s*Components\s*,\s*([^>]+)>\s*>/);
+  if (pickMatch) {
+    const pickedUnion = pickMatch[1].trim();
+    return parseUnionOfStrings(pickedUnion);
+  }
+
+  // Handle AnyComponentBuilder<Omit<Components, 'Comp1' | 'Comp2'>>
+  const omitMatch = componentString.match(/AnyComponentBuilder<\s*Omit<\s*Components\s*,\s*([^>]+)>\s*>/);
+  if (omitMatch) {
+    const omittedUnion = omitMatch[1].trim();
+    const omittedComponents = parseUnionOfStrings(omittedUnion);
+    
+    // Get all components and filter out the omitted ones
+    if (allComponents.length > 0) {
+      return allComponents.filter((c) => !omittedComponents.includes(c));
+    }
+    // Fallback: try to get from checkout components if allComponents not set
+    const checkoutComponents = parseCheckoutComponents();
+    return checkoutComponents.filter((c) => !omittedComponents.includes(c));
+  }
+
+  // Handle plain AnyComponentBuilder<Components>
+  const anyComponentBuilderMatch = componentString.match(/AnyComponentBuilder<\s*Components\s*>/);
+  if (anyComponentBuilderMatch) {
+    if (allComponents.length > 0) {
+      return allComponents;
+    }
+    return parseCheckoutComponents();
+  }
+
+  // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
+  const checkoutExceptMatch = componentString.match(/AnyCheckoutComponentExcept<([^>]+)>/);
+  if (checkoutExceptMatch) {
+    const excludedUnion = checkoutExceptMatch[1];
+    // Get all checkout components
+    const allCheckoutComponents = parseCheckoutComponents();
+    // Parse the union of excluded components
+    const excludedComponents = parseUnionOfStrings(excludedUnion);
+    // Filter out the excluded components
+    return allCheckoutComponents.filter((c) => !excludedComponents.includes(c));
+  }
+
+  // Handle Exclude<BaseType, ExcludedComponent>
+  const excludeMatch = componentString.match(/Exclude<(\w+),\s*'([^']+)'>/);
+  if (excludeMatch) {
+    const baseType = excludeMatch[1];
+    const excluded = excludeMatch[2];
+    const baseComponents = resolveComponentType(baseType, componentTypesMap);
+    return baseComponents.filter((c) => c !== excluded);
+  }
+
+  // Handle AllowedComponents<ComponentType>
+  const allowedMatch = componentString.match(/AllowedComponents<([^>]+)>/);
+  if (allowedMatch) {
+    const innerType = allowedMatch[1].trim();
+    return resolveComponentType(innerType, componentTypesMap);
+  }
+
+  // Check if it's a direct type reference
+  const result = resolveComponentType(componentString, componentTypesMap);
+  if (result.length > 0) {
+    return result;
+  }
+
+  // Default to all components if we have them
+  if (allComponents.length > 0) {
+    return allComponents;
+  }
+
+  return ['[Unknown]'];
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'" or "| 'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Resolve a component type name to a list of component names
+ */
+function resolveComponentType(typeName, componentTypesMap) {
+  typeName = typeName.trim();
+
+  // Check if it's in our component types map
+  if (componentTypesMap[typeName]) {
+    return componentTypesMap[typeName];
+  }
+
+  // Handle special checkout types
+  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyComponent' || typeName === 'AnyThankYouComponent') {
+    return parseCheckoutComponents();
+  }
+
+  // Check if it's a quoted string literal
+  const quotedMatch = typeName.match(/^'([^']+)'$/);
+  if (quotedMatch) {
+    return [quotedMatch[1]];
+  }
+
+  return [];
+}
+
+function createCombinedMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for admin surface');
+  console.log(`📁 Base path: ${config.basePath}`);
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the combined JSON with reverse mappings
+  const combinedJson = createCombinedMapping(targetsJson);
+
+  // Write to output file
+  const outputDir = path.dirname(config.outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
+
+  console.log('✅ Generated combined targets JSON at:', config.outputPath);
+  
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+  ).length;
+  const componentEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+  ).length;
+  
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(combinedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
@@ -56,6 +56,14 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
+# Generate targets.json
+echo "Generating targets.json..."
+node $DOCS_PATH/build-docs-targets-json.mjs $API_VERSION
+targets_exit=$?
+if [ $targets_exit -ne 0 ]; then
+  echo "Warning: Failed to generate targets.json"
+fi
+
 if [ -d $SHOPIFY_DEV_PATH ]; then
   mkdir -p $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION
   cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
@@ -1,0 +1,375 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const API_VERSION = process.argv[2];
+
+if (!API_VERSION) {
+  console.error('Error: API_VERSION is required.');
+  console.error('Usage: node build-docs-targets-json.mjs <API_VERSION>');
+  console.error('Example: node build-docs-targets-json.mjs 2025-10');
+  process.exit(1);
+}
+
+// All checkout components
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+/**
+ * Parse components from the local components.ts file
+ */
+function parseLocalComponents() {
+  try {
+    const componentsPath = path.join(
+      __dirname,
+      '../../../src/surfaces/checkout/components.ts',
+    );
+
+    if (!fs.existsSync(componentsPath)) {
+      console.warn('components.ts not found at:', componentsPath);
+      return [];
+    }
+
+    const content = fs.readFileSync(componentsPath, 'utf-8');
+    
+    // Match export statements like: export {ComponentName} from './components/ComponentName/ComponentName';
+    const exportMatches = content.matchAll(/export\s*\{\s*(\w+)\s*\}\s*from/g);
+    const components = [];
+    
+    for (const match of exportMatches) {
+      const componentName = match[1];
+      // Filter out Props types and other exports
+      if (!componentName.endsWith('Props') && 
+          !componentName.includes('Type') &&
+          componentName.charAt(0) === componentName.charAt(0).toUpperCase()) {
+        components.push(componentName);
+      }
+    }
+    
+    return components;
+  } catch (error) {
+    console.error('Error parsing local components:', error);
+    return [];
+  }
+}
+
+/**
+ * Parse component types - checkout doesn't have separate component type files
+ */
+function parseComponentTypesFromFiles() {
+  // Checkout doesn't have separate component type files
+  // Component types are defined inline in targets.ts or shared.ts
+  return {};
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(
+    __dirname,
+    '../../../src/surfaces/checkout/targets.ts',
+  );
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse and populate allComponents from the local components.ts file if not already set
+  if (allComponents.length === 0) {
+    const localComponents = parseLocalComponents();
+    if (localComponents.length > 0) {
+      allComponents = localComponents.sort();
+    }
+  }
+
+  // Parse component type definitions
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match && match[1].includes('RenderExtension<')) {
+      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    }
+  }
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const fallbackMatch = part.match(/(\w+Api)\b/);
+      if (fallbackMatch) {
+        apiName = fallbackMatch[1];
+      }
+    }
+
+    if (apiName) {
+      apisSet.add(apiName);
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+function parseComponents(componentString, componentTypesMap) {
+  // Remove whitespace and newlines
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyComponent (checkout's main component type)
+  if (componentString === 'AnyComponent') {
+    return allComponents;
+  }
+
+  // Handle AllowedComponents<'Comp1' | 'Comp2'>
+  const allowedMatch = componentString.match(/AllowedComponents<\s*([^>]+)\s*>/);
+  if (allowedMatch) {
+    const allowedUnion = allowedMatch[1].trim();
+    return parseUnionOfStrings(allowedUnion);
+  }
+
+  // Handle AnyComponentExcept<'Comp1' | 'Comp2'>
+  const exceptMatch = componentString.match(/AnyComponentExcept<\s*([^>]+)\s*>/);
+  if (exceptMatch) {
+    const exceptedUnion = exceptMatch[1].trim();
+    const exceptedComponents = parseUnionOfStrings(exceptedUnion);
+    return allComponents.filter((c) => !exceptedComponents.includes(c));
+  }
+
+  // Check if it directly references one of our parsed component types
+  for (const [typeName, components] of Object.entries(componentTypesMap)) {
+    if (componentString.includes(typeName)) {
+      return components;
+    }
+  }
+
+  // Default to all components if no match
+  return allComponents;
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+function createReverseMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for checkout surface');
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the extended JSON with reverse mappings
+  const extendedJson = createReverseMapping(targetsJson);
+
+  // Write to output file
+  const outputPath = path.join(
+    __dirname,
+    'generated/targets.json',
+  );
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  fs.writeFileSync(outputPath, JSON.stringify(extendedJson, null, 2));
+
+  console.log('✅ Generated targets JSON at:', outputPath);
+  
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(extendedJson).filter(
+    (key) => extendedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+  ).length;
+  const componentEntries = Object.keys(extendedJson).filter(
+    (key) => extendedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+  ).length;
+  
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(extendedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
@@ -88,11 +88,12 @@ function parseTargetsFile() {
 
   const targets = {};
 
-  // Look for all interfaces that might contain RenderExtension targets
+  // Look for all interfaces that might contain RenderExtension or RunnableExtension targets
   const interfaceNames = [
     'RenderExtensionTargets',
     'OrderStatusExtensionTargets',
     'ExtensionTargets',
+    'RunnableExtensionTargets',
   ];
 
   for (const interfaceName of interfaceNames) {
@@ -102,8 +103,15 @@ function parseTargetsFile() {
     );
     const match = content.match(regex);
 
-    if (match && match[1].includes('RenderExtension<')) {
-      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    if (match) {
+      // Handle RenderExtension targets
+      if (match[1].includes('RenderExtension<')) {
+        parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+      }
+      // Handle RunnableExtension targets (like address-autocomplete)
+      if (match[1].includes('RunnableExtension<')) {
+        parseRunnableTargetsFromInterfaceBody(match[1], targets);
+      }
     }
   }
 
@@ -122,6 +130,22 @@ function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap
   while ((match = targetRegex.exec(interfaceBody)) !== null) {
     const targetName = match[1];
     let renderExtensionContent = match[2].trim();
+
+    // Check for @private JSDoc comment before this target
+    const beforeMatch = interfaceBody.slice(0, match.index);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+    if (lastJsDocEnd !== -1) {
+      const jsDocStart = beforeMatch.lastIndexOf('/**', lastJsDocEnd);
+      if (jsDocStart !== -1) {
+        const betweenJsDocAndMatch = beforeMatch.slice(lastJsDocEnd);
+        if (!betweenJsDocAndMatch.includes("': RenderExtension<")) {
+          const jsDocContent = beforeMatch.slice(jsDocStart, lastJsDocEnd + 2);
+          if (jsDocContent.includes('@private')) {
+            continue; // Skip private targets
+          }
+        }
+      }
+    }
 
     // Remove comments before parsing
     renderExtensionContent = renderExtensionContent
@@ -143,6 +167,55 @@ function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap
 
       targets[targetName] = {
         components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+/**
+ * Parse RunnableExtension targets from interface body
+ * RunnableExtension targets don't render UI, so they have components: []
+ */
+function parseRunnableTargetsFromInterfaceBody(interfaceBody, targets) {
+  const targetRegex = /'([^']+)':\s*RunnableExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let runnableContent = match[2].trim();
+
+    // Check for @private JSDoc comment before this target
+    const beforeMatch = interfaceBody.slice(0, match.index);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+    if (lastJsDocEnd !== -1) {
+      const jsDocStart = beforeMatch.lastIndexOf('/**', lastJsDocEnd);
+      if (jsDocStart !== -1) {
+        const betweenJsDocAndMatch = beforeMatch.slice(lastJsDocEnd);
+        if (!betweenJsDocAndMatch.includes("': RunnableExtension<")) {
+          const jsDocContent = beforeMatch.slice(jsDocStart, lastJsDocEnd + 2);
+          if (jsDocContent.includes('@private')) {
+            continue; // Skip private targets
+          }
+        }
+      }
+    }
+
+    // Remove comments
+    runnableContent = runnableContent
+      .replace(/\/\/[^\n]*/g, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // RunnableExtension has API type and return type, parse APIs
+    const parts = splitByTopLevelComma(runnableContent);
+    
+    if (parts.length >= 1) {
+      const apiString = parts[0].trim();
+      const apis = parseApis(apiString);
+
+      // RunnableExtension targets don't render components
+      targets[targetName] = {
+        components: [],
         apis: apis.sort(),
       };
     }

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -72,6 +72,14 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
+# Generate targets.json
+echo "Generating targets.json..."
+node $DOCS_PATH/build-docs-targets-json.mjs $API_VERSION
+targets_exit=$?
+if [ $targets_exit -ne 0 ]; then
+  echo "Warning: Failed to generate targets.json"
+fi
+
 # Copy the generated docs to shopify-dev
 if [ -d $SHOPIFY_DEV_PATH ]; then
   mkdir -p $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
@@ -1,0 +1,675 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const EXTENSIONS_API_VERSION = process.argv[2] || 'unstable';
+
+// Configuration for customer-account surface
+const config = {
+  basePath: path.join(
+    __dirname,
+    '../../../src/surfaces/customer-account',
+  ),
+  outputPath: path.join(
+    __dirname,
+    'generated/targets.json',
+  ),
+  componentTypesPath: 'components',
+  hasComponentTypes: true,
+};
+
+// All components will be populated from StandardComponents
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+// Cache for checkout components
+let checkoutComponentsCache = null;
+
+/**
+ * Parse components from checkout's shared.ts file
+ */
+function parseCheckoutComponents() {
+  // Return cached value if available
+  if (checkoutComponentsCache !== null) {
+    return checkoutComponentsCache;
+  }
+
+  try {
+    // Always look in the checkout surface directory
+    const checkoutBasePath = path.join(
+      __dirname,
+      '../../../src/surfaces/checkout',
+    );
+    const sharedPath = path.join(checkoutBasePath, 'shared.ts');
+    const componentsPath = path.join(checkoutBasePath, 'components.ts');
+
+    // First try to parse from shared.ts (legacy format with SUPPORTED_COMPONENTS)
+    if (fs.existsSync(sharedPath)) {
+      const content = fs.readFileSync(sharedPath, 'utf-8');
+
+      // Look for SUPPORTED_COMPONENTS array
+      const supportedMatch = content.match(
+        /export const SUPPORTED_COMPONENTS\s*=\s*\[([\s\S]*?)\]\s*as const/,
+      );
+
+      if (supportedMatch) {
+        const arrayContent = supportedMatch[1];
+        // Extract all quoted strings
+        const components = arrayContent.match(/'([^']+)'/g);
+        if (components) {
+          checkoutComponentsCache = components.map((c) => c.replace(/'/g, ''));
+          return checkoutComponentsCache;
+        }
+      }
+    }
+
+    // If SUPPORTED_COMPONENTS not found, try to parse from components.ts
+    if (fs.existsSync(componentsPath)) {
+      const content = fs.readFileSync(componentsPath, 'utf-8');
+      
+      // Match export statements like: export {ComponentName} from './components/ComponentName/ComponentName';
+      const exportMatches = content.matchAll(/export\s*\{\s*(\w+)\s*\}\s*from/g);
+      const components = [];
+      
+      for (const match of exportMatches) {
+        const componentName = match[1];
+        // Filter out Props types and other exports
+        if (!componentName.endsWith('Props') && 
+            !componentName.includes('Type') &&
+            componentName.charAt(0) === componentName.charAt(0).toUpperCase()) {
+          components.push(componentName);
+        }
+      }
+      
+      if (components.length > 0) {
+        checkoutComponentsCache = components;
+        return checkoutComponentsCache;
+      }
+    }
+
+    if (!fs.existsSync(sharedPath) && !fs.existsSync(componentsPath)) {
+      checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
+      return checkoutComponentsCache;
+    }
+
+    checkoutComponentsCache = ['[CheckoutComponentsParseError]'];
+    return checkoutComponentsCache;
+  } catch (error) {
+    console.error('Error parsing checkout components:', error);
+    checkoutComponentsCache = ['[CheckoutComponentsError]'];
+    return checkoutComponentsCache;
+  }
+}
+
+/**
+ * Parse a string union type from a component file and resolve type references
+ * e.g., export type StandardComponents = AnyComponent | 'Avatar' | ... (with AnyComponent imported)
+ */
+function parseStringUnionType(filePath, componentTypesMap = {}) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    
+    // Extract all quoted component names from the file (but not from import statements)
+    // Remove import lines first
+    const contentWithoutImports = content.replace(/^import.*?;$/gm, '');
+    const componentNames = contentWithoutImports.match(/'([^']+)'/g);
+    const quotedComponents = componentNames
+      ? componentNames.map((name) => name.replace(/'/g, ''))
+      : [];
+    
+    // Check if the type references other types (like StandardComponents or AnyComponent)
+    // Look for patterns like: StandardComponents | 'OtherComponent'
+    const typeRefPattern = /export type \w+ =\s*([\s\S]*?);/;
+    const typeDefMatch = content.match(typeRefPattern);
+    
+    if (typeDefMatch) {
+      const typeDef = typeDefMatch[1];
+      // Find references to other types (capitalized words that aren't in quotes)
+      const typeRefs = typeDef.match(/\b([A-Z]\w+(?:Components?)?)\b/g);
+      
+      if (typeRefs) {
+        const allComponents = [...quotedComponents];
+        
+        for (const typeRef of typeRefs) {
+          // Check if this is AnyComponent (imported from checkout)
+          if (typeRef === 'AnyComponent') {
+            // Add all checkout components
+            const checkoutComponents = parseCheckoutComponents();
+            allComponents.push(...checkoutComponents);
+          }
+          // If this type reference exists in our map, include its components
+          else if (componentTypesMap[typeRef]) {
+            allComponents.push(...componentTypesMap[typeRef]);
+          }
+        }
+        
+        // Remove duplicates
+        return [...new Set(allComponents)];
+      }
+    }
+    
+    return quotedComponents.length > 0 ? quotedComponents : null;
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from files in the components directory
+ * Uses a two-pass approach:
+ * 1. First pass: Parse all component types that only contain quoted strings
+ * 2. Second pass: Parse types that reference other types (like StandardComponents)
+ */
+function parseComponentTypesFromFiles() {
+  if (!config.hasComponentTypes || !config.componentTypesPath) {
+    return {};
+  }
+
+  const componentsPath = path.join(config.basePath, config.componentTypesPath);
+  const componentTypesMap = {};
+
+  try {
+    // Look for all TypeScript files in the components directory
+    const files = fs.readdirSync(componentsPath);
+    const tsFiles = files.filter(
+      (file) => file.endsWith('.ts') && !file.endsWith('.d.ts'),
+    );
+
+    // First pass: Parse files with only quoted strings
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, {});
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+
+        // If this is StandardComponents, use it as the base
+        if (componentTypeName === 'StandardComponents') {
+          allComponents = components.sort();
+        }
+      }
+    }
+
+    // Second pass: Re-parse files that might reference other types
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, componentTypesMap);
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+      }
+    }
+  } catch (error) {
+    console.error('Error parsing component types:', error.message);
+  }
+
+  return componentTypesMap;
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(config.basePath, 'targets.ts');
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse component type definitions
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'CustomerAccountExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match && match[1].includes('RenderExtension<')) {
+      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    }
+  }
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (apiDefinitionsCache.hasOwnProperty(apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Try to find the API file in the surface's api directory
+  const apiDir = path.join(config.basePath, 'api');
+
+  if (!fs.existsSync(apiDir)) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Convert API name to potential file paths
+  // e.g., StandardApi -> standard-api, CartApi -> cart-api
+  const kebabName = apiName
+    .replace(/Api$/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+  // Try multiple possible locations
+  const possiblePaths = [
+    path.join(apiDir, `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}`, `${kebabName}.ts`),
+    path.join(apiDir, kebabName.replace(/-/g, ''), `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}-api`, `${kebabName}-api.ts`),
+    path.join(apiDir, `${kebabName}-api.ts`),
+    path.join(apiDir, `standard-api`, `standard-api.ts`),
+  ];
+
+  let content = null;
+  for (const apiFilePath of possiblePaths) {
+    try {
+      if (fs.existsSync(apiFilePath)) {
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      }
+    } catch (error) {
+      // Continue to next path
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    let startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const generalMatch = part.match(/(\w+Api)\b/);
+      if (generalMatch) {
+        apiName = generalMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+/**
+ * Parse a TypeScript component type expression
+ * Handles various patterns: type refs, unions, Exclude, AllowedComponents, etc.
+ */
+function parseComponents(componentString, componentTypesMap) {
+  // Normalize whitespace
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
+  const checkoutExceptMatch = componentString.match(/AnyCheckoutComponentExcept<([^>]+)>/);
+  if (checkoutExceptMatch) {
+    const excludedUnion = checkoutExceptMatch[1];
+    // Get all checkout components
+    const allCheckoutComponents = parseCheckoutComponents();
+    // Parse the union of excluded components
+    const excludedComponents = parseUnionOfStrings(excludedUnion);
+    // Filter out the excluded components
+    return allCheckoutComponents.filter((c) => !excludedComponents.includes(c));
+  }
+
+  // Handle Exclude<BaseType, ExcludedComponent>
+  const excludeMatch = componentString.match(/Exclude<(\w+),\s*'([^']+)'>/);
+  if (excludeMatch) {
+    const baseType = excludeMatch[1];
+    const excluded = excludeMatch[2];
+    const baseComponents = resolveComponentType(baseType, componentTypesMap);
+    return baseComponents.filter((c) => c !== excluded);
+  }
+
+  // Handle AllowedComponents<ComponentType>
+  const allowedMatch = componentString.match(/AllowedComponents<([^>]+)>/);
+  if (allowedMatch) {
+    const innerType = allowedMatch[1].trim();
+    return resolveComponentType(innerType, componentTypesMap);
+  }
+
+  // Check if it's a direct type reference
+  const result = resolveComponentType(componentString, componentTypesMap);
+  if (result.length > 0) {
+    return result;
+  }
+
+  // Default to all components if we have them
+  if (allComponents.length > 0) {
+    return allComponents;
+  }
+
+  return ['[Unknown]'];
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Resolve a component type name to a list of component names
+ */
+function resolveComponentType(typeName, componentTypesMap) {
+  typeName = typeName.trim();
+
+  // Check if it's in our component types map
+  if (componentTypesMap[typeName]) {
+    return componentTypesMap[typeName];
+  }
+
+  // Handle special checkout types
+  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyComponent' || typeName === 'AnyThankYouComponent') {
+    return parseCheckoutComponents();
+  }
+
+  // Check if it's a quoted string literal
+  const quotedMatch = typeName.match(/^'([^']+)'$/);
+  if (quotedMatch) {
+    return [quotedMatch[1]];
+  }
+
+  return [];
+}
+
+function createCombinedMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for customer-account surface');
+  console.log(`📁 Base path: ${config.basePath}`);
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the combined JSON with reverse mappings
+  const combinedJson = createCombinedMapping(targetsJson);
+
+  // Write to output file
+  const outputDir = path.dirname(config.outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
+
+  console.log('✅ Generated combined targets JSON at:', config.outputPath);
+  
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+  ).length;
+  const componentEntries = Object.keys(combinedJson).filter(
+    (key) => combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+  ).length;
+  
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(combinedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
@@ -106,6 +106,219 @@ function parseCheckoutComponents() {
   }
 }
 
+// Cache for customer-account components
+let customerAccountComponentsCache = null;
+
+/**
+ * Check if an export line has @internal marker before it
+ */
+function hasInternalMarker(content, matchIndex) {
+  // Find the start of the current line
+  const lineStart = content.lastIndexOf('\n', matchIndex - 1) + 1;
+  
+  // If this is the first line (no newline before it), there's no previous line
+  if (lineStart === 0 && matchIndex < content.indexOf('\n')) {
+    return false;
+  }
+  
+  // Find the previous line
+  const prevLineEnd = lineStart - 1;
+  if (prevLineEnd < 0) {
+    return false; // No previous line
+  }
+  
+  const prevLineStart = content.lastIndexOf('\n', prevLineEnd - 1) + 1;
+  const prevLine = content.slice(prevLineStart, prevLineEnd);
+  
+  return prevLine.includes('@internal');
+}
+
+/**
+ * Extract component name from an export - checks if it's a valid component (PascalCase, not Props/Type)
+ */
+function isValidComponentName(name) {
+  if (!name) return false;
+  const trimmed = name.trim();
+  return (
+    trimmed.length > 0 &&
+    trimmed.charAt(0) === trimmed.charAt(0).toUpperCase() &&
+    !trimmed.endsWith('Props') &&
+    !trimmed.includes('Type') &&
+    !trimmed.startsWith('type ')
+  );
+}
+
+/**
+ * Recursively parse exports from a file and collect component names
+ * Follows both `export * from` and `export { } from` patterns
+ * 
+ * @param {string} filePath - Path to the file to parse
+ * @param {Set} components - Set to collect component names into
+ * @param {Set} visited - Set of already visited files to prevent cycles
+ * @param {string} baseDir - Base directory for resolving relative paths
+ */
+function parseExportsRecursively(filePath, components, visited, baseDir) {
+  // Normalize path
+  const normalizedPath = path.resolve(filePath);
+  
+  // Resolve to actual file path (handle directories and missing extensions)
+  let actualPath = normalizedPath;
+  
+  if (fs.existsSync(actualPath)) {
+    // Check if it's a directory - if so, look for index.ts
+    const stats = fs.statSync(actualPath);
+    if (stats.isDirectory()) {
+      actualPath = path.join(actualPath, 'index.ts');
+      if (!fs.existsSync(actualPath)) {
+        return; // No index.ts in directory
+      }
+    }
+  } else {
+    // Path doesn't exist - try adding .ts extension or looking for index.ts
+    if (fs.existsSync(normalizedPath + '.ts')) {
+      actualPath = normalizedPath + '.ts';
+    } else if (fs.existsSync(path.join(normalizedPath, 'index.ts'))) {
+      actualPath = path.join(normalizedPath, 'index.ts');
+    } else {
+      return; // File not found
+    }
+  }
+  
+  // Check if already visited (using resolved actual path)
+  if (visited.has(actualPath)) {
+    return;
+  }
+  visited.add(actualPath);
+
+  try {
+    const content = fs.readFileSync(actualPath, 'utf-8');
+    const currentDir = path.dirname(actualPath);
+
+    // Pattern 1: export * from './path'
+    const starExportRegex = /export\s*\*\s*from\s*'([^']+)'/g;
+    let match;
+    while ((match = starExportRegex.exec(content)) !== null) {
+      // Check for @internal marker
+      if (hasInternalMarker(content, match.index)) {
+        continue;
+      }
+
+      const exportPath = match[1];
+      
+      // If it's a relative path, recurse into it
+      if (exportPath.startsWith('.')) {
+        const resolvedPath = path.resolve(currentDir, exportPath);
+        parseExportsRecursively(resolvedPath, components, visited, baseDir);
+      }
+      // If it's an external module path (like '../../checkout/components'), 
+      // try to parse named exports from that module
+      else if (!exportPath.startsWith('@')) {
+        const resolvedPath = path.resolve(currentDir, exportPath);
+        parseExportsRecursively(resolvedPath, components, visited, baseDir);
+      }
+    }
+
+    // Pattern 2: export { Name1, Name2, ... } from './path'
+    const namedExportRegex = /export\s*\{([\s\S]*?)\}\s*from\s*'([^']+)'/g;
+    while ((match = namedExportRegex.exec(content)) !== null) {
+      const exportContent = match[1];
+      const exportPath = match[2];
+      
+      // Check for @internal marker
+      if (hasInternalMarker(content, match.index)) {
+        continue;
+      }
+
+      // Parse the named exports
+      const parts = exportContent.split(',');
+      for (const part of parts) {
+        const trimmed = part.trim();
+        // Skip type exports
+        if (trimmed.startsWith('type ')) {
+          continue;
+        }
+        // Extract the component name (handle 'Name as Alias' syntax)
+        const componentName = trimmed.split(/\s+/)[0];
+        if (isValidComponentName(componentName)) {
+          components.add(componentName);
+        }
+      }
+    }
+
+    // Pattern 3: export { Name } (direct exports, likely from same directory)
+    // These are usually re-exports from a component's index.ts
+    const directExportRegex = /export\s*\{\s*(\w+)\s*\}(?!\s*from)/g;
+    while ((match = directExportRegex.exec(content)) !== null) {
+      if (hasInternalMarker(content, match.index)) {
+        continue;
+      }
+      const componentName = match[1];
+      if (isValidComponentName(componentName)) {
+        components.add(componentName);
+      }
+    }
+
+  } catch (error) {
+    // Silently skip files that can't be read
+  }
+}
+
+/**
+ * Parse components from customer-account's own component exports
+ * Recursively follows all export statements to build complete component list
+ */
+function parseCustomerAccountComponents() {
+  // Return cached value if available
+  if (customerAccountComponentsCache !== null) {
+    return customerAccountComponentsCache;
+  }
+
+  try {
+    const components = new Set();
+    const visited = new Set();
+    const componentsDir = path.join(config.basePath, 'components');
+    const indexPath = path.join(componentsDir, 'index.ts');
+
+    // Start recursive parsing from the components index
+    if (fs.existsSync(indexPath)) {
+      parseExportsRecursively(indexPath, components, visited, componentsDir);
+    }
+
+    if (components.size > 0) {
+      customerAccountComponentsCache = Array.from(components);
+      console.log(`Parsed ${customerAccountComponentsCache.length} customer-account components (from ${visited.size} files)`);
+      return customerAccountComponentsCache;
+    }
+
+    customerAccountComponentsCache = ['[CustomerAccountComponentsNotFound]'];
+    return customerAccountComponentsCache;
+  } catch (error) {
+    console.error('Error parsing customer-account components:', error);
+    customerAccountComponentsCache = ['[CustomerAccountComponentsError]'];
+    return customerAccountComponentsCache;
+  }
+}
+
+/**
+ * Parse inline component type definitions from targets.ts
+ * Handles types like: type AllComponents = Components[keyof Components]
+ */
+function parseInlineComponentTypes(content, componentTypesMap) {
+  // Match any type definition: type <NAME> = Components[keyof Components]
+  // This pattern means "all components from the local Components type"
+  const regex = /type\s+(\w+)\s*=\s*Components\[keyof\s+Components\]/g;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    const typeName = match[1];
+    // Use customer-account's own components (not all checkout components)
+    const customerAccountComponents = parseCustomerAccountComponents();
+    if (customerAccountComponents.length > 0) {
+      componentTypesMap[typeName] = customerAccountComponents;
+      console.log(`Parsed ${typeName}: ${customerAccountComponents.length} components (from customer-account exports)`);
+    }
+  }
+}
+
 /**
  * Parse a string union type from a component file and resolve type references
  * e.g., export type StandardComponents = AnyComponent | 'Avatar' | ... (with AnyComponent imported)
@@ -136,11 +349,10 @@ function parseStringUnionType(filePath, componentTypesMap = {}) {
         const allComponents = [...quotedComponents];
         
         for (const typeRef of typeRefs) {
-          // Check if this is AnyComponent (imported from checkout)
+          // Check if this is AnyComponent - use customer-account's own components
           if (typeRef === 'AnyComponent') {
-            // Add all checkout components
-            const checkoutComponents = parseCheckoutComponents();
-            allComponents.push(...checkoutComponents);
+            const customerAccountComponents = parseCustomerAccountComponents();
+            allComponents.push(...customerAccountComponents);
           }
           // If this type reference exists in our map, include its components
           else if (componentTypesMap[typeRef]) {
@@ -238,6 +450,9 @@ function parseTargetsFile() {
   // Parse component type definitions
   const componentTypesMap = parseComponentTypesFromFiles();
 
+  // Also parse inline component types from targets.ts (like AllComponents)
+  parseInlineComponentTypes(content, componentTypesMap);
+
   const targets = {};
 
   // Look for all interfaces that might contain RenderExtension targets
@@ -275,6 +490,26 @@ function parseTargetsFromInterfaceBody(interfaceBody, targets, componentTypesMap
   while ((match = targetRegex.exec(interfaceBody)) !== null) {
     const targetName = match[1];
     let renderExtensionContent = match[2].trim();
+
+    // Check for @private JSDoc comment before this target
+    // Look backwards from the match to find any JSDoc comment
+    const beforeMatch = interfaceBody.slice(0, match.index);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+    if (lastJsDocEnd !== -1) {
+      // Find the start of this JSDoc comment
+      const jsDocStart = beforeMatch.lastIndexOf('/**', lastJsDocEnd);
+      if (jsDocStart !== -1) {
+        // Check if there's no other target definition between this JSDoc and our match
+        const betweenJsDocAndMatch = beforeMatch.slice(lastJsDocEnd);
+        if (!betweenJsDocAndMatch.includes("': RenderExtension<")) {
+          const jsDocContent = beforeMatch.slice(jsDocStart, lastJsDocEnd + 2);
+          if (jsDocContent.includes('@private')) {
+            // Skip this target - it's marked as private
+            continue;
+          }
+        }
+      }
+    }
 
     // Remove comments before parsing
     renderExtensionContent = renderExtensionContent
@@ -578,7 +813,12 @@ function resolveComponentType(typeName, componentTypesMap) {
   }
 
   // Handle special checkout types
-  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyComponent' || typeName === 'AnyThankYouComponent') {
+  // For customer-account, AnyComponent refers to customer-account's own component set
+  if (typeName === 'AnyComponent') {
+    return parseCustomerAccountComponents();
+  }
+  // AnyCheckoutComponent and AnyThankYouComponent refer to full checkout component set
+  if (typeName === 'AnyCheckoutComponent' || typeName === 'AnyThankYouComponent') {
     return parseCheckoutComponents();
   }
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.sh
@@ -72,6 +72,14 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
+# Generate targets.json
+echo "Generating targets.json..."
+node $DOCS_PATH/build-docs-targets-json.mjs $API_VERSION
+targets_exit=$?
+if [ $targets_exit -ne 0 ]; then
+  echo "Warning: Failed to generate targets.json"
+fi
+
 if [ -d $SHOPIFY_DEV_PATH ]; then
   mkdir -p $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/customer_account_ui_extensions/$API_VERSION
   cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/customer_account_ui_extensions/$API_VERSION

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
@@ -1,0 +1,545 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const EXTENSIONS_API_VERSION = process.argv[2];
+
+if (!EXTENSIONS_API_VERSION) {
+  console.error('Error: API_VERSION is required.');
+  console.error('Usage: node build-docs-targets-json.mjs <API_VERSION>');
+  console.error('Example: node build-docs-targets-json.mjs 2024-01');
+  process.exit(1);
+}
+
+// All POS components will be populated from StandardComponents.ts
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+/**
+ * Parse components from the local components.ts file
+ */
+function parseLocalComponents() {
+  try {
+    const componentsPath = path.join(
+      __dirname,
+      '../../../src/surfaces/point-of-sale/components.ts',
+    );
+
+    if (!existsSync(componentsPath)) {
+      console.warn('components.ts not found at:', componentsPath);
+      return [];
+    }
+
+    const content = fs.readFileSync(componentsPath, 'utf-8');
+    
+    // Match export statements like: export {ComponentName} from './components/ComponentName/ComponentName';
+    const exportMatches = content.matchAll(/export\s*\{\s*(\w+)\s*\}\s*from/g);
+    const components = [];
+    
+    for (const match of exportMatches) {
+      const componentName = match[1];
+      // Filter out Props types and other exports
+      if (!componentName.endsWith('Props') && 
+          !componentName.includes('Type') &&
+          componentName.charAt(0) === componentName.charAt(0).toUpperCase()) {
+        components.push(componentName);
+      }
+    }
+    
+    return components;
+  } catch (error) {
+    console.error('Error parsing local components:', error);
+    return [];
+  }
+}
+
+function existsSync(filePath) {
+  try {
+    fs.accessSync(filePath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse a string union type from a component file
+ * e.g., export type SmartGridComponents = 'Tile';
+ * or multi-line: export type BlockExtensionComponents = 'Badge' | 'Box' | ...;
+ */
+function parseStringUnionType(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    // Extract all quoted component names from the file
+    const componentNames = content.match(/'([^']+)'/g);
+    if (componentNames) {
+      return componentNames.map((name) => name.replace(/'/g, ''));
+    }
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from the separate files in ./components/targets/
+ */
+function parseComponentTypesFromFiles() {
+  // Point-of-sale doesn't have separate component type files
+  // Component types are defined inline in targets.ts
+  // We'll parse them directly from the targets.ts content
+  return {};
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(
+    __dirname,
+    '../../../src/surfaces/point-of-sale/targets.ts',
+  );
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse and populate allComponents from the local components.ts file if not already set
+  if (allComponents.length === 0) {
+    const localComponents = parseLocalComponents();
+    if (localComponents.length > 0) {
+      allComponents = localComponents.sort();
+    }
+  }
+
+  // Parse component type definitions from the separate files
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  // Extract the ExtensionTargets interface (not RenderExtensionTargets for POS)
+  const interfaceMatch = content.match(
+    /export interface ExtensionTargets \{([\s\S]+?)\n\}/,
+  );
+  if (!interfaceMatch) {
+    throw new Error('Could not find ExtensionTargets interface');
+  }
+
+  const interfaceBody = interfaceMatch[1];
+
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+  const targets = {};
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing (they can contain commas that break splitting)
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components (but be careful with nested <> brackets)
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+
+  return targets;
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (apiDefinitionsCache.hasOwnProperty(apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Map API names to their file paths (try multiple possible locations)
+  const apiFilePaths = {
+    StandardApi: [
+      './api/standard/standard-api',
+      './render/api/standard/standard-api',
+    ],
+    SmartGridApi: ['./api/smartgrid-api/smartgrid-api'],
+    ActionApi: [
+      './api/action-api/action-api',
+      './render/api/action-api/action-api',
+    ],
+    NavigationApi: [
+      './api/navigation-api/navigation-api',
+      './render/api/navigation-api/navigation-api',
+    ],
+    ScannerApi: [
+      './api/scanner-api/scanner-api',
+      './render/api/scanner-api/scanner-api',
+    ],
+    CartApi: ['./api/cart-api/cart-api', './render/api/cart-api/cart-api'],
+    OrderApi: ['./api/order-api/order-api', './render/api/order-api/order-api'],
+    ConnectivityApi: [
+      './api/connectivity-api/connectivity-api',
+      './render/api/connectivity-api/connectivity-api',
+    ],
+    DeviceApi: [
+      './api/device-api/device-api',
+      './render/api/device-api/device-api',
+    ],
+    LocaleApi: [
+      './api/locale-api/locale-api',
+      './render/api/locale-api/locale-api',
+    ],
+    SessionApi: [
+      './api/session-api/session-api',
+      './render/api/session-api/session-api',
+    ],
+    ToastApi: ['./api/toast-api/toast-api', './render/api/toast-api/toast-api'],
+    ProductSearchApi: [
+      './api/product-search-api/product-search-api',
+      './render/api/product-search-api/product-search-api',
+    ],
+    ActionTargetApi: [
+      './api/action-target-api/action-target-api',
+      './render/api/action-target-api/action-target-api',
+    ],
+    ProductApi: [
+      './api/product-api/product-api',
+      './render/api/product-api/product-api',
+    ],
+    CustomerApi: [
+      './api/customer-api/customer-api',
+      './render/api/customer-api/customer-api',
+    ],
+    DraftOrderApi: [
+      './api/draft-order-api/draft-order-api',
+      './render/api/draft-order-api/draft-order-api',
+    ],
+    PrintApi: ['./api/print-api/print-api', './render/api/print-api/print-api'],
+    StorageApi: ['./api/storage-api/storage-api'],
+    CartLineItemApi: ['./api/cart-line-item-api/cart-line-item-api'],
+    CashDrawerApi: ['./api/cash-drawer-api/cash-drawer-api'],
+    PinPadApi: ['./api/pin-pad-api'],
+  };
+
+  const relativePaths = apiFilePaths[apiName];
+  if (!relativePaths) {
+    // Unknown API, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Try each possible path
+  let content = null;
+
+  for (const relativePath of relativePaths) {
+    const basePath = path.join(
+      __dirname,
+      '../../../src/surfaces/point-of-sale',
+      relativePath,
+    );
+
+    // Try both .ts and .tsx extensions
+    for (const ext of ['.ts', '.tsx']) {
+      try {
+        const apiFilePath = basePath + ext;
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      } catch (error) {
+        // Try next extension
+      }
+    }
+
+    if (content) {
+      break;
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    // We need to capture everything until we find a semicolon that's not inside braces
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    let startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match StandardApi<'...'> or just ApiName
+    let apiName = null;
+
+    if (part.includes('StandardApi')) {
+      apiName = 'StandardApi';
+    } else {
+      // Extract just the type name before any generic parameters
+      const apiMatch = part.match(/^(\w+Api)/);
+      if (apiMatch) {
+        apiName = apiMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+function parseComponents(componentString, componentTypesMap) {
+  // Remove whitespace and newlines
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyComponentBuilder<Pick<Components, 'Comp1' | 'Comp2'>>
+  const pickMatch = componentString.match(/AnyComponentBuilder<\s*Pick<\s*Components\s*,\s*([^>]+)>\s*>/);
+  if (pickMatch) {
+    const pickedUnion = pickMatch[1].trim();
+    // Parse the union of component names
+    const components = [];
+    const parts = pickedUnion.split('|');
+    for (const part of parts) {
+      const trimmed = part.trim();
+      const match = trimmed.match(/^'([^']+)'$/);
+      if (match) {
+        components.push(match[1]);
+      }
+    }
+    return components;
+  }
+
+  // Handle AnyComponentBuilder<Omit<Components, 'Comp1'>>
+  const omitMatch = componentString.match(/AnyComponentBuilder<\s*Omit<\s*Components\s*,\s*'([^']+)'\s*>\s*>/);
+  if (omitMatch) {
+    const omittedComponent = omitMatch[1];
+    // Return all components except the omitted one
+    return allComponents.filter((c) => c !== omittedComponent);
+  }
+
+  // Check if it directly references one of our parsed component types
+  for (const [typeName, components] of Object.entries(componentTypesMap)) {
+    if (componentString.includes(typeName)) {
+      return components;
+    }
+  }
+
+  // Default to all components if no match
+  return allComponents;
+}
+
+function createReverseMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for point-of-sale surface');
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the extended JSON with reverse mappings
+  const extendedJson = createReverseMapping(targetsJson);
+
+  // Write to output file
+  const outputPath = path.join(
+    __dirname,
+    'generated/targets.json',
+  );
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  fs.writeFileSync(outputPath, JSON.stringify(extendedJson, null, 2));
+
+  console.log('✅ Generated targets JSON at:', outputPath);
+  
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(extendedJson).filter(
+    (key) => extendedJson[key].targets && !targetsJson[key] && key.endsWith('Api')
+  ).length;
+  const componentEntries = Object.keys(extendedJson).filter(
+    (key) => extendedJson[key].targets && !targetsJson[key] && !key.endsWith('Api')
+  ).length;
+  
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(extendedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
@@ -87,6 +87,66 @@ function parseStringUnionType(filePath) {
 }
 
 /**
+ * Parse a union of string literals (e.g., "'Button' | 'Text'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Parse inline component type definitions from targets.ts
+ * Handles types like: type ActionComponents = AnyComponentBuilder<Pick<Components, 'Button'>>
+ */
+function parseInlineComponentTypes(content, componentTypesMap) {
+  // Match type definitions like: type TypeName = AnyComponentBuilder<...>
+  const typeDefRegex = /type\s+(\w+)\s*=\s*(AnyComponentBuilder<[\s\S]*?>)\s*;/g;
+  
+  let match;
+  while ((match = typeDefRegex.exec(content)) !== null) {
+    const typeName = match[1];
+    const typeDefinition = match[2];
+    
+    // Handle AnyComponentBuilder<Pick<Components, 'Comp1' | 'Comp2'>>
+    const pickMatch = typeDefinition.match(/AnyComponentBuilder<\s*Pick<\s*Components\s*,\s*([\s\S]+?)>\s*>/);
+    if (pickMatch) {
+      const pickedUnion = pickMatch[1].trim();
+      const pickedComponents = parseUnionOfStrings(pickedUnion);
+      componentTypesMap[typeName] = pickedComponents;
+      console.log(`Parsed ${typeName} (Pick): ${pickedComponents.length} components`);
+      continue;
+    }
+    
+    // Handle AnyComponentBuilder<Omit<Components, 'Comp1' | 'Comp2'>>
+    const omitMatch = typeDefinition.match(/AnyComponentBuilder<\s*Omit<\s*Components\s*,\s*([\s\S]+?)>\s*>/);
+    if (omitMatch) {
+      const omittedUnion = omitMatch[1].trim();
+      const omittedComponents = parseUnionOfStrings(omittedUnion);
+      if (allComponents.length > 0) {
+        componentTypesMap[typeName] = allComponents.filter((c) => !omittedComponents.includes(c));
+        console.log(`Parsed ${typeName} (Omit): ${componentTypesMap[typeName].length} components`);
+      }
+      continue;
+    }
+    
+    // Handle plain AnyComponentBuilder<Components>
+    if (typeDefinition.match(/AnyComponentBuilder<\s*Components\s*>/)) {
+      componentTypesMap[typeName] = allComponents.length > 0 ? [...allComponents] : [];
+      console.log(`Parsed ${typeName} (All): ${componentTypesMap[typeName].length} components`);
+    }
+  }
+}
+
+/**
  * Parse component types from the separate files in ./components/targets/
  */
 function parseComponentTypesFromFiles() {
@@ -115,6 +175,9 @@ function parseTargetsFile() {
   // Parse component type definitions from the separate files
   const componentTypesMap = parseComponentTypesFromFiles();
 
+  // Also parse inline component types from targets.ts
+  parseInlineComponentTypes(content, componentTypesMap);
+
   // Extract the ExtensionTargets interface (not RenderExtensionTargets for POS)
   const interfaceMatch = content.match(
     /export interface ExtensionTargets \{([\s\S]+?)\n\}/,
@@ -133,6 +196,22 @@ function parseTargetsFile() {
   while ((match = targetRegex.exec(interfaceBody)) !== null) {
     const targetName = match[1];
     let renderExtensionContent = match[2].trim();
+
+    // Check for @private JSDoc comment before this target
+    const beforeMatch = interfaceBody.slice(0, match.index);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+    if (lastJsDocEnd !== -1) {
+      const jsDocStart = beforeMatch.lastIndexOf('/**', lastJsDocEnd);
+      if (jsDocStart !== -1) {
+        const betweenJsDocAndMatch = beforeMatch.slice(lastJsDocEnd);
+        if (!betweenJsDocAndMatch.includes("': RenderExtension<")) {
+          const jsDocContent = beforeMatch.slice(jsDocStart, lastJsDocEnd + 2);
+          if (jsDocContent.includes('@private')) {
+            continue; // Skip private targets
+          }
+        }
+      }
+    }
 
     // Remove comments before parsing (they can contain commas that break splitting)
     renderExtensionContent = renderExtensionContent

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.sh
@@ -53,6 +53,14 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
+# Generate targets.json
+echo "Generating targets.json..."
+node $DOCS_PATH/build-docs-targets-json.mjs $API_VERSION
+targets_exit=$?
+if [ $targets_exit -ne 0 ]; then
+  echo "Warning: Failed to generate targets.json"
+fi
+
 if [ -d $SHOPIFY_DEV_PATH ]; then
   mkdir -p $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/pos_ui_extensions/$API_VERSION
   cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/pos_ui_extensions/$API_VERSION


### PR DESCRIPTION
### Background

Part of: https://github.com/Shopify/temp-project-mover-Archetypically-20260312105649/issues/14

We want to parse target information for the dev docs for each surface.

### Solution

Added scripts for each surface to pull target information from `extension-targets.ts` or `targets.ts` into a format that shopify-dev needs to display that information.

The scripts handle:

- **`@private` JSDoc tags**: Targets marked with `@private` are excluded from the generated output
- **`RunnableExtension` targets**: Included with `components: []` since they don't render UI
- **`Pick<>` and `Omit<>` types**: Correctly resolved to their component lists
- **Union types**: Component types like `AllComponents | OrderRoutingComponents` are correctly merged

Also updated the build-docs.sh script to run the above script to create the targets output in the same place as other docs information for the reference.

### 🎩

Run the docs generation script for the different surfaces and verify that targets.json gets created correctly:

```
# 1. Admin surface
yarn docs:admin 2024-07

# 2. Checkout surface
yarn docs:checkout 2024-07

# 3. Point-of-Sale surface
yarn docs:point-of-sale 2024-07

# 4. Customer account surface
yarn docs:customer-account 2024-07
```

Verify that:

- Targets with `@private` JSDoc tags are NOT included in the output (e.g., `Playground` in admin, `purchase.checkout.gift-card.render` in checkout)
- `RunnableExtension` targets (e.g., `purchase.address-autocomplete.suggest`) have `components: []`
- Component types using `Pick<>` resolve to only the picked components (e.g., `pos.home.tile.render` should have only `['Tile']`)
- Component types using `Omit<>` resolve to all components except the omitted ones

### Checklist

- [x] I have :tophat:'d these changes
