### PR TITLE
chore: update shopify-dev asset path

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -511,7 +511,7 @@ try {
     path.join(docsPath, 'screenshots'),
     path.join(
       shopifyDevPath,
-      'react-app/public/images/templated-apis-screenshots/admin',
+      'content-v2/assets/images/templated-apis-screenshots/admin',
     ),
     {recursive: true},
   );

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -113,7 +113,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
     fi
   done
 
-  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/react-app/public/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
+  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/content-v2/assets/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
   echo "Docs: https://shopify-dev.shop.dev/docs/api/checkout-ui-extensions"
 else
   echo "Not copying docs to shopify-dev because it was not found at $SHOPIFY_DEV_PATH."

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
@@ -85,7 +85,7 @@ const generateExtensionsDocs = async () => {
     path.join(docsPath, 'screenshots'),
     path.join(
       shopifyDevPath,
-      'react-app/public/images/templated-apis-screenshots/customer-account-ui-extensions',
+      'content-v2/assets/images/templated-apis-screenshots/customer-account-ui-extensions',
       EXTENSIONS_API_VERSION,
     ),
     {recursive: true},

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
@@ -144,7 +144,7 @@ const generateExtensionsDocs = async () => {
     path.join(docsPath, 'screenshots'),
     path.join(
       shopifyDevPath,
-      'react-app/public/images/templated-apis-screenshots/pos-ui-extensions',
+      'content-v2/assets/images/templated-apis-screenshots/pos-ui-extensions',
       EXTENSIONS_API_VERSION,
     ),
     {recursive: true},


### PR DESCRIPTION
### Background

Assets in shopify-dev are no longer under `react-app` and have moved to under `content-v2`

See https://github.com/Shopify/shopify-dev/pull/67138 for more context

This automated PR https://github.com/Shopify/shopify-dev/pull/67623 still attempts to copy assets into the old path, `build-docs.mjs` is called from the [extensibility](https://github.com/Shopify/extensibility/blob/2ee838e59f6c462fadcffb78c54847c5c17ace27/scripts/sync-docs.js#L99) repo and the path in `build-docs.mjs` is incorrect

### Solution

Update the path to the new asset path in shopify-dev

Also, is this something I will have to do for all the version branches in this repo? or will this suffice?

### 🎩

- review PRs mentioned and change

### Checklist

- [x] I have :tophat:'d these changes
- [] I have updated relevant documentation (is there any documentation for this?)
