### PR TITLE
add deviceId to SessionApi

### DIFF
--- a/.changeset/slick-hornets-decide.md
+++ b/.changeset/slick-hornets-decide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+add deviceId to SessionApi

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -62,6 +62,14 @@ const data: ReferenceEntityTemplateSchema = {
         description:
           'Access session data and generate authentication tokens. This example shows how to access shop details, user information, and location data through `shopify.session`, and use `shopify.session.getSessionToken()` to generate tokens for authenticated requests to your backend services.',
       },
+      {
+        codeblock: generateJsxCodeBlockForSessionApi(
+          'Retrieve the device ID',
+          'device-id',
+        ),
+        description:
+          'Access the unique identifier of the current POS device. This example demonstrates using `shopify.deviceId` to retrieve the device ID. Use this data to construct a GID to query device details via GraphQL Admin API.',
+      },
     ],
   },
 };

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/session-api/device-id.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/session-api/device-id.jsx
@@ -1,0 +1,19 @@
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+const Extension = () => {
+  const {deviceId} = shopify.session;
+  const deviceGid = `gid://shopify/PointOfSaleDevice/${deviceId}`;
+
+  return (
+    <s-page heading="Device Details">
+      <s-scroll-box>
+        <s-text>Device ID: {deviceId}</s-text>
+        <s-text>Device GID: {deviceGid}</s-text>
+      </s-scroll-box>
+    </s-page>
+  );
+};

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
@@ -9,6 +9,16 @@ export interface SessionApiContent {
    * Generates a fresh session token for secure communication with your app's backend service. Returns `undefined` when the authenticated user lacks proper app permissions. The token is a Shopify OpenID Connect ID Token that should be used in `Authorization` headers for backend API calls. This is based on the authenticated user, not the pinned staff member.
    */
   getSessionToken: () => Promise<string | undefined>;
+  /**
+   * The numeric ID of the device running this session.
+   *
+   * Use this to construct a [GID](https://shopify.dev/docs/api/pos-ui-extensions/latest/target-apis/platform-apis/device-api) to query device details via GraphQL Admin API.
+   *
+   * @example 123456
+   * @see [Global IDs documentation](https://shopify.dev/docs/api/usage/gids) for more about GID format and structure
+   * @see [device.getDeviceId()](https://shopify.dev/docs/api/pos-ui-extensions/latest/target-apis/platform-apis/device-api) for physical device identifier (UUID format)
+   */
+  deviceId: number;
 }
 
 /**


### PR DESCRIPTION
https://github.com/shop/issues-retail/issues/22897
### Background

Following discussion with the [POS-Extensibility team](https://shopify.slack.com/archives/C07TB5BRP0Q/p1768588183896849), and [approval from TAG](https://github.com/Shopify/ui-api-design/pull/1360/changes), this PR implements deviceId on the POS UI Extensions SessionApi.

As part of the [Extensible Cash Management Project](https://vault.shopify.io/gsd/projects/45834-POS-App-More-Robust-Cash-Management-on-Shopify-POS), this PR exposes deviceId in the SessionApi to enable developers to fetch PointOfSaleDevice data via DirectAPI Access, and build cash management extensions in Point of Sale.

### Solution
Return deviceId directly from the SessionApi.

Note: we are not putting this as part of currentSession as upcoming work as part of 2026-04 will be to expose all of currentSession as part of the SessionAPI return.

|SessionApi Docs|Example|
|--|--|
|<img width="618" height="870" alt="Screenshot 2026-01-30 at 12 31 44 PM" src="https://github.com/user-attachments/assets/bee7c032-5e21-42b9-91e8-abb49cf6c91f" />|<img width="1261" height="651" alt="Screenshot 2026-01-30 at 12 31 53 PM" src="https://github.com/user-attachments/assets/19da3bcc-edac-4f2e-a505-af72fb77513e" />|

### Alternatives Considered

1. **Modify device.getDeviceId() to return GID instead of UUID**
   - ❌ Breaking change - [this is the most used API](https://observe.shopify.io/d/aez5i7xd4opoga/product-pos-ui-extensions-dashboard?orgId=1&from=now-7d&to=now&timezone=browser&var-shop_id=&refresh=1d&viewPanel=panel-14)
   - ❌ Loses physical device identity (UUID's cross-shop capability)
   - ❌ Loses offline functionality (Numeric ID requires active session)
   - ❌ UUID serves valid purposes that numeric ID cannot replace

2. **Add a conversion method like `device.toGid()`**
   - ❌ Requires async API call
   - ❌ Adds latency unnecessarily
   - ❌ Session should provide ready-to-use identifiers
  
3. Exposing GID on the DeviceAPI rather than SessionAPI
  - [The DeviceAPI currently returns data pertaining to a device specifically.](https://shopify.dev/docs/api/pos-ui-extensions/latest/target-apis/platform-apis/device-api). Adding the deviceGID here would be confusing with the existing getDeviceId function
  - [Meanwhile the SessionAPI returns data pertaining to the PointOfSale Session.](https://shopify.dev/docs/api/pos-ui-extensions/latest/target-apis/standard-apis/session-api)
  - Since the DeviceGID only exists in the context of device logged into a shop, it is more closely aligned with fields exposed in the SessionAPI rather than the DeviceAPI.
