### PR TITLE
chore: update shopify-dev asset path

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
@@ -64,11 +64,11 @@ if [ -d ~/src/github.com/Shopify/shopify-dev ]; then
     fail_and_exit $sed_exit
   fi
   
-  mkdir -p ~/src/github.com/Shopify/shopify-dev/app/assets/images/templated-apis-screenshots/admin-extensions/$API_VERSION
-  rsync -a --delete ./$DOCS_PATH/screenshots/ ~/src/github.com/Shopify/shopify-dev/app/assets/images/templated-apis-screenshots/admin-extensions/$API_VERSION/
+  mkdir -p ~/src/github.com/Shopify/shopify-dev/content-v2/assets/images/templated-apis-screenshots/admin-extensions/$API_VERSION
+  rsync -a --delete ./$DOCS_PATH/screenshots/ ~/src/github.com/Shopify/shopify-dev/content-v2/assets/images/templated-apis-screenshots/admin-extensions/$API_VERSION/
 
   echo "✓ Docs copied to ~/src/github.com/Shopify/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION"
-  echo "✓ Screenshots copied to ~/src/github.com/Shopify/shopify-dev/app/assets/images/templated-apis-screenshots/admin-extensions/$API_VERSION"
+  echo "✓ Screenshots copied to ~/src/github.com/Shopify/shopify-dev/content-v2/assets/images/templated-apis-screenshots/admin-extensions/$API_VERSION"
 else
   echo "shopify-dev directory not found at ~/src/github.com/Shopify/shopify-dev - skipping docs copy"
 fi

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -56,7 +56,7 @@ if [ -d ../../../shopify-dev ]; then
     if [ $sed_exit -ne 0 ]; then
       fail_and_exit $sed_exit
     fi
-    rsync -a --delete ./$DOCS_PATH/screenshots/ ../../../shopify-dev/app/assets/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
+    rsync -a --delete ./$DOCS_PATH/screenshots/ ../../../shopify-dev/content-v2/assets/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
 else
   echo "Not copying docs to shopify-dev because it was not found at ../../../shopify-dev."
 fi


### PR DESCRIPTION
### Background

Assets in shopify-dev are no longer under `react-app` and have moved to under `content-v2`

See https://github.com/Shopify/shopify-dev/pull/67138 for more context

This automated PR https://github.com/Shopify/shopify-dev/pull/67623 still attempts to copy assets into the old path, `build-docs.mjs` is called from the [extensibility](https://github.com/Shopify/extensibility/blob/2ee838e59f6c462fadcffb78c54847c5c17ace27/scripts/sync-docs.js#L99) repo and the path in `build-docs.mjs` is incorrect

### Solution

Update the path to the new asset path in shopify-dev

Also, is this something I will have to do for all the version branches in this repo? or will this suffice?

### 🎩

- review PRs mentioned and change

### Checklist

- [x] I have :tophat:'d these changes
- [] I have updated relevant documentation (is there any documentation for this?)
