### PR TITLE
Expose picker and resource picker APIs for all rendering extensions

### DIFF
--- a/.changeset/expose-picker-apis-rendering-targets.md
+++ b/.changeset/expose-picker-apis-rendering-targets.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Admin: Expose picker and resource picker APIs for all rendering extensions

--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -1,5 +1,6 @@
 export type {I18n, I18nTranslate} from '../../api';
 export type {StandardApi, Intents} from './api/standard/standard';
+export type {StandardRenderingExtensionApi} from './api/standard/standard-rendering';
 export type {Navigation} from './api/block/block';
 export type {
   CustomerSegmentTemplateApi,

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.ts
@@ -1,11 +1,9 @@
-import type {StandardApi} from '../standard/standard';
+import type {StandardRenderingExtensionApi} from '../standard/standard-rendering';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 import type {Data} from '../shared';
-import type {ResourcePickerApi} from '../resource-picker/resource-picker';
-import type {PickerApi} from '../picker/picker';
 
 export interface ActionExtensionApi<ExtensionTarget extends AnyExtensionTarget>
-  extends StandardApi<ExtensionTarget> {
+  extends StandardRenderingExtensionApi<ExtensionTarget> {
   /**
    * Closes the extension. Calling this method is equivalent to the merchant clicking the "x" in the corner of the overlay.
    */
@@ -15,14 +13,4 @@ export interface ActionExtensionApi<ExtensionTarget extends AnyExtensionTarget>
    * Information about the currently viewed or selected items.
    */
   data: Data;
-
-  /**
-   * Renders the [Resource Picker](resource-picker), allowing users to select a resource for the extension to use as part of its flow.
-   */
-  resourcePicker: ResourcePickerApi;
-
-  /**
-   * Renders a custom [Picker](picker) dialog allowing users to select values from a list.
-   */
-  picker: PickerApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.ts
@@ -1,8 +1,6 @@
-import type {StandardApi} from '../standard/standard';
+import type {StandardRenderingExtensionApi} from '../standard/standard-rendering';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 import type {Data} from '../shared';
-import type {ResourcePickerApi} from '../resource-picker/resource-picker';
-import type {PickerApi} from '../picker/picker';
 
 export interface Navigation {
   /**
@@ -14,7 +12,7 @@ export interface Navigation {
 }
 
 export interface BlockExtensionApi<ExtensionTarget extends AnyExtensionTarget>
-  extends StandardApi<ExtensionTarget> {
+  extends StandardRenderingExtensionApi<ExtensionTarget> {
   /**
    * Information about the currently viewed or selected items.
    */
@@ -25,14 +23,4 @@ export interface BlockExtensionApi<ExtensionTarget extends AnyExtensionTarget>
    * For example, you can navigate from an admin block on the product details page (`admin.product-details.block.render`) to an admin action on the product details page (`admin.product-details.action.render`).
    */
   navigation: Navigation;
-
-  /**
-   * Renders the [Resource Picker](resource-picker), allowing users to select a resource for the extension to use as part of its flow.
-   */
-  resourcePicker: ResourcePickerApi;
-
-  /**
-   * Renders a custom [Picker](picker) dialog allowing users to select values from a list.
-   */
-  picker: PickerApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.ts
@@ -1,4 +1,4 @@
-import type {StandardApi} from '../standard/standard';
+import type {StandardRenderingExtensionApi} from '../standard/standard-rendering';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
 import {ApplyMetafieldChange} from './metafields';
@@ -6,7 +6,7 @@ import {ValidationData} from './launch-options';
 
 export interface ValidationSettingsApi<
   ExtensionTarget extends AnyExtensionTarget,
-> extends StandardApi<ExtensionTarget> {
+> extends StandardRenderingExtensionApi<ExtensionTarget> {
   /**
    * Applies a change to the validation settings.
    */

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.ts
@@ -1,11 +1,11 @@
-import type {StandardApi} from '../standard/standard';
+import type {StandardRenderingExtensionApi} from '../standard/standard-rendering';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 
 import {ApplyMetafieldsChange} from './metafields';
 import {Data} from './data';
 
 export interface OrderRoutingRuleApi<ExtensionTarget extends AnyExtensionTarget>
-  extends StandardApi<ExtensionTarget> {
+  extends StandardRenderingExtensionApi<ExtensionTarget> {
   applyMetafieldsChange: ApplyMetafieldsChange;
   data: Data;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -11,8 +11,6 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Target APIs',
   subCategory: 'Utility APIs',
   thumbnail: 'picker.png',
-  requires:
-    'an Admin [block](/docs/api/admin-extensions/unstable/extension-targets#block-locations), [action](/docs/api/admin-extensions/unstable/extension-targets#action-locations), or [print](/docs/api/admin-extensions/unstable/extension-targets#print-locations) extension.',
   defaultExample: {
     image: 'picker.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.ts
@@ -1,24 +1,12 @@
-import type {StandardApi} from '../standard/standard';
+import type {StandardRenderingExtensionApi} from '../standard/standard-rendering';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 import type {Data} from '../shared';
-import type {ResourcePickerApi} from '../resource-picker/resource-picker';
-import type {PickerApi} from '../picker/picker';
 
 export interface PrintActionExtensionApi<
   ExtensionTarget extends AnyExtensionTarget,
-> extends StandardApi<ExtensionTarget> {
+> extends StandardRenderingExtensionApi<ExtensionTarget> {
   /**
    * Information about the currently viewed or selected items.
    */
   data: Data;
-
-  /**
-   * Renders the [Resource Picker](resource-picker), allowing users to select a resource for the extension to use as part of its flow.
-   */
-  resourcePicker: ResourcePickerApi;
-
-  /**
-   * Renders a custom [Picker](picker) dialog allowing users to select values from a list.
-   */
-  picker: PickerApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -12,8 +12,6 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'Target APIs',
   subCategory: 'Utility APIs',
   thumbnail: 'resource-picker.png',
-  requires:
-    'an Admin [block](/docs/api/admin-extensions/unstable/extension-targets#block-locations), [action](/docs/api/admin-extensions/unstable/extension-targets#action-locations), or [print](/docs/api/admin-extensions/unstable/extension-targets#print-locations) extension.',
   defaultExample: {
     image: 'resource-picker.png',
     codeblock: {

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard-rendering.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard-rendering.ts
@@ -1,0 +1,18 @@
+import type {PickerApi} from '../picker/picker';
+import type {ResourcePickerApi} from '../resource-picker/resource-picker';
+import type {StandardApi} from './standard';
+import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+
+export interface StandardRenderingExtensionApi<
+  ExtensionTarget extends AnyExtensionTarget,
+> extends StandardApi<ExtensionTarget> {
+  /**
+   * Renders the [Resource Picker](resource-picker), allowing users to select a resource for the extension to use as part of its flow.
+   */
+  resourcePicker: ResourcePickerApi;
+
+  /**
+   * Renders a custom [Picker](picker) dialog allowing users to select values from a list.
+   */
+  picker: PickerApi;
+}


### PR DESCRIPTION
### Background

Cherry-pick of #3781 for the `2026-04-rc` branch.

Fixes a bug where picker and resource picker APIs were only available to block, action, and print extensions. This PR exposes them to all rendering extensions.

### Solution

Introduces `StandardRenderingExtensionApi` that extends `StandardApi` with `resourcePicker` and `picker` APIs. All rendering extension APIs (`BlockExtensionApi`, `ActionExtensionApi`, `PrintActionExtensionApi`, `ValidationSettingsApi`, `OrderRoutingRuleApi`) now extend this instead of `StandardApi` directly.

This keeps `StandardApi` minimal for non-rendering extensions like `admin.app.tools.data` that have no use for picker dialogs.

### 🎩

1. Generate an order routing rule settings extension `shopify app generate extension --template order_routing_location_rule_ui`
2. Verify that you can access `shopify.picker` and `shopify.resourcePicker`

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation

---
🤖 This PR was generated with Claude Code