### PR TITLE
Update content for App Home Polaris component pages

### DIFF
--- a/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
@@ -3,7 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'ChoiceList',
   description:
-    'Present multiple options to users, allowing either single selections with radio buttons or multiple selections with checkboxes.',
+    'The `ChoiceList` component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
+    '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It offers multiple layout variants including list, inline, block, and grid formats to suit different space constraints and visual requirements.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/DateField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DateField.ts
@@ -2,7 +2,11 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'DateField',
-  description: 'Allow users to select a specific date with a date picker.',
+  description:
+    'The `DateField` component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
+    // Removed reference to DateSpinner (POS-specific component not available in App Home)
+    // Removed POS-specific links to DatePicker
+    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using `DatePicker`.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
@@ -2,7 +2,11 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'DatePicker',
-  description: 'Allow users to select a specific date or date range.',
+  description:
+    'The `DatePicker` component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
+    // Removed reference to DateSpinner (POS-specific component not available in App Home)
+    // Removed POS-specific link to DateField
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use `DateField`.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/EmailField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/EmailField.ts
@@ -3,7 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'EmailField',
   description:
-    'Let users enter email addresses with optimized keyboard settings.',
+    'The `EmailField` component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
+    "\n\n`EmailField` doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results.",
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/NumberField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/NumberField.ts
@@ -3,7 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'NumberField',
   description:
-    'Collect numerical values from users with optimized keyboard settings and built-in validation.',
+    'The `NumberField` component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
+    '\n\nThe component supports optional stepper controls, min/max constraints, and step increments for guided numeric entry.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/SearchField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/SearchField.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'SearchField',
   description:
-    'Let users enter search terms or find specific items using a single-line input field.',
+    'The `SearchField` component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/TextArea.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextArea.ts
@@ -3,7 +3,9 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'TextArea',
   description:
-    'Collect longer text content from users with a multi-line input that expands automatically.',
+    'The `TextArea` component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
+    // Removed POS-specific link to TextField
+    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use `TextField`.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/TextField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextField.ts
@@ -3,7 +3,9 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'TextField',
   description:
