### PR TITLE
Chore/update shopify dev asset path 2024 10

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
@@ -67,7 +67,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   if [ $sed_exit -ne 0 ]; then
     fail_and_exit $sed_exit
   fi
-  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/app/assets/images/templated-apis-screenshots/admin-extensions/$API_VERSION
+  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/content-v2/assets/images/templated-apis-screenshots/admin-extensions/$API_VERSION
 
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/admin-extensions"

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -84,7 +84,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   if [ $sed_exit -ne 0 ]; then
     fail_and_exit $sed_exit
   fi
-  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/app/assets/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
+  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/content-v2/assets/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
 
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/checkout-ui-extensions"

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.sh
@@ -83,7 +83,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   if [ $sed_exit -ne 0 ]; then
     fail_and_exit $sed_exit
   fi
-  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/app/assets/images/templated-apis-screenshots/customer-account-ui-extensions/$API_VERSION
+  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/content-v2/assets/images/templated-apis-screenshots/customer-account-ui-extensions/$API_VERSION
 
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/customer-account-ui-extensions"

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.sh
@@ -64,7 +64,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   if [ $sed_exit -ne 0 ]; then
     fail_and_exit $sed_exit
   fi
-  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/app/assets/images/templated-apis-screenshots/pos-ui-extensions/$API_VERSION
+  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/content-v2/assets/images/templated-apis-screenshots/pos-ui-extensions/$API_VERSION
 
   if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
     echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/pos-ui-extensions"


### PR DESCRIPTION
### Background

Assets in shopify-dev are no longer under `react-app` and have moved to under `content-v2`

See https://github.com/Shopify/shopify-dev/pull/67138 for more context

This automated PR https://github.com/Shopify/shopify-dev/pull/67623 still attempts to copy assets into the old path, `build-docs.mjs` is called from the [extensibility](https://github.com/Shopify/extensibility/blob/2ee838e59f6c462fadcffb78c54847c5c17ace27/scripts/sync-docs.js#L99) repo and the path in `build-docs.mjs` is incorrect

### Solution

Update the path to the new asset path in shopify-dev

Also, is this something I will have to do for all the version branches in this repo? or will this suffice?

### 🎩

- review PRs mentioned and change

### Checklist

- [x] I have :tophat:'d these changes
- [] I have updated relevant documentation (is there any documentation for this?)
