### PR TITLE
[2026-01] Update metafield docs

### DIFF
--- a/.changeset/giant-trains-repeat.md
+++ b/.changeset/giant-trains-repeat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add deprecation warning to checkout metafield write APIs in Checkout UI Extension API

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -352,7 +352,11 @@ export interface GiftCardChangeResultError {
   message: string;
 }
 
-/** Removes a metafield. */
+/**
+ * Removes a metafield. This change type is deprecated and will be removed in a future API version. Use `MetafieldRemoveCartChange` instead.
+ *
+ * @deprecated - Consumers should use cart metafields instead.
+ */
 export interface MetafieldRemoveChange {
   /**
    * The type of the `MetafieldRemoveChange` API.
@@ -391,6 +395,9 @@ export interface MetafieldRemoveCartChange {
 /**
  * Updates a metafield. If a metafield with the
  * provided key and namespace does not already exist, it gets created.
+ * This change type is deprecated and will be removed in a future API version. Use `MetafieldUpdateCartChange` instead.
+ *
+ * @deprecated - Consumers should use cart metafields instead.
  */
 export interface MetafieldUpdateChange {
   /**
@@ -544,6 +551,8 @@ export interface CheckoutApi {
    * through the [`attributes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/attributes#standardapi-propertydetail-attributes) property.
    *
    * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   *
+   * @deprecated - Consumers should use cart metafields instead.
    */
   applyAttributeChange(change: AttributeChange): Promise<AttributeChangeResult>;
 
@@ -588,6 +597,10 @@ export interface CheckoutApi {
    * Performs an update on a piece of metadata attached to the checkout. If
    * successful, this mutation results in an update to the value retrieved
    * through the [`metafields`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/metafields#standardapi-propertydetail-metafields) property.
+   *
+   * Cart metafields will be copied to order metafields at order creation time if there is a matching order metafield definition with the [`cart to order copyable`](https://shopify.dev/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable) capability enabled.
+   *
+   * > Caution: `MetafieldRemoveChange` and `MetafieldUpdateChange` are deprecated. Use cart metafields with `MetafieldRemoveCartChange` and `MetafieldUpdateCartChange` instead. If `MetafieldUpdateChange` writes a metafield with the same namespace and key as a cart metafield that’s configured to copy, the cart metafield won’t be copied.
    *
    * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */


### PR DESCRIPTION
### Background

Add deprecation warning and guidance for `MetafieldRemoveChange` and `MetafieldUpdateChange` in checkout metafields API.

This PR will kick off a patch to `2026-01`. We typically do not do a release for doc changes, but making an exception here since we want developers to benefit from annotations while referencing types.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