-    'Lets users enter or edit text within a single-line input. Use to collect short, free-form information from users.',
+    'The `TextField` component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
+    // Removed POS-specific link to TextArea
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use `TextArea`.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
@@ -12,18 +12,17 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- Include a title that tells merchants what to do or explains the available options
-- Label options clearly based on what the option will do
-- Avoid mutually exclusive options when allowing multiple selection`,
+      sectionContent: `
+- **Choose appropriate selection modes:** Use single selection for mutually exclusive options. Enable \`multiple\` when merchants can select more than one.
+- **Write clear, concise choice labels:** Keep labels short but descriptive enough that merchants understand each option without additional explanation.
+`,
     },
     {
-      title: 'Content guidelines',
+      title: 'Limitations',
       type: 'Generic' as const,
-      anchorLink: 'content-guidelines',
-      sectionContent: `- Write titles and choices in sentence case
-- End titles with a colon if they introduce the list
-- Start each choice with a capital letter
-- Don't use commas or semicolons at the end of lines`,
+      anchorLink: 'limitations',
+      sectionContent: `
+\`ChoiceList\` component types other than \`Choice\` can't be used as options within the choice list.`,
     },
   ],
   definitions: [

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
@@ -11,10 +11,11 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- Use smart defaults and highlight common selections
-- Use \`allow\` and \`disallow\` properties to restrict selectable dates appropriately
-- Provide clear labels and use details text to explain date restrictions
-- Don't use for dates that are many years in the future or the past`,
+      sectionContent: `
+- **Choose for direct text input:** Use \`DateField\` when users know the exact date and can type it efficiently. Use \`DatePicker\` for calendar selection.
+- **Explain date constraints:** Use \`details\` to clarify requirements like "Select a date within the next 30 days" or "Must be a future date."
+- **Write actionable error messages:** Provide clear validation messages for invalid dates that help users correct their input.
+`,
     },
   ],
   definitions: [

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
@@ -11,8 +11,10 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- Use smart defaults and highlight common selections
-- Don't use to enter a date that is many years in the future or the past`,
+      sectionContent: `
+- **Choose for calendar-based selection:** Use \`DatePicker\` when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use \`DateField\` when users know the exact date.
+- **Provide adequate space:** Ensure sufficient spacing around the picker to avoid interfering with on-screen keyboards or other interactive elements.
+`,
     },
   ],
   definitions: [

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
@@ -6,6 +6,18 @@ const data: AdminReferenceEntityTemplateSchema = {
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/emailfield.png',
   isVisualComponent: true,
+  subSections: [
+    {
+      title: 'Best practices',
+      type: 'Generic' as const,
+      anchorLink: 'best-practices',
+      sectionContent: `
+- **Write descriptive labels:** Use specific labels like "Customer Email" or "Receipt Email Address" rather than generic "Email."
+- **Provide context in details:** Use \`details\` for additional context like "Required for digital receipts" or "We'll send order updates to this address."
+- **Write actionable error messages:** Provide clear validation messages like "Please enter a valid email address" that help users correct their input.
+`,
+    },
+  ],
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
@@ -6,6 +6,18 @@ const data: AdminReferenceEntityTemplateSchema = {
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/numberfield.png',
   isVisualComponent: true,
+  subSections: [
+    {
+      title: 'Best practices',
+      type: 'Generic' as const,
+      anchorLink: 'best-practices',
+      sectionContent: `
+- **Choose appropriate controls:** Use \`stepper\` for quantities or small adjustments. Use \`none\` for prices or large values where steppers are impractical.
+- **Select the right input mode:** Use \`decimal\` for prices and measurements. Use \`numeric\` for quantities and counts.
+- **Explain constraints in details:** Use \`details\` to clarify valid ranges or formatting, like "Enter a quantity between 1 and 999."
+`,
+    },
+  ],
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
@@ -11,7 +11,12 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- The SearchField automatically includes a clear button when text is entered, so you should not create your own clear button`,
+      sectionContent: `
+- **Use for inline search and filtering:** Choose \`SearchField\` for filtering within specific sections or lists, not for global navigation or complex multi-step searches.
+- **Follow placeholder pattern:** Use "Search {items}" format like "Search products" or "Search customers" to clarify scope.
+- **Choose the right event:** Use \`input\` for real-time filtering as users type. Use \`change\` for expensive operations that should wait until typing completes.
+- **Handle empty values:** When the field is cleared, reset filters or show all items appropriately.
+`,
     },
   ],
   definitions: [

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
@@ -5,6 +5,18 @@ const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
   thumbnail: '/assets/templated-apis-screenshots/admin/components/textarea.png',
   isVisualComponent: true,
+  subSections: [
+    {
+      title: 'Best practices',
+      type: 'Generic' as const,
+      anchorLink: 'best-practices',
+      sectionContent: `
+- **Set appropriate row count:** Use 2-3 \`rows\` for brief notes, 4-6 for descriptions, and more for extensive content.
+- **Show character limit feedback:** When approaching \`maxLength\`, display remaining characters in the \`details\` text.
+- **Write descriptive labels:** Use specific labels like "Product Description" or "Special Instructions" rather than generic terms.
+`,
+    },
+  ],
   definitions: [
     {
       title: 'Properties',

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
@@ -6,6 +6,26 @@ const data: AdminReferenceEntityTemplateSchema = {
   thumbnail:
     '/assets/templated-apis-screenshots/admin/components/textfield.png',
   isVisualComponent: true,
+  subSections: [
+    {
+      title: 'Best practices',
+      type: 'Generic' as const,
+      anchorLink: 'best-practices',
+      sectionContent: `
+- **Use for single-line text input:** Choose \`TextField\` for short values like names, titles, or identifiers. For multi-line content, use \`TextArea\`.
+- **Show character limit feedback:** When approaching \`maxLength\`, display remaining characters in the \`details\` text.
+- **Write descriptive labels:** Use specific labels like "Product Name" or "Reference Code" rather than generic terms.
+`,
+    },
+    {
+      title: 'Limitations',
+      type: 'Generic' as const,
+      anchorLink: 'limitations',
+      sectionContent: `
+The \`accessory\` slot supports only \`Button\` and \`Clickable\` components with text content only—other component types or complex layouts can't be used for field accessories.
+`,
+    },
+  ],
   definitions: [
     {
       title: 'TextField',


### PR DESCRIPTION
### Background

We're revamping the App Home and App Bridge reference sections of the docs. This work includes updating the descriptions, best practices, limitations, etc. for the Polaris web component pages.

### Solution

This PR adds updated descriptions, best practices, and limitations for the following Polaris components:
ChoiceList
DatePicker
DateField
EmailField
NumberField
SearchField
TextArea
TextField

The content for these components is shared with the 2026-01 API version for the Admin UI extensions reference docs.
