### PR TITLE
Fix /snapit trigger in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,10 @@ on:
       - 20[0-9][0-9]-[01][1470]
       # RC version branches
       - 20[0-9][0-9]-[01][1470]-rc
+  # Snapit trigger - runs when /snapit comment is made on a PR
+  issue_comment:
+    types:
+      - created
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
### Background

The `/snapit` command wasn't working on PRs targeting the `2026-04-rc` branch. The `issue_comment` trigger was lost when merging from `2025-10` - likely a merge conflict resolution error.

Same fix as #3782 for the `2026-01` branch.

### Solution

Added the missing `issue_comment` trigger to the deploy workflow:

```yaml
issue_comment:
  types:
    - created
```

### Checklist

- [x] I have :tophat:'d these changes

---
🤖 This PR was generated with Claude Code