### PR TITLE
[Target APIs content]: Examples and descriptions for 2025-01

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -22,8 +22,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Process selected products',
       tabs: [
-        {code: './examples/process-selected-products.ts', language: 'ts'},
-        {code: './examples/process-selected-products.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/process-selected-products.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/process-selected-products.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -37,7 +45,11 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select additional resources',
           tabs: [
-            {code: './examples/select-additional-resources.ts', language: 'ts'},
+            {
+              title: 'TS',
+              code: './examples/select-additional-resources.ts',
+              language: 'ts',
+            },
             {
               code: './examples/select-additional-resources.tsx',
               language: 'tsx',
@@ -51,8 +63,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Fulfill order with error handling',
           tabs: [
-            {code: './examples/handle-errors.ts', language: 'ts'},
-            {code: './examples/handle-errors.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/handle-errors.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/handle-errors.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -28,7 +28,8 @@ const data: ReferenceEntityTemplateSchema = {
     },
   },
   examples: {
-    description: 'Examples that demonstrate how to use the Action Extension API.',
+    description:
+      'Examples that demonstrate how to use the Action Extension API.',
     examples: [
       {
         description:

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -23,14 +23,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Process selected products',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/process-selected-products.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/process-selected-products.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/process-selected-products.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -64,14 +69,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Fulfill order with error handling',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/handle-errors.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/handle-errors.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/handle-errors.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Send selected product IDs to your backend for bulk processing. This example shows how to map items from `data.selected`, make an authenticated API call to `/api/bulk-process`, and close the modal with `close()` when the operation completes successfully.',
+      'Send selected product IDs to your backend for bulk processing operations like inventory updates, tag management, or status changes. This example demonstrates extracting product IDs from `data.selected`, posting them to your backend API, and closing the modal after successful processing.',
     codeblock: {
       title: 'Process selected products',
       tabs: [
@@ -28,11 +28,11 @@ const data: ReferenceEntityTemplateSchema = {
     },
   },
   examples: {
-    description: 'Action extension patterns',
+    description: 'Examples that demonstrate how to use the Action Extension API.',
     examples: [
       {
         description:
-          'Launch the resource picker to select component products for a bundle, then save the configuration to your backend. This example shows how to use `resourcePicker()` with `multiple: 5` to limit selection, send the main product and selected components to `/api/create-bundle`, and close the modal when complete—useful for bundle builders, kit assembly, or product grouping workflows.',
+          'Launch the [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select component products for a [bundle](/docs/apps/build/product-merchandising/bundles), then save the bundle configuration to your backend. This example demonstrates opening the resource picker from an action modal, limiting selection to 5 products, and posting the bundle composition to your API.',
         codeblock: {
           title: 'Select additional resources',
           tabs: [
@@ -46,7 +46,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Fulfill an order through your app backend with proper error handling. This example uses `try-catch` blocks to catch errors and logs failures when the fulfillment service encounters issues, essential for third-party fulfillment integrations or dropshipping workflows where backend operations might fail and need graceful degradation.',
+          'Fulfill an order through your app backend with proper error handling to catch and display failures from your fulfillment service. This example demonstrates using `try-catch` blocks to handle errors, displaying critical [banners](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/banner) when fulfillment fails, and closing the modal on success.',
         codeblock: {
           title: 'Fulfill order with error handling',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -99,7 +99,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.
 ' +
-        "- **Use `loading` state on buttons:** Modal actions don\'t show loading indicators automatically. Use the `loading` prop on [`Button`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
+        "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [`Button`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
     },
     {
       type: 'Generic',
@@ -108,11 +108,11 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- Action extensions must call `api.close()` to dismiss the modal. Modal actions remain open indefinitely until explicitly closed.
 ' +
-        "- Modal overlays can\'t be resized. The modal dimensions are fixed by the Shopify admin.
+        "- Modal overlays can't be resized. The modal dimensions are fixed by the Shopify admin.
 " +
-        "- Action extensions can\'t modify the page layout underneath the modal or persist UI after closing.
+        "- Action extensions can't modify the page layout underneath the modal or persist UI after closing.
 " +
-        "- Multiple modals can\'t be stacked. Opening a [picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) closes the current modal context temporarily.",
+        "- Multiple modals can't be stacked. Opening a [picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) closes the current modal context temporarily.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -97,7 +97,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.\n' +
+        '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.
+' +
         "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [`Button`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
     },
     {
@@ -105,9 +106,12 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Action extensions must call `api.close()` to dismiss the modal. Modal actions remain open indefinitely until explicitly closed.\n' +
-        "- Modal overlays can't be resized. The modal dimensions are fixed by the Shopify admin.\n" +
-        "- Action extensions can't modify the page layout underneath the modal or persist UI after closing.\n" +
+        '- Action extensions must call `api.close()` to dismiss the modal. Modal actions remain open indefinitely until explicitly closed.
+' +
+        "- Modal overlays can't be resized. The modal dimensions are fixed by the Shopify admin.
+" +
+        "- Action extensions can't modify the page layout underneath the modal or persist UI after closing.
+" +
         "- Multiple modals can't be stacked. Opening a [picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) closes the current modal context temporarily.",
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Send selected product IDs to your backend for bulk processing. This example shows how to map selected items from `data.selected`, make an authenticated API call, and close the action modal when the operation completes.',
+      'Send selected product IDs to your backend for bulk processing. This example shows how to map items from `data.selected`, make an authenticated API call to `/api/bulk-process`, and close the modal with `close()` when the operation completes successfully.',
     codeblock: {
       title: 'Process selected products',
       tabs: [
@@ -32,7 +32,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Launch the resource picker to select component products for a bundle, then save the bundle configuration to your backend. This example demonstrates opening a resource picker from within an action modal with a limit of 5 products, filtering out draft and archived items, and handling the selection result.',
+          'Launch the resource picker to select component products for a bundle, then save the configuration to your backend. This example shows how to use `resourcePicker()` with `multiple: 5` to limit selection, send the main product and selected components to `/api/create-bundle`, and close the modal when complete—useful for bundle builders, kit assembly, or product grouping workflows.',
         codeblock: {
           title: 'Select additional resources',
           tabs: [
@@ -46,7 +46,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Fulfill an order through your app backend with proper error handling. This example shows using `try-catch` blocks to catch errors, logging errors when your backend fulfillment service fails, and displaying error messages through console output.',
+          'Fulfill an order through your app backend with proper error handling. This example uses `try-catch` blocks to catch errors and logs failures when the fulfillment service encounters issues, essential for third-party fulfillment integrations or dropshipping workflows where backend operations might fail and need graceful degradation.',
         codeblock: {
           title: 'Fulfill order with error handling',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -99,7 +99,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.
 ' +
-        "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [`Button`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
+        "- **Use `loading` state on buttons:** Modal actions don\'t show loading indicators automatically. Use the `loading` prop on [`Button`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
     },
     {
       type: 'Generic',
@@ -108,11 +108,11 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- Action extensions must call `api.close()` to dismiss the modal. Modal actions remain open indefinitely until explicitly closed.
 ' +
-        "- Modal overlays can't be resized. The modal dimensions are fixed by the Shopify admin.
+        "- Modal overlays can\'t be resized. The modal dimensions are fixed by the Shopify admin.
 " +
-        "- Action extensions can't modify the page layout underneath the modal or persist UI after closing.
+        "- Action extensions can\'t modify the page layout underneath the modal or persist UI after closing.
 " +
-        "- Multiple modals can't be stacked. Opening a [picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) closes the current modal context temporarily.",
+        "- Multiple modals can\'t be stacked. Opening a [picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) closes the current modal context temporarily.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -16,6 +16,47 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ActionExtensionApi',
     },
   ],
+  defaultExample: {
+    description:
+      'Send selected product IDs to your backend for bulk processing. This example shows how to map selected items from `data.selected`, make an authenticated API call, and close the action modal when the operation completes.',
+    codeblock: {
+      title: 'Process selected products',
+      tabs: [
+        {code: './examples/process-selected-products.ts', language: 'ts'},
+        {code: './examples/process-selected-products.tsx', language: 'tsx'},
+      ],
+    },
+  },
+  examples: {
+    description: 'Action extension patterns',
+    examples: [
+      {
+        description:
+          'Launch the resource picker to select component products for a bundle, then save the bundle configuration to your backend. This example demonstrates opening a resource picker from within an action modal with a limit of 5 products, filtering out draft and archived items, and handling the selection result.',
+        codeblock: {
+          title: 'Select additional resources',
+          tabs: [
+            {code: './examples/select-additional-resources.ts', language: 'ts'},
+            {
+              code: './examples/select-additional-resources.tsx',
+              language: 'tsx',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Fulfill an order through your app backend with proper error handling. This example shows using `try-catch` blocks to catch errors, logging errors when your backend fulfillment service fails, and displaying error messages through console output.',
+        codeblock: {
+          title: 'Fulfill order with error handling',
+          tabs: [
+            {code: './examples/handle-errors.ts', language: 'ts'},
+            {code: './examples/handle-errors.tsx', language: 'tsx'},
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Core APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/handle-errors.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/handle-errors.ts
@@ -1,0 +1,26 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.order-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+
+    const orderId = data.selected[0]?.id;
+
+    fetch(`/api/orders/${orderId}/fulfill`, {
+      method: 'POST',
+    })
+      .then((response) => response.json())
+      .then((result) => {
+        if (result.success) {
+          console.log('Order fulfilled:', result);
+          close();
+        } else {
+          console.error('Fulfillment failed:', result.error);
+        }
+      })
+      .catch((error) => {
+        console.error('Error:', error.message);
+      });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/handle-errors.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/handle-errors.ts
@@ -1,26 +1,47 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Button, Banner} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.order-details.action.render',
   (root, api) => {
     const {data, close} = api;
 
-    const orderId = data.selected[0]?.id;
+    let errorBanner;
 
-    fetch(`/api/orders/${orderId}/fulfill`, {
-      method: 'POST',
-    })
-      .then((response) => response.json())
-      .then((result) => {
-        if (result.success) {
+    const button = root.createComponent(Button, {
+      title: 'Fulfill Order',
+      onPress: async () => {
+        // Remove any existing error banner
+        if (errorBanner) {
+          root.removeChild(errorBanner);
+          errorBanner = null;
+        }
+
+        try {
+          const orderId = data.selected[0]?.id;
+
+          const response = await fetch(`/api/orders/${orderId}/fulfill`, {
+            method: 'POST',
+          });
+
+          const result = await response.json();
+
+          if (!response.ok) {
+            throw new Error(result.error || 'Fulfillment failed');
+          }
+
           console.log('Order fulfilled:', result);
           close();
-        } else {
-          console.error('Fulfillment failed:', result.error);
+        } catch (err) {
+          errorBanner = root.createComponent(
+            Banner,
+            {status: 'critical'},
+            err.message,
+          );
+          root.insertChildBefore(errorBanner, button);
         }
-      })
-      .catch((error) => {
-        console.error('Error:', error.message);
-      });
+      },
+    });
+
+    root.appendChild(button);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/handle-errors.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/handle-errors.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const FulfillOrder = () => {
+  const {data, close} = useApi<'admin.order-details.action.render'>();
+
+  const handleFulfill = async () => {
+    try {
+      const orderId = data.selected[0]?.id;
+
+      const response = await fetch(`/api/orders/${orderId}/fulfill`, {
+        method: 'POST',
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        console.log('Order fulfilled:', result);
+        close();
+      } else {
+        console.error('Fulfillment failed:', result.error);
+      }
+    } catch (error) {
+      console.error('Error:', error.message);
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension(
+  'admin.order-details.action.render',
+  () => <FulfillOrder />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/handle-errors.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/handle-errors.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
   reactExtension,
   useApi,
+  Button,
+  Banner,
 } from '@shopify/ui-extensions-react/admin';
 
 const FulfillOrder = () => {
   const {data, close} = useApi<'admin.order-details.action.render'>();
+  const [error, setError] = useState<string | null>(null);
 
   const handleFulfill = async () => {
+    setError(null);
+
     try {
       const orderId = data.selected[0]?.id;
 
@@ -17,18 +22,23 @@ const FulfillOrder = () => {
 
       const result = await response.json();
 
-      if (result.success) {
-        console.log('Order fulfilled:', result);
-        close();
-      } else {
-        console.error('Fulfillment failed:', result.error);
+      if (!response.ok) {
+        throw new Error(result.error || 'Fulfillment failed');
       }
-    } catch (error) {
-      console.error('Error:', error.message);
+
+      console.log('Order fulfilled:', result);
+      close();
+    } catch (err) {
+      setError(err.message);
     }
   };
 
-  return null;
+  return (
+    <>
+      {error && <Banner status="critical">{error}</Banner>}
+      <Button title="Fulfill Order" onPress={handleFulfill} />
+    </>
+  );
 };
 
 export default reactExtension(

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/process-selected-products.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/process-selected-products.ts
@@ -1,27 +1,37 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.action.render',
   (root, api) => {
     const {data, close} = api;
 
-    const productIds = data.selected.map((item) => item.id);
+    const text = root.createComponent(
+      Text,
+      {},
+      `Processing ${data.selected.length} products`,
+    );
 
-    fetch('/api/bulk-process', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({productIds}),
-    })
-      .then((response) => {
+    const button = root.createComponent(Button, {
+      title: 'Process Products',
+      onPress: async () => {
+        const productIds = data.selected.map((item) => item.id);
+
+        const response = await fetch('/api/bulk-process', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({productIds}),
+        });
+
         if (response.ok) {
           console.log('Products processed successfully');
           close();
         } else {
           console.error('Failed to process products');
         }
-      })
-      .catch((error) => {
-        console.error('Error:', error);
-      });
+      },
+    });
+
+    root.appendChild(text);
+    root.appendChild(button);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/process-selected-products.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/process-selected-products.ts
@@ -1,0 +1,27 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+
+    const productIds = data.selected.map((item) => item.id);
+
+    fetch('/api/bulk-process', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({productIds}),
+    })
+      .then((response) => {
+        if (response.ok) {
+          console.log('Products processed successfully');
+          close();
+        } else {
+          console.error('Failed to process products');
+        }
+      })
+      .catch((error) => {
+        console.error('Error:', error);
+      });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/process-selected-products.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/process-selected-products.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {
   reactExtension,
   useApi,
+  Button,
+  Text,
 } from '@shopify/ui-extensions-react/admin';
 
 const ProcessProducts = () => {
@@ -24,7 +26,12 @@ const ProcessProducts = () => {
     }
   };
 
-  return null;
+  return (
+    <>
+      <Text>Processing {data.selected.length} products</Text>
+      <Button title="Process Products" onPress={handleProcess} />
+    </>
+  );
 };
 
 export default reactExtension(

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/process-selected-products.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/process-selected-products.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const ProcessProducts = () => {
+  const {data, close} = useApi<'admin.product-details.action.render'>();
+
+  const handleProcess = async () => {
+    const productIds = data.selected.map((item) => item.id);
+
+    const response = await fetch('/api/bulk-process', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({productIds}),
+    });
+
+    if (response.ok) {
+      console.log('Products processed successfully');
+      close();
+    } else {
+      console.error('Failed to process products');
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <ProcessProducts />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/select-additional-resources.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/select-additional-resources.ts
@@ -1,4 +1,4 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.action.render',
@@ -6,24 +6,48 @@ export default extension(
     const {data, resourcePicker, close} = api;
 
     const currentProductId = data.selected[0]?.id;
+    let selectedCount = 0;
 
-    resourcePicker({
-      type: 'product',
-      multiple: 5,
-      action: 'select',
-    }).then((selectedProducts) => {
-      if (selectedProducts) {
-        fetch('/api/create-bundle', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({
-            mainProduct: currentProductId,
-            components: selectedProducts.map((p) => p.id),
-          }),
-        }).then(() => {
-          close();
+    const mainText = root.createComponent(
+      Text,
+      {},
+      `Main product: ${currentProductId}`,
+    );
+
+    const button = root.createComponent(Button, {
+      title: 'Select Component Products',
+      onPress: async () => {
+        const selectedProducts = await resourcePicker({
+          type: 'product',
+          multiple: 5,
+          action: 'select',
         });
-      }
+
+        if (selectedProducts) {
+          selectedCount = selectedProducts.length;
+
+          await fetch('/api/create-bundle', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+              mainProduct: currentProductId,
+              components: selectedProducts.map((p) => p.id),
+            }),
+          });
+
+          const countText = root.createComponent(
+            Text,
+            {},
+            `Selected ${selectedCount} products`,
+          );
+          root.appendChild(countText);
+          
+          close();
+        }
+      },
     });
+
+    root.appendChild(mainText);
+    root.appendChild(button);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/select-additional-resources.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/select-additional-resources.ts
@@ -1,0 +1,29 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, resourcePicker, close} = api;
+
+    const currentProductId = data.selected[0]?.id;
+
+    resourcePicker({
+      type: 'product',
+      multiple: 5,
+      action: 'select',
+    }).then((selectedProducts) => {
+      if (selectedProducts) {
+        fetch('/api/create-bundle', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            mainProduct: currentProductId,
+            components: selectedProducts.map((p) => p.id),
+          }),
+        }).then(() => {
+          close();
+        });
+      }
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/select-additional-resources.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/select-additional-resources.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const SelectResources = () => {
+  const {data, resourcePicker, close} = useApi<'admin.product-details.action.render'>();
+
+  const handleSelect = async () => {
+    const currentProductId = data.selected[0]?.id;
+
+    const selectedProducts = await resourcePicker({
+      type: 'product',
+      multiple: 5,
+      action: 'select',
+    });
+
+    if (selectedProducts) {
+      await fetch('/api/create-bundle', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          mainProduct: currentProductId,
+          components: selectedProducts.map((p) => p.id),
+        }),
+      });
+
+      close();
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <SelectResources />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/action/examples/select-additional-resources.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/examples/select-additional-resources.tsx
@@ -1,15 +1,18 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
   reactExtension,
   useApi,
+  Button,
+  Text,
 } from '@shopify/ui-extensions-react/admin';
 
-const SelectResources = () => {
+const SelectComponents = () => {
   const {data, resourcePicker, close} = useApi<'admin.product-details.action.render'>();
+  const [selected, setSelected] = useState<any[] | null>(null);
 
-  const handleSelect = async () => {
-    const currentProductId = data.selected[0]?.id;
+  const currentProductId = data.selected[0]?.id;
 
+  const handleSelectProducts = async () => {
     const selectedProducts = await resourcePicker({
       type: 'product',
       multiple: 5,
@@ -17,6 +20,8 @@ const SelectResources = () => {
     });
 
     if (selectedProducts) {
+      setSelected(selectedProducts);
+
       await fetch('/api/create-bundle', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
@@ -30,10 +35,16 @@ const SelectResources = () => {
     }
   };
 
-  return null;
+  return (
+    <>
+      <Text>Main product: {currentProductId}</Text>
+      <Button title="Select Component Products" onPress={handleSelectProducts} />
+      {selected && <Text>Selected {selected.length} products</Text>}
+    </>
+  );
 };
 
 export default reactExtension(
   'admin.product-details.action.render',
-  () => <SelectResources />,
+  () => <SelectComponents />,
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -16,6 +16,44 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'BlockExtensionApi',
     },
   ],
+  defaultExample: {
+    description:
+      "Fetch and display a product's title, inventory, and status in a block extension. This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql) when the page loads, retrieves product data using the selected product's ID, and displays a loading state while fetching.",
+    codeblock: {
+      title: 'Display product information',
+      tabs: [
+        {code: './examples/display-product-info.ts', language: 'ts'},
+        {code: './examples/display-product-info.tsx', language: 'tsx'},
+      ],
+    },
+  },
+  examples: {
+    description: 'Block extension patterns',
+    examples: [
+      {
+        description:
+          'Check product eligibility with your backend API before launching an action extension. This example validates that the product meets criteria, shows a loading state during the check, and uses `navigation.navigate` to open the action extension when the product is approved.',
+        codeblock: {
+          title: 'Navigate to action extension',
+          tabs: [
+            {code: './examples/navigate-to-action.ts', language: 'ts'},
+            {code: './examples/navigate-to-action.tsx', language: 'tsx'},
+          ],
+        },
+      },
+      {
+        description:
+          'Open the resource picker to select related products, then save the associations to your backend. This example allows unlimited product selection using `multiple: true` and posts the relationship data when selection is confirmed.',
+        codeblock: {
+          title: 'Select related products',
+          tabs: [
+            {code: './examples/select-related-products.ts', language: 'ts'},
+            {code: './examples/select-related-products.tsx', language: 'tsx'},
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Core APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -14,8 +14,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Display product information',
       tabs: [
-        {code: './examples/display-product-info.ts', language: 'ts'},
-        {code: './examples/display-product-info.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/display-product-info.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/display-product-info.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -36,8 +44,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Navigate to action extension',
           tabs: [
-            {code: './examples/navigate-to-action.ts', language: 'ts'},
-            {code: './examples/navigate-to-action.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/navigate-to-action.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/navigate-to-action.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -47,8 +63,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select related products',
           tabs: [
-            {code: './examples/select-related-products.ts', language: 'ts'},
-            {code: './examples/select-related-products.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/select-related-products.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/select-related-products.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -8,17 +8,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'API',
   requires:
     'the [`AdminBlock`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
-  definitions: [
-    {
-      title: 'BlockExtensionApi',
-      description:
-        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following properties on the `BlockExtensionApi` object to interact with the current context, navigate to other extensions, and display picker dialogs.',
-      type: 'BlockExtensionApi',
-    },
-  ],
   defaultExample: {
     description:
-      "Fetch and display a product's title, inventory, and status in a block extension. This example shows how to use `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql) when the page loads, retrieving `title`, `totalInventory`, and `status` fields, while tracking loading state during the fetch operation.",
+      "Fetch and display a product's title, inventory, and status to provide quick insights directly on the product details page. This example demonstrates querying the [GraphQL Admin API](/docs/api/admin-graphql/) when the extension loads, showing a loading [`Spinner`](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/spinner) while fetching, and rendering product information as [`Text`](/docs/api/admin-extensions/{API_VERSION}/components/typography/text) components.",
     codeblock: {
       title: 'Display product information',
       tabs: [
@@ -27,29 +19,37 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  definitions: [
+    {
+      title: 'BlockExtensionApi',
+      description:
+        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following properties on the `BlockExtensionApi` object to interact with the current context, navigate to other extensions, and display picker dialogs.',
+      type: 'BlockExtensionApi',
+    },
+  ],
   examples: {
-    description: 'Block extension patterns',
+    description: 'Common block extension patterns',
     examples: [
       {
         description:
-          'Check product eligibility with your backend API before launching an action extension. This example demonstrates calling your backend eligibility endpoint with the product ID to validate that the product meets criteria, tracking the eligibility state, and using `navigation.navigate()` to open the action extension when the product is approved.',
+          'Check product eligibility with your backend API before showing advanced workflow options to prevent invalid operations on incompatible products. This example demonstrates fetching eligibility status from your backend, displaying a loading [`Spinner`](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/spinner) during the check, and conditionally showing a navigation [`Button`](/docs/api/admin-extensions/{API_VERSION}/components/actions/button) or ineligibility message.',
         codeblock: {
           title: 'Navigate to action extension',
           tabs: [
-            {code: './examples/navigate-to-action.ts', language: 'ts'},
-            {code: './examples/navigate-to-action.tsx', language: 'tsx'},
-          ],
+        {code: './examples/navigate-to-action.ts', language: 'ts'},
+        {code: './examples/navigate-to-action.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Open the resource picker to select related products, then save the associations to your backend. This example shows using `resourcePicker()` with `multiple: true` for unlimited selection, posting the relationship data to `/api/save-related`, and tracking the count of selected products.',
+          'Open the [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select related products for recommendation features, cross-selling, or product associations. This example demonstrates launching the resource picker with filters for published products, saving the relationships to your backend, and displaying confirmation feedback showing the count of added products.',
         codeblock: {
           title: 'Select related products',
           tabs: [
-            {code: './examples/select-related-products.ts', language: 'ts'},
-            {code: './examples/select-related-products.tsx', language: 'tsx'},
-          ],
+        {code: './examples/select-related-products.ts', language: 'ts'},
+        {code: './examples/select-related-products.tsx', language: 'tsx'},
+      ],
         },
       },
     ],

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -36,9 +36,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Navigate to action extension',
           tabs: [
-        {code: './examples/navigate-to-action.ts', language: 'ts'},
-        {code: './examples/navigate-to-action.tsx', language: 'tsx'},
-      ],
+            {code: './examples/navigate-to-action.ts', language: 'ts'},
+            {code: './examples/navigate-to-action.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -47,9 +47,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select related products',
           tabs: [
-        {code: './examples/select-related-products.ts', language: 'ts'},
-        {code: './examples/select-related-products.tsx', language: 'tsx'},
-      ],
+            {code: './examples/select-related-products.ts', language: 'ts'},
+            {code: './examples/select-related-products.tsx', language: 'tsx'},
+          ],
         },
       },
     ],

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      "Fetch and display a product's title, inventory, and status in a block extension. This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql) when the page loads, retrieves product data using the selected product's ID, and displays a loading state while fetching.",
+      "Fetch and display a product's title, inventory, and status in a block extension. This example shows how to use `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql) when the page loads, retrieving `title`, `totalInventory`, and `status` fields, while tracking loading state during the fetch operation.",
     codeblock: {
       title: 'Display product information',
       tabs: [
@@ -32,7 +32,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Check product eligibility with your backend API before launching an action extension. This example validates that the product meets criteria, shows a loading state during the check, and uses `navigation.navigate` to open the action extension when the product is approved.',
+          'Check product eligibility with your backend API before launching an action extension. This example demonstrates calling your backend eligibility endpoint with the product ID to validate that the product meets criteria, tracking the eligibility state, and using `navigation.navigate()` to open the action extension when the product is approved.',
         codeblock: {
           title: 'Navigate to action extension',
           tabs: [
@@ -43,7 +43,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Open the resource picker to select related products, then save the associations to your backend. This example allows unlimited product selection using `multiple: true` and posts the relationship data when selection is confirmed.',
+          'Open the resource picker to select related products, then save the associations to your backend. This example shows using `resourcePicker()` with `multiple: true` for unlimited selection, posting the relationship data to `/api/save-related`, and tracking the count of selected products.',
         codeblock: {
           title: 'Select related products',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -111,11 +111,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Block extensions share horizontal space with other blocks and must adapt to variable container widths. Placement order is determined by Shopify and can\'t be configured.
+        "- Block extensions share horizontal space with other blocks and must adapt to variable container widths. Placement order is determined by Shopify and can't be configured.
 " +
-        "- Navigation is limited to action extensions on the same resource page. You can\'t navigate to detail pages of other resources or to index pages.
+        "- Navigation is limited to action extensions on the same resource page. You can't navigate to detail pages of other resources or to index pages.
 " +
-        "- Block extensions don\'t have access to information about other extensions on the page and can\'t communicate with them.",
+        "- Block extensions don't have access to information about other extensions on the page and can't communicate with them.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -15,14 +15,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Display product information',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/display-product-info.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/display-product-info.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/display-product-info.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -45,14 +50,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Navigate to action extension',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/navigate-to-action.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/navigate-to-action.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/navigate-to-action.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -64,14 +74,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Select related products',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/select-related-products.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/select-related-products.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/select-related-products.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -111,11 +111,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Block extensions share horizontal space with other blocks and must adapt to variable container widths. Placement order is determined by Shopify and can't be configured.
+        "- Block extensions share horizontal space with other blocks and must adapt to variable container widths. Placement order is determined by Shopify and can\'t be configured.
 " +
-        "- Navigation is limited to action extensions on the same resource page. You can't navigate to detail pages of other resources or to index pages.
+        "- Navigation is limited to action extensions on the same resource page. You can\'t navigate to detail pages of other resources or to index pages.
 " +
-        "- Block extensions don't have access to information about other extensions on the page and can't communicate with them.",
+        "- Block extensions don\'t have access to information about other extensions on the page and can\'t communicate with them.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -102,7 +102,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Test layouts at narrow widths:** Block extensions render in responsive containers that resize with browser width. Test down to ~300px where blocks stack vertically to ensure your UI remains usable.\n' +
+        '- **Test layouts at narrow widths:** Block extensions render in responsive containers that resize with browser width. Test down to ~300px where blocks stack vertically to ensure your UI remains usable.
+' +
         '- **Defer expensive operations until user interaction:** Blocks render immediately when pages load. Defer expensive operations until user interaction to avoid slowing down page rendering for merchants.',
     },
     {
@@ -110,8 +111,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Block extensions share horizontal space with other blocks and must adapt to variable container widths. Placement order is determined by Shopify and can't be configured.\n" +
-        "- Navigation is limited to action extensions on the same resource page. You can't navigate to detail pages of other resources or to index pages.\n" +
+        "- Block extensions share horizontal space with other blocks and must adapt to variable container widths. Placement order is determined by Shopify and can't be configured.
+" +
+        "- Navigation is limited to action extensions on the same resource page. You can't navigate to detail pages of other resources or to index pages.
+" +
         "- Block extensions don't have access to information about other extensions on the page and can't communicate with them.",
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/display-product-info.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/display-product-info.ts
@@ -1,0 +1,26 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data, query} = api;
+
+    const productId = data.selected[0]?.id;
+
+    query(
+      `query GetProduct($id: ID!) {
+        product(id: $id) {
+          title
+          totalInventory
+          status
+        }
+      }`,
+      {variables: {id: productId}},
+    ).then(({data: productData}) => {
+      const product = productData.product;
+      console.log('Product:', product.title);
+      console.log('Inventory:', product.totalInventory);
+      console.log('Status:', product.status);
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/display-product-info.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/display-product-info.ts
@@ -1,4 +1,4 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Text, Spinner} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.block.render',
@@ -6,6 +6,8 @@ export default extension(
     const {data, query} = api;
 
     const productId = data.selected[0]?.id;
+    const spinner = root.createComponent(Spinner);
+    root.appendChild(spinner);
 
     query(
       `query GetProduct($id: ID!) {
@@ -18,9 +20,16 @@ export default extension(
       {variables: {id: productId}},
     ).then(({data: productData}) => {
       const product = productData.product;
-      console.log('Product:', product.title);
-      console.log('Inventory:', product.totalInventory);
-      console.log('Status:', product.status);
+      
+      root.removeChild(spinner);
+
+      const titleText = root.createComponent(Text, {}, `Title: ${product.title}`);
+      const inventoryText = root.createComponent(Text, {}, `Inventory: ${product.totalInventory}`);
+      const statusText = root.createComponent(Text, {}, `Status: ${product.status}`);
+
+      root.appendChild(titleText);
+      root.appendChild(inventoryText);
+      root.appendChild(statusText);
     });
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/display-product-info.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/display-product-info.tsx
@@ -1,31 +1,49 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {
   reactExtension,
   useApi,
+  Text,
+  Spinner,
 } from '@shopify/ui-extensions-react/admin';
 
 const ProductInfo = () => {
   const {data, query} = useApi<'admin.product-details.block.render'>();
-  const [product, setProduct] = useState(null);
+  const [product, setProduct] = useState<any>(null);
 
   useEffect(() => {
-    const productId = data.selected[0]?.id;
+    const fetchProduct = async () => {
+      const productId = data.selected[0]?.id;
 
-    query(
-      `query GetProduct($id: ID!) {
-        product(id: $id) {
-          title
-          totalInventory
-          status
-        }
-      }`,
-      {variables: {id: productId}},
-    ).then(({data: productData}) => {
+      const {data: productData} = await query(
+        `query GetProduct($id: ID!) {
+          product(id: $id) {
+            title
+            totalInventory
+            status
+          }
+        }`,
+        {variables: {id: productId}},
+      );
+
       setProduct(productData.product);
-    });
+    };
+
+    fetchProduct();
   }, [data, query]);
 
-  return null;
+  return (
+    <>
+      {product ? (
+        <>
+          <Text>Title: {product.title}</Text>
+          <Text>Inventory: {product.totalInventory}</Text>
+          <Text>Status: {product.status}</Text>
+        </>
+      ) : (
+        <Spinner />
+      )}
+    </>
+  );
 };
 
 export default reactExtension(

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/display-product-info.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/display-product-info.tsx
@@ -1,0 +1,34 @@
+import React, {useEffect, useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const ProductInfo = () => {
+  const {data, query} = useApi<'admin.product-details.block.render'>();
+  const [product, setProduct] = useState(null);
+
+  useEffect(() => {
+    const productId = data.selected[0]?.id;
+
+    query(
+      `query GetProduct($id: ID!) {
+        product(id: $id) {
+          title
+          totalInventory
+          status
+        }
+      }`,
+      {variables: {id: productId}},
+    ).then(({data: productData}) => {
+      setProduct(productData.product);
+    });
+  }, [data, query]);
+
+  return null;
+};
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <ProductInfo />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/navigate-to-action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/navigate-to-action.ts
@@ -1,0 +1,18 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data, navigation} = api;
+
+    const productId = data.selected[0]?.id;
+
+    fetch(`/api/products/${productId}/check-eligibility`)
+      .then((response) => response.json())
+      .then((result) => {
+        if (result.eligible) {
+          navigation.navigate('extension://my-admin-action-extension-handle');
+        }
+      });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/navigate-to-action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/navigate-to-action.ts
@@ -1,4 +1,4 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Button, Text, Spinner} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.block.render',
@@ -7,11 +7,36 @@ export default extension(
 
     const productId = data.selected[0]?.id;
 
-    fetch(`/api/products/${productId}/check-eligibility`)
+    if (!productId) {
+      return;
+    }
+
+    const spinner = root.createComponent(Spinner);
+    root.appendChild(spinner);
+
+    fetch(`/api/products/${productId}/check-eligibility`, {
+      method: 'GET',
+      headers: {'Content-Type': 'application/json'},
+    })
       .then((response) => response.json())
-      .then((result) => {
-        if (result.eligible) {
-          navigation.navigate('extension://my-admin-action-extension-handle');
+      .then(({eligible}) => {
+        root.removeChild(spinner);
+
+        if (eligible) {
+          const button = root.createComponent(Button, {
+            title: 'Launch Advanced Workflow',
+            onPress: () => {
+              navigation.navigate('extension://my-product-action-extension-handle');
+            },
+          });
+          root.appendChild(button);
+        } else {
+          const text = root.createComponent(
+            Text,
+            {},
+            'Product not eligible for advanced actions',
+          );
+          root.appendChild(text);
         }
       });
   },

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/navigate-to-action.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/navigate-to-action.tsx
@@ -1,0 +1,30 @@
+import React, {useEffect, useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const NavigateToAction = () => {
+  const {data, navigation} = useApi<'admin.product-details.block.render'>();
+  const [eligible, setEligible] = useState(false);
+
+  useEffect(() => {
+    const productId = data.selected[0]?.id;
+
+    fetch(`/api/products/${productId}/check-eligibility`)
+      .then((response) => response.json())
+      .then((result) => {
+        setEligible(result.eligible);
+        if (result.eligible) {
+          navigation.navigate('extension://my-admin-action-extension-handle');
+        }
+      });
+  }, [data, navigation]);
+
+  return null;
+};
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <NavigateToAction />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/navigate-to-action.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/navigate-to-action.tsx
@@ -1,27 +1,54 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {
   reactExtension,
   useApi,
+  Button,
+  Text,
+  Spinner,
 } from '@shopify/ui-extensions-react/admin';
 
 const NavigateToAction = () => {
   const {data, navigation} = useApi<'admin.product-details.block.render'>();
   const [eligible, setEligible] = useState(false);
+  const [checking, setChecking] = useState(true);
 
   useEffect(() => {
-    const productId = data.selected[0]?.id;
+    const checkEligibility = async () => {
+      const productId = data.selected[0]?.id;
 
-    fetch(`/api/products/${productId}/check-eligibility`)
-      .then((response) => response.json())
-      .then((result) => {
-        setEligible(result.eligible);
-        if (result.eligible) {
-          navigation.navigate('extension://my-admin-action-extension-handle');
-        }
+      if (!productId) {
+        setChecking(false);
+        return;
+      }
+
+      const response = await fetch(`/api/products/${productId}/check-eligibility`, {
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'},
       });
-  }, [data, navigation]);
 
-  return null;
+      const {eligible} = await response.json();
+      setEligible(eligible);
+      setChecking(false);
+    };
+
+    checkEligibility();
+  }, [data]);
+
+  const handleNavigate = () => {
+    navigation.navigate('extension://my-product-action-extension-handle');
+  };
+
+  return (
+    <>
+      {checking ? (
+        <Spinner />
+      ) : eligible ? (
+        <Button title="Launch Advanced Workflow" onPress={handleNavigate} />
+      ) : (
+        <Text>Product not eligible for advanced actions</Text>
+      )}
+    </>
+  );
 };
 
 export default reactExtension(

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/select-related-products.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/select-related-products.ts
@@ -1,23 +1,52 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.block.render',
   (root, api) => {
-    const {resourcePicker} = api;
+    const {data, resourcePicker} = api;
 
-    resourcePicker({
-      type: 'product',
-      multiple: true,
-    }).then((selectedProducts) => {
-      if (selectedProducts) {
-        fetch('/api/save-related-products', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({
-            productIds: selectedProducts.map((p) => p.id),
-          }),
+    const currentProductId = data.selected[0]?.id;
+    let relatedCount = 0;
+    let countText;
+
+    const button = root.createComponent(Button, {
+      title: 'Select Related Products',
+      onPress: async () => {
+        const selectedProducts = await resourcePicker({
+          type: 'product',
+          multiple: true,
+          filter: {
+            hidden: false,
+            draft: false,
+          },
         });
-      }
+
+        if (selectedProducts) {
+          await fetch('/api/product-recommendations', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+              productId: currentProductId,
+              relatedProducts: selectedProducts.map((p) => p.id),
+            }),
+          });
+
+          relatedCount = selectedProducts.length;
+          
+          if (countText) {
+            root.removeChild(countText);
+          }
+          
+          countText = root.createComponent(
+            Text,
+            {},
+            `Added ${relatedCount} related products`,
+          );
+          root.appendChild(countText);
+        }
+      },
     });
+
+    root.appendChild(button);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/select-related-products.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/select-related-products.ts
@@ -1,0 +1,23 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+
+    resourcePicker({
+      type: 'product',
+      multiple: true,
+    }).then((selectedProducts) => {
+      if (selectedProducts) {
+        fetch('/api/save-related-products', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            productIds: selectedProducts.map((p) => p.id),
+          }),
+        });
+      }
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/select-related-products.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/select-related-products.tsx
@@ -1,30 +1,47 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
   reactExtension,
   useApi,
+  Button,
+  Text,
 } from '@shopify/ui-extensions-react/admin';
 
 const SelectRelatedProducts = () => {
-  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const {data, resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [relatedCount, setRelatedCount] = useState(0);
 
-  const handleSelect = async () => {
+  const currentProductId = data.selected[0]?.id;
+
+  const handleSelectRelated = async () => {
     const selectedProducts = await resourcePicker({
       type: 'product',
       multiple: true,
+      filter: {
+        hidden: false,
+        draft: false,
+      },
     });
 
     if (selectedProducts) {
-      await fetch('/api/save-related-products', {
+      await fetch('/api/product-recommendations', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
-          productIds: selectedProducts.map((p) => p.id),
+          productId: currentProductId,
+          relatedProducts: selectedProducts.map((p) => p.id),
         }),
       });
+
+      setRelatedCount(selectedProducts.length);
     }
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Related Products" onPress={handleSelectRelated} />
+      {relatedCount > 0 && <Text>Added {relatedCount} related products</Text>}
+    </>
+  );
 };
 
 export default reactExtension(

--- a/packages/ui-extensions/src/surfaces/admin/api/block/examples/select-related-products.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/examples/select-related-products.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const SelectRelatedProducts = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+
+  const handleSelect = async () => {
+    const selectedProducts = await resourcePicker({
+      type: 'product',
+      multiple: true,
+    });
+
+    if (selectedProducts) {
+      await fetch('/api/save-related-products', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          productIds: selectedProducts.map((p) => p.id),
+        }),
+      });
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <SelectRelatedProducts />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/configure-shipping-restrictions.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/configure-shipping-restrictions.ts
@@ -1,22 +1,72 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, TextField, Button, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.settings.validation.render',
   (root, api) => {
-    const {applyMetafieldChange} = api;
+    const {data, applyMetafieldChange} = api;
 
-    const blockedCountries = ['US', 'CA', 'MX'];
+    let countries = 'US, CA, GB';
+    let errorMsg = 'Shipping not available to your location';
 
-    applyMetafieldChange({
-      type: 'updateMetafield',
-      key: 'blocked_countries',
-      namespace: 'validation',
-      value: JSON.stringify(blockedCountries),
-      valueType: 'json',
-    }).then((result) => {
-      if (result.type === 'success') {
-        console.log('Shipping restrictions saved');
-      }
+    const stack = root.createComponent(BlockStack);
+
+    const countriesField = root.createComponent(TextField, {
+      label: 'Blocked countries (comma-separated)',
+      value: countries,
+      onChange: (value) => {
+        countries = value;
+      },
     });
+
+    const errorField = root.createComponent(TextField, {
+      label: 'Error message',
+      value: errorMsg,
+      onChange: (value) => {
+        errorMsg = value;
+      },
+    });
+
+    const saveButton = root.createComponent(Button, {
+      title: 'Save Restrictions',
+      onPress: async () => {
+        const blockedCountries = countries.split(',').map((c) => c.trim());
+
+        await applyMetafieldChange({
+          type: 'updateMetafield',
+          namespace: 'validation',
+          key: 'blocked_shipping_countries',
+          value: JSON.stringify(blockedCountries),
+          valueType: 'json',
+        });
+
+        await applyMetafieldChange({
+          type: 'updateMetafield',
+          namespace: 'validation',
+          key: 'error_message',
+          value: errorMsg,
+          valueType: 'single_line_text_field',
+        });
+      },
+    });
+
+    const validationIdText = root.createComponent(
+      Text,
+      {},
+      `Validation ID: ${data.validation?.id}`,
+    );
+
+    const functionIdText = root.createComponent(
+      Text,
+      {},
+      `Function ID: ${data.shopifyFunction.id}`,
+    );
+
+    stack.appendChild(countriesField);
+    stack.appendChild(errorField);
+    stack.appendChild(saveButton);
+    stack.appendChild(validationIdText);
+    stack.appendChild(functionIdText);
+
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/configure-shipping-restrictions.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/configure-shipping-restrictions.ts
@@ -1,0 +1,22 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.settings.validation.render',
+  (root, api) => {
+    const {applyMetafieldChange} = api;
+
+    const blockedCountries = ['US', 'CA', 'MX'];
+
+    applyMetafieldChange({
+      type: 'updateMetafield',
+      key: 'blocked_countries',
+      namespace: 'validation',
+      value: JSON.stringify(blockedCountries),
+      valueType: 'json',
+    }).then((result) => {
+      if (result.type === 'success') {
+        console.log('Shipping restrictions saved');
+      }
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/configure-shipping-restrictions.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/configure-shipping-restrictions.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const ConfigureShippingRestrictions = () => {
+  const {applyMetafieldChange} = useApi<'admin.settings.validation.render'>();
+
+  const handleSave = async () => {
+    const blockedCountries = ['US', 'CA', 'MX'];
+
+    const result = await applyMetafieldChange({
+      type: 'updateMetafield',
+      key: 'blocked_countries',
+      namespace: 'validation',
+      value: JSON.stringify(blockedCountries),
+      valueType: 'json',
+    });
+
+    if (result.type === 'success') {
+      console.log('Shipping restrictions saved');
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension(
+  'admin.settings.validation.render',
+  () => <ConfigureShippingRestrictions />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/configure-shipping-restrictions.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/configure-shipping-restrictions.tsx
@@ -1,29 +1,55 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
   reactExtension,
   useApi,
+  TextField,
+  Button,
+  Text,
+  BlockStack,
 } from '@shopify/ui-extensions-react/admin';
 
 const ConfigureShippingRestrictions = () => {
-  const {applyMetafieldChange} = useApi<'admin.settings.validation.render'>();
+  const {data, applyMetafieldChange} = useApi<'admin.settings.validation.render'>();
+  const [countries, setCountries] = useState('US, CA, GB');
+  const [errorMsg, setErrorMsg] = useState('Shipping not available to your location');
 
   const handleSave = async () => {
-    const blockedCountries = ['US', 'CA', 'MX'];
+    const blockedCountries = countries.split(',').map((c) => c.trim());
 
-    const result = await applyMetafieldChange({
+    await applyMetafieldChange({
       type: 'updateMetafield',
-      key: 'blocked_countries',
       namespace: 'validation',
+      key: 'blocked_shipping_countries',
       value: JSON.stringify(blockedCountries),
       valueType: 'json',
     });
 
-    if (result.type === 'success') {
-      console.log('Shipping restrictions saved');
-    }
+    await applyMetafieldChange({
+      type: 'updateMetafield',
+      namespace: 'validation',
+      key: 'error_message',
+      value: errorMsg,
+      valueType: 'single_line_text_field',
+    });
   };
 
-  return null;
+  return (
+    <BlockStack>
+      <TextField
+        label="Blocked countries (comma-separated)"
+        value={countries}
+        onChange={setCountries}
+      />
+      <TextField
+        label="Error message"
+        value={errorMsg}
+        onChange={setErrorMsg}
+      />
+      <Button title="Save Restrictions" onPress={handleSave} />
+      <Text>Validation ID: {data.validation?.id}</Text>
+      <Text>Function ID: {data.shopifyFunction.id}</Text>
+    </BlockStack>
+  );
 };
 
 export default reactExtension(

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/load-validation-config.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/load-validation-config.ts
@@ -1,20 +1,49 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Text, Spinner} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.settings.validation.render',
   (root, api) => {
-    const {data} = api;
+    const {data, applyMetafieldChange} = api;
 
-    if (data.validation) {
-      const metafields = data.validation.metafields;
-      const config = metafields.reduce((acc, mf) => {
-        acc[mf.key] = mf.value;
-        return acc;
-      }, {});
-      
-      console.log('Existing validation:', config);
-    } else {
-      console.log('Creating new validation');
-    }
+    const spinner = root.createComponent(Spinner);
+    root.appendChild(spinner);
+
+    const initializeSettings = async () => {
+      root.removeChild(spinner);
+
+      if (data.validation) {
+        // Edit mode - load existing metafields
+        const config = data.validation.metafields.reduce((acc, field) => {
+          acc[field.key] = field.value;
+          return acc;
+        }, {});
+
+        const editText = root.createComponent(Text, {}, 'Editing existing validation');
+        root.appendChild(editText);
+
+        Object.entries(config).forEach(([key, value]) => {
+          const fieldText = root.createComponent(Text, {}, `${key}: ${value}`);
+          root.appendChild(fieldText);
+        });
+      } else {
+        // Create mode - set defaults
+        await applyMetafieldChange({
+          type: 'updateMetafield',
+          namespace: 'validation',
+          key: 'default_rule',
+          value: 'require_minimum_cart_total',
+          valueType: 'single_line_text_field',
+        });
+
+        const createdText = root.createComponent(
+          Text,
+          {},
+          'Created new validation configuration',
+        );
+        root.appendChild(createdText);
+      }
+    };
+
+    initializeSettings();
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/load-validation-config.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/load-validation-config.ts
@@ -1,0 +1,20 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.settings.validation.render',
+  (root, api) => {
+    const {data} = api;
+
+    if (data.validation) {
+      const metafields = data.validation.metafields;
+      const config = metafields.reduce((acc, mf) => {
+        acc[mf.key] = mf.value;
+        return acc;
+      }, {});
+      
+      console.log('Existing validation:', config);
+    } else {
+      console.log('Creating new validation');
+    }
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/load-validation-config.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/load-validation-config.tsx
@@ -1,26 +1,60 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {
   reactExtension,
   useApi,
+  Text,
+  Spinner,
 } from '@shopify/ui-extensions-react/admin';
 
 const LoadValidationConfig = () => {
-  const {data} = useApi<'admin.settings.validation.render'>();
-  const [config, setConfig] = useState(null);
+  const {data, applyMetafieldChange} = useApi<'admin.settings.validation.render'>();
+  const [mode, setMode] = useState<'loading' | 'edit' | 'created'>('loading');
+  const [settings, setSettings] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (data.validation) {
-      const metafields = data.validation.metafields;
-      const loadedConfig = metafields.reduce((acc, mf) => {
-        acc[mf.key] = mf.value;
-        return acc;
-      }, {});
-      
-      setConfig(loadedConfig);
-    }
-  }, [data]);
+    const initializeSettings = async () => {
+      if (data.validation) {
+        // Edit mode - load existing metafields
+        const config = data.validation.metafields.reduce((acc, field) => {
+          acc[field.key] = field.value;
+          return acc;
+        }, {});
 
-  return null;
+        setSettings(config);
+        setMode('edit');
+      } else {
+        // Create mode - set defaults
+        await applyMetafieldChange({
+          type: 'updateMetafield',
+          namespace: 'validation',
+          key: 'default_rule',
+          value: 'require_minimum_cart_total',
+          valueType: 'single_line_text_field',
+        });
+
+        setMode('created');
+      }
+    };
+
+    initializeSettings();
+  }, [data, applyMetafieldChange]);
+
+  return (
+    <>
+      {mode === 'loading' && <Spinner />}
+      {mode === 'edit' && (
+        <>
+          <Text>Editing existing validation</Text>
+          {Object.entries(settings).map(([key, value]) => (
+            <Text key={key}>
+              {key}: {value}
+            </Text>
+          ))}
+        </>
+      )}
+      {mode === 'created' && <Text>Created new validation configuration</Text>}
+    </>
+  );
 };
 
 export default reactExtension(

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/load-validation-config.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/load-validation-config.tsx
@@ -1,0 +1,29 @@
+import React, {useEffect, useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const LoadValidationConfig = () => {
+  const {data} = useApi<'admin.settings.validation.render'>();
+  const [config, setConfig] = useState(null);
+
+  useEffect(() => {
+    if (data.validation) {
+      const metafields = data.validation.metafields;
+      const loadedConfig = metafields.reduce((acc, mf) => {
+        acc[mf.key] = mf.value;
+        return acc;
+      }, {});
+      
+      setConfig(loadedConfig);
+    }
+  }, [data]);
+
+  return null;
+};
+
+export default reactExtension(
+  'admin.settings.validation.render',
+  () => <LoadValidationConfig />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/set-minimum-quantity.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/set-minimum-quantity.ts
@@ -1,0 +1,22 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.settings.validation.render',
+  (root, api) => {
+    const {applyMetafieldChange} = api;
+
+    applyMetafieldChange({
+      type: 'updateMetafield',
+      key: 'min_quantity',
+      namespace: 'validation',
+      value: '5',
+      valueType: 'number_integer',
+    }).then((result) => {
+      if (result.type === 'success') {
+        console.log('Minimum quantity saved');
+      } else {
+        console.error('Error:', result.message);
+      }
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/set-minimum-quantity.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/set-minimum-quantity.ts
@@ -1,22 +1,55 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, NumberField, Button, Banner} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.settings.validation.render',
   (root, api) => {
     const {applyMetafieldChange} = api;
 
-    applyMetafieldChange({
-      type: 'updateMetafield',
-      key: 'min_quantity',
-      namespace: 'validation',
-      value: '5',
-      valueType: 'number_integer',
-    }).then((result) => {
-      if (result.type === 'success') {
-        console.log('Minimum quantity saved');
-      } else {
-        console.error('Error:', result.message);
-      }
+    let quantity = '3';
+    let resultBanner;
+
+    const numberField = root.createComponent(NumberField, {
+      label: 'Minimum quantity',
+      value: quantity,
+      onChange: (value) => {
+        quantity = value;
+      },
     });
+
+    const saveButton = root.createComponent(Button, {
+      title: 'Save Validation',
+      onPress: async () => {
+        const result = await applyMetafieldChange({
+          type: 'updateMetafield',
+          namespace: 'validation',
+          key: 'minimum_quantity',
+          value: quantity,
+          valueType: 'number_integer',
+        });
+
+        if (resultBanner) {
+          root.removeChild(resultBanner);
+        }
+
+        if (result.type === 'success') {
+          resultBanner = root.createComponent(
+            Banner,
+            {status: 'success'},
+            'Minimum quantity configured',
+          );
+        } else {
+          resultBanner = root.createComponent(
+            Banner,
+            {status: 'critical'},
+            result.message,
+          );
+        }
+
+        root.appendChild(resultBanner);
+      },
+    });
+
+    root.appendChild(numberField);
+    root.appendChild(saveButton);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/set-minimum-quantity.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/set-minimum-quantity.tsx
@@ -1,29 +1,45 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
   reactExtension,
   useApi,
+  NumberField,
+  Button,
+  Banner,
 } from '@shopify/ui-extensions-react/admin';
 
 const SetMinimumQuantity = () => {
   const {applyMetafieldChange} = useApi<'admin.settings.validation.render'>();
+  const [quantity, setQuantity] = useState('3');
+  const [result, setResult] = useState<{type: string; message?: string} | null>(null);
 
   const handleSave = async () => {
-    const result = await applyMetafieldChange({
+    const res = await applyMetafieldChange({
       type: 'updateMetafield',
-      key: 'min_quantity',
       namespace: 'validation',
-      value: '5',
+      key: 'minimum_quantity',
+      value: quantity,
       valueType: 'number_integer',
     });
 
-    if (result.type === 'success') {
-      console.log('Minimum quantity saved');
-    } else {
-      console.error('Error:', result.message);
-    }
+    setResult(res);
   };
 
-  return null;
+  return (
+    <>
+      <NumberField
+        label="Minimum quantity"
+        value={quantity}
+        onChange={setQuantity}
+      />
+      <Button title="Save Validation" onPress={handleSave} />
+      {result?.type === 'success' && (
+        <Banner status="success">Minimum quantity configured</Banner>
+      )}
+      {result?.type === 'error' && (
+        <Banner status="critical">{result.message}</Banner>
+      )}
+    </>
+  );
 };
 
 export default reactExtension(

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/set-minimum-quantity.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/examples/set-minimum-quantity.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const SetMinimumQuantity = () => {
+  const {applyMetafieldChange} = useApi<'admin.settings.validation.render'>();
+
+  const handleSave = async () => {
+    const result = await applyMetafieldChange({
+      type: 'updateMetafield',
+      key: 'min_quantity',
+      namespace: 'validation',
+      value: '5',
+      valueType: 'number_integer',
+    });
+
+    if (result.type === 'success') {
+      console.log('Minimum quantity saved');
+    } else {
+      console.error('Error:', result.message);
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension(
+  'admin.settings.validation.render',
+  () => <SetMinimumQuantity />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -101,20 +101,20 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Check operation result type:** `applyMetafieldChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don\'t throw exceptions, so always check the returned `type` property.",
+        "- **Check operation result type:** `applyMetafieldChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don't throw exceptions, so always check the returned `type` property.",
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can\'t exceed 256KB, and total metafield storage per validation is limited.
+        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can't exceed 256KB, and total metafield storage per validation is limited.
 " +
         '- The `applyMetafieldChange` method is sequential. Operations process one at a time. Rapid successive calls can cause race conditions where later updates overwrite earlier ones.
 ' +
         '- Metafield changes apply immediately. Unlike admin forms, metafield changes persist right away without waiting for merchants to save.
 ' +
-        "- Your extension can\'t modify the Function ID. The `shopifyFunctionId` is read-only and determined when the validation rule is created.",
+        "- Your extension can't modify the Function ID. The `shopifyFunctionId` is read-only and determined when the validation rule is created.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -24,7 +24,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Save a minimum quantity validation rule to a metafield. This example calls `applyMetafieldChange` with an integer value of 5, then checks the result type to confirm success or handle errors.',
+      'Save a minimum quantity validation rule to a metafield. This example shows calling `applyMetafieldChange()` with key `min_quantity`, value `5`, and `valueType: "number_integer"`, then checking if `result.type === "success"` to confirm the operation or log errors.',
     codeblock: {
       title: 'Set minimum quantity',
       tabs: [
@@ -38,7 +38,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Block shipping to specific countries with custom error messages. This example saves blocked countries (US, CA, MX) as a JSON array and stores the configuration in a validation metafield for use by your checkout function.',
+          'Block shipping to specific countries with custom error messages. This example shows saving blocked countries (US, CA, MX) as a JSON array using `applyMetafieldChange()` with key `blocked_countries` and `valueType: "json"`, storing the configuration in the `validation` namespace for use by your checkout function.',
         codeblock: {
           title: 'Configure shipping restrictions',
           tabs: [
@@ -55,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Detect whether the merchant is editing an existing validation or creating a new one. This example checks for the presence of `data.validation`, loads existing metafields if found, and initializes default values for a new validation otherwise.',
+          'Detect whether the merchant is editing an existing validation or creating a new one. Checks for `data.validation` presence, loads existing metafields if found, or initializes defaults for new validations—useful for edit/create workflows where you need to prepopulate forms with existing settings.',
         codeblock: {
           title: 'Load validation configuration',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -108,9 +108,12 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can't exceed 256KB, and total metafield storage per validation is limited.\n" +
-        '- The `applyMetafieldChange` method is sequential. Operations process one at a time. Rapid successive calls can cause race conditions where later updates overwrite earlier ones.\n' +
-        '- Metafield changes apply immediately. Unlike admin forms, metafield changes persist right away without waiting for merchants to save.\n' +
+        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can't exceed 256KB, and total metafield storage per validation is limited.
+" +
+        '- The `applyMetafieldChange` method is sequential. Operations process one at a time. Rapid successive calls can cause race conditions where later updates overwrite earlier ones.
+' +
+        '- Metafield changes apply immediately. Unlike admin forms, metafield changes persist right away without waiting for merchants to save.
+' +
         "- Your extension can't modify the Function ID. The `shopifyFunctionId` is read-only and determined when the validation rule is created.",
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -29,14 +29,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Set minimum quantity',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/set-minimum-quantity.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/set-minimum-quantity.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/set-minimum-quantity.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -68,14 +73,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Load validation configuration',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/load-validation-config.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/load-validation-config.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/load-validation-config.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -22,6 +22,50 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ValidationData',
     },
   ],
+  defaultExample: {
+    description:
+      'Save a minimum quantity validation rule to a metafield. This example calls `applyMetafieldChange` with an integer value of 5, then checks the result type to confirm success or handle errors.',
+    codeblock: {
+      title: 'Set minimum quantity',
+      tabs: [
+        {code: './examples/set-minimum-quantity.ts', language: 'ts'},
+        {code: './examples/set-minimum-quantity.tsx', language: 'tsx'},
+      ],
+    },
+  },
+  examples: {
+    description: 'Configure cart and checkout validation rules',
+    examples: [
+      {
+        description:
+          'Block shipping to specific countries with custom error messages. This example saves blocked countries (US, CA, MX) as a JSON array and stores the configuration in a validation metafield for use by your checkout function.',
+        codeblock: {
+          title: 'Configure shipping restrictions',
+          tabs: [
+            {
+              code: './examples/configure-shipping-restrictions.ts',
+              language: 'ts',
+            },
+            {
+              code: './examples/configure-shipping-restrictions.tsx',
+              language: 'tsx',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Detect whether the merchant is editing an existing validation or creating a new one. This example checks for the presence of `data.validation`, loads existing metafields if found, and initializes default values for a new validation otherwise.',
+        codeblock: {
+          title: 'Load validation configuration',
+          tabs: [
+            {code: './examples/load-validation-config.ts', language: 'ts'},
+            {code: './examples/load-validation-config.tsx', language: 'tsx'},
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Contextual APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -28,8 +28,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Set minimum quantity',
       tabs: [
-        {code: './examples/set-minimum-quantity.ts', language: 'ts'},
-        {code: './examples/set-minimum-quantity.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/set-minimum-quantity.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/set-minimum-quantity.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -59,8 +67,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Load validation configuration',
           tabs: [
-            {code: './examples/load-validation-config.ts', language: 'ts'},
-            {code: './examples/load-validation-config.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/load-validation-config.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/load-validation-config.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -101,20 +101,20 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Check operation result type:** `applyMetafieldChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don't throw exceptions, so always check the returned `type` property.",
+        "- **Check operation result type:** `applyMetafieldChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don\'t throw exceptions, so always check the returned `type` property.",
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can't exceed 256KB, and total metafield storage per validation is limited.
+        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can\'t exceed 256KB, and total metafield storage per validation is limited.
 " +
         '- The `applyMetafieldChange` method is sequential. Operations process one at a time. Rapid successive calls can cause race conditions where later updates overwrite earlier ones.
 ' +
         '- Metafield changes apply immediately. Unlike admin forms, metafield changes persist right away without waiting for merchants to save.
 ' +
-        "- Your extension can't modify the Function ID. The `shopifyFunctionId` is read-only and determined when the validation rule is created.",
+        "- Your extension can\'t modify the Function ID. The `shopifyFunctionId` is read-only and determined when the validation rule is created.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -24,7 +24,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Save a minimum quantity validation rule to a metafield. This example shows calling `applyMetafieldChange()` with key `min_quantity`, value `5`, and `valueType: "number_integer"`, then checking if `result.type === "success"` to confirm the operation or log errors.',
+      'Save a minimum quantity validation rule to enforce purchase minimums at checkout, preventing orders below your threshold. This example demonstrates using a [`NumberField`](/docs/api/admin-extensions/{API_VERSION}/components/forms/numberfield) for quantity input, calling `applyMetafieldChange` to save the value, and displaying success or error [`Banners`](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/banner) based on the operation result.',
     codeblock: {
       title: 'Set minimum quantity',
       tabs: [
@@ -38,7 +38,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Block shipping to specific countries with custom error messages. This example shows saving blocked countries (US, CA, MX) as a JSON array using `applyMetafieldChange()` with key `blocked_countries` and `valueType: "json"`, storing the configuration in the `validation` namespace for use by your checkout function.',
+          'Block shipping to specific countries with custom error messages to comply with regulations or prevent fulfillment to restricted locations. This example demonstrates using [`TextField`](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) inputs for countries and error messages, saving the configuration as JSON metafields, and displaying validation and function IDs for reference.',
         codeblock: {
           title: 'Configure shipping restrictions',
           tabs: [
@@ -55,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Detect whether the merchant is editing an existing validation or creating a new one. Checks for `data.validation` presence, loads existing metafields if found, or initializes defaults for new validations—useful for edit/create workflows where you need to prepopulate forms with existing settings.',
+          "Detect whether you're editing an existing validation or creating a new one to provide appropriate UI for both create and edit workflows. This example demonstrates checking for `data.validation` presence, loading and displaying existing metafield configuration if found, or initializing default validation settings and applying them for new validation rules.",
         codeblock: {
           title: 'Load validation configuration',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -12,8 +12,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Target high-value customers',
       tabs: [
-        {code: './examples/high-value-customers.ts', language: 'ts'},
-        {code: './examples/high-value-customers.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/high-value-customers.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/high-value-customers.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -34,8 +42,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Target customers with birthdays this month',
           tabs: [
-            {code: './examples/birthday-this-month.ts', language: 'ts'},
-            {code: './examples/birthday-this-month.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/birthday-this-month.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/birthday-this-month.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -45,8 +61,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: "Target customers who started checkout but didn't finish",
           tabs: [
-            {code: './examples/abandoned-cart-recovery.ts', language: 'ts'},
-            {code: './examples/abandoned-cart-recovery.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/abandoned-cart-recovery.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/abandoned-cart-recovery.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -100,7 +100,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Test queries in admin before shipping:** Template queries aren't validated until merchants save them. Test query syntax in the [Shopify admin segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments) before shipping to avoid merchant-facing errors.
+        "- **Test queries in admin before shipping:** Template queries aren\'t validated until merchants save them. Test query syntax in the [Shopify admin segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments) before shipping to avoid merchant-facing errors.
 " +
         '- **Declare all metafield dependencies:** Use both `standardMetafields` (for Shopify-defined metafields) and `customMetafields` (for app-defined metafields) in the `dependencies` object. Missing dependencies cause queries to fail when merchants lack required metafields.
 ' +
@@ -111,13 +111,13 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Query validation only occurs when merchants save. Syntax errors in queries aren't caught by the API and only surface in the admin when merchants attempt to save the segment.
+        "- Query validation only occurs when merchants save. Syntax errors in queries aren\'t caught by the API and only surface in the admin when merchants attempt to save the segment.
 " +
-        "- Your extension can't programmatically create segments. Templates only provide the query and metadata. Merchants must manually save templates as segments.
+        "- Your extension can\'t programmatically create segments. Templates only provide the query and metadata. Merchants must manually save templates as segments.
 " +
-        "- Dependencies don't auto-create metafields. If required metafields don't exist, then merchants see errors when trying to use the template. The API only declares dependencies, it doesn't create them.
+        "- Dependencies don\'t auto-create metafields. If required metafields don\'t exist, then merchants see errors when trying to use the template. The API only declares dependencies, it doesn\'t create them.
 " +
-        "- Dynamic query generation isn't supported. Queries must be static strings. You can't parameterize queries based on merchant input or shop configuration.",
+        "- Dynamic query generation isn\'t supported. Queries must be static strings. You can\'t parameterize queries based on merchant input or shop configuration.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -16,6 +16,44 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'CustomerSegmentTemplateApi',
     },
   ],
+  defaultExample: {
+    description:
+      'Create a segment template targeting customers who spent $500+ across 5+ orders. This example uses `total_spent` and `orders_count` queries to identify high-value customers, and demonstrates using `shopify.i18n.translate` for internationalized template titles and descriptions.',
+    codeblock: {
+      title: 'Target high-value customers',
+      tabs: [
+        {code: './examples/high-value-customers.ts', language: 'ts'},
+        {code: './examples/high-value-customers.tsx', language: 'tsx'},
+      ],
+    },
+  },
+  examples: {
+    description: 'Pre-built customer segment templates',
+    examples: [
+      {
+        description:
+          'Create a segment template targeting customers with birthdays this month. This example requires the `facts.birth_date` metafield to be set up, and queries the metafields namespace with the current month value to enable birthday-based customer targeting.',
+        codeblock: {
+          title: 'Target customers with birthdays this month',
+          tabs: [
+            {code: './examples/birthday-this-month.ts', language: 'ts'},
+            {code: './examples/birthday-this-month.tsx', language: 'tsx'},
+          ],
+        },
+      },
+      {
+        description:
+          'Create a segment template targeting customers who abandoned at least one checkout in the last 7 days. This example uses `abandoned_checkouts_count` and `last_abandoned_order_date` queries with dynamic date calculation to identify customers for recovery outreach.',
+        codeblock: {
+          title: "Target customers who started checkout but didn't finish",
+          tabs: [
+            {code: './examples/abandoned-cart-recovery.ts', language: 'ts'},
+            {code: './examples/abandoned-cart-recovery.tsx', language: 'tsx'},
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Contextual APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -3,22 +3,12 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Customer Segment Template Extension API',
   description:
-    'The Customer Segment Template Extension API lets you [build a customer segment template extension](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension). Merchants can use your templates to quickly set up [customer segments](/docs/apps/build/marketing-analytics/customer-segments) based on custom criteria.',
+    'The Customer Segment Template Extension API lets you [build a customer segment template extension](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension). Merchants can use your templates to set up [customer segments](/docs/apps/build/marketing-analytics/customer-segments) based on custom criteria.',
   isVisualComponent: false,
   type: 'API',
-  requires:
-    'the [`CustomerSegmentTemplate`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/other/customersegmenttemplate) component.',
-  definitions: [
-    {
-      title: 'CustomerSegmentTemplateApi',
-      description:
-        'The `CustomerSegmentTemplateApi` object includes tools for creating segment templates and translating content. Access the following properties on the `CustomerSegmentTemplateApi` object in the `admin.customers.segmentation-templates.render` target.',
-      type: 'CustomerSegmentTemplateApi',
-    },
-  ],
   defaultExample: {
     description:
-      'Create a segment template targeting customers who spent $500+ across 5+ orders. This example uses `total_spent` and `orders_count` queries to identify high-value customers, which enables VIP loyalty programs or premium tier targeting.',
+      'Create a segment template targeting customers who spent $500+ across 5+ orders. This example uses `total_spent` and `orders_count` queries to identify high-value customers, and demonstrates `shopify.i18n.translate` for internationalized template titles and descriptions.',
     codeblock: {
       title: 'Target high-value customers',
       tabs: [
@@ -27,12 +17,20 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  definitions: [
+    {
+      title: 'CustomerSegmentTemplateApi',
+      description:
+        'The `CustomerSegmentTemplateApi` object includes tools for creating segment templates and translating content. Access the following properties on the `CustomerSegmentTemplateApi` object in the `admin.customers.segmentation-templates.data` target.',
+      type: 'CustomerSegmentTemplateApi',
+    },
+  ],
   examples: {
     description: 'Pre-built customer segment templates',
     examples: [
       {
         description:
-          'Create a segment template targeting customers with birthdays this month. Requires the `facts.birth_date` metafield to be set up, which enables birthday-based customer targeting for marketing campaigns.',
+          'Create a segment template targeting customers with birthdays this month. This example requires the `facts.birth_date` metafield to be set up, which enables birthday-based customer targeting for marketing campaigns.',
         codeblock: {
           title: 'Target customers with birthdays this month',
           tabs: [
@@ -65,7 +63,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         "- **Test queries in admin before shipping:** Template queries aren't validated until merchants save them. Test query syntax in the [Shopify admin segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments) before shipping to avoid merchant-facing errors.\n" +
         '- **Declare all metafield dependencies:** Use both `standardMetafields` (for Shopify-defined metafields) and `customMetafields` (for app-defined metafields) in the `dependencies` object. Missing dependencies cause queries to fail when merchants lack required metafields.\n' +
-        '- **Use `queryToInsert` for formatted display queries:** If your `query` includes formatting or comments for readability, then provide a clean executable version in `queryToInsert`. If omitting `queryToInsert`, then ensure `query` has no comments that would break execution.',
+        '- **Use `queryToInsert` for formatted display queries:** If your `query` includes formatting or comments for readability, provide a clean executable version in `queryToInsert`. If omitting `queryToInsert`, ensure `query` has no comments that would break execution.',
     },
     {
       type: 'Generic',
@@ -74,7 +72,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         "- Query validation only occurs when merchants save. Syntax errors in queries aren't caught by the API and only surface in the admin when merchants attempt to save the segment.\n" +
         "- Your extension can't programmatically create segments. Templates only provide the query and metadata. Merchants must manually save templates as segments.\n" +
-        "- Dependencies don't auto-create metafields. If required metafields don't exist, then merchants see errors when trying to use the template. The API only declares dependencies, it doesn't create them.\n" +
+        "- Dependencies don't auto-create metafields. If required metafields don't exist, merchants see errors when trying to use the template. The API only declares dependencies, it doesn't create them.\n" +
         "- Dynamic query generation isn't supported. Queries must be static strings. You can't parameterize queries based on merchant input or shop configuration.",
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -13,23 +13,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Target high-value customers',
       tabs: [
         {
-
           title: 'React',
 
           code: './examples/high-value-customers.tsx',
 
           language: 'tsx',
-
         },
 
         {
-
           title: 'TS',
 
           code: './examples/high-value-customers.ts',
 
           language: 'ts',
-
         },
       ],
     },
@@ -52,23 +48,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Target customers with birthdays this month',
           tabs: [
             {
-
               title: 'React',
 
               code: './examples/birthday-this-month.tsx',
 
               language: 'tsx',
-
             },
 
             {
-
               title: 'TS',
 
               code: './examples/birthday-this-month.ts',
 
               language: 'ts',
-
             },
           ],
         },
@@ -80,23 +72,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: "Target customers who started checkout but didn't finish",
           tabs: [
             {
-
               title: 'React',
 
               code: './examples/abandoned-cart-recovery.tsx',
 
               language: 'tsx',
-
             },
 
             {
-
               title: 'TS',
 
               code: './examples/abandoned-cart-recovery.ts',
 
               language: 'ts',
-
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -100,7 +100,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Test queries in admin before shipping:** Template queries aren\'t validated until merchants save them. Test query syntax in the [Shopify admin segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments) before shipping to avoid merchant-facing errors.
+        "- **Test queries in admin before shipping:** Template queries aren't validated until merchants save them. Test query syntax in the [Shopify admin segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments) before shipping to avoid merchant-facing errors.
 " +
         '- **Declare all metafield dependencies:** Use both `standardMetafields` (for Shopify-defined metafields) and `customMetafields` (for app-defined metafields) in the `dependencies` object. Missing dependencies cause queries to fail when merchants lack required metafields.
 ' +
@@ -111,13 +111,13 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Query validation only occurs when merchants save. Syntax errors in queries aren\'t caught by the API and only surface in the admin when merchants attempt to save the segment.
+        "- Query validation only occurs when merchants save. Syntax errors in queries aren't caught by the API and only surface in the admin when merchants attempt to save the segment.
 " +
-        "- Your extension can\'t programmatically create segments. Templates only provide the query and metadata. Merchants must manually save templates as segments.
+        "- Your extension can't programmatically create segments. Templates only provide the query and metadata. Merchants must manually save templates as segments.
 " +
-        "- Dependencies don\'t auto-create metafields. If required metafields don\'t exist, then merchants see errors when trying to use the template. The API only declares dependencies, it doesn\'t create them.
+        "- Dependencies don't auto-create metafields. If required metafields don't exist, then merchants see errors when trying to use the template. The API only declares dependencies, it doesn't create them.
 " +
-        "- Dynamic query generation isn\'t supported. Queries must be static strings. You can\'t parameterize queries based on merchant input or shop configuration.",
+        "- Dynamic query generation isn't supported. Queries must be static strings. You can't parameterize queries based on merchant input or shop configuration.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Create a segment template targeting customers who spent $500+ across 5+ orders. This example uses `total_spent` and `orders_count` queries to identify high-value customers, and demonstrates using `shopify.i18n.translate` for internationalized template titles and descriptions.',
+      'Create a segment template targeting customers who spent $500+ across 5+ orders. This example uses `total_spent` and `orders_count` queries to identify high-value customers, which enables VIP loyalty programs or premium tier targeting.',
     codeblock: {
       title: 'Target high-value customers',
       tabs: [
@@ -32,7 +32,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Create a segment template targeting customers with birthdays this month. This example requires the `facts.birth_date` metafield to be set up, and queries the metafields namespace with the current month value to enable birthday-based customer targeting.',
+          'Create a segment template targeting customers with birthdays this month. Requires the `facts.birth_date` metafield to be set up, which enables birthday-based customer targeting for marketing campaigns.',
         codeblock: {
           title: 'Target customers with birthdays this month',
           tabs: [
@@ -43,7 +43,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Create a segment template targeting customers who abandoned at least one checkout in the last 7 days. This example uses `abandoned_checkouts_count` and `last_abandoned_order_date` queries with dynamic date calculation to identify customers for recovery outreach.',
+          'Create a segment template targeting customers who abandoned at least one checkout in the last 7 days. This example uses `abandoned_checkouts_count` and `last_abandoned_order_date` queries with dynamic date calculation to identify customers for abandoned cart email outreach.',
         codeblock: {
           title: "Target customers who started checkout but didn't finish",
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -13,14 +13,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Target high-value customers',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/high-value-customers.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/high-value-customers.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/high-value-customers.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -43,14 +48,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Target customers with birthdays this month',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/birthday-this-month.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/birthday-this-month.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/birthday-this-month.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -62,14 +72,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: "Target customers who started checkout but didn't finish",
           tabs: [
             {
-              title: 'TS',
-              code: './examples/abandoned-cart-recovery.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/abandoned-cart-recovery.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/abandoned-cart-recovery.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -13,19 +13,23 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Target high-value customers',
       tabs: [
         {
+
           title: 'React',
 
           code: './examples/high-value-customers.tsx',
 
           language: 'tsx',
+
         },
 
         {
+
           title: 'TS',
 
           code: './examples/high-value-customers.ts',
 
           language: 'ts',
+
         },
       ],
     },
@@ -48,19 +52,23 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Target customers with birthdays this month',
           tabs: [
             {
+
               title: 'React',
 
               code: './examples/birthday-this-month.tsx',
 
               language: 'tsx',
+
             },
 
             {
+
               title: 'TS',
 
               code: './examples/birthday-this-month.ts',
 
               language: 'ts',
+
             },
           ],
         },
@@ -72,19 +80,23 @@ const data: ReferenceEntityTemplateSchema = {
           title: "Target customers who started checkout but didn't finish",
           tabs: [
             {
+
               title: 'React',
 
               code: './examples/abandoned-cart-recovery.tsx',
 
               language: 'tsx',
+
             },
 
             {
+
               title: 'TS',
 
               code: './examples/abandoned-cart-recovery.ts',
 
               language: 'ts',
+
             },
           ],
         },
@@ -102,7 +114,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         "- **Test queries in admin before shipping:** Template queries aren't validated until merchants save them. Test query syntax in the [Shopify admin segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments) before shipping to avoid merchant-facing errors.\n" +
         '- **Declare all metafield dependencies:** Use both `standardMetafields` (for Shopify-defined metafields) and `customMetafields` (for app-defined metafields) in the `dependencies` object. Missing dependencies cause queries to fail when merchants lack required metafields.\n' +
-        '- **Use `queryToInsert` for formatted display queries:** If your `query` includes formatting or comments for readability, provide a clean executable version in `queryToInsert`. If omitting `queryToInsert`, ensure `query` has no comments that would break execution.',
+        '- **Use `queryToInsert` for formatted display queries:** If your `query` includes formatting or comments for readability, then provide a clean executable version in `queryToInsert`. If omitting `queryToInsert`, then ensure `query` has no comments that would break execution.',
     },
     {
       type: 'Generic',
@@ -111,7 +123,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         "- Query validation only occurs when merchants save. Syntax errors in queries aren't caught by the API and only surface in the admin when merchants attempt to save the segment.\n" +
         "- Your extension can't programmatically create segments. Templates only provide the query and metadata. Merchants must manually save templates as segments.\n" +
-        "- Dependencies don't auto-create metafields. If required metafields don't exist, merchants see errors when trying to use the template. The API only declares dependencies, it doesn't create them.\n" +
+        "- Dependencies don't auto-create metafields. If required metafields don't exist, then merchants see errors when trying to use the template. The API only declares dependencies, it doesn't create them.\n" +
         "- Dynamic query generation isn't supported. Queries must be static strings. You can't parameterize queries based on merchant input or shop configuration.",
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -100,8 +100,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Test queries in admin before shipping:** Template queries aren't validated until merchants save them. Test query syntax in the [Shopify admin segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments) before shipping to avoid merchant-facing errors.\n" +
-        '- **Declare all metafield dependencies:** Use both `standardMetafields` (for Shopify-defined metafields) and `customMetafields` (for app-defined metafields) in the `dependencies` object. Missing dependencies cause queries to fail when merchants lack required metafields.\n' +
+        "- **Test queries in admin before shipping:** Template queries aren't validated until merchants save them. Test query syntax in the [Shopify admin segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments) before shipping to avoid merchant-facing errors.
+" +
+        '- **Declare all metafield dependencies:** Use both `standardMetafields` (for Shopify-defined metafields) and `customMetafields` (for app-defined metafields) in the `dependencies` object. Missing dependencies cause queries to fail when merchants lack required metafields.
+' +
         '- **Use `queryToInsert` for formatted display queries:** If your `query` includes formatting or comments for readability, then provide a clean executable version in `queryToInsert`. If omitting `queryToInsert`, then ensure `query` has no comments that would break execution.',
     },
     {
@@ -109,9 +111,12 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Query validation only occurs when merchants save. Syntax errors in queries aren't caught by the API and only surface in the admin when merchants attempt to save the segment.\n" +
-        "- Your extension can't programmatically create segments. Templates only provide the query and metadata. Merchants must manually save templates as segments.\n" +
-        "- Dependencies don't auto-create metafields. If required metafields don't exist, then merchants see errors when trying to use the template. The API only declares dependencies, it doesn't create them.\n" +
+        "- Query validation only occurs when merchants save. Syntax errors in queries aren't caught by the API and only surface in the admin when merchants attempt to save the segment.
+" +
+        "- Your extension can't programmatically create segments. Templates only provide the query and metadata. Merchants must manually save templates as segments.
+" +
+        "- Dependencies don't auto-create metafields. If required metafields don't exist, then merchants see errors when trying to use the template. The API only declares dependencies, it doesn't create them.
+" +
         "- Dynamic query generation isn't supported. Queries must be static strings. You can't parameterize queries based on merchant input or shop configuration.",
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/abandoned-cart-recovery.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/abandoned-cart-recovery.ts
@@ -1,21 +1,30 @@
 import {extension} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'admin.customers.segmentation-templates.render',
-  (root, api) => {
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
-
+  'admin.customers.segmentation-templates.data',
+  () => {
     return {
       templates: [
         {
           title: 'Cart abandoners',
-          description: 'Customers who abandoned carts in the last 7 days',
+          description: [
+            'Customers who abandoned carts in the last 7 days',
+            'Use this segment for email recovery campaigns',
+          ],
           query: `{
   abandoned_checkouts_count: {
     min: 1
   }
   last_abandoned_order_date: {
-    min: "${sevenDaysAgo}"
+    min: "${new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()}"
+  }
+}`,
+          queryToInsert: `{
+  abandoned_checkouts_count: {
+    min: 1
+  }
+  last_abandoned_order_date: {
+    min: "LAST_7_DAYS"
   }
 }`,
           createdOn: '2025-01-15T00:00:00Z',

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/abandoned-cart-recovery.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/abandoned-cart-recovery.ts
@@ -1,0 +1,26 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.customers.segmentation-templates.render',
+  (root, api) => {
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    return {
+      templates: [
+        {
+          title: 'Cart abandoners',
+          description: 'Customers who abandoned carts in the last 7 days',
+          query: `{
+  abandoned_checkouts_count: {
+    min: 1
+  }
+  last_abandoned_order_date: {
+    min: "${sevenDaysAgo}"
+  }
+}`,
+          createdOn: '2025-01-15T00:00:00Z',
+        },
+      ],
+    };
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/abandoned-cart-recovery.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/abandoned-cart-recovery.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const AbandonedCartRecovery = () => {
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  return {
+    templates: [
+      {
+        title: 'Cart abandoners',
+        description: 'Customers who abandoned carts in the last 7 days',
+        query: `{
+  abandoned_checkouts_count: {
+    min: 1
+  }
+  last_abandoned_order_date: {
+    min: "${sevenDaysAgo}"
+  }
+}`,
+        createdOn: '2025-01-15T00:00:00Z',
+      },
+    ],
+  };
+};
+
+export default reactExtension(
+  'admin.customers.segmentation-templates.render',
+  () => <AbandonedCartRecovery />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/abandoned-cart-recovery.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/abandoned-cart-recovery.tsx
@@ -1,23 +1,28 @@
-import React from 'react';
-import {
-  reactExtension,
-  useApi,
-} from '@shopify/ui-extensions-react/admin';
+import {reactExtension} from '@shopify/ui-extensions-react/admin';
 
 const AbandonedCartRecovery = () => {
-  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
-
   return {
     templates: [
       {
         title: 'Cart abandoners',
-        description: 'Customers who abandoned carts in the last 7 days',
+        description: [
+          'Customers who abandoned carts in the last 7 days',
+          'Use this segment for email recovery campaigns',
+        ],
         query: `{
   abandoned_checkouts_count: {
     min: 1
   }
   last_abandoned_order_date: {
-    min: "${sevenDaysAgo}"
+    min: "${new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()}"
+  }
+}`,
+        queryToInsert: `{
+  abandoned_checkouts_count: {
+    min: 1
+  }
+  last_abandoned_order_date: {
+    min: "LAST_7_DAYS"
   }
 }`,
         createdOn: '2025-01-15T00:00:00Z',
@@ -27,6 +32,6 @@ const AbandonedCartRecovery = () => {
 };
 
 export default reactExtension(
-  'admin.customers.segmentation-templates.render',
-  () => <AbandonedCartRecovery />,
+  'admin.customers.segmentation-templates.data',
+  () => AbandonedCartRecovery(),
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/birthday-this-month.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/birthday-this-month.ts
@@ -1,0 +1,28 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.customers.segmentation-templates.render',
+  (root, api) => {
+    return {
+      templates: [
+        {
+          title: 'Birthday this month',
+          description: 'Customers with birthdays in the current month',
+          query: `{
+  metafields: {
+    key: "birth_date"
+    namespace: "customer"
+    value: {
+      month: ${new Date().getMonth() + 1}
+    }
+  }
+}`,
+          dependencies: {
+            standardMetafields: ['facts.birth_date'],
+          },
+          createdOn: '2025-01-15T00:00:00Z',
+        },
+      ],
+    };
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/birthday-this-month.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/birthday-this-month.ts
@@ -1,14 +1,23 @@
 import {extension} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'admin.customers.segmentation-templates.render',
-  (root, api) => {
+  'admin.customers.segmentation-templates.data',
+  () => {
     return {
       templates: [
         {
           title: 'Birthday this month',
           description: 'Customers with birthdays in the current month',
           query: `{
+  metafields: {
+    key: "birth_date"
+    namespace: "customer"
+    value: {
+      month: ${new Date().getMonth() + 1}
+    }
+  }
+}`,
+          queryToInsert: `{
   metafields: {
     key: "birth_date"
     namespace: "customer"

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/birthday-this-month.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/birthday-this-month.tsx
@@ -1,8 +1,4 @@
-import React from 'react';
-import {
-  reactExtension,
-  useApi,
-} from '@shopify/ui-extensions-react/admin';
+import {reactExtension} from '@shopify/ui-extensions-react/admin';
 
 const BirthdayThisMonth = () => {
   return {
@@ -11,6 +7,15 @@ const BirthdayThisMonth = () => {
         title: 'Birthday this month',
         description: 'Customers with birthdays in the current month',
         query: `{
+  metafields: {
+    key: "birth_date"
+    namespace: "customer"
+    value: {
+      month: ${new Date().getMonth() + 1}
+    }
+  }
+}`,
+        queryToInsert: `{
   metafields: {
     key: "birth_date"
     namespace: "customer"
@@ -29,6 +34,6 @@ const BirthdayThisMonth = () => {
 };
 
 export default reactExtension(
-  'admin.customers.segmentation-templates.render',
-  () => <BirthdayThisMonth />,
+  'admin.customers.segmentation-templates.data',
+  () => BirthdayThisMonth(),
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/birthday-this-month.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/birthday-this-month.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const BirthdayThisMonth = () => {
+  return {
+    templates: [
+      {
+        title: 'Birthday this month',
+        description: 'Customers with birthdays in the current month',
+        query: `{
+  metafields: {
+    key: "birth_date"
+    namespace: "customer"
+    value: {
+      month: ${new Date().getMonth() + 1}
+    }
+  }
+}`,
+        dependencies: {
+          standardMetafields: ['facts.birth_date'],
+        },
+        createdOn: '2025-01-15T00:00:00Z',
+      },
+    ],
+  };
+};
+
+export default reactExtension(
+  'admin.customers.segmentation-templates.render',
+  () => <BirthdayThisMonth />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/high-value-customers.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/high-value-customers.ts
@@ -1,16 +1,22 @@
 import {extension} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'admin.customers.segmentation-templates.render',
-  (root, api) => {
-    const {i18n} = api;
-
+  'admin.customers.segmentation-templates.data',
+  (api) => {
     return {
       templates: [
         {
-          title: i18n.translate('templates.highValue.title'),
-          description: i18n.translate('templates.highValue.description'),
+          title: api.i18n.translate('templates.highValue.title'),
+          description: api.i18n.translate('templates.highValue.description'),
           query: `{
+  total_spent: {
+    min: 500
+  }
+  orders_count: {
+    min: 5
+  }
+}`,
+          queryToInsert: `{
   total_spent: {
     min: 500
   }

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/high-value-customers.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/high-value-customers.ts
@@ -1,0 +1,26 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.customers.segmentation-templates.render',
+  (root, api) => {
+    const {i18n} = api;
+
+    return {
+      templates: [
+        {
+          title: i18n.translate('templates.highValue.title'),
+          description: i18n.translate('templates.highValue.description'),
+          query: `{
+  total_spent: {
+    min: 500
+  }
+  orders_count: {
+    min: 5
+  }
+}`,
+          createdOn: '2025-01-15T00:00:00Z',
+        },
+      ],
+    };
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/high-value-customers.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/high-value-customers.tsx
@@ -1,18 +1,22 @@
-import React from 'react';
-import {
-  reactExtension,
-  useApi,
-} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
 
 const HighValueCustomers = () => {
-  const {i18n} = useApi<'admin.customers.segmentation-templates.render'>();
+  const api = useApi<'admin.customers.segmentation-templates.data'>();
 
   return {
     templates: [
       {
-        title: i18n.translate('templates.highValue.title'),
-        description: i18n.translate('templates.highValue.description'),
+        title: api.i18n.translate('templates.highValue.title'),
+        description: api.i18n.translate('templates.highValue.description'),
         query: `{
+  total_spent: {
+    min: 500
+  }
+  orders_count: {
+    min: 5
+  }
+}`,
+        queryToInsert: `{
   total_spent: {
     min: 500
   }
@@ -27,6 +31,6 @@ const HighValueCustomers = () => {
 };
 
 export default reactExtension(
-  'admin.customers.segmentation-templates.render',
-  () => <HighValueCustomers />,
+  'admin.customers.segmentation-templates.data',
+  () => HighValueCustomers(),
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/high-value-customers.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/examples/high-value-customers.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/admin';
+
+const HighValueCustomers = () => {
+  const {i18n} = useApi<'admin.customers.segmentation-templates.render'>();
+
+  return {
+    templates: [
+      {
+        title: i18n.translate('templates.highValue.title'),
+        description: i18n.translate('templates.highValue.description'),
+        query: `{
+  total_spent: {
+    min: 500
+  }
+  orders_count: {
+    min: 5
+  }
+}`,
+        createdOn: '2025-01-15T00:00:00Z',
+      },
+    ],
+  };
+};
+
+export default reactExtension(
+  'admin.customers.segmentation-templates.render',
+  () => <HighValueCustomers />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -15,23 +15,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Configure discount threshold',
       tabs: [
         {
-
           title: 'React',
 
           code: './examples/configure-discount-threshold.tsx',
 
           language: 'tsx',
-
         },
 
         {
-
           title: 'TS',
 
           code: './examples/configure-discount-threshold.ts',
 
           language: 'ts',
-
         },
       ],
     },
@@ -78,23 +74,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Load existing settings',
           tabs: [
             {
-
               title: 'React',
 
               code: './examples/load-existing-settings.tsx',
 
               language: 'tsx',
-
             },
 
             {
-
               title: 'TS',
 
               code: './examples/load-existing-settings.ts',
 
               language: 'ts',
-
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -109,8 +109,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Metafields are subject to [size limits](/docs/apps/build/metafields/metafield-limits). Individual metafield values can't exceed 256KB, and total metafields per resource have storage limits.\n" +
-        '- The `applyMetafieldChange` method is sequential. Operations are processed one at a time. Rapid successive calls might lead to race conditions where later updates overwrite earlier ones.\n' +
+        "- Metafields are subject to [size limits](/docs/apps/build/metafields/metafield-limits). Individual metafield values can't exceed 256KB, and total metafields per resource have storage limits.
+" +
+        '- The `applyMetafieldChange` method is sequential. Operations are processed one at a time. Rapid successive calls might lead to race conditions where new updates overwrite earlier ones.
+' +
         '- Metafield changes are applied immediately. Unlike some admin forms, metafield changes persist right away without waiting for the merchant to save the discount.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -10,24 +10,28 @@ const data: ReferenceEntityTemplateSchema = {
     'the [`FunctionSettings`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
   defaultExample: {
     description:
-      'Save a minimum purchase threshold to enable discounts only when cart totals meet your requirements, preventing discount abuse on small orders. This example demonstrates using a [`TextField`](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) for decimal input, calling `applyMetafieldChange` to save the threshold, and displaying a success [`Banner`](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/banner) when configured.',
+      'Save a minimum purchase threshold to enable discounts only when cart totals meet your requirements, ensuring discounts apply to appropriately sized orders. This example demonstrates using a [`TextField`](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) for decimal input, calling `applyMetafieldChange` to save the threshold, and displaying a success [`Banner`](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/banner) when configured.',
     codeblock: {
       title: 'Configure discount threshold',
       tabs: [
         {
+
           title: 'React',
 
           code: './examples/configure-discount-threshold.tsx',
 
           language: 'tsx',
+
         },
 
         {
+
           title: 'TS',
 
           code: './examples/configure-discount-threshold.ts',
 
           language: 'ts',
+
         },
       ],
     },
@@ -74,19 +78,23 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Load existing settings',
           tabs: [
             {
+
               title: 'React',
 
               code: './examples/load-existing-settings.tsx',
 
               language: 'tsx',
+
             },
 
             {
+
               title: 'TS',
 
               code: './examples/load-existing-settings.ts',
 
               language: 'ts',
+
             },
           ],
         },
@@ -110,7 +118,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent:
         "- Metafields are subject to [size limits](/docs/apps/build/metafields/metafield-limits). Individual metafield values can't exceed 256KB, and total metafields per resource have storage limits.\n" +
-        '- The `applyMetafieldChange` method is sequential. Operations are processed one at a time. Rapid successive calls may lead to race conditions where later updates overwrite earlier ones.\n' +
+        '- The `applyMetafieldChange` method is sequential. Operations are processed one at a time. Rapid successive calls might lead to race conditions where later updates overwrite earlier ones.\n' +
         '- Metafield changes are applied immediately. Unlike some admin forms, metafield changes persist right away without waiting for the merchant to save the discount.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -24,7 +24,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Save a minimum purchase threshold ($50) to a metafield with decimal validation. This example uses `applyMetafieldChange` with `number_decimal` type to ensure proper handling of currency values, and displays a success confirmation.',
+      'Save a minimum purchase threshold ($50) to a metafield with decimal validation. This example uses `applyMetafieldChange()` with `number_decimal` type for proper currency handling.',
     codeblock: {
       title: 'Configure discount threshold',
       tabs: [
@@ -38,7 +38,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Save multiple discount configuration settings in a single operation. This example stores eligible customer tags as a JSON array (vip, wholesale) and a usage limit as an integer (100), applying both metafield changes sequentially.',
+          'Save multiple discount configuration settings in a single operation. Stores eligible customer tags as a JSON array (vip, wholesale) and a usage limit as an integer (100), demonstrating how to apply multiple metafield changes sequentially.',
         codeblock: {
           title: 'Configure eligibility rules',
           tabs: [
@@ -52,7 +52,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Load discount metafields on mount and display the current configuration. This example uses `useEffect` to reduce the metafields array into a settings object, checks for missing values, and applies defaults where needed.',
+          'Load discount metafields on mount and display current configuration. Uses `useEffect` to reduce the metafields array into a settings object, checking for missing values and applying defaults only when needed.',
         codeblock: {
           title: 'Load existing settings',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -102,14 +102,14 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Check operation result type:** `applyMetafieldChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don't throw exceptions, so always check the returned `type` property.",
+        "- **Check operation result type:** `applyMetafieldChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don\'t throw exceptions, so always check the returned `type` property.",
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Metafields are subject to [size limits](/docs/apps/build/metafields/metafield-limits). Individual metafield values can't exceed 256KB, and total metafields per resource have storage limits.
+        "- Metafields are subject to [size limits](/docs/apps/build/metafields/metafield-limits). Individual metafield values can\'t exceed 256KB, and total metafields per resource have storage limits.
 " +
         '- The `applyMetafieldChange` method is sequential. Operations are processed one at a time. Rapid successive calls might lead to race conditions where new updates overwrite earlier ones.
 ' +

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -15,14 +15,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Configure discount threshold',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/configure-discount-threshold.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/configure-discount-threshold.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/configure-discount-threshold.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -69,14 +74,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Load existing settings',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/load-existing-settings.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/load-existing-settings.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/load-existing-settings.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -102,14 +102,14 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Check operation result type:** `applyMetafieldChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don\'t throw exceptions, so always check the returned `type` property.",
+        "- **Check operation result type:** `applyMetafieldChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don't throw exceptions, so always check the returned `type` property.",
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Metafields are subject to [size limits](/docs/apps/build/metafields/metafield-limits). Individual metafield values can\'t exceed 256KB, and total metafields per resource have storage limits.
+        "- Metafields are subject to [size limits](/docs/apps/build/metafields/metafield-limits). Individual metafield values can't exceed 256KB, and total metafields per resource have storage limits.
 " +
         '- The `applyMetafieldChange` method is sequential. Operations are processed one at a time. Rapid successive calls might lead to race conditions where new updates overwrite earlier ones.
 ' +

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -42,9 +42,12 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Configure eligibility rules',
           tabs: [
-        {code: './examples/configure-eligibility-rules.ts', language: 'ts'},
-        {code: './examples/configure-eligibility-rules.tsx', language: 'tsx'},
-      ],
+            {code: './examples/configure-eligibility-rules.ts', language: 'ts'},
+            {
+              code: './examples/configure-eligibility-rules.tsx',
+              language: 'tsx',
+            },
+          ],
         },
       },
       {
@@ -53,9 +56,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Load existing settings',
           tabs: [
-        {code: './examples/load-existing-settings.ts', language: 'ts'},
-        {code: './examples/load-existing-settings.tsx', language: 'tsx'},
-      ],
+            {code: './examples/load-existing-settings.ts', language: 'ts'},
+            {code: './examples/load-existing-settings.tsx', language: 'tsx'},
+          ],
         },
       },
     ],

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -8,6 +8,17 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'API',
   requires:
     'the [`FunctionSettings`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
+  defaultExample: {
+    description:
+      'Save a minimum purchase threshold to enable discounts only when cart totals meet your requirements, preventing discount abuse on small orders. This example demonstrates using a [`TextField`](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) for decimal input, calling `applyMetafieldChange` to save the threshold, and displaying a success [`Banner`](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/banner) when configured.',
+    codeblock: {
+      title: 'Configure discount threshold',
+      tabs: [
+        {code: './examples/configure-discount-threshold.ts', language: 'ts'},
+        {code: './examples/configure-discount-threshold.tsx', language: 'tsx'},
+      ],
+    },
+  },
   definitions: [
     {
       title: 'applyMetafieldChange',
@@ -22,43 +33,29 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'DiscountFunctionSettingsData',
     },
   ],
-  defaultExample: {
-    description:
-      'Save a minimum purchase threshold ($50) to a metafield with decimal validation. This example uses `applyMetafieldChange()` with `number_decimal` type for proper currency handling.',
-    codeblock: {
-      title: 'Configure discount threshold',
-      tabs: [
-        {code: './examples/configure-discount-threshold.ts', language: 'ts'},
-        {code: './examples/configure-discount-threshold.tsx', language: 'tsx'},
-      ],
-    },
-  },
   examples: {
     description: 'Configure discount function settings',
     examples: [
       {
         description:
-          'Save multiple discount configuration settings in a single operation. Stores eligible customer tags as a JSON array (vip, wholesale) and a usage limit as an integer (100), demonstrating how to apply multiple metafield changes sequentially.',
+          'Configure customer eligibility and usage limits to restrict discounts to specific customer segments and prevent overuse. This example demonstrates using [`TextField`](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) and [`NumberField`](/docs/api/admin-extensions/{API_VERSION}/components/forms/numberfield) inputs, saving customer tags as JSON and usage limits as integers by applying multiple metafield changes in sequence.',
         codeblock: {
           title: 'Configure eligibility rules',
           tabs: [
-            {code: './examples/configure-eligibility-rules.ts', language: 'ts'},
-            {
-              code: './examples/configure-eligibility-rules.tsx',
-              language: 'tsx',
-            },
-          ],
+        {code: './examples/configure-eligibility-rules.ts', language: 'ts'},
+        {code: './examples/configure-eligibility-rules.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Load discount metafields on mount and display current configuration. Uses `useEffect` to reduce the metafields array into a settings object, checking for missing values and applying defaults only when needed.',
+          'Load and display existing discount function configuration when merchants edit discounts, showing current settings and applying sensible defaults for new configurations. This example demonstrates reducing metafields into a settings object, displaying current key-value pairs, and initializing missing required fields with default values.',
         codeblock: {
           title: 'Load existing settings',
           tabs: [
-            {code: './examples/load-existing-settings.ts', language: 'ts'},
-            {code: './examples/load-existing-settings.tsx', language: 'tsx'},
-          ],
+        {code: './examples/load-existing-settings.ts', language: 'ts'},
+        {code: './examples/load-existing-settings.tsx', language: 'tsx'},
+      ],
         },
       },
     ],
@@ -80,7 +77,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent:
         "- Metafields are subject to [size limits](/docs/apps/build/metafields/metafield-limits). Individual metafield values can't exceed 256KB, and total metafields per resource have storage limits.\n" +
-        '- The `applyMetafieldChange` method is sequential. Operations are processed one at a time. Rapid successive calls might lead to race conditions where new updates overwrite earlier ones.\n' +
+        '- The `applyMetafieldChange` method is sequential. Operations are processed one at a time. Rapid successive calls may lead to race conditions where later updates overwrite earlier ones.\n' +
         '- Metafield changes are applied immediately. Unlike some admin forms, metafield changes persist right away without waiting for the merchant to save the discount.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -22,6 +22,47 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'DiscountFunctionSettingsData',
     },
   ],
+  defaultExample: {
+    description:
+      'Save a minimum purchase threshold ($50) to a metafield with decimal validation. This example uses `applyMetafieldChange` with `number_decimal` type to ensure proper handling of currency values, and displays a success confirmation.',
+    codeblock: {
+      title: 'Configure discount threshold',
+      tabs: [
+        {code: './examples/configure-discount-threshold.ts', language: 'ts'},
+        {code: './examples/configure-discount-threshold.tsx', language: 'tsx'},
+      ],
+    },
+  },
+  examples: {
+    description: 'Configure discount function settings',
+    examples: [
+      {
+        description:
+          'Save multiple discount configuration settings in a single operation. This example stores eligible customer tags as a JSON array (vip, wholesale) and a usage limit as an integer (100), applying both metafield changes sequentially.',
+        codeblock: {
+          title: 'Configure eligibility rules',
+          tabs: [
+            {code: './examples/configure-eligibility-rules.ts', language: 'ts'},
+            {
+              code: './examples/configure-eligibility-rules.tsx',
+              language: 'tsx',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Load discount metafields on mount and display the current configuration. This example uses `useEffect` to reduce the metafields array into a settings object, checks for missing values, and applies defaults where needed.',
+        codeblock: {
+          title: 'Load existing settings',
+          tabs: [
+            {code: './examples/load-existing-settings.ts', language: 'ts'},
+            {code: './examples/load-existing-settings.tsx', language: 'tsx'},
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Contextual APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -14,8 +14,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Configure discount threshold',
       tabs: [
-        {code: './examples/configure-discount-threshold.ts', language: 'ts'},
-        {code: './examples/configure-discount-threshold.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/configure-discount-threshold.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/configure-discount-threshold.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -42,7 +50,11 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Configure eligibility rules',
           tabs: [
-            {code: './examples/configure-eligibility-rules.ts', language: 'ts'},
+            {
+              title: 'TS',
+              code: './examples/configure-eligibility-rules.ts',
+              language: 'ts',
+            },
             {
               code: './examples/configure-eligibility-rules.tsx',
               language: 'tsx',
@@ -56,8 +68,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Load existing settings',
           tabs: [
-            {code: './examples/load-existing-settings.ts', language: 'ts'},
-            {code: './examples/load-existing-settings.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/load-existing-settings.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/load-existing-settings.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-discount-threshold.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-discount-threshold.ts
@@ -1,20 +1,49 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, TextField, Button, Banner} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.discount-details.function-settings.render',
   (root, api) => {
     const {applyMetafieldChange} = api;
 
-    applyMetafieldChange({
-      type: 'updateMetafield',
-      key: 'min_purchase_amount',
-      namespace: 'discount_function',
-      value: '50.00',
-      valueType: 'number_decimal',
-    }).then((result) => {
-      if (result.type === 'success') {
-        console.log('Threshold saved');
-      }
+    let threshold = '50.00';
+    let savedBanner;
+
+    const textField = root.createComponent(TextField, {
+      label: 'Minimum purchase amount',
+      value: threshold,
+      onChange: (value) => {
+        threshold = value;
+      },
     });
+
+    const saveButton = root.createComponent(Button, {
+      title: 'Save Threshold',
+      onPress: async () => {
+        const result = await applyMetafieldChange({
+          type: 'updateMetafield',
+          namespace: 'discount-config',
+          key: 'minimum_purchase',
+          value: threshold,
+          valueType: 'number_decimal',
+        });
+
+        if (result.type === 'success') {
+          if (savedBanner) {
+            root.removeChild(savedBanner);
+          }
+          savedBanner = root.createComponent(
+            Banner,
+            {status: 'success'},
+            'Threshold configured!',
+          );
+          root.appendChild(savedBanner);
+        } else {
+          console.error('Configuration failed:', result.message);
+        }
+      },
+    });
+
+    root.appendChild(textField);
+    root.appendChild(saveButton);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-discount-threshold.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-discount-threshold.ts
@@ -1,0 +1,20 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.discount-details.function-settings.render',
+  (root, api) => {
+    const {applyMetafieldChange} = api;
+
+    applyMetafieldChange({
+      type: 'updateMetafield',
+      key: 'min_purchase_amount',
+      namespace: 'discount_function',
+      value: '50.00',
+      valueType: 'number_decimal',
+    }).then((result) => {
+      if (result.type === 'success') {
+        console.log('Threshold saved');
+      }
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-discount-threshold.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-discount-threshold.tsx
@@ -1,24 +1,47 @@
-import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  TextField,
+  Button,
+  Banner,
+} from '@shopify/ui-extensions-react/admin';
 
 const ConfigureDiscountThreshold = () => {
   const {applyMetafieldChange} = useApi<'admin.discount-details.function-settings.render'>();
+  const [threshold, setThreshold] = useState('50.00');
+  const [saved, setSaved] = useState(false);
 
   const handleSave = async () => {
     const result = await applyMetafieldChange({
       type: 'updateMetafield',
-      key: 'min_purchase_amount',
-      namespace: 'discount_function',
-      value: '50.00',
+      namespace: 'discount-config',
+      key: 'minimum_purchase',
+      value: threshold,
       valueType: 'number_decimal',
     });
 
     if (result.type === 'success') {
-      console.log('Threshold saved');
+      setSaved(true);
+    } else {
+      console.error('Configuration failed:', result.message);
     }
   };
 
-  return null;
+  return (
+    <>
+      <TextField
+        label="Minimum purchase amount"
+        value={threshold}
+        onChange={setThreshold}
+      />
+      <Button title="Save Threshold" onPress={handleSave} />
+      {saved && <Banner status="success">Threshold configured!</Banner>}
+    </>
+  );
 };
 
-export default reactExtension('admin.discount-details.function-settings.render', () => <ConfigureDiscountThreshold />);
+export default reactExtension(
+  'admin.discount-details.function-settings.render',
+  () => <ConfigureDiscountThreshold />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-discount-threshold.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-discount-threshold.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const ConfigureDiscountThreshold = () => {
+  const {applyMetafieldChange} = useApi<'admin.discount-details.function-settings.render'>();
+
+  const handleSave = async () => {
+    const result = await applyMetafieldChange({
+      type: 'updateMetafield',
+      key: 'min_purchase_amount',
+      namespace: 'discount_function',
+      value: '50.00',
+      valueType: 'number_decimal',
+    });
+
+    if (result.type === 'success') {
+      console.log('Threshold saved');
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.discount-details.function-settings.render', () => <ConfigureDiscountThreshold />);

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-eligibility-rules.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-eligibility-rules.ts
@@ -1,0 +1,26 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.discount-details.function-settings.render',
+  (root, api) => {
+    const {applyMetafieldChange} = api;
+
+    const tags = ['vip', 'wholesale'];
+
+    applyMetafieldChange({
+      type: 'updateMetafield',
+      key: 'customer_tags',
+      namespace: 'discount_function',
+      value: JSON.stringify(tags),
+      valueType: 'json',
+    }).then(() => {
+      return applyMetafieldChange({
+        type: 'updateMetafield',
+        key: 'usage_limit',
+        namespace: 'discount_function',
+        value: '100',
+        valueType: 'number_integer',
+      });
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-eligibility-rules.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-eligibility-rules.ts
@@ -1,26 +1,56 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, TextField, NumberField, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.discount-details.function-settings.render',
   (root, api) => {
     const {applyMetafieldChange} = api;
 
-    const tags = ['vip', 'wholesale'];
+    let tags = 'vip, wholesale, premium';
+    let maxUses = '5';
 
-    applyMetafieldChange({
-      type: 'updateMetafield',
-      key: 'customer_tags',
-      namespace: 'discount_function',
-      value: JSON.stringify(tags),
-      valueType: 'json',
-    }).then(() => {
-      return applyMetafieldChange({
-        type: 'updateMetafield',
-        key: 'usage_limit',
-        namespace: 'discount_function',
-        value: '100',
-        valueType: 'number_integer',
-      });
+    const stack = root.createComponent(BlockStack);
+
+    const tagsField = root.createComponent(TextField, {
+      label: 'Eligible customer tags (comma-separated)',
+      value: tags,
+      onChange: (value) => {
+        tags = value;
+      },
     });
+
+    const maxUsesField = root.createComponent(NumberField, {
+      label: 'Max uses per customer',
+      value: maxUses,
+      onChange: (value) => {
+        maxUses = value;
+      },
+    });
+
+    const saveButton = root.createComponent(Button, {
+      title: 'Save Eligibility Rules',
+      onPress: async () => {
+        await applyMetafieldChange({
+          type: 'updateMetafield',
+          namespace: 'discount-config',
+          key: 'eligible_customer_tags',
+          value: JSON.stringify(tags.split(',').map((t) => t.trim())),
+          valueType: 'json',
+        });
+
+        await applyMetafieldChange({
+          type: 'updateMetafield',
+          namespace: 'discount-config',
+          key: 'max_uses_per_customer',
+          value: maxUses,
+          valueType: 'number_integer',
+        });
+      },
+    });
+
+    stack.appendChild(tagsField);
+    stack.appendChild(maxUsesField);
+    stack.appendChild(saveButton);
+
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-eligibility-rules.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-eligibility-rules.tsx
@@ -1,30 +1,54 @@
-import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  TextField,
+  NumberField,
+  Button,
+  BlockStack,
+} from '@shopify/ui-extensions-react/admin';
 
 const ConfigureEligibilityRules = () => {
   const {applyMetafieldChange} = useApi<'admin.discount-details.function-settings.render'>();
+  const [tags, setTags] = useState('vip, wholesale, premium');
+  const [maxUses, setMaxUses] = useState('5');
 
   const handleSave = async () => {
-    const tags = ['vip', 'wholesale'];
-
     await applyMetafieldChange({
       type: 'updateMetafield',
-      key: 'customer_tags',
-      namespace: 'discount_function',
-      value: JSON.stringify(tags),
+      namespace: 'discount-config',
+      key: 'eligible_customer_tags',
+      value: JSON.stringify(tags.split(',').map((t) => t.trim())),
       valueType: 'json',
     });
 
     await applyMetafieldChange({
       type: 'updateMetafield',
-      key: 'usage_limit',
-      namespace: 'discount_function',
-      value: '100',
+      namespace: 'discount-config',
+      key: 'max_uses_per_customer',
+      value: maxUses,
       valueType: 'number_integer',
     });
   };
 
-  return null;
+  return (
+    <BlockStack>
+      <TextField
+        label="Eligible customer tags (comma-separated)"
+        value={tags}
+        onChange={setTags}
+      />
+      <NumberField
+        label="Max uses per customer"
+        value={maxUses}
+        onChange={setMaxUses}
+      />
+      <Button title="Save Eligibility Rules" onPress={handleSave} />
+    </BlockStack>
+  );
 };
 
-export default reactExtension('admin.discount-details.function-settings.render', () => <ConfigureEligibilityRules />);
+export default reactExtension(
+  'admin.discount-details.function-settings.render',
+  () => <ConfigureEligibilityRules />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-eligibility-rules.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/configure-eligibility-rules.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const ConfigureEligibilityRules = () => {
+  const {applyMetafieldChange} = useApi<'admin.discount-details.function-settings.render'>();
+
+  const handleSave = async () => {
+    const tags = ['vip', 'wholesale'];
+
+    await applyMetafieldChange({
+      type: 'updateMetafield',
+      key: 'customer_tags',
+      namespace: 'discount_function',
+      value: JSON.stringify(tags),
+      valueType: 'json',
+    });
+
+    await applyMetafieldChange({
+      type: 'updateMetafield',
+      key: 'usage_limit',
+      namespace: 'discount_function',
+      value: '100',
+      valueType: 'number_integer',
+    });
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.discount-details.function-settings.render', () => <ConfigureEligibilityRules />);

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/load-existing-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/load-existing-settings.ts
@@ -1,16 +1,35 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.discount-details.function-settings.render',
   (root, api) => {
-    const {data} = api;
+    const {data, applyMetafieldChange} = api;
 
-    const metafields = data.metafields;
-    const settings = metafields.reduce((acc, mf) => {
-      acc[mf.key] = mf.value;
-      return acc;
-    }, {});
+    const initializeSettings = async () => {
+      const existingSettings = data.metafields.reduce((acc, field) => {
+        acc[field.key] = field.value;
+        return acc;
+      }, {});
 
-    console.log('Current discount settings:', settings);
+      const headerText = root.createComponent(Text, {}, 'Current settings:');
+      root.appendChild(headerText);
+
+      Object.entries(existingSettings).forEach(([key, value]) => {
+        const settingText = root.createComponent(Text, {}, `${key}: ${String(value)}`);
+        root.appendChild(settingText);
+      });
+
+      if (!existingSettings.eligible_tags) {
+        await applyMetafieldChange({
+          type: 'updateMetafield',
+          namespace: 'discount-config',
+          key: 'eligible_tags',
+          value: JSON.stringify(['vip', 'wholesale']),
+          valueType: 'json',
+        });
+      }
+    };
+
+    initializeSettings();
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/load-existing-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/load-existing-settings.ts
@@ -1,0 +1,16 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.discount-details.function-settings.render',
+  (root, api) => {
+    const {data} = api;
+
+    const metafields = data.metafields;
+    const settings = metafields.reduce((acc, mf) => {
+      acc[mf.key] = mf.value;
+      return acc;
+    }, {});
+
+    console.log('Current discount settings:', settings);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/load-existing-settings.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/load-existing-settings.tsx
@@ -1,0 +1,21 @@
+import React, {useEffect, useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const LoadExistingSettings = () => {
+  const {data} = useApi<'admin.discount-details.function-settings.render'>();
+  const [settings, setSettings] = useState(null);
+
+  useEffect(() => {
+    const metafields = data.metafields;
+    const loadedSettings = metafields.reduce((acc, mf) => {
+      acc[mf.key] = mf.value;
+      return acc;
+    }, {});
+
+    setSettings(loadedSettings);
+  }, [data]);
+
+  return null;
+};
+
+export default reactExtension('admin.discount-details.function-settings.render', () => <LoadExistingSettings />);

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/load-existing-settings.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/examples/load-existing-settings.tsx
@@ -1,21 +1,50 @@
-import React, {useEffect, useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState, useEffect} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
 
 const LoadExistingSettings = () => {
-  const {data} = useApi<'admin.discount-details.function-settings.render'>();
-  const [settings, setSettings] = useState(null);
+  const {data, applyMetafieldChange} = useApi<'admin.discount-details.function-settings.render'>();
+  const [settings, setSettings] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    const metafields = data.metafields;
-    const loadedSettings = metafields.reduce((acc, mf) => {
-      acc[mf.key] = mf.value;
-      return acc;
-    }, {});
+    const initializeSettings = async () => {
+      const existingSettings = data.metafields.reduce((acc, field) => {
+        acc[field.key] = field.value;
+        return acc;
+      }, {});
 
-    setSettings(loadedSettings);
-  }, [data]);
+      setSettings(existingSettings);
 
-  return null;
+      if (!existingSettings.eligible_tags) {
+        await applyMetafieldChange({
+          type: 'updateMetafield',
+          namespace: 'discount-config',
+          key: 'eligible_tags',
+          value: JSON.stringify(['vip', 'wholesale']),
+          valueType: 'json',
+        });
+      }
+    };
+
+    initializeSettings();
+  }, [data, applyMetafieldChange]);
+
+  return (
+    <>
+      <Text>Current settings:</Text>
+      {Object.entries(settings).map(([key, value]) => (
+        <Text key={key}>
+          {key}: {String(value)}
+        </Text>
+      ))}
+    </>
+  );
 };
 
-export default reactExtension('admin.discount-details.function-settings.render', () => <LoadExistingSettings />);
+export default reactExtension(
+  'admin.discount-details.function-settings.render',
+  () => <LoadExistingSettings />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/configure-location-priority.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/configure-location-priority.ts
@@ -1,0 +1,23 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.settings.order-routing-rule.render',
+  (root, api) => {
+    const {applyMetafieldsChange} = api;
+
+    applyMetafieldsChange([
+      {
+        type: 'updateMetafield',
+        key: 'preferred_location',
+        namespace: 'routing',
+        value: 'New York Warehouse',
+      },
+      {
+        type: 'updateMetafield',
+        key: 'fallback_location',
+        namespace: 'routing',
+        value: 'Los Angeles Warehouse',
+      },
+    ]);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/configure-location-priority.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/configure-location-priority.ts
@@ -1,23 +1,57 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, TextField, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.settings.order-routing-rule.render',
   (root, api) => {
     const {applyMetafieldsChange} = api;
 
-    applyMetafieldsChange([
-      {
-        type: 'updateMetafield',
-        key: 'preferred_location',
-        namespace: 'routing',
-        value: 'New York Warehouse',
+    let preferred = 'gid://shopify/Location/123456789';
+    let fallback = 'gid://shopify/Location/987654321';
+
+    const stack = root.createComponent(BlockStack);
+
+    const preferredField = root.createComponent(TextField, {
+      label: 'Preferred location ID',
+      value: preferred,
+      onChange: (value) => {
+        preferred = value;
       },
-      {
-        type: 'updateMetafield',
-        key: 'fallback_location',
-        namespace: 'routing',
-        value: 'Los Angeles Warehouse',
+    });
+
+    const fallbackField = root.createComponent(TextField, {
+      label: 'Fallback location ID',
+      value: fallback,
+      onChange: (value) => {
+        fallback = value;
       },
-    ]);
+    });
+
+    const saveButton = root.createComponent(Button, {
+      title: 'Save Location Priority',
+      onPress: () => {
+        applyMetafieldsChange([
+          {
+            type: 'updateMetafield',
+            namespace: 'routing',
+            key: 'preferred_location',
+            value: preferred,
+            valueType: 'single_line_text_field',
+          },
+          {
+            type: 'updateMetafield',
+            namespace: 'routing',
+            key: 'fallback_location',
+            value: fallback,
+            valueType: 'single_line_text_field',
+          },
+        ]);
+      },
+    });
+
+    stack.appendChild(preferredField);
+    stack.appendChild(fallbackField);
+    stack.appendChild(saveButton);
+
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/configure-location-priority.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/configure-location-priority.tsx
@@ -1,27 +1,54 @@
-import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  TextField,
+  Button,
+  BlockStack,
+} from '@shopify/ui-extensions-react/admin';
 
 const ConfigureLocationPriority = () => {
   const {applyMetafieldsChange} = useApi<'admin.settings.order-routing-rule.render'>();
+  const [preferred, setPreferred] = useState('gid://shopify/Location/123456789');
+  const [fallback, setFallback] = useState('gid://shopify/Location/987654321');
 
-  const handleSave = async () => {
-    await applyMetafieldsChange([
+  const handleSave = () => {
+    applyMetafieldsChange([
       {
         type: 'updateMetafield',
-        key: 'preferred_location',
         namespace: 'routing',
-        value: 'New York Warehouse',
+        key: 'preferred_location',
+        value: preferred,
+        valueType: 'single_line_text_field',
       },
       {
         type: 'updateMetafield',
-        key: 'fallback_location',
         namespace: 'routing',
-        value: 'Los Angeles Warehouse',
+        key: 'fallback_location',
+        value: fallback,
+        valueType: 'single_line_text_field',
       },
     ]);
   };
 
-  return null;
+  return (
+    <BlockStack>
+      <TextField
+        label="Preferred location ID"
+        value={preferred}
+        onChange={setPreferred}
+      />
+      <TextField
+        label="Fallback location ID"
+        value={fallback}
+        onChange={setFallback}
+      />
+      <Button title="Save Location Priority" onPress={handleSave} />
+    </BlockStack>
+  );
 };
 
-export default reactExtension('admin.settings.order-routing-rule.render', () => <ConfigureLocationPriority />);
+export default reactExtension(
+  'admin.settings.order-routing-rule.render',
+  () => <ConfigureLocationPriority />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/configure-location-priority.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/configure-location-priority.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const ConfigureLocationPriority = () => {
+  const {applyMetafieldsChange} = useApi<'admin.settings.order-routing-rule.render'>();
+
+  const handleSave = async () => {
+    await applyMetafieldsChange([
+      {
+        type: 'updateMetafield',
+        key: 'preferred_location',
+        namespace: 'routing',
+        value: 'New York Warehouse',
+      },
+      {
+        type: 'updateMetafield',
+        key: 'fallback_location',
+        namespace: 'routing',
+        value: 'Los Angeles Warehouse',
+      },
+    ]);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.settings.order-routing-rule.render', () => <ConfigureLocationPriority />);

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/remove-deprecated-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/remove-deprecated-settings.ts
@@ -1,18 +1,49 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Text, Button, Banner, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.settings.order-routing-rule.render',
   (root, api) => {
-    const {applyMetafieldsChange} = api;
+    const {data, applyMetafieldsChange} = api;
 
-    const deprecatedKeys = ['old_setting_1', 'old_setting_2'];
-    
-    const removals = deprecatedKeys.map((key) => ({
-      type: 'removeMetafield',
-      key,
-      namespace: 'routing',
-    }));
+    let removed = false;
+    let resultBanner;
 
-    applyMetafieldsChange(removals);
+    const stack = root.createComponent(BlockStack);
+
+    const priorityText = root.createComponent(Text, {}, `Rule priority: ${data.rule.priority}`);
+    const settingsText = root.createComponent(Text, {}, `Current settings: ${data.rule.metafields.length}`);
+
+    const removeButton = root.createComponent(Button, {
+      title: 'Remove Deprecated Settings',
+      onPress: () => {
+        const deprecatedKeys = ['old_setting', 'legacy_config'];
+
+        const changes = deprecatedKeys.map((key) => ({
+          type: 'removeMetafield',
+          namespace: 'routing',
+          key,
+        }));
+
+        applyMetafieldsChange(changes);
+        removed = true;
+
+        if (resultBanner) {
+          stack.removeChild(resultBanner);
+        }
+
+        resultBanner = root.createComponent(
+          Banner,
+          {status: 'success'},
+          'Deprecated settings removed',
+        );
+        stack.appendChild(resultBanner);
+      },
+    });
+
+    stack.appendChild(priorityText);
+    stack.appendChild(settingsText);
+    stack.appendChild(removeButton);
+
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/remove-deprecated-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/remove-deprecated-settings.ts
@@ -1,0 +1,18 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.settings.order-routing-rule.render',
+  (root, api) => {
+    const {applyMetafieldsChange} = api;
+
+    const deprecatedKeys = ['old_setting_1', 'old_setting_2'];
+    
+    const removals = deprecatedKeys.map((key) => ({
+      type: 'removeMetafield',
+      key,
+      namespace: 'routing',
+    }));
+
+    applyMetafieldsChange(removals);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/remove-deprecated-settings.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/remove-deprecated-settings.tsx
@@ -1,22 +1,41 @@
-import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Text,
+  Button,
+  Banner,
+  BlockStack,
+} from '@shopify/ui-extensions-react/admin';
 
 const RemoveDeprecatedSettings = () => {
-  const {applyMetafieldsChange} = useApi<'admin.settings.order-routing-rule.render'>();
+  const {data, applyMetafieldsChange} = useApi<'admin.settings.order-routing-rule.render'>();
+  const [removed, setRemoved] = useState(false);
 
-  const handleCleanup = async () => {
-    const deprecatedKeys = ['old_setting_1', 'old_setting_2'];
-    
-    const removals = deprecatedKeys.map((key) => ({
+  const handleRemove = () => {
+    const deprecatedKeys = ['old_setting', 'legacy_config'];
+
+    const changes = deprecatedKeys.map((key) => ({
       type: 'removeMetafield',
-      key,
       namespace: 'routing',
+      key,
     }));
 
-    await applyMetafieldsChange(removals);
+    applyMetafieldsChange(changes);
+    setRemoved(true);
   };
 
-  return null;
+  return (
+    <BlockStack>
+      <Text>Rule priority: {data.rule.priority}</Text>
+      <Text>Current settings: {data.rule.metafields.length}</Text>
+      <Button title="Remove Deprecated Settings" onPress={handleRemove} />
+      {removed && <Banner status="success">Deprecated settings removed</Banner>}
+    </BlockStack>
+  );
 };
 
-export default reactExtension('admin.settings.order-routing-rule.render', () => <RemoveDeprecatedSettings />);
+export default reactExtension(
+  'admin.settings.order-routing-rule.render',
+  () => <RemoveDeprecatedSettings />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/remove-deprecated-settings.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/remove-deprecated-settings.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const RemoveDeprecatedSettings = () => {
+  const {applyMetafieldsChange} = useApi<'admin.settings.order-routing-rule.render'>();
+
+  const handleCleanup = async () => {
+    const deprecatedKeys = ['old_setting_1', 'old_setting_2'];
+    
+    const removals = deprecatedKeys.map((key) => ({
+      type: 'removeMetafield',
+      key,
+      namespace: 'routing',
+    }));
+
+    await applyMetafieldsChange(removals);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.settings.order-routing-rule.render', () => <RemoveDeprecatedSettings />);

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/set-routing-criteria.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/set-routing-criteria.ts
@@ -1,0 +1,32 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.settings.order-routing-rule.render',
+  (root, api) => {
+    const {applyMetafieldsChange} = api;
+
+    applyMetafieldsChange([
+      {
+        type: 'updateMetafield',
+        key: 'max_distance',
+        namespace: 'routing',
+        value: '50',
+        valueType: 'number_integer',
+      },
+      {
+        type: 'updateMetafield',
+        key: 'check_inventory',
+        namespace: 'routing',
+        value: 'true',
+        valueType: 'boolean',
+      },
+      {
+        type: 'updateMetafield',
+        key: 'excluded_zips',
+        namespace: 'routing',
+        value: JSON.stringify(['90210', '10001']),
+        valueType: 'json',
+      },
+    ]);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/set-routing-criteria.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/set-routing-criteria.ts
@@ -1,32 +1,64 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, NumberField, Checkbox, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.settings.order-routing-rule.render',
   (root, api) => {
     const {applyMetafieldsChange} = api;
 
-    applyMetafieldsChange([
-      {
-        type: 'updateMetafield',
-        key: 'max_distance',
-        namespace: 'routing',
-        value: '50',
-        valueType: 'number_integer',
+    let distance = '50';
+    let enableInventory = true;
+
+    const stack = root.createComponent(BlockStack);
+
+    const distanceField = root.createComponent(NumberField, {
+      label: 'Maximum distance (km)',
+      value: distance,
+      onChange: (value) => {
+        distance = value;
       },
-      {
-        type: 'updateMetafield',
-        key: 'check_inventory',
-        namespace: 'routing',
-        value: 'true',
-        valueType: 'boolean',
+    });
+
+    const inventoryCheckbox = root.createComponent(Checkbox, {
+      checked: enableInventory,
+      onChange: (checked) => {
+        enableInventory = checked;
       },
-      {
-        type: 'updateMetafield',
-        key: 'excluded_zips',
-        namespace: 'routing',
-        value: JSON.stringify(['90210', '10001']),
-        valueType: 'json',
+    });
+    const checkboxLabel = root.createText('Enable inventory check');
+
+    const saveButton = root.createComponent(Button, {
+      title: 'Save Routing Criteria',
+      onPress: () => {
+        applyMetafieldsChange([
+          {
+            type: 'updateMetafield',
+            namespace: 'routing',
+            key: 'max_distance_km',
+            value: distance,
+            valueType: 'number_integer',
+          },
+          {
+            type: 'updateMetafield',
+            namespace: 'routing',
+            key: 'enable_inventory_check',
+            value: String(enableInventory),
+            valueType: 'boolean',
+          },
+          {
+            type: 'updateMetafield',
+            namespace: 'routing',
+            key: 'excluded_zip_codes',
+            value: JSON.stringify(['10001', '90210']),
+            valueType: 'json',
+          },
+        ]);
       },
-    ]);
+    });
+
+    stack.appendChild(distanceField);
+    stack.appendChild(inventoryCheckbox);
+    stack.appendChild(saveButton);
+
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/set-routing-criteria.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/set-routing-criteria.tsx
@@ -1,36 +1,60 @@
-import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  NumberField,
+  Checkbox,
+  Button,
+  BlockStack,
+} from '@shopify/ui-extensions-react/admin';
 
 const SetRoutingCriteria = () => {
   const {applyMetafieldsChange} = useApi<'admin.settings.order-routing-rule.render'>();
+  const [distance, setDistance] = useState('50');
+  const [enableInventory, setEnableInventory] = useState(true);
 
-  const handleSave = async () => {
-    await applyMetafieldsChange([
+  const handleSave = () => {
+    applyMetafieldsChange([
       {
         type: 'updateMetafield',
-        key: 'max_distance',
         namespace: 'routing',
-        value: '50',
+        key: 'max_distance_km',
+        value: distance,
         valueType: 'number_integer',
       },
       {
         type: 'updateMetafield',
-        key: 'check_inventory',
         namespace: 'routing',
-        value: 'true',
+        key: 'enable_inventory_check',
+        value: String(enableInventory),
         valueType: 'boolean',
       },
       {
         type: 'updateMetafield',
-        key: 'excluded_zips',
         namespace: 'routing',
-        value: JSON.stringify(['90210', '10001']),
+        key: 'excluded_zip_codes',
+        value: JSON.stringify(['10001', '90210']),
         valueType: 'json',
       },
     ]);
   };
 
-  return null;
+  return (
+    <BlockStack>
+      <NumberField
+        label="Maximum distance (km)"
+        value={distance}
+        onChange={setDistance}
+      />
+      <Checkbox checked={enableInventory} onChange={setEnableInventory}>
+        Enable inventory check
+      </Checkbox>
+      <Button title="Save Routing Criteria" onPress={handleSave} />
+    </BlockStack>
+  );
 };
 
-export default reactExtension('admin.settings.order-routing-rule.render', () => <SetRoutingCriteria />);
+export default reactExtension(
+  'admin.settings.order-routing-rule.render',
+  () => <SetRoutingCriteria />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/set-routing-criteria.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/examples/set-routing-criteria.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const SetRoutingCriteria = () => {
+  const {applyMetafieldsChange} = useApi<'admin.settings.order-routing-rule.render'>();
+
+  const handleSave = async () => {
+    await applyMetafieldsChange([
+      {
+        type: 'updateMetafield',
+        key: 'max_distance',
+        namespace: 'routing',
+        value: '50',
+        valueType: 'number_integer',
+      },
+      {
+        type: 'updateMetafield',
+        key: 'check_inventory',
+        namespace: 'routing',
+        value: 'true',
+        valueType: 'boolean',
+      },
+      {
+        type: 'updateMetafield',
+        key: 'excluded_zips',
+        namespace: 'routing',
+        value: JSON.stringify(['90210', '10001']),
+        valueType: 'json',
+      },
+    ]);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.settings.order-routing-rule.render', () => <SetRoutingCriteria />);

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -98,16 +98,16 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- **Batch metafield changes for atomic updates:** `applyMetafieldsChange` accepts an array of change objects. Pass multiple changes in a single call to ensure all changes succeed or all fail together.
 ' +
-        "- **Check operation result type:** `applyMetafieldsChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don't throw, so always check the returned `type`.",
+        "- **Check operation result type:** `applyMetafieldsChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don\'t throw, so always check the returned `type`.",
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can't exceed 256KB, and total metafield storage per rule is limited.
+        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can\'t exceed 256KB, and total metafield storage per rule is limited.
 " +
-        "- Rule priority is read-only. Evaluation order can't be modified through the settings interface. Merchants manage priority through the main rules interface.
+        "- Rule priority is read-only. Evaluation order can\'t be modified through the settings interface. Merchants manage priority through the main rules interface.
 " +
         '- Batch operations are all-or-nothing. If any metafield change in the array fails validation, then the entire batch fails and no changes apply.
 ' +

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -98,16 +98,16 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- **Batch metafield changes for atomic updates:** `applyMetafieldsChange` accepts an array of change objects. Pass multiple changes in a single call to ensure all changes succeed or all fail together.
 ' +
-        "- **Check operation result type:** `applyMetafieldsChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don\'t throw, so always check the returned `type`.",
+        "- **Check operation result type:** `applyMetafieldsChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don't throw, so always check the returned `type`.",
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can\'t exceed 256KB, and total metafield storage per rule is limited.
+        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can't exceed 256KB, and total metafield storage per rule is limited.
 " +
-        "- Rule priority is read-only. Evaluation order can\'t be modified through the settings interface. Merchants manage priority through the main rules interface.
+        "- Rule priority is read-only. Evaluation order can't be modified through the settings interface. Merchants manage priority through the main rules interface.
 " +
         '- Batch operations are all-or-nothing. If any metafield change in the array fails validation, then the entire batch fails and no changes apply.
 ' +

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -8,17 +8,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'API',
   requires:
     'the [`FunctionSettings`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
-  definitions: [
-    {
-      title: 'OrderRoutingRuleApi',
-      description:
-        'The `OrderRoutingRuleApi` object provides access to order routing rule data and configuration methods. Access the following properties on the `OrderRoutingRuleApi` object to interact with the current order routing rule context in the `admin.settings.order-routing-rule.render` target.',
-      type: 'OrderRoutingRuleApi',
-    },
-  ],
   defaultExample: {
     description:
-      'Set preferred and fallback fulfillment locations for order routing. This example shows how to apply two metafield changes in a single batch using `applyMetafieldsChange()`—New York Warehouse as preferred and Los Angeles Warehouse as fallback.',
+      'Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/textfield) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.',
     codeblock: {
       title: 'Configure location priority',
       tabs: [
@@ -27,32 +19,37 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  definitions: [
+    {
+      title: 'OrderRoutingRuleApi',
+      description:
+        'The `OrderRoutingRuleApi` object provides access to order routing rule data and configuration methods. Access the following properties on the `OrderRoutingRuleApi` object to interact with the current order routing rule context in the `admin.settings.order-routing-rule.render` target.',
+      type: 'OrderRoutingRuleApi',
+    },
+  ],
   examples: {
     description: 'Configure order routing rules',
     examples: [
       {
         description:
-          'Batch remove outdated metafields from your routing configuration. Maps deprecated keys to removal operations and cleans up old settings in one `applyMetafieldsChange()` call.',
+          'Batch remove outdated metafields from routing configuration. This example maps deprecated keys to removal operations, displays current rule stats, and shows a success banner after cleanup.',
         codeblock: {
           title: 'Remove deprecated settings',
           tabs: [
-            {code: './examples/remove-deprecated-settings.ts', language: 'ts'},
-            {
-              code: './examples/remove-deprecated-settings.tsx',
-              language: 'tsx',
-            },
-          ],
+        {code: './examples/remove-deprecated-settings.ts', language: 'ts'},
+        {code: './examples/remove-deprecated-settings.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Configure multiple routing criteria including maximum distance (50km), inventory checking (true), and excluded zip codes (90210, 10001). This example demonstrates setting all criteria in one batch with different value types—integer, boolean, and JSON.',
+          'Configure maximum distance, inventory checking, and excluded zip codes in one save. This example demonstrates using number fields, checkboxes, and JSON storage for complex routing criteria.',
         codeblock: {
           title: 'Set routing criteria',
           tabs: [
-            {code: './examples/set-routing-criteria.ts', language: 'ts'},
-            {code: './examples/set-routing-criteria.tsx', language: 'tsx'},
-          ],
+        {code: './examples/set-routing-criteria.ts', language: 'ts'},
+        {code: './examples/set-routing-criteria.tsx', language: 'tsx'},
+      ],
         },
       },
     ],
@@ -76,7 +73,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can't exceed 256KB, and total metafield storage per rule is limited.\n" +
         "- Rule priority is read-only. Evaluation order can't be modified through the settings interface. Merchants manage priority through the main rules interface.\n" +
-        '- Batch operations are all-or-nothing. If any metafield change in the array fails validation, then the entire batch fails and no changes apply.\n' +
+        '- Batch operations are all-or-nothing. If any metafield change in the array fails validation, the entire batch fails and no changes apply.\n' +
         '- Metafield changes apply immediately. They persist right away without waiting for merchants to save the rule.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -14,8 +14,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Configure location priority',
       tabs: [
-        {code: './examples/configure-location-priority.ts', language: 'ts'},
-        {code: './examples/configure-location-priority.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/configure-location-priority.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/configure-location-priority.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -36,7 +44,11 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Remove deprecated settings',
           tabs: [
-            {code: './examples/remove-deprecated-settings.ts', language: 'ts'},
+            {
+              title: 'TS',
+              code: './examples/remove-deprecated-settings.ts',
+              language: 'ts',
+            },
             {
               code: './examples/remove-deprecated-settings.tsx',
               language: 'tsx',
@@ -50,8 +62,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Set routing criteria',
           tabs: [
-            {code: './examples/set-routing-criteria.ts', language: 'ts'},
-            {code: './examples/set-routing-criteria.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/set-routing-criteria.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/set-routing-criteria.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -36,9 +36,12 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Remove deprecated settings',
           tabs: [
-        {code: './examples/remove-deprecated-settings.ts', language: 'ts'},
-        {code: './examples/remove-deprecated-settings.tsx', language: 'tsx'},
-      ],
+            {code: './examples/remove-deprecated-settings.ts', language: 'ts'},
+            {
+              code: './examples/remove-deprecated-settings.tsx',
+              language: 'tsx',
+            },
+          ],
         },
       },
       {
@@ -47,9 +50,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Set routing criteria',
           tabs: [
-        {code: './examples/set-routing-criteria.ts', language: 'ts'},
-        {code: './examples/set-routing-criteria.tsx', language: 'tsx'},
-      ],
+            {code: './examples/set-routing-criteria.ts', language: 'ts'},
+            {code: './examples/set-routing-criteria.tsx', language: 'tsx'},
+          ],
         },
       },
     ],

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -16,6 +16,47 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'OrderRoutingRuleApi',
     },
   ],
+  defaultExample: {
+    description:
+      'Set preferred and fallback fulfillment locations for order routing. This example applies two metafield changes in a single batch using `applyMetafieldsChange`: New York Warehouse as the preferred location and Los Angeles Warehouse as the fallback.',
+    codeblock: {
+      title: 'Configure location priority',
+      tabs: [
+        {code: './examples/configure-location-priority.ts', language: 'ts'},
+        {code: './examples/configure-location-priority.tsx', language: 'tsx'},
+      ],
+    },
+  },
+  examples: {
+    description: 'Configure order routing rules',
+    examples: [
+      {
+        description:
+          'Batch remove outdated metafields from your routing configuration. This example maps an array of deprecated keys to removal operations, and cleans up old settings in a single `applyMetafieldsChange` operation.',
+        codeblock: {
+          title: 'Remove deprecated settings',
+          tabs: [
+            {code: './examples/remove-deprecated-settings.ts', language: 'ts'},
+            {
+              code: './examples/remove-deprecated-settings.tsx',
+              language: 'tsx',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Configure multiple routing criteria including maximum distance (50km), inventory checking (true), and excluded zip codes (90210, 10001). This example sets all routing criteria in a single batch operation with different value types (integer, boolean, and JSON).',
+        codeblock: {
+          title: 'Set routing criteria',
+          tabs: [
+            {code: './examples/set-routing-criteria.ts', language: 'ts'},
+            {code: './examples/set-routing-criteria.tsx', language: 'tsx'},
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Contextual APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -15,19 +15,23 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Configure location priority',
       tabs: [
         {
+
           title: 'React',
 
           code: './examples/configure-location-priority.tsx',
 
           language: 'tsx',
+
         },
 
         {
+
           title: 'TS',
 
           code: './examples/configure-location-priority.ts',
 
           language: 'ts',
+
         },
       ],
     },
@@ -63,24 +67,28 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Configure maximum distance, inventory checking, and excluded zip codes in one save. This example demonstrates using number fields, checkboxes, and JSON storage for complex routing criteria.',
+          'Configure maximum distance, inventory checking, and excluded zip codes in one save. This example demonstrates using [`NumberField`](/docs/api/admin-extensions/{API_VERSION}/components/forms/numberfield), [`Checkbox`](/docs/api/admin-extensions/{API_VERSION}/components/forms/checkbox), and JSON storage for complex routing criteria.',
         codeblock: {
           title: 'Set routing criteria',
           tabs: [
             {
+
               title: 'React',
 
               code: './examples/set-routing-criteria.tsx',
 
               language: 'tsx',
+
             },
 
             {
+
               title: 'TS',
 
               code: './examples/set-routing-criteria.ts',
 
               language: 'ts',
+
             },
           ],
         },
@@ -106,7 +114,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can't exceed 256KB, and total metafield storage per rule is limited.\n" +
         "- Rule priority is read-only. Evaluation order can't be modified through the settings interface. Merchants manage priority through the main rules interface.\n" +
-        '- Batch operations are all-or-nothing. If any metafield change in the array fails validation, the entire batch fails and no changes apply.\n' +
+        '- Batch operations are all-or-nothing. If any metafield change in the array fails validation, then the entire batch fails and no changes apply.\n' +
         '- Metafield changes apply immediately. They persist right away without waiting for merchants to save the rule.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -96,7 +96,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Batch metafield changes for atomic updates:** `applyMetafieldsChange` accepts an array of change objects. Pass multiple changes in a single call to ensure all changes succeed or all fail together.\n' +
+        '- **Batch metafield changes for atomic updates:** `applyMetafieldsChange` accepts an array of change objects. Pass multiple changes in a single call to ensure all changes succeed or all fail together.
+' +
         "- **Check operation result type:** `applyMetafieldsChange` returns `{ type: 'success' }` or `{ type: 'error', message: string }`. Errors don't throw, so always check the returned `type`.",
     },
     {
@@ -104,9 +105,12 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can't exceed 256KB, and total metafield storage per rule is limited.\n" +
-        "- Rule priority is read-only. Evaluation order can't be modified through the settings interface. Merchants manage priority through the main rules interface.\n" +
-        '- Batch operations are all-or-nothing. If any metafield change in the array fails validation, then the entire batch fails and no changes apply.\n' +
+        "- Metafields have [size limits](/docs/apps/build/metafields/metafield-limits). Individual values can't exceed 256KB, and total metafield storage per rule is limited.
+" +
+        "- Rule priority is read-only. Evaluation order can't be modified through the settings interface. Merchants manage priority through the main rules interface.
+" +
+        '- Batch operations are all-or-nothing. If any metafield change in the array fails validation, then the entire batch fails and no changes apply.
+' +
         '- Metafield changes apply immediately. They persist right away without waiting for merchants to save the rule.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Set preferred and fallback fulfillment locations for order routing. This example applies two metafield changes in a single batch using `applyMetafieldsChange`: New York Warehouse as the preferred location and Los Angeles Warehouse as the fallback.',
+      'Set preferred and fallback fulfillment locations for order routing. This example shows how to apply two metafield changes in a single batch using `applyMetafieldsChange()`—New York Warehouse as preferred and Los Angeles Warehouse as fallback.',
     codeblock: {
       title: 'Configure location priority',
       tabs: [
@@ -32,7 +32,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Batch remove outdated metafields from your routing configuration. This example maps an array of deprecated keys to removal operations, and cleans up old settings in a single `applyMetafieldsChange` operation.',
+          'Batch remove outdated metafields from your routing configuration. Maps deprecated keys to removal operations and cleans up old settings in one `applyMetafieldsChange()` call.',
         codeblock: {
           title: 'Remove deprecated settings',
           tabs: [
@@ -46,7 +46,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Configure multiple routing criteria including maximum distance (50km), inventory checking (true), and excluded zip codes (90210, 10001). This example sets all routing criteria in a single batch operation with different value types (integer, boolean, and JSON).',
+          'Configure multiple routing criteria including maximum distance (50km), inventory checking (true), and excluded zip codes (90210, 10001). This example demonstrates setting all criteria in one batch with different value types—integer, boolean, and JSON.',
         codeblock: {
           title: 'Set routing criteria',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -15,23 +15,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Configure location priority',
       tabs: [
         {
-
           title: 'React',
 
           code: './examples/configure-location-priority.tsx',
 
           language: 'tsx',
-
         },
 
         {
-
           title: 'TS',
 
           code: './examples/configure-location-priority.ts',
 
           language: 'ts',
-
         },
       ],
     },
@@ -72,23 +68,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Set routing criteria',
           tabs: [
             {
-
               title: 'React',
 
               code: './examples/set-routing-criteria.tsx',
 
               language: 'tsx',
-
             },
 
             {
-
               title: 'TS',
 
               code: './examples/set-routing-criteria.ts',
 
               language: 'ts',
-
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -15,14 +15,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Configure location priority',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/configure-location-priority.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/configure-location-priority.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/configure-location-priority.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -63,14 +68,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Set routing criteria',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/set-routing-criteria.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/set-routing-criteria.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/set-routing-criteria.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/direct-api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/direct-api.ts
@@ -1,0 +1,73 @@
+const r = await fetch('shopify:admin/api/graphql.json', {
+  method: 'POST',
+  body: JSON.stringify({
+    query: `
+      query GetOrders($first: Int!) {
+        orders(first: $first) {
+          edges {
+            node {
+              id
+              name
+              customer {
+                displayName
+              }
+              originalTotalPriceSet {
+                shopMoney {
+                  amount
+                }
+              }
+              displayFulfillmentStatus
+              displayFinancialStatus
+              unpaid
+            }
+          }
+        }
+      }
+    `,
+    variables: {first: 10},
+  }),
+});
+const {data} = await r.json();
+const orderData = data.orders.edges;
+
+const selected = await picker({
+  heading: 'Select orders',
+  multiple: true,
+  headers: [
+    {title: 'Order'},
+    {title: 'Customer'},
+    {title: 'Total', type: 'number'},
+  ],
+  items: orderData.map((order) => {
+    const {
+      id,
+      name,
+      customer,
+      originalTotalPriceSet: {shopMoney},
+      displayFulfillmentStatus,
+      displayFinancialStatus,
+    } = order.node;
+
+    return {
+      id,
+      heading: name,
+      data: [customer.displayName, `$${shopMoney.amount}`],
+      badges: [
+        {
+          content: displayFulfillmentStatus,
+          tone: displayFulfillmentStatus === 'FULFILLED' ? '' : 'attention',
+          progress:
+            displayFulfillmentStatus === 'FULFILLED'
+              ? 'complete'
+              : 'incomplete',
+        },
+        {
+          content: displayFinancialStatus,
+          tone: displayFinancialStatus === 'PENDING' ? 'warning' : '',
+          progress:
+            displayFinancialStatus === 'PENDING' ? 'incomplete' : 'complete',
+        },
+      ],
+    };
+  }),
+});

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/direct-api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/direct-api.ts
@@ -1,73 +1,42 @@
-const r = await fetch('shopify:admin/api/graphql.json', {
-  method: 'POST',
-  body: JSON.stringify({
-    query: `
-      query GetOrders($first: Int!) {
-        orders(first: $first) {
-          edges {
-            node {
-              id
-              name
-              customer {
-                displayName
-              }
-              originalTotalPriceSet {
-                shopMoney {
-                  amount
+import {extension, Button} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {picker} = api;
+
+    const openButton = root.createComponent(Button, {
+      title: 'Open Order Picker',
+      onPress: async () => {
+        const response = await fetch('shopify:admin/api/graphql.json', {
+          method: 'POST',
+          body: JSON.stringify({
+            query: `query GetOrders($first: Int!) {
+              orders(first: $first) {
+                edges {
+                  node {
+                    id
+                    name
+                  }
                 }
               }
-              displayFulfillmentStatus
-              displayFinancialStatus
-              unpaid
-            }
-          }
-        }
-      }
-    `,
-    variables: {first: 10},
-  }),
-});
-const {data} = await r.json();
-const orderData = data.orders.edges;
+            }`,
+            variables: {first: 10},
+          }),
+        });
 
-const selected = await picker({
-  heading: 'Select orders',
-  multiple: true,
-  headers: [
-    {title: 'Order'},
-    {title: 'Customer'},
-    {title: 'Total', type: 'number'},
-  ],
-  items: orderData.map((order) => {
-    const {
-      id,
-      name,
-      customer,
-      originalTotalPriceSet: {shopMoney},
-      displayFulfillmentStatus,
-      displayFinancialStatus,
-    } = order.node;
+        const {data} = await response.json();
 
-    return {
-      id,
-      heading: name,
-      data: [customer.displayName, `$${shopMoney.amount}`],
-      badges: [
-        {
-          content: displayFulfillmentStatus,
-          tone: displayFulfillmentStatus === 'FULFILLED' ? '' : 'attention',
-          progress:
-            displayFulfillmentStatus === 'FULFILLED'
-              ? 'complete'
-              : 'incomplete',
-        },
-        {
-          content: displayFinancialStatus,
-          tone: displayFinancialStatus === 'PENDING' ? 'warning' : '',
-          progress:
-            displayFinancialStatus === 'PENDING' ? 'incomplete' : 'complete',
-        },
-      ],
-    };
-  }),
-});
+        await picker({
+          heading: 'Select orders',
+          items: data.orders.edges.map((edge) => ({
+            id: edge.node.id,
+            heading: edge.node.name,
+          })),
+        });
+      },
+    });
+
+    root.appendChild(openButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/direct-api.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/direct-api.tsx
@@ -1,0 +1,41 @@
+import React, {useEffect, useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const DirectApiPicker = () => {
+  const {picker, query} = useApi<'admin.product-details.block.render'>();
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    query(
+      `query GetOrders($first: Int!) {
+        orders(first: $first) {
+          edges {
+            node {
+              id
+              name
+            }
+          }
+        }
+      }`,
+      {variables: {first: 10}},
+    ).then(({data}) => {
+      setOrders(data.orders.edges);
+    });
+  }, [query]);
+
+  const handlePick = async () => {
+    if (orders.length > 0) {
+      await picker({
+        heading: 'Select orders',
+        items: orders.map((edge) => ({
+          id: edge.node.id,
+          heading: edge.node.name,
+        })),
+      });
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <DirectApiPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/direct-api.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/direct-api.tsx
@@ -1,41 +1,42 @@
-import React, {useEffect, useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React from 'react';
+import {reactExtension, useApi, Button} from '@shopify/ui-extensions-react/admin';
 
 const DirectApiPicker = () => {
-  const {picker, query} = useApi<'admin.product-details.block.render'>();
-  const [orders, setOrders] = useState([]);
-
-  useEffect(() => {
-    query(
-      `query GetOrders($first: Int!) {
-        orders(first: $first) {
-          edges {
-            node {
-              id
-              name
-            }
-          }
-        }
-      }`,
-      {variables: {first: 10}},
-    ).then(({data}) => {
-      setOrders(data.orders.edges);
-    });
-  }, [query]);
+  const {picker} = useApi<'admin.product-details.block.render'>();
 
   const handlePick = async () => {
-    if (orders.length > 0) {
-      await picker({
-        heading: 'Select orders',
-        items: orders.map((edge) => ({
-          id: edge.node.id,
-          heading: edge.node.name,
-        })),
-      });
-    }
+    const response = await fetch('shopify:admin/api/graphql.json', {
+      method: 'POST',
+      body: JSON.stringify({
+        query: `query GetOrders($first: Int!) {
+          orders(first: $first) {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }`,
+        variables: {first: 10},
+      }),
+    });
+
+    const {data} = await response.json();
+
+    await picker({
+      heading: 'Select orders',
+      items: data.orders.edges.map((edge) => ({
+        id: edge.node.id,
+        heading: edge.node.name,
+      })),
+    });
   };
 
-  return null;
+  return <Button title="Open Order Picker" onPress={handlePick} />;
 };
 
-export default reactExtension('admin.product-details.block.render', () => <DirectApiPicker />);
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <DirectApiPicker />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/disabled.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/disabled.ts
@@ -1,0 +1,16 @@
+const pickerInstance = await picker({
+  heading: 'Disabled items',
+  items: [
+    {
+      id: '1',
+      heading: 'Item 1',
+      disabled: true,
+    },
+    {
+      id: '2',
+      heading: 'Item 2',
+    },
+  ],
+});
+
+const selected = await pickerInstance.selected;

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/disabled.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/disabled.ts
@@ -1,16 +1,23 @@
-const pickerInstance = await picker({
-  heading: 'Disabled items',
-  items: [
-    {
-      id: '1',
-      heading: 'Item 1',
-      disabled: true,
-    },
-    {
-      id: '2',
-      heading: 'Item 2',
-    },
-  ],
-});
+import {extension, Button} from '@shopify/ui-extensions/admin';
 
-const selected = await pickerInstance.selected;
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {picker} = api;
+
+    const openButton = root.createComponent(Button, {
+      title: 'Open Picker',
+      onPress: async () => {
+        await picker({
+          heading: 'Select items',
+          items: [
+            {id: '1', heading: 'Available item'},
+            {id: '2', heading: 'Disabled item', disabled: true},
+          ],
+        });
+      },
+    });
+
+    root.appendChild(openButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/disabled.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/disabled.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const DisabledItems = () => {
+  const {picker} = useApi<'admin.product-details.block.render'>();
+
+  const handlePick = async () => {
+    await picker({
+      heading: 'Select items',
+      items: [
+        {id: '1', heading: 'Available item'},
+        {id: '2', heading: 'Disabled item', disabled: true},
+      ],
+    });
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <DisabledItems />);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/disabled.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/disabled.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {
+  reactExtension,
+  useApi,
+  Button,
+} from '@shopify/ui-extensions-react/admin';
 
-const DisabledItems = () => {
+const DisabledPicker = () => {
   const {picker} = useApi<'admin.product-details.block.render'>();
 
   const handlePick = async () => {
@@ -14,7 +18,10 @@ const DisabledItems = () => {
     });
   };
 
-  return null;
+  return <Button title="Open Picker" onPress={handlePick} />;
 };
 
-export default reactExtension('admin.product-details.block.render', () => <DisabledItems />);
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <DisabledPicker />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/minimal.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/minimal.ts
@@ -1,0 +1,16 @@
+const pickerInstance = await picker({
+  heading: 'Select an item',
+  headers: [{title: 'Main heading'}],
+  items: [
+    {
+      id: '1',
+      heading: 'Item 1',
+    },
+    {
+      id: '2',
+      heading: 'Item 2',
+    },
+  ],
+});
+
+const selected = await pickerInstance.selected;

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/minimal.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/minimal.ts
@@ -1,16 +1,41 @@
-const pickerInstance = await picker({
-  heading: 'Select an item',
-  headers: [{title: 'Main heading'}],
-  items: [
-    {
-      id: '1',
-      heading: 'Item 1',
-    },
-    {
-      id: '2',
-      heading: 'Item 2',
-    },
-  ],
-});
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
-const selected = await pickerInstance.selected;
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {picker} = api;
+
+    let selectedText;
+
+    const openButton = root.createComponent(Button, {
+      title: 'Open Picker',
+      onPress: async () => {
+        const pickerInstance = await picker({
+          heading: 'Select an item',
+          headers: [{title: 'Main heading'}],
+          items: [
+            {id: '1', heading: 'Item 1'},
+            {id: '2', heading: 'Item 2'},
+          ],
+        });
+
+        const result = await pickerInstance.selected;
+
+        if (selectedText) {
+          root.removeChild(selectedText);
+        }
+
+        if (result) {
+          selectedText = root.createComponent(
+            Text,
+            {},
+            `${result.length} items selected`,
+          );
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(openButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/minimal.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/minimal.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const MinimalPicker = () => {
+  const {picker} = useApi<'admin.product-details.block.render'>();
+
+  const handlePick = async () => {
+    await picker({
+      heading: 'Select item',
+      items: [
+        {id: '1', heading: 'Option 1'},
+        {id: '2', heading: 'Option 2'},
+      ],
+    });
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <MinimalPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/minimal.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/minimal.tsx
@@ -1,20 +1,38 @@
-import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Button,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
 
 const MinimalPicker = () => {
   const {picker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState<string[] | null>(null);
 
   const handlePick = async () => {
-    await picker({
-      heading: 'Select item',
+    const pickerInstance = await picker({
+      heading: 'Select an item',
+      headers: [{title: 'Main heading'}],
       items: [
-        {id: '1', heading: 'Option 1'},
-        {id: '2', heading: 'Option 2'},
+        {id: '1', heading: 'Item 1'},
+        {id: '2', heading: 'Item 2'},
       ],
     });
+
+    const result = await pickerInstance.selected;
+    setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Open Picker" onPress={handlePick} />
+      {selected && <Text>{selected.length} items selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <MinimalPicker />);
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <MinimalPicker />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-limit.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-limit.ts
@@ -1,0 +1,21 @@
+const pickerInstance = await picker({
+  heading: 'Select items (up to 2)',
+  multiple: 2,
+  headers: [{title: 'Main heading'}],
+  items: [
+    {
+      id: '1',
+      heading: 'Item 1',
+    },
+    {
+      id: '2',
+      heading: 'Item 2',
+    },
+    {
+      id: '3',
+      heading: 'Item 3',
+    },
+  ],
+});
+
+const selected = await pickerInstance.selected;

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-limit.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-limit.ts
@@ -1,21 +1,26 @@
-const pickerInstance = await picker({
-  heading: 'Select items (up to 2)',
-  multiple: 2,
-  headers: [{title: 'Main heading'}],
-  items: [
-    {
-      id: '1',
-      heading: 'Item 1',
-    },
-    {
-      id: '2',
-      heading: 'Item 2',
-    },
-    {
-      id: '3',
-      heading: 'Item 3',
-    },
-  ],
-});
+import {extension, Button} from '@shopify/ui-extensions/admin';
 
-const selected = await pickerInstance.selected;
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {picker} = api;
+
+    const openButton = root.createComponent(Button, {
+      title: 'Open Picker',
+      onPress: async () => {
+        await picker({
+          heading: 'Select items (up to 2)',
+          multiple: 2,
+          headers: [{title: 'Main heading'}],
+          items: [
+            {id: '1', heading: 'Item 1'},
+            {id: '2', heading: 'Item 2'},
+            {id: '3', heading: 'Item 3'},
+          ],
+        });
+      },
+    });
+
+    root.appendChild(openButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-limit.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-limit.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const MultipleLimitPicker = () => {
+  const {picker} = useApi<'admin.product-details.block.render'>();
+
+  const handlePick = async () => {
+    await picker({
+      heading: 'Select items (up to 2)',
+      multiple: 2,
+      items: [
+        {id: '1', heading: 'Item 1'},
+        {id: '2', heading: 'Item 2'},
+        {id: '3', heading: 'Item 3'},
+      ],
+    });
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <MultipleLimitPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-limit.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-limit.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {
+  reactExtension,
+  useApi,
+  Button,
+} from '@shopify/ui-extensions-react/admin';
 
 const MultipleLimitPicker = () => {
   const {picker} = useApi<'admin.product-details.block.render'>();
@@ -8,6 +12,7 @@ const MultipleLimitPicker = () => {
     await picker({
       heading: 'Select items (up to 2)',
       multiple: 2,
+      headers: [{title: 'Main heading'}],
       items: [
         {id: '1', heading: 'Item 1'},
         {id: '2', heading: 'Item 2'},
@@ -16,7 +21,10 @@ const MultipleLimitPicker = () => {
     });
   };
 
-  return null;
+  return <Button title="Open Picker" onPress={handlePick} />;
 };
 
-export default reactExtension('admin.product-details.block.render', () => <MultipleLimitPicker />);
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <MultipleLimitPicker />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-true.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-true.ts
@@ -1,0 +1,21 @@
+const pickerInstance = await picker({
+  heading: 'Select items',
+  multiple: true,
+  headers: [{title: 'Main heading'}],
+  items: [
+    {
+      id: '1',
+      heading: 'Item 1',
+    },
+    {
+      id: '2',
+      heading: 'Item 2',
+    },
+    {
+      id: '3',
+      heading: 'Item 3',
+    },
+  ],
+});
+
+const selected = await pickerInstance.selected;

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-true.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-true.ts
@@ -1,21 +1,25 @@
-const pickerInstance = await picker({
-  heading: 'Select items',
-  multiple: true,
-  headers: [{title: 'Main heading'}],
-  items: [
-    {
-      id: '1',
-      heading: 'Item 1',
-    },
-    {
-      id: '2',
-      heading: 'Item 2',
-    },
-    {
-      id: '3',
-      heading: 'Item 3',
-    },
-  ],
-});
+import {extension, Button} from '@shopify/ui-extensions/admin';
 
-const selected = await pickerInstance.selected;
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {picker} = api;
+
+    const openButton = root.createComponent(Button, {
+      title: 'Open Picker',
+      onPress: async () => {
+        await picker({
+          heading: 'Select items',
+          multiple: true,
+          items: [
+            {id: '1', heading: 'Item 1'},
+            {id: '2', heading: 'Item 2'},
+            {id: '3', heading: 'Item 3'},
+          ],
+        });
+      },
+    });
+
+    root.appendChild(openButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-true.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-true.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button} from '@shopify/ui-extensions-react/admin';
 
-const MultipleUnlimitedPicker = () => {
+const MultipleTruePicker = () => {
   const {picker} = useApi<'admin.product-details.block.render'>();
 
   const handlePick = async () => {
@@ -16,7 +16,10 @@ const MultipleUnlimitedPicker = () => {
     });
   };
 
-  return null;
+  return <Button title="Open Picker" onPress={handlePick} />;
 };
 
-export default reactExtension('admin.product-details.block.render', () => <MultipleUnlimitedPicker />);
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <MultipleTruePicker />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-true.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/multiple-true.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const MultipleUnlimitedPicker = () => {
+  const {picker} = useApi<'admin.product-details.block.render'>();
+
+  const handlePick = async () => {
+    await picker({
+      heading: 'Select items',
+      multiple: true,
+      items: [
+        {id: '1', heading: 'Item 1'},
+        {id: '2', heading: 'Item 2'},
+        {id: '3', heading: 'Item 3'},
+      ],
+    });
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <MultipleUnlimitedPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/preselected.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/preselected.ts
@@ -1,0 +1,16 @@
+const pickerInstance = await picker({
+  heading: 'Preselected items',
+  items: [
+    {
+      id: '1',
+      heading: 'Item 1',
+      selected: true,
+    },
+    {
+      id: '2',
+      heading: 'Item 2',
+    },
+  ],
+});
+
+const selected = await pickerInstance.selected;

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/preselected.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/preselected.ts
@@ -1,16 +1,23 @@
-const pickerInstance = await picker({
-  heading: 'Preselected items',
-  items: [
-    {
-      id: '1',
-      heading: 'Item 1',
-      selected: true,
-    },
-    {
-      id: '2',
-      heading: 'Item 2',
-    },
-  ],
-});
+import {extension, Button} from '@shopify/ui-extensions/admin';
 
-const selected = await pickerInstance.selected;
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {picker} = api;
+
+    const openButton = root.createComponent(Button, {
+      title: 'Open Picker',
+      onPress: async () => {
+        await picker({
+          heading: 'Select items',
+          items: [
+            {id: '1', heading: 'Item 1', selected: true},
+            {id: '2', heading: 'Item 2'},
+          ],
+        });
+      },
+    });
+
+    root.appendChild(openButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/preselected.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/preselected.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button} from '@shopify/ui-extensions-react/admin';
 
 const PreselectedPicker = () => {
   const {picker} = useApi<'admin.product-details.block.render'>();
@@ -14,7 +14,10 @@ const PreselectedPicker = () => {
     });
   };
 
-  return null;
+  return <Button title="Open Picker" onPress={handlePick} />;
 };
 
-export default reactExtension('admin.product-details.block.render', () => <PreselectedPicker />);
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <PreselectedPicker />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/preselected.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/preselected.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const PreselectedPicker = () => {
+  const {picker} = useApi<'admin.product-details.block.render'>();
+
+  const handlePick = async () => {
+    await picker({
+      heading: 'Select items',
+      items: [
+        {id: '1', heading: 'Item 1', selected: true},
+        {id: '2', heading: 'Item 2'},
+      ],
+    });
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <PreselectedPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/template-picker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/template-picker.ts
@@ -1,0 +1,37 @@
+const {picker} = useApi(TARGET);
+
+const pickerInstance = await picker({
+  heading: 'Select a template',
+  multiple: false,
+  headers: [
+    {title: 'Templates'},
+    {title: 'Created by'},
+    {title: 'Times used', type: 'number'},
+  ],
+  items: [
+    {
+      id: '1',
+      heading: 'Full width, 1 column',
+      data: ['Karine Ruby', '0'],
+      badges: [{content: 'Draft', tone: 'info'}, {content: 'Marketing'}],
+    },
+    {
+      id: '2',
+      heading: 'Large graphic, 3 column',
+      data: ['Russell Winfield', '5'],
+      badges: [
+        {content: 'Published', tone: 'success'},
+        {content: 'New feature'},
+      ],
+      selected: true,
+    },
+    {
+      id: '3',
+      heading: 'Promo header, 2 column',
+      data: ['Russel Winfield', '10'],
+      badges: [{content: 'Published', tone: 'success'}],
+    },
+  ],
+});
+
+const selected = await pickerInstance.selected;

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/template-picker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/template-picker.ts
@@ -1,37 +1,66 @@
-const {picker} = useApi(TARGET);
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
-const pickerInstance = await picker({
-  heading: 'Select a template',
-  multiple: false,
-  headers: [
-    {title: 'Templates'},
-    {title: 'Created by'},
-    {title: 'Times used', type: 'number'},
-  ],
-  items: [
-    {
-      id: '1',
-      heading: 'Full width, 1 column',
-      data: ['Karine Ruby', '0'],
-      badges: [{content: 'Draft', tone: 'info'}, {content: 'Marketing'}],
-    },
-    {
-      id: '2',
-      heading: 'Large graphic, 3 column',
-      data: ['Russell Winfield', '5'],
-      badges: [
-        {content: 'Published', tone: 'success'},
-        {content: 'New feature'},
-      ],
-      selected: true,
-    },
-    {
-      id: '3',
-      heading: 'Promo header, 2 column',
-      data: ['Russel Winfield', '10'],
-      badges: [{content: 'Published', tone: 'success'}],
-    },
-  ],
-});
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {picker} = api;
 
-const selected = await pickerInstance.selected;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Choose Template',
+      onPress: async () => {
+        const pickerInstance = await picker({
+          heading: 'Select a template',
+          multiple: false,
+          headers: [
+            {title: 'Templates'},
+            {title: 'Created by'},
+            {title: 'Times used', type: 'number'},
+          ],
+          items: [
+            {
+              id: '1',
+              heading: 'Full width, 1 column',
+              data: ['Karine Ruby', '0'],
+              badges: [{content: 'Draft', tone: 'info'}, {content: 'Marketing'}],
+            },
+            {
+              id: '2',
+              heading: 'Large graphic, 3 column',
+              data: ['Russell Winfield', '5'],
+              badges: [
+                {content: 'Published', tone: 'success'},
+                {content: 'New feature'},
+              ],
+              selected: true,
+            },
+            {
+              id: '3',
+              heading: 'Promo header, 2 column',
+              data: ['Russel Winfield', '10'],
+              badges: [{content: 'Published', tone: 'success'}],
+            },
+          ],
+        });
+
+        const result = await pickerInstance.selected;
+
+        if (selectedText) {
+          root.removeChild(selectedText);
+        }
+
+        if (result && result.length > 0) {
+          selectedText = root.createComponent(
+            Text,
+            {},
+            `Selected template: ${result[0]}`,
+          );
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/template-picker.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/template-picker.tsx
@@ -1,11 +1,16 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {
+  reactExtension,
+  useApi,
+  Button,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
 
 const TemplatePicker = () => {
   const {picker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<string[] | null>(null);
 
-  const handlePick = async () => {
+  const handlePickTemplate = async () => {
     const pickerInstance = await picker({
       heading: 'Select a template',
       multiple: false,
@@ -25,7 +30,10 @@ const TemplatePicker = () => {
           id: '2',
           heading: 'Large graphic, 3 column',
           data: ['Russell Winfield', '5'],
-          badges: [{content: 'Published', tone: 'success'}, {content: 'New feature'}],
+          badges: [
+            {content: 'Published', tone: 'success'},
+            {content: 'New feature'},
+          ],
           selected: true,
         },
         {
@@ -41,7 +49,15 @@ const TemplatePicker = () => {
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Choose Template" onPress={handlePickTemplate} />
+      {selected && selected.length > 0 && <Text>Selected template: {selected[0]}</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <TemplatePicker />);
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <TemplatePicker />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/examples/template-picker.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/examples/template-picker.tsx
@@ -1,0 +1,47 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const TemplatePicker = () => {
+  const {picker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const pickerInstance = await picker({
+      heading: 'Select a template',
+      multiple: false,
+      headers: [
+        {title: 'Templates'},
+        {title: 'Created by'},
+        {title: 'Times used', type: 'number'},
+      ],
+      items: [
+        {
+          id: '1',
+          heading: 'Full width, 1 column',
+          data: ['Karine Ruby', '0'],
+          badges: [{content: 'Draft', tone: 'info'}, {content: 'Marketing'}],
+        },
+        {
+          id: '2',
+          heading: 'Large graphic, 3 column',
+          data: ['Russell Winfield', '5'],
+          badges: [{content: 'Published', tone: 'success'}, {content: 'New feature'}],
+          selected: true,
+        },
+        {
+          id: '3',
+          heading: 'Promo header, 2 column',
+          data: ['Russel Winfield', '10'],
+          badges: [{content: 'Published', tone: 'success'}],
+        },
+      ],
+    });
+
+    const result = await pickerInstance.selected;
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <TemplatePicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -177,16 +177,19 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Handle undefined return on cancellation:** When merchants cancel or close the picker, it returns `undefined` rather than an empty array. Check for `undefined` explicitly to distinguish cancellation from empty selection.\n' +
-        "- **Disable items to prevent modification:** Use the `disabled` property on items combined with `initialSelectionIds` to create preselected items that merchants can't deselect.",
+        '- **Handle undefined return on cancellation:** When merchants cancel or close the picker, it returns `undefined` rather than an empty array. Check for `undefined` explicitly to distinguish cancellation from empty selection.
+' +
+        "- **Disable items to prevent modification:** Use the `disabled` property on items combined with `selected: true` to create preselected items that merchants can't deselect.",
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- The Picker API only supports app-specific data. It can't display Shopify resources like products or variants. Use [Resource Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) for Shopify resources.\n" +
-        "- Picker items don't support hierarchical or nested structures. All items appear in a flat list.\n" +
+        "- The Picker API only supports app-specific data. It can't display Shopify resources like products or variants. Use [Resource Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) for Shopify resources.
+" +
+        "- Picker items don't support hierarchical or nested structures. All items appear in a flat list.
+" +
         "- The picker can't be customized with additional filters, search operators, or sorting beyond what merchants type in the search field.",
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -146,7 +146,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          "Populate the picker with live data from the [GraphQL Admin API](/docs/api/admin-graphql). This example fetches order data when the button is clicked, transforms results into picker-compatible items, and opens the picker with the dynamically populated data. Use this pattern for showing real-time Shopify data that isn\'t available through the Resource Picker API, such as orders, draft orders, or fulfillments.",
+          "Populate the picker with live data from the [GraphQL Admin API](/docs/api/admin-graphql). This example fetches order data when the button is clicked, transforms results into picker-compatible items, and opens the picker with the dynamically populated data. Use this pattern for showing real-time Shopify data that isn't available through the Resource Picker API, such as orders, draft orders, or fulfillments.",
         codeblock: {
           title: 'Use GraphQL data',
           tabs: [
@@ -179,18 +179,18 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- **Handle undefined return on cancellation:** When merchants cancel or close the picker, it returns `undefined` rather than an empty array. Check for `undefined` explicitly to distinguish cancellation from empty selection.
 ' +
-        "- **Disable items to prevent modification:** Use the `disabled` property on items combined with `selected: true` to create preselected items that merchants can\'t deselect.",
+        "- **Disable items to prevent modification:** Use the `disabled` property on items combined with `selected: true` to create preselected items that merchants can't deselect.",
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- The Picker API only supports app-specific data. It can\'t display Shopify resources like products or variants. Use [Resource Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) for Shopify resources.
+        "- The Picker API only supports app-specific data. It can't display Shopify resources like products or variants. Use [Resource Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) for Shopify resources.
 " +
-        "- Picker items don\'t support hierarchical or nested structures. All items appear in a flat list.
+        "- Picker items don't support hierarchical or nested structures. All items appear in a flat list.
 " +
-        "- The picker can\'t be customized with additional filters, search operators, or sorting beyond what merchants type in the search field.",
+        "- The picker can't be customized with additional filters, search operators, or sorting beyond what merchants type in the search field.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
     'an Admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.',
   defaultExample: {
     description:
-      'Build a custom picker for email templates with columns and badges. This example defines table headers (Templates, Created by, Times used), populates picker items with data fields for each column, and adds status badges (Draft/Published) to visually distinguish template states.',
+      'Build a custom picker for email templates with multiple columns and status badges. This example shows defining column headers, populating items with searchable data fields, adding visual status indicators, and handling the selection promise. Use this pattern for app-specific resources like templates, product reviews, or subscription options where you need custom data structures beyond standard Shopify resources.',
     image: 'picker.png',
     codeblock: {
       title: 'Select email templates',
@@ -33,72 +33,61 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   examples: {
-    description: 'Picker API patterns',
+    description: 'Examples that demonstrate how to use the Picker API.',
     examples: [
       {
         description:
-          'Create a minimal picker with only required fields (heading and items). Basic picker with two selectable options and no additional configuration.',
+          'Disable specific picker items to prevent selection while keeping them visible for context. This example shows setting `disabled: true` on individual items to mark them as non-selectable. This is useful for showing all available options while preventing selection of incompatible resources, templates currently being edited by others, or deprecated features that require upgrades.',
         codeblock: {
-          title: 'Simple picker',
+          title: 'Disable specific items',
           tabs: [
-            {code: './examples/minimal.ts', language: 'ts'},
-            {code: './examples/minimal.tsx', language: 'tsx'},
-          ],
+        {code: './examples/disabled.ts', language: 'ts'},
+        {code: './examples/disabled.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Limit selection to a maximum of 2 items. Sets `multiple: 2` to restrict selection count.',
+          'Limit selection to a maximum number of items by setting `multiple: 2` in the picker options. This example shows restricting selection to exactly 2 items. Use this when your feature has hard constraints, such as A/B test variants needing exactly two options, comparison views with fixed slots, or integration mappings that support a specific connection count.',
         codeblock: {
-          title: 'Limited selectable items',
+          title: 'Limit selection count',
           tabs: [
-            {code: './examples/multiple-limit.ts', language: 'ts'},
-            {code: './examples/multiple-limit.tsx', language: 'tsx'},
-          ],
+        {code: './examples/multiple-limit.ts', language: 'ts'},
+        {code: './examples/multiple-limit.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Allow unlimited selection. Sets `multiple: true` without a numeric limit.',
+          'Open the picker with items already selected by setting `selected: true` on individual items. This example shows pre-marking items as selected when the picker opens. Use this for edit workflows where you need to show what resources are already associated with a configuration, such as automation rule triggers or notification recipients. Merchants can modify the selection before confirming.',
         codeblock: {
-          title: 'Unlimited selectable items',
+          title: 'Preselect items',
           tabs: [
-            {code: './examples/multiple-true.ts', language: 'ts'},
-            {code: './examples/multiple-true.tsx', language: 'tsx'},
-          ],
+        {code: './examples/preselected.ts', language: 'ts'},
+        {code: './examples/preselected.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Open picker with items already preselected. Sets `selected: true` on specific items when the picker opens, though merchants can still deselect them.',
+          'Allow unlimited selection by setting `multiple: true` without a numeric limit. This example shows enabling multi-selection where merchants control how many items to choose. This is useful for bulk operations, mass notification sending, export tools, or tag management where selection quantity depends on merchant needs without artificial constraints.',
         codeblock: {
-          title: 'Preselected items',
+          title: 'Select unlimited items',
           tabs: [
-            {code: './examples/preselected.ts', language: 'ts'},
-            {code: './examples/preselected.tsx', language: 'tsx'},
-          ],
+        {code: './examples/multiple-true.ts', language: 'ts'},
+        {code: './examples/multiple-true.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Disable specific picker items to prevent selection. Sets `disabled: true` on certain items, which causes them to appear but prevents selection.',
-        codeblock: {
-          title: 'Disabled items',
-          tabs: [
-            {code: './examples/disabled.ts', language: 'ts'},
-            {code: './examples/disabled.tsx', language: 'tsx'},
-          ],
-        },
-      },
-      {
-        description:
-          'Populate the picker with live GraphQL data. This example uses `useEffect` to fetch orders via the [GraphQL Admin API](/docs/api/admin-graphql), transforms them into picker format, and opens with dynamic data.',
+          "Populate the picker with live data from the [GraphQL Admin API](/docs/api/admin-graphql). This example shows fetching order data when the button is clicked, transforming results into picker-compatible items, and opening the picker with the dynamically populated data. Use this pattern for showing real-time Shopify data that isn't available through the Resource Picker API, such as orders, draft orders, or fulfillments.",
         codeblock: {
           title: 'Use GraphQL data',
           tabs: [
-            {code: './examples/direct-api.ts', language: 'ts'},
-            {code: './examples/direct-api.tsx', language: 'tsx'},
-          ],
+        {code: './examples/direct-api.ts', language: 'ts'},
+        {code: './examples/direct-api.tsx', language: 'tsx'},
+      ],
         },
       },
     ],
@@ -111,7 +100,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Handle undefined return on cancellation:** When merchants cancel or close the picker, it returns `undefined` rather than an empty array. Check for `undefined` explicitly to distinguish cancellation from empty selection.\n' +
-        "- **Disable items to prevent modification:** Use the `disabled` property on items combined with `selected: true` to create preselected items that merchants can't deselect.",
+        '- **Disable items to prevent modification:** Use the `disabled` property on items combined with `initialSelectionIds` to create preselected items that merchants can't deselect.',
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -37,7 +37,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Create a minimal picker with only the required fields (heading and items). This example shows a basic picker with two selectable options and no additional configuration.',
+          'Create a minimal picker with only required fields (heading and items). Basic picker with two selectable options and no additional configuration.',
         codeblock: {
           title: 'Simple picker',
           tabs: [
@@ -48,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Limit selection to a maximum of 2 items. This example sets `multiple: 2` to restrict how many items the merchant can select.',
+          'Limit selection to a maximum of 2 items. Sets `multiple: 2` to restrict selection count.',
         codeblock: {
           title: 'Limited selectable items',
           tabs: [
@@ -59,7 +59,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Allow unlimited selection. This example sets `multiple: true` without a numeric limit, allowing the merchant to select as many items as needed.',
+          'Allow unlimited selection. Sets `multiple: true` without a numeric limit.',
         codeblock: {
           title: 'Unlimited selectable items',
           tabs: [
@@ -70,7 +70,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Open the picker with items already preselected. This example sets `selected: true` on specific items when the picker opens, though the merchant can still deselect them.',
+          'Open picker with items already preselected. Sets `selected: true` on specific items when the picker opens, though merchants can still deselect them.',
         codeblock: {
           title: 'Preselected items',
           tabs: [
@@ -81,7 +81,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Disable specific picker items to prevent selection. This example sets `disabled: true` on certain items, which causes them to appear in the picker but prevents the merchant from selecting them.',
+          'Disable specific picker items to prevent selection. Sets `disabled: true` on certain items, which causes them to appear but prevents selection.',
         codeblock: {
           title: 'Disabled items',
           tabs: [
@@ -92,7 +92,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Populate the picker with live GraphQL data. This example uses `useEffect` to fetch orders via the [GraphQL Admin API](/docs/api/admin-graphql), transforms them into picker item format, and opens the picker with dynamically loaded data.',
+          'Populate the picker with live GraphQL data. This example uses `useEffect` to fetch orders via the [GraphQL Admin API](/docs/api/admin-graphql), transforms them into picker format, and opens with dynamic data.',
         codeblock: {
           title: 'Use GraphQL data',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -14,14 +14,14 @@ const data: ReferenceEntityTemplateSchema = {
   requires:
     'an Admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.',
   defaultExample: {
+    description:
+      'Build a custom picker for email templates with columns and badges. This example defines table headers (Templates, Created by, Times used), populates picker items with data fields for each column, and adds status badges (Draft/Published) to visually distinguish template states.',
     image: 'picker.png',
     codeblock: {
-      title: 'Picker',
+      title: 'Select email templates',
       tabs: [
-        {
-          code: './examples/template-picker.js',
-          language: 'js',
-        },
+        {code: './examples/template-picker.ts', language: 'ts'},
+        {code: './examples/template-picker.tsx', language: 'tsx'},
       ],
     },
   },
@@ -33,69 +33,71 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   examples: {
-    description: 'Pickers with different options',
+    description: 'Picker API patterns',
     examples: [
       {
         description:
-          "Minimal required fields picker configuration.\n\nIf you don't provide the required options (`heading` and `items`), the picker will not open and an error will be logged.",
+          'Create a minimal picker with only the required fields (heading and items). This example shows a basic picker with two selectable options and no additional configuration.',
         codeblock: {
           title: 'Simple picker',
           tabs: [
-            {
-              code: './examples/minimal.js',
-              language: 'js',
-            },
+            {code: './examples/minimal.ts', language: 'ts'},
+            {code: './examples/minimal.tsx', language: 'tsx'},
           ],
         },
       },
       {
         description:
-          'Setting a specific number of selectable items. In this example, the user can select up to 2 items.',
+          'Limit selection to a maximum of 2 items. This example sets `multiple: 2` to restrict how many items the merchant can select.',
         codeblock: {
           title: 'Limited selectable items',
           tabs: [
-            {
-              code: './examples/multiple-limit.js',
-              language: 'js',
-            },
+            {code: './examples/multiple-limit.ts', language: 'ts'},
+            {code: './examples/multiple-limit.tsx', language: 'tsx'},
           ],
         },
       },
       {
-        description: 'Setting an unlimited number of selectable items.',
+        description:
+          'Allow unlimited selection. This example sets `multiple: true` without a numeric limit, allowing the merchant to select as many items as needed.',
         codeblock: {
           title: 'Unlimited selectable items',
           tabs: [
-            {
-              code: './examples/multiple-true.js',
-              language: 'js',
-            },
+            {code: './examples/multiple-true.ts', language: 'ts'},
+            {code: './examples/multiple-true.tsx', language: 'tsx'},
           ],
         },
       },
       {
         description:
-          'Providing preselected items in the picker. These will be selected when the picker opens but can be deselected by the user.',
+          'Open the picker with items already preselected. This example sets `selected: true` on specific items when the picker opens, though the merchant can still deselect them.',
         codeblock: {
           title: 'Preselected items',
           tabs: [
-            {
-              code: './examples/preselected.js',
-              language: 'js',
-            },
+            {code: './examples/preselected.ts', language: 'ts'},
+            {code: './examples/preselected.tsx', language: 'tsx'},
           ],
         },
       },
       {
         description:
-          "Providing disabled items in the picker. These are disabled and can't be selected by the user.",
+          'Disable specific picker items to prevent selection. This example sets `disabled: true` on certain items, which causes them to appear in the picker but prevents the merchant from selecting them.',
         codeblock: {
           title: 'Disabled items',
           tabs: [
-            {
-              code: './examples/disabled.js',
-              language: 'js',
-            },
+            {code: './examples/disabled.ts', language: 'ts'},
+            {code: './examples/disabled.tsx', language: 'tsx'},
+          ],
+        },
+      },
+      {
+        description:
+          'Populate the picker with live GraphQL data. This example uses `useEffect` to fetch orders via the [GraphQL Admin API](/docs/api/admin-graphql), transforms them into picker item format, and opens the picker with dynamically loaded data.',
+        codeblock: {
+          title: 'Use GraphQL data',
+          tabs: [
+            {code: './examples/direct-api.ts', language: 'ts'},
+            {code: './examples/direct-api.tsx', language: 'tsx'},
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -21,19 +21,23 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Select email templates',
       tabs: [
         {
+
           title: 'React',
 
           code: './examples/template-picker.tsx',
 
           language: 'tsx',
+
         },
 
         {
+
           title: 'TS',
 
           code: './examples/template-picker.ts',
 
           language: 'ts',
+
         },
       ],
     },
@@ -55,19 +59,23 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Disable specific items',
           tabs: [
             {
+
               title: 'React',
 
               code: './examples/disabled.tsx',
 
               language: 'tsx',
+
             },
 
             {
+
               title: 'TS',
 
               code: './examples/disabled.ts',
 
               language: 'ts',
+
             },
           ],
         },
@@ -79,19 +87,23 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Limit selection count',
           tabs: [
             {
+
               title: 'React',
 
               code: './examples/multiple-limit.tsx',
 
               language: 'tsx',
+
             },
 
             {
+
               title: 'TS',
 
               code: './examples/multiple-limit.ts',
 
               language: 'ts',
+
             },
           ],
         },
@@ -103,19 +115,23 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Preselect items',
           tabs: [
             {
+
               title: 'React',
 
               code: './examples/preselected.tsx',
 
               language: 'tsx',
+
             },
 
             {
+
               title: 'TS',
 
               code: './examples/preselected.ts',
 
               language: 'ts',
+
             },
           ],
         },
@@ -127,43 +143,51 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Select unlimited items',
           tabs: [
             {
+
               title: 'React',
 
               code: './examples/multiple-true.tsx',
 
               language: 'tsx',
+
             },
 
             {
+
               title: 'TS',
 
               code: './examples/multiple-true.ts',
 
               language: 'ts',
+
             },
           ],
         },
       },
       {
         description:
-          "Populate the picker with live data from the [GraphQL Admin API](/docs/api/admin-graphql). This example shows fetching order data when the button is clicked, transforming results into picker-compatible items, and opening the picker with the dynamically populated data. Use this pattern for showing real-time Shopify data that isn't available through the Resource Picker API, such as orders, draft orders, or fulfillments.",
+          "Populate the picker with live data from the [GraphQL Admin API](/docs/api/admin-graphql). This example fetches order data when the button is clicked, transforms results into picker-compatible items, and opens the picker with the dynamically populated data. Use this pattern for showing real-time Shopify data that isn't available through the Resource Picker API, such as orders, draft orders, or fulfillments.",
         codeblock: {
           title: 'Use GraphQL data',
           tabs: [
             {
+
               title: 'React',
 
               code: './examples/direct-api.tsx',
 
               language: 'tsx',
+
             },
 
             {
+
               title: 'TS',
 
               code: './examples/direct-api.ts',
 
               language: 'ts',
+
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -21,14 +21,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Select email templates',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/template-picker.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/template-picker.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/template-picker.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -50,14 +55,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Disable specific items',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/disabled.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/disabled.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/disabled.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -69,14 +79,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Limit selection count',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/multiple-limit.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/multiple-limit.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/multiple-limit.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -88,14 +103,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Preselect items',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/preselected.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/preselected.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/preselected.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -107,14 +127,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Select unlimited items',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/multiple-true.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/multiple-true.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/multiple-true.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -126,14 +151,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Use GraphQL data',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/direct-api.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/direct-api.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/direct-api.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -21,23 +21,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Select email templates',
       tabs: [
         {
-
           title: 'React',
 
           code: './examples/template-picker.tsx',
 
           language: 'tsx',
-
         },
 
         {
-
           title: 'TS',
 
           code: './examples/template-picker.ts',
 
           language: 'ts',
-
         },
       ],
     },
@@ -59,23 +55,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Disable specific items',
           tabs: [
             {
-
               title: 'React',
 
               code: './examples/disabled.tsx',
 
               language: 'tsx',
-
             },
 
             {
-
               title: 'TS',
 
               code: './examples/disabled.ts',
 
               language: 'ts',
-
             },
           ],
         },
@@ -87,23 +79,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Limit selection count',
           tabs: [
             {
-
               title: 'React',
 
               code: './examples/multiple-limit.tsx',
 
               language: 'tsx',
-
             },
 
             {
-
               title: 'TS',
 
               code: './examples/multiple-limit.ts',
 
               language: 'ts',
-
             },
           ],
         },
@@ -115,23 +103,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Preselect items',
           tabs: [
             {
-
               title: 'React',
 
               code: './examples/preselected.tsx',
 
               language: 'tsx',
-
             },
 
             {
-
               title: 'TS',
 
               code: './examples/preselected.ts',
 
               language: 'ts',
-
             },
           ],
         },
@@ -143,23 +127,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Select unlimited items',
           tabs: [
             {
-
               title: 'React',
 
               code: './examples/multiple-true.tsx',
 
               language: 'tsx',
-
             },
 
             {
-
               title: 'TS',
 
               code: './examples/multiple-true.ts',
 
               language: 'ts',
-
             },
           ],
         },
@@ -171,23 +151,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Use GraphQL data',
           tabs: [
             {
-
               title: 'React',
 
               code: './examples/direct-api.tsx',
 
               language: 'tsx',
-
             },
 
             {
-
               title: 'TS',
 
               code: './examples/direct-api.ts',
 
               language: 'ts',
-
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -100,7 +100,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Handle undefined return on cancellation:** When merchants cancel or close the picker, it returns `undefined` rather than an empty array. Check for `undefined` explicitly to distinguish cancellation from empty selection.\n' +
-        '- **Disable items to prevent modification:** Use the `disabled` property on items combined with `initialSelectionIds` to create preselected items that merchants can't deselect.',
+        '- **Disable items to prevent modification:** Use the `disabled` property on items combined with `initialSelectionIds` to create preselected items that merchants can\'t deselect.',
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -20,8 +20,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Select email templates',
       tabs: [
-        {code: './examples/template-picker.ts', language: 'ts'},
-        {code: './examples/template-picker.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/template-picker.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/template-picker.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -41,8 +49,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Disable specific items',
           tabs: [
-            {code: './examples/disabled.ts', language: 'ts'},
-            {code: './examples/disabled.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/disabled.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/disabled.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -52,8 +68,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Limit selection count',
           tabs: [
-            {code: './examples/multiple-limit.ts', language: 'ts'},
-            {code: './examples/multiple-limit.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/multiple-limit.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/multiple-limit.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -63,8 +87,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Preselect items',
           tabs: [
-            {code: './examples/preselected.ts', language: 'ts'},
-            {code: './examples/preselected.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/preselected.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/preselected.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -74,8 +106,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select unlimited items',
           tabs: [
-            {code: './examples/multiple-true.ts', language: 'ts'},
-            {code: './examples/multiple-true.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/multiple-true.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/multiple-true.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -85,8 +125,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Use GraphQL data',
           tabs: [
-            {code: './examples/direct-api.ts', language: 'ts'},
-            {code: './examples/direct-api.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/direct-api.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/direct-api.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -146,7 +146,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          "Populate the picker with live data from the [GraphQL Admin API](/docs/api/admin-graphql). This example fetches order data when the button is clicked, transforms results into picker-compatible items, and opens the picker with the dynamically populated data. Use this pattern for showing real-time Shopify data that isn't available through the Resource Picker API, such as orders, draft orders, or fulfillments.",
+          "Populate the picker with live data from the [GraphQL Admin API](/docs/api/admin-graphql). This example fetches order data when the button is clicked, transforms results into picker-compatible items, and opens the picker with the dynamically populated data. Use this pattern for showing real-time Shopify data that isn\'t available through the Resource Picker API, such as orders, draft orders, or fulfillments.",
         codeblock: {
           title: 'Use GraphQL data',
           tabs: [
@@ -179,18 +179,18 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- **Handle undefined return on cancellation:** When merchants cancel or close the picker, it returns `undefined` rather than an empty array. Check for `undefined` explicitly to distinguish cancellation from empty selection.
 ' +
-        "- **Disable items to prevent modification:** Use the `disabled` property on items combined with `selected: true` to create preselected items that merchants can't deselect.",
+        "- **Disable items to prevent modification:** Use the `disabled` property on items combined with `selected: true` to create preselected items that merchants can\'t deselect.",
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- The Picker API only supports app-specific data. It can't display Shopify resources like products or variants. Use [Resource Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) for Shopify resources.
+        "- The Picker API only supports app-specific data. It can\'t display Shopify resources like products or variants. Use [Resource Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) for Shopify resources.
 " +
-        "- Picker items don't support hierarchical or nested structures. All items appear in a flat list.
+        "- Picker items don\'t support hierarchical or nested structures. All items appear in a flat list.
 " +
-        "- The picker can't be customized with additional filters, search operators, or sorting beyond what merchants type in the search field.",
+        "- The picker can\'t be customized with additional filters, search operators, or sorting beyond what merchants type in the search field.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -41,9 +41,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Disable specific items',
           tabs: [
-        {code: './examples/disabled.ts', language: 'ts'},
-        {code: './examples/disabled.tsx', language: 'tsx'},
-      ],
+            {code: './examples/disabled.ts', language: 'ts'},
+            {code: './examples/disabled.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -52,9 +52,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Limit selection count',
           tabs: [
-        {code: './examples/multiple-limit.ts', language: 'ts'},
-        {code: './examples/multiple-limit.tsx', language: 'tsx'},
-      ],
+            {code: './examples/multiple-limit.ts', language: 'ts'},
+            {code: './examples/multiple-limit.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -63,9 +63,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Preselect items',
           tabs: [
-        {code: './examples/preselected.ts', language: 'ts'},
-        {code: './examples/preselected.tsx', language: 'tsx'},
-      ],
+            {code: './examples/preselected.ts', language: 'ts'},
+            {code: './examples/preselected.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -74,9 +74,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select unlimited items',
           tabs: [
-        {code: './examples/multiple-true.ts', language: 'ts'},
-        {code: './examples/multiple-true.tsx', language: 'tsx'},
-      ],
+            {code: './examples/multiple-true.ts', language: 'ts'},
+            {code: './examples/multiple-true.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -85,9 +85,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Use GraphQL data',
           tabs: [
-        {code: './examples/direct-api.ts', language: 'ts'},
-        {code: './examples/direct-api.tsx', language: 'tsx'},
-      ],
+            {code: './examples/direct-api.ts', language: 'ts'},
+            {code: './examples/direct-api.tsx', language: 'tsx'},
+          ],
         },
       },
     ],
@@ -100,7 +100,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Handle undefined return on cancellation:** When merchants cancel or close the picker, it returns `undefined` rather than an empty array. Check for `undefined` explicitly to distinguish cancellation from empty selection.\n' +
-        '- **Disable items to prevent modification:** Use the `disabled` property on items combined with `initialSelectionIds` to create preselected items that merchants can\'t deselect.',
+        "- **Disable items to prevent modification:** Use the `disabled` property on items combined with `initialSelectionIds` to create preselected items that merchants can't deselect.",
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/custom-product-labels.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/custom-product-labels.ts
@@ -1,23 +1,58 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Text, Button} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.print-action.render',
   async (root, api) => {
     const {data, resourcePicker} = api;
 
-    const initialProducts = data.selected;
-    const additionalProducts = await resourcePicker({type: 'product'});
+    let additionalCount = 0;
+    let additionalText;
 
-    const allProducts = additionalProducts 
-      ? [...initialProducts, ...additionalProducts]
-      : initialProducts;
+    const countText = root.createComponent(
+      Text,
+      {},
+      `${data.selected.length} products selected`,
+    );
+
+    const addButton = root.createComponent(Button, {
+      title: 'Add More Products',
+      onPress: async () => {
+        const additionalProducts = await resourcePicker({
+          type: 'product',
+          multiple: 10,
+          action: 'add',
+        });
+
+        if (additionalProducts) {
+          additionalCount = additionalProducts.length;
+          
+          if (additionalText) {
+            root.removeChild(additionalText);
+          }
+          
+          additionalText = root.createComponent(
+            Text,
+            {},
+            `+${additionalCount} additional`,
+          );
+          root.appendChild(additionalText);
+        }
+      },
+    });
+
+    root.appendChild(countText);
+    root.appendChild(addButton);
+
+    // Return print URL
+    const productIds = data.selected.map((item) => item.id);
 
     const response = await fetch('/api/generate-labels', {
       method: 'POST',
-      body: JSON.stringify({productIds: allProducts.map((p) => p.id)}),
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({productIds}),
     });
 
-    const result = await response.json();
-    return result.labelUrl;
+    const {printUrl} = await response.json();
+    return printUrl;
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/custom-product-labels.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/custom-product-labels.ts
@@ -1,0 +1,23 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.print-action.render',
+  async (root, api) => {
+    const {data, resourcePicker} = api;
+
+    const initialProducts = data.selected;
+    const additionalProducts = await resourcePicker({type: 'product'});
+
+    const allProducts = additionalProducts 
+      ? [...initialProducts, ...additionalProducts]
+      : initialProducts;
+
+    const response = await fetch('/api/generate-labels', {
+      method: 'POST',
+      body: JSON.stringify({productIds: allProducts.map((p) => p.id)}),
+    });
+
+    const result = await response.json();
+    return result.labelUrl;
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/custom-product-labels.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/custom-product-labels.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const CustomProductLabels = () => {
+  const {data, resourcePicker} = useApi<'admin.product-details.print-action.render'>();
+
+  const generate = async () => {
+    const initialProducts = data.selected;
+    const additionalProducts = await resourcePicker({type: 'product'});
+
+    const allProducts = additionalProducts 
+      ? [...initialProducts, ...additionalProducts]
+      : initialProducts;
+
+    const response = await fetch('/api/generate-labels', {
+      method: 'POST',
+      body: JSON.stringify({productIds: allProducts.map((p) => p.id)}),
+    });
+
+    const result = await response.json();
+    return result.labelUrl;
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.print-action.render', () => <CustomProductLabels />);

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/custom-product-labels.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/custom-product-labels.tsx
@@ -1,27 +1,50 @@
-import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Text,
+  Button,
+} from '@shopify/ui-extensions-react/admin';
 
 const CustomProductLabels = () => {
   const {data, resourcePicker} = useApi<'admin.product-details.print-action.render'>();
+  const [additionalCount, setAdditionalCount] = useState(0);
 
-  const generate = async () => {
-    const initialProducts = data.selected;
-    const additionalProducts = await resourcePicker({type: 'product'});
+  const handleSelectMore = async () => {
+    const additionalProducts = await resourcePicker({
+      type: 'product',
+      multiple: 10,
+      action: 'add',
+    });
 
-    const allProducts = additionalProducts 
-      ? [...initialProducts, ...additionalProducts]
-      : initialProducts;
+    if (additionalProducts) {
+      setAdditionalCount(additionalProducts.length);
+    }
+  };
+
+  return (
+    <>
+      <Text>{data.selected.length} products selected</Text>
+      <Button title="Add More Products" onPress={handleSelectMore} />
+      {additionalCount > 0 && <Text>+{additionalCount} additional</Text>}
+    </>
+  );
+};
+
+export default reactExtension(
+  'admin.product-details.print-action.render',
+  async (api) => {
+    const {data} = api;
+
+    const productIds = data.selected.map((item) => item.id);
 
     const response = await fetch('/api/generate-labels', {
       method: 'POST',
-      body: JSON.stringify({productIds: allProducts.map((p) => p.id)}),
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({productIds}),
     });
 
-    const result = await response.json();
-    return result.labelUrl;
-  };
-
-  return null;
-};
-
-export default reactExtension('admin.product-details.print-action.render', () => <CustomProductLabels />);
+    const {printUrl} = await response.json();
+    return printUrl;
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/generate-packing-slip.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/generate-packing-slip.ts
@@ -1,4 +1,4 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.order-details.print-action.render',
@@ -7,13 +7,20 @@ export default extension(
 
     const orderIds = data.selected.map((item) => item.id);
 
+    const text = root.createComponent(
+      Text,
+      {},
+      `Generating packing slip for ${data.selected.length} orders`,
+    );
+    root.appendChild(text);
+
     const response = await fetch('/api/generate-packing-slip', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({orderIds}),
     });
 
-    const result = await response.json();
-    return result.pdfUrl;
+    const {printUrl} = await response.json();
+    return printUrl;
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/generate-packing-slip.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/generate-packing-slip.ts
@@ -1,0 +1,19 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.order-details.print-action.render',
+  async (root, api) => {
+    const {data} = api;
+
+    const orderIds = data.selected.map((item) => item.id);
+
+    const response = await fetch('/api/generate-packing-slip', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({orderIds}),
+    });
+
+    const result = await response.json();
+    return result.pdfUrl;
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/generate-packing-slip.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/generate-packing-slip.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const GeneratePackingSlip = () => {
+  const {data} = useApi<'admin.order-details.print-action.render'>();
+
+  const generate = async () => {
+    const orderIds = data.selected.map((item) => item.id);
+
+    const response = await fetch('/api/generate-packing-slip', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({orderIds}),
+    });
+
+    const result = await response.json();
+    return result.pdfUrl;
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.order-details.print-action.render', () => <GeneratePackingSlip />);

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/generate-packing-slip.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/generate-packing-slip.tsx
@@ -1,10 +1,21 @@
 import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {
+  reactExtension,
+  useApi,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
 
 const GeneratePackingSlip = () => {
   const {data} = useApi<'admin.order-details.print-action.render'>();
 
-  const generate = async () => {
+  return <Text>Generating packing slip for {data.selected.length} orders</Text>;
+};
+
+export default reactExtension(
+  'admin.order-details.print-action.render',
+  async (api) => {
+    const {data} = api;
+
     const orderIds = data.selected.map((item) => item.id);
 
     const response = await fetch('/api/generate-packing-slip', {
@@ -13,11 +24,7 @@ const GeneratePackingSlip = () => {
       body: JSON.stringify({orderIds}),
     });
 
-    const result = await response.json();
-    return result.pdfUrl;
-  };
-
-  return null;
-};
-
-export default reactExtension('admin.order-details.print-action.render', () => <GeneratePackingSlip />);
+    const {printUrl} = await response.json();
+    return printUrl;
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/shipping-manifest.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/shipping-manifest.ts
@@ -1,0 +1,34 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.order-details.print-action.render',
+  async (root, api) => {
+    const {data, query} = api;
+
+    const orderIds = data.selected.map((item) => item.id);
+
+    const {data: ordersData} = await query(
+      `query GetOrders($ids: [ID!]!) {
+        nodes(ids: $ids) {
+          ... on Order {
+            id
+            name
+            shippingAddress {
+              address1
+              city
+            }
+          }
+        }
+      }`,
+      {variables: {ids: orderIds}},
+    );
+
+    const response = await fetch('/api/generate-manifest', {
+      method: 'POST',
+      body: JSON.stringify({orders: ordersData.nodes}),
+    });
+
+    const result = await response.json();
+    return result.manifestUrl;
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/shipping-manifest.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/shipping-manifest.ts
@@ -1,4 +1,4 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.order-details.print-action.render',
@@ -16,6 +16,7 @@ export default extension(
             shippingAddress {
               address1
               city
+              country
             }
           }
         }
@@ -23,12 +24,27 @@ export default extension(
       {variables: {ids: orderIds}},
     );
 
-    const response = await fetch('/api/generate-manifest', {
-      method: 'POST',
-      body: JSON.stringify({orders: ordersData.nodes}),
+    const orders = ordersData.nodes;
+
+    const summaryText = root.createComponent(
+      Text,
+      {},
+      `Shipping manifest for ${orders.length} orders`,
+    );
+    root.appendChild(summaryText);
+
+    orders.forEach((order) => {
+      const orderText = root.createComponent(Text, {}, order.name);
+      root.appendChild(orderText);
     });
 
-    const result = await response.json();
-    return result.manifestUrl;
+    const response = await fetch('/api/generate-shipping-manifest', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({orders}),
+    });
+
+    const {printUrl} = await response.json();
+    return printUrl;
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/shipping-manifest.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/shipping-manifest.tsx
@@ -1,0 +1,43 @@
+import React, {useEffect, useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const ShippingManifest = () => {
+  const {data, query} = useApi<'admin.order-details.print-action.render'>();
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    const orderIds = data.selected.map((item) => item.id);
+
+    query(
+      `query GetOrders($ids: [ID!]!) {
+        nodes(ids: $ids) {
+          ... on Order {
+            id
+            name
+            shippingAddress {
+              address1
+              city
+            }
+          }
+        }
+      }`,
+      {variables: {ids: orderIds}},
+    ).then(({data: ordersData}) => {
+      setOrders(ordersData.nodes);
+    });
+  }, [data, query]);
+
+  const generate = async () => {
+    const response = await fetch('/api/generate-manifest', {
+      method: 'POST',
+      body: JSON.stringify({orders}),
+    });
+
+    const result = await response.json();
+    return result.manifestUrl;
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.order-details.print-action.render', () => <ShippingManifest />);

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/shipping-manifest.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/shipping-manifest.tsx
@@ -1,14 +1,59 @@
-import React, {useEffect, useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState, useEffect} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
 
 const ShippingManifest = () => {
   const {data, query} = useApi<'admin.order-details.print-action.render'>();
-  const [orders, setOrders] = useState([]);
+  const [orders, setOrders] = useState<any[]>([]);
 
   useEffect(() => {
+    const fetchOrders = async () => {
+      const orderIds = data.selected.map((item) => item.id);
+
+      const {data: ordersData} = await query(
+        `query GetOrders($ids: [ID!]!) {
+          nodes(ids: $ids) {
+            ... on Order {
+              id
+              name
+              shippingAddress {
+                address1
+                city
+                country
+              }
+            }
+          }
+        }`,
+        {variables: {ids: orderIds}},
+      );
+
+      setOrders(ordersData.nodes);
+    };
+
+    fetchOrders();
+  }, [data, query]);
+
+  return (
+    <>
+      <Text>Shipping manifest for {orders.length} orders</Text>
+      {orders.map((order) => (
+        <Text key={order.id}>{order.name}</Text>
+      ))}
+    </>
+  );
+};
+
+export default reactExtension(
+  'admin.order-details.print-action.render',
+  async (api) => {
+    const {data, query} = api;
+
     const orderIds = data.selected.map((item) => item.id);
 
-    query(
+    const {data: ordersData} = await query(
       `query GetOrders($ids: [ID!]!) {
         nodes(ids: $ids) {
           ... on Order {
@@ -17,27 +62,21 @@ const ShippingManifest = () => {
             shippingAddress {
               address1
               city
+              country
             }
           }
         }
       }`,
       {variables: {ids: orderIds}},
-    ).then(({data: ordersData}) => {
-      setOrders(ordersData.nodes);
-    });
-  }, [data, query]);
+    );
 
-  const generate = async () => {
-    const response = await fetch('/api/generate-manifest', {
+    const response = await fetch('/api/generate-shipping-manifest', {
       method: 'POST',
-      body: JSON.stringify({orders}),
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({orders: ordersData.nodes}),
     });
 
-    const result = await response.json();
-    return result.manifestUrl;
-  };
-
-  return null;
-};
-
-export default reactExtension('admin.order-details.print-action.render', () => <ShippingManifest />);
+    const {printUrl} = await response.json();
+    return printUrl;
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Generate a packing slip PDF for selected orders. This example extracts order IDs from `data.selected`, calls your app backend to generate the PDF, and returns a printable URL.',
+      'Generate a packing slip PDF for selected orders. This example shows extracting order IDs from `data.selected`, calling your app backend to generate the PDF, and returning a printable URL.',
     codeblock: {
       title: 'Generate packing slip',
       tabs: [
@@ -32,7 +32,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Generate product labels with the option to add products beyond the initial selection. This example uses `resourcePicker` within a print action to allow additional product selection, combines initially selected products with newly picked ones, and sends all product IDs to your label generator.',
+          'Generate product labels with the option to add products beyond the initial selection. This example demonstrates using `resourcePicker()` within a print action, combining initially selected products with newly picked ones, and sending all product IDs to your label generator.',
         codeblock: {
           title: 'Generate custom product labels',
           tabs: [
@@ -43,7 +43,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Query order details via GraphQL then generate a shipping manifest. This example fetches order data including shipping addresses using the [GraphQL Admin API](/docs/api/admin-graphql), passes the order information to your manifest generator, and returns the manifest URL for printing.',
+          'Query order details via GraphQL then generate a shipping manifest. Fetches order data including shipping addresses using the [GraphQL Admin API](/docs/api/admin-graphql) and passes the order information to your manifest generator.',
         codeblock: {
           title: 'Generate shipping manifest',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -8,17 +8,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'API',
   requires:
     'the [`AdminPrintAction`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminprintaction) component.',
-  definitions: [
-    {
-      title: 'PrintActionExtensionApi',
-      description:
-        'The `PrintActionExtensionApi` object provides methods for print action extensions that generate custom printable documents. Access the following properties on the `PrintActionExtensionApi` object to access selected resources and display picker dialogs for print configuration.',
-      type: 'PrintActionExtensionApi',
-    },
-  ],
   defaultExample: {
     description:
-      'Generate a packing slip PDF for selected orders. This example shows extracting order IDs from `data.selected`, calling your app backend to generate the PDF, and returning a printable URL.',
+      "Generate a packing slip PDF for selected orders to provide warehouse staff with pick-and-pack instructions. This example demonstrates extracting order IDs from `data.selected`, posting them to your backend printing service, and returning the PDF URL for the print dialog.",
     codeblock: {
       title: 'Generate packing slip',
       tabs: [
@@ -27,29 +19,37 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  definitions: [
+    {
+      title: 'PrintActionExtensionApi',
+      description:
+        'The `PrintActionExtensionApi` object provides methods for print action extensions that generate custom printable documents. Access the following properties on the `PrintActionExtensionApi` object to access selected resources and display picker dialogs for print configuration.',
+      type: 'PrintActionExtensionApi',
+    },
+  ],
   examples: {
     description: 'Generate custom printable documents',
     examples: [
       {
         description:
-          'Generate product labels with the option to add products beyond the initial selection. This example demonstrates using `resourcePicker()` within a print action, combining initially selected products with newly picked ones, and sending all product IDs to your label generator.',
+          'Generate custom product labels with the option to add more products beyond the initial selection for batch labeling operations. This example demonstrates launching the [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) from within a print action, tracking additional selections, and generating labels for the combined product set.',
         codeblock: {
           title: 'Generate custom product labels',
           tabs: [
-            {code: './examples/custom-product-labels.ts', language: 'ts'},
-            {code: './examples/custom-product-labels.tsx', language: 'tsx'},
-          ],
+        {code: './examples/custom-product-labels.ts', language: 'ts'},
+        {code: './examples/custom-product-labels.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Query order details via GraphQL then generate a shipping manifest. Fetches order data including shipping addresses using the [GraphQL Admin API](/docs/api/admin-graphql) and passes the order information to your manifest generator.',
+          'Query order details using the [GraphQL Admin API](/docs/api/admin-graphql/) to generate a shipping manifest PDF with addresses and order numbers for warehouse logistics. This example demonstrates fetching order shipping data, displaying the order list while generating the document, and posting the complete order information to your print service.',
         codeblock: {
           title: 'Generate shipping manifest',
           tabs: [
-            {code: './examples/shipping-manifest.ts', language: 'ts'},
-            {code: './examples/shipping-manifest.tsx', language: 'tsx'},
-          ],
+        {code: './examples/shipping-manifest.ts', language: 'ts'},
+        {code: './examples/shipping-manifest.tsx', language: 'tsx'},
+      ],
         },
       },
     ],
@@ -64,8 +64,8 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Use `@media print` CSS for print-optimized styling:** Apply print-specific styles with `@media print` queries to control page breaks, hide UI elements, and optimize for paper output. The print preview shows the screen styles until printing.\n' +
-        '- **Set document MIME type correctly:** Return `Content-Type: application/pdf` for PDFs, `image/png` for images, or `text/html` for HTML documents. Incorrect MIME types might trigger browser download instead of preview.\n' +
-        '- **Test `window.print()` behavior:** If generating HTML, then test that `window.print()` works correctly. Some CSS frameworks or scripts might interfere with browser print dialogs.',
+        '- **Set document MIME type correctly:** Return `Content-Type: application/pdf` for PDFs, `image/png` for images, or `text/html` for HTML documents. Incorrect MIME types may cause browser download instead of preview.\n' +
+        '- **Test `window.print()` behavior:** If generating HTML, test that `window.print()` works correctly. Some CSS frameworks or scripts may interfere with browser print dialogs.',
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -113,11 +113,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Print action extensions must return a URL string. You can\'t render the print UI directly within the extension or control the print preview appearance.
+        "- Print action extensions must return a URL string. You can't render the print UI directly within the extension or control the print preview appearance.
 " +
         '- URLs must be publicly accessible with CORS headers allowing the Shopify admin origin. Authentication tokens in URLs can expire while merchants have the preview open.
 ' +
-        "- Extensions don\'t have access to printer settings. You can\'t configure print options like page orientation, margins, or paper size. Merchants control these through browser print dialogs.",
+        "- Extensions don't have access to printer settings. You can't configure print options like page orientation, margins, or paper size. Merchants control these through browser print dialogs.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -14,8 +14,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Generate packing slip',
       tabs: [
-        {code: './examples/generate-packing-slip.ts', language: 'ts'},
-        {code: './examples/generate-packing-slip.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/generate-packing-slip.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/generate-packing-slip.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -36,8 +44,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Generate custom product labels',
           tabs: [
-            {code: './examples/custom-product-labels.ts', language: 'ts'},
-            {code: './examples/custom-product-labels.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/custom-product-labels.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/custom-product-labels.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -47,8 +63,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Generate shipping manifest',
           tabs: [
-            {code: './examples/shipping-manifest.ts', language: 'ts'},
-            {code: './examples/shipping-manifest.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/shipping-manifest.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/shipping-manifest.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -16,6 +16,44 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'PrintActionExtensionApi',
     },
   ],
+  defaultExample: {
+    description:
+      'Generate a packing slip PDF for selected orders. This example extracts order IDs from `data.selected`, calls your app backend to generate the PDF, and returns a printable URL.',
+    codeblock: {
+      title: 'Generate packing slip',
+      tabs: [
+        {code: './examples/generate-packing-slip.ts', language: 'ts'},
+        {code: './examples/generate-packing-slip.tsx', language: 'tsx'},
+      ],
+    },
+  },
+  examples: {
+    description: 'Generate custom printable documents',
+    examples: [
+      {
+        description:
+          'Generate product labels with the option to add products beyond the initial selection. This example uses `resourcePicker` within a print action to allow additional product selection, combines initially selected products with newly picked ones, and sends all product IDs to your label generator.',
+        codeblock: {
+          title: 'Generate custom product labels',
+          tabs: [
+            {code: './examples/custom-product-labels.ts', language: 'ts'},
+            {code: './examples/custom-product-labels.tsx', language: 'tsx'},
+          ],
+        },
+      },
+      {
+        description:
+          'Query order details via GraphQL then generate a shipping manifest. This example fetches order data including shipping addresses using the [GraphQL Admin API](/docs/api/admin-graphql), passes the order information to your manifest generator, and returns the manifest URL for printing.',
+        codeblock: {
+          title: 'Generate shipping manifest',
+          tabs: [
+            {code: './examples/shipping-manifest.ts', language: 'ts'},
+            {code: './examples/shipping-manifest.tsx', language: 'tsx'},
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Core APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -113,11 +113,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Print action extensions must return a URL string. You can't render the print UI directly within the extension or control the print preview appearance.
+        "- Print action extensions must return a URL string. You can\'t render the print UI directly within the extension or control the print preview appearance.
 " +
         '- URLs must be publicly accessible with CORS headers allowing the Shopify admin origin. Authentication tokens in URLs can expire while merchants have the preview open.
 ' +
-        "- Extensions don't have access to printer settings. You can't configure print options like page orientation, margins, or paper size. Merchants control these through browser print dialogs.",
+        "- Extensions don\'t have access to printer settings. You can\'t configure print options like page orientation, margins, or paper size. Merchants control these through browser print dialogs.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -10,7 +10,7 @@ const data: ReferenceEntityTemplateSchema = {
     'the [`AdminPrintAction`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminprintaction) component.',
   defaultExample: {
     description:
-      "Generate a packing slip PDF for selected orders to provide warehouse staff with pick-and-pack instructions. This example demonstrates extracting order IDs from `data.selected`, posting them to your backend printing service, and returning the PDF URL for the print dialog.",
+      'Generate a packing slip PDF for selected orders to provide warehouse staff with pick-and-pack instructions. This example demonstrates extracting order IDs from `data.selected`, posting them to your backend printing service, and returning the PDF URL for the print dialog.',
     codeblock: {
       title: 'Generate packing slip',
       tabs: [
@@ -36,9 +36,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Generate custom product labels',
           tabs: [
-        {code: './examples/custom-product-labels.ts', language: 'ts'},
-        {code: './examples/custom-product-labels.tsx', language: 'tsx'},
-      ],
+            {code: './examples/custom-product-labels.ts', language: 'ts'},
+            {code: './examples/custom-product-labels.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -47,9 +47,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Generate shipping manifest',
           tabs: [
-        {code: './examples/shipping-manifest.ts', language: 'ts'},
-        {code: './examples/shipping-manifest.tsx', language: 'tsx'},
-      ],
+            {code: './examples/shipping-manifest.ts', language: 'ts'},
+            {code: './examples/shipping-manifest.tsx', language: 'tsx'},
+          ],
         },
       },
     ],

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -102,17 +102,21 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Use `@media print` CSS for print-optimized styling:** Apply print-specific styles with `@media print` queries to control page breaks, hide UI elements, and optimize for paper output. The print preview shows the screen styles until printing.\n' +
-        '- **Set document MIME type correctly:** Return `Content-Type: application/pdf` for PDFs, `image/png` for images, or `text/html` for HTML documents. Incorrect MIME types may cause browser download instead of preview.\n' +
-        '- **Test `window.print()` behavior:** If generating HTML, test that `window.print()` works correctly. Some CSS frameworks or scripts may interfere with browser print dialogs.',
+        '- **Use `@media print` CSS for print-optimized styling:** Apply print-specific styles with `@media print` queries to control page breaks, hide UI elements, and optimize for paper output. The print preview shows the screen styles until printing.
+' +
+        '- **Set document MIME type correctly:** Return `Content-Type: application/pdf` for PDFs, `image/png` for images, or `text/html` for HTML documents. Incorrect MIME types might trigger browser download instead of preview.
+' +
+        '- **Test `window.print()` behavior:** If generating HTML, then test that `window.print()` works correctly. Some CSS frameworks or scripts might interfere with browser print dialogs.',
     },
     {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Print action extensions must return a URL string. You can't render the print UI directly within the extension or control the print preview appearance.\n" +
-        '- URLs must be publicly accessible with CORS headers allowing the Shopify admin origin. Authentication tokens in URLs can expire while merchants have the preview open.\n' +
+        "- Print action extensions must return a URL string. You can't render the print UI directly within the extension or control the print preview appearance.
+" +
+        '- URLs must be publicly accessible with CORS headers allowing the Shopify admin origin. Authentication tokens in URLs can expire while merchants have the preview open.
+' +
         "- Extensions don't have access to printer settings. You can't configure print options like page orientation, margins, or paper size. Merchants control these through browser print dialogs.",
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -15,14 +15,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Generate packing slip',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/generate-packing-slip.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/generate-packing-slip.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/generate-packing-slip.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -45,14 +50,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Generate custom product labels',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/custom-product-labels.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/custom-product-labels.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/custom-product-labels.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -64,14 +74,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Generate shipping manifest',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/shipping-manifest.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/shipping-manifest.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/shipping-manifest.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-bundle-config.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-bundle-config.ts
@@ -1,24 +1,43 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.configuration.render',
   (root, api) => {
     const {data, query} = api;
 
-    const productId = data.selected[0]?.id;
+    const loadConfig = async () => {
+      const productId = data.selected[0]?.id;
 
-    query(
-      `query GetProductBundle($id: ID!) {
-        product(id: $id) {
-          metafield(namespace: "bundle", key: "components") {
-            value
+      const {data: bundleData} = await query(
+        `query GetBundleComponents($id: ID!) {
+          product(id: $id) {
+            id
+            title
+            metafield(namespace: "bundle", key: "components") {
+              value
+            }
           }
-        }
-      }`,
-      {variables: {id: productId}},
-    ).then(({data: productData}) => {
-      const components = JSON.parse(productData.product.metafield?.value || '[]');
-      console.log('Bundle components:', components);
-    });
+        }`,
+        {variables: {id: productId}},
+      );
+
+      const components = bundleData.product.metafield
+        ? JSON.parse(bundleData.product.metafield.value)
+        : [];
+
+      const summaryText = root.createComponent(
+        Text,
+        {},
+        `${components.length} components configured`,
+      );
+      root.appendChild(summaryText);
+
+      components.forEach((comp, i) => {
+        const compText = root.createComponent(Text, {}, `Component ${i + 1}`);
+        root.appendChild(compText);
+      });
+    };
+
+    loadConfig();
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-bundle-config.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-bundle-config.ts
@@ -1,0 +1,24 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.configuration.render',
+  (root, api) => {
+    const {data, query} = api;
+
+    const productId = data.selected[0]?.id;
+
+    query(
+      `query GetProductBundle($id: ID!) {
+        product(id: $id) {
+          metafield(namespace: "bundle", key: "components") {
+            value
+          }
+        }
+      }`,
+      {variables: {id: productId}},
+    ).then(({data: productData}) => {
+      const components = JSON.parse(productData.product.metafield?.value || '[]');
+      console.log('Bundle components:', components);
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-bundle-config.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-bundle-config.tsx
@@ -1,0 +1,29 @@
+import React, {useEffect, useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const LoadBundleConfig = () => {
+  const {data, query} = useApi<'admin.product-details.configuration.render'>();
+  const [components, setComponents] = useState([]);
+
+  useEffect(() => {
+    const productId = data.selected[0]?.id;
+
+    query(
+      `query GetProductBundle($id: ID!) {
+        product(id: $id) {
+          metafield(namespace: "bundle", key: "components") {
+            value
+          }
+        }
+      }`,
+      {variables: {id: productId}},
+    ).then(({data: productData}) => {
+      const parsed = JSON.parse(productData.product.metafield?.value || '[]');
+      setComponents(parsed);
+    });
+  }, [data, query]);
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.configuration.render', () => <LoadBundleConfig />);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-bundle-config.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-bundle-config.tsx
@@ -1,29 +1,52 @@
-import React, {useEffect, useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState, useEffect} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
 
 const LoadBundleConfig = () => {
   const {data, query} = useApi<'admin.product-details.configuration.render'>();
-  const [components, setComponents] = useState([]);
+  const [components, setComponents] = useState<any[]>([]);
 
   useEffect(() => {
-    const productId = data.selected[0]?.id;
+    const loadConfig = async () => {
+      const productId = data.selected[0]?.id;
 
-    query(
-      `query GetProductBundle($id: ID!) {
-        product(id: $id) {
-          metafield(namespace: "bundle", key: "components") {
-            value
+      const {data: bundleData} = await query(
+        `query GetBundleComponents($id: ID!) {
+          product(id: $id) {
+            id
+            title
+            metafield(namespace: "bundle", key: "components") {
+              value
+            }
           }
-        }
-      }`,
-      {variables: {id: productId}},
-    ).then(({data: productData}) => {
-      const parsed = JSON.parse(productData.product.metafield?.value || '[]');
-      setComponents(parsed);
-    });
+        }`,
+        {variables: {id: productId}},
+      );
+
+      const comps = bundleData.product.metafield
+        ? JSON.parse(bundleData.product.metafield.value)
+        : [];
+
+      setComponents(comps);
+    };
+
+    loadConfig();
   }, [data, query]);
 
-  return null;
+  return (
+    <>
+      <Text>{components.length} components configured</Text>
+      {components.map((comp, i) => (
+        <Text key={i}>Component {i + 1}</Text>
+      ))}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.configuration.render', () => <LoadBundleConfig />);
+export default reactExtension(
+  'admin.product-details.configuration.render',
+  () => <LoadBundleConfig />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-variant-bundle-config.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-variant-bundle-config.ts
@@ -1,0 +1,50 @@
+import {extension, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-variant-details.configuration.render',
+  (root, api) => {
+    const {data, query} = api;
+
+    const loadConfig = async () => {
+      const variantId = data.selected[0]?.id;
+
+      const {data: variantData} = await query(
+        `query GetVariantBundleConfig($id: ID!) {
+          productVariant(id: $id) {
+            id
+            sku
+            displayName
+            metafield(namespace: "bundle", key: "variant_components") {
+              value
+            }
+          }
+        }`,
+        {variables: {id: variantId}},
+      );
+
+      const variant = variantData.productVariant;
+      const components = variant.metafield
+        ? JSON.parse(variant.metafield.value)
+        : [];
+
+      const skuText = root.createComponent(Text, {}, `SKU: ${variant.sku}`);
+      const nameText = root.createComponent(Text, {}, `Display: ${variant.displayName}`);
+      const countText = root.createComponent(
+        Text,
+        {},
+        `${components.length} variant components configured`,
+      );
+
+      root.appendChild(skuText);
+      root.appendChild(nameText);
+      root.appendChild(countText);
+
+      components.forEach((comp, i) => {
+        const compText = root.createComponent(Text, {}, `Component ${i + 1}: ${comp.variantId}`);
+        root.appendChild(compText);
+      });
+    };
+
+    loadConfig();
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-variant-bundle-config.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/load-variant-bundle-config.tsx
@@ -1,0 +1,64 @@
+import React, {useState, useEffect} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
+
+const LoadVariantBundleConfig = () => {
+  const {data, query} = useApi<'admin.product-variant-details.configuration.render'>();
+  const [variant, setVariant] = useState<any>(null);
+  const [components, setComponents] = useState<any[]>([]);
+
+  useEffect(() => {
+    const loadConfig = async () => {
+      const variantId = data.selected[0]?.id;
+
+      const {data: variantData} = await query(
+        `query GetVariantBundleConfig($id: ID!) {
+          productVariant(id: $id) {
+            id
+            sku
+            displayName
+            metafield(namespace: "bundle", key: "variant_components") {
+              value
+            }
+          }
+        }`,
+        {variables: {id: variantId}},
+      );
+
+      const variantInfo = variantData.productVariant;
+      const comps = variantInfo.metafield
+        ? JSON.parse(variantInfo.metafield.value)
+        : [];
+
+      setVariant(variantInfo);
+      setComponents(comps);
+    };
+
+    loadConfig();
+  }, [data, query]);
+
+  return (
+    <>
+      {variant && (
+        <>
+          <Text>SKU: {variant.sku}</Text>
+          <Text>Display: {variant.displayName}</Text>
+          <Text>{components.length} variant components configured</Text>
+          {components.map((comp, i) => (
+            <Text key={i}>
+              Component {i + 1}: {comp.variantId}
+            </Text>
+          ))}
+        </>
+      )}
+    </>
+  );
+};
+
+export default reactExtension(
+  'admin.product-variant-details.configuration.render',
+  () => <LoadVariantBundleConfig />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/navigate-to-parent-product.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/navigate-to-parent-product.ts
@@ -1,0 +1,39 @@
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-variant-details.configuration.render',
+  (root, api) => {
+    const {data, query, navigation} = api;
+
+    const loadParent = async () => {
+      const variantId = data.selected[0]?.id;
+
+      const {data: parentData} = await query(
+        `query GetParentProduct($id: ID!) {
+          productVariant(id: $id) {
+            product {
+              id
+              title
+            }
+          }
+        }`,
+        {variables: {id: variantId}},
+      );
+
+      const product = parentData.productVariant.product;
+
+      const titleText = root.createComponent(Text, {}, `Parent: ${product.title}`);
+      const navButton = root.createComponent(Button, {
+        title: 'View Parent Product',
+        onPress: () => {
+          navigation.navigate(`shopify:admin/products/${product.id.split('/').pop()}`);
+        },
+      });
+
+      root.appendChild(titleText);
+      root.appendChild(navButton);
+    };
+
+    loadParent();
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/navigate-to-parent-product.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/navigate-to-parent-product.tsx
@@ -1,0 +1,56 @@
+import React, {useState, useEffect} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Button,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
+
+const NavigateToParentProduct = () => {
+  const {data, query, navigation} = useApi<'admin.product-variant-details.configuration.render'>();
+  const [product, setProduct] = useState<any>(null);
+
+  useEffect(() => {
+    const loadParent = async () => {
+      const variantId = data.selected[0]?.id;
+
+      const {data: parentData} = await query(
+        `query GetParentProduct($id: ID!) {
+          productVariant(id: $id) {
+            product {
+              id
+              title
+            }
+          }
+        }`,
+        {variables: {id: variantId}},
+      );
+
+      setProduct(parentData.productVariant.product);
+    };
+
+    loadParent();
+  }, [data, query]);
+
+  const handleNavigate = () => {
+    if (product) {
+      navigation.navigate(`shopify:admin/products/${product.id.split('/').pop()}`);
+    }
+  };
+
+  return (
+    <>
+      {product && (
+        <>
+          <Text>Parent: {product.title}</Text>
+          <Button title="View Parent Product" onPress={handleNavigate} />
+        </>
+      )}
+    </>
+  );
+};
+
+export default reactExtension(
+  'admin.product-variant-details.configuration.render',
+  () => <NavigateToParentProduct />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-bundle-components.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-bundle-components.ts
@@ -1,0 +1,26 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.configuration.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+
+    resourcePicker({
+      type: 'product',
+      multiple: 5,
+      filter: {
+        hidden: false,
+        variants: false,
+        draft: false,
+        archived: false,
+      },
+    }).then((selected) => {
+      if (selected) {
+        fetch('/api/save-bundle', {
+          method: 'POST',
+          body: JSON.stringify({components: selected.map((p) => p.id)}),
+        });
+      }
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-bundle-components.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-bundle-components.ts
@@ -1,26 +1,57 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.configuration.render',
   (root, api) => {
-    const {resourcePicker} = api;
+    const {data, resourcePicker} = api;
 
-    resourcePicker({
-      type: 'product',
-      multiple: 5,
-      filter: {
-        hidden: false,
-        variants: false,
-        draft: false,
-        archived: false,
-      },
-    }).then((selected) => {
-      if (selected) {
-        fetch('/api/save-bundle', {
-          method: 'POST',
-          body: JSON.stringify({components: selected.map((p) => p.id)}),
+    let selectedCount = 0;
+    let countText;
+
+    const parentProductId = data.selected[0]?.id;
+
+    const selectButton = root.createComponent(Button, {
+      title: 'Select Components',
+      onPress: async () => {
+        const componentProducts = await resourcePicker({
+          type: 'product',
+          multiple: 5,
+          action: 'select',
+          filter: {
+            draft: false,
+            archived: false,
+          },
         });
-      }
+
+        if (componentProducts) {
+          selectedCount = componentProducts.length;
+
+          await fetch('/api/bundles/configure', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+              bundleProductId: parentProductId,
+              components: componentProducts.map((p) => ({
+                productId: p.id,
+                quantity: 1,
+              })),
+            }),
+          });
+
+          if (countText) {
+            root.removeChild(countText);
+          }
+
+          countText = root.createComponent(
+            Text,
+            {},
+            `${selectedCount} components selected`,
+          );
+          root.appendChild(countText);
+        }
+      },
     });
+
+    root.appendChild(selectButton);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-bundle-components.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-bundle-components.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const SelectBundleComponents = () => {
+  const {resourcePicker} = useApi<'admin.product-details.configuration.render'>();
+
+  const handleSelect = async () => {
+    const selected = await resourcePicker({
+      type: 'product',
+      multiple: 5,
+      filter: {
+        hidden: false,
+        variants: false,
+        draft: false,
+        archived: false,
+      },
+    });
+
+    if (selected) {
+      await fetch('/api/save-bundle', {
+        method: 'POST',
+        body: JSON.stringify({components: selected.map((p) => p.id)}),
+      });
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.configuration.render', () => <SelectBundleComponents />);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-bundle-components.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-bundle-components.tsx
@@ -1,30 +1,54 @@
-import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Button,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
 
 const SelectBundleComponents = () => {
-  const {resourcePicker} = useApi<'admin.product-details.configuration.render'>();
+  const {data, resourcePicker} = useApi<'admin.product-details.configuration.render'>();
+  const [selected, setSelected] = useState<any[]>([]);
 
-  const handleSelect = async () => {
-    const selected = await resourcePicker({
+  const parentProductId = data.selected[0]?.id;
+
+  const handleSelectComponents = async () => {
+    const componentProducts = await resourcePicker({
       type: 'product',
       multiple: 5,
+      action: 'select',
       filter: {
-        hidden: false,
-        variants: false,
         draft: false,
         archived: false,
       },
     });
 
-    if (selected) {
-      await fetch('/api/save-bundle', {
+    if (componentProducts) {
+      setSelected(componentProducts);
+
+      await fetch('/api/bundles/configure', {
         method: 'POST',
-        body: JSON.stringify({components: selected.map((p) => p.id)}),
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          bundleProductId: parentProductId,
+          components: componentProducts.map((p) => ({
+            productId: p.id,
+            quantity: 1,
+          })),
+        }),
       });
     }
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Components" onPress={handleSelectComponents} />
+      {selected.length > 0 && <Text>{selected.length} components selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.configuration.render', () => <SelectBundleComponents />);
+export default reactExtension(
+  'admin.product-details.configuration.render',
+  () => <SelectBundleComponents />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-variant-components.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-variant-components.ts
@@ -1,19 +1,57 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-variant-details.configuration.render',
   (root, api) => {
-    const {resourcePicker} = api;
+    const {data, resourcePicker} = api;
 
-    resourcePicker({
-      type: 'variant',
-    }).then((selected) => {
-      if (selected) {
-        fetch('/api/save-variant-bundle', {
-          method: 'POST',
-          body: JSON.stringify({variantIds: selected.map((v) => v.id)}),
+    let selectedCount = 0;
+    let countText;
+
+    const parentVariantId = data.selected[0]?.id;
+
+    const selectButton = root.createComponent(Button, {
+      title: 'Select Variant Components',
+      onPress: async () => {
+        const componentVariants = await resourcePicker({
+          type: 'variant',
+          multiple: 5,
+          action: 'select',
+          filter: {
+            draft: false,
+            archived: false,
+          },
         });
-      }
+
+        if (componentVariants) {
+          selectedCount = componentVariants.length;
+
+          await fetch('/api/bundles/configure-variant', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+              bundleVariantId: parentVariantId,
+              componentVariants: componentVariants.map((v) => ({
+                variantId: v.id,
+                quantity: 1,
+              })),
+            }),
+          });
+
+          if (countText) {
+            root.removeChild(countText);
+          }
+
+          countText = root.createComponent(
+            Text,
+            {},
+            `${selectedCount} variant components selected`,
+          );
+          root.appendChild(countText);
+        }
+      },
     });
+
+    root.appendChild(selectButton);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-variant-components.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-variant-components.ts
@@ -1,0 +1,19 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-variant-details.configuration.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+
+    resourcePicker({
+      type: 'variant',
+    }).then((selected) => {
+      if (selected) {
+        fetch('/api/save-variant-bundle', {
+          method: 'POST',
+          body: JSON.stringify({variantIds: selected.map((v) => v.id)}),
+        });
+      }
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-variant-components.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-variant-components.tsx
@@ -1,23 +1,54 @@
-import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Button,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
 
 const SelectVariantComponents = () => {
-  const {resourcePicker} = useApi<'admin.product-variant-details.configuration.render'>();
+  const {data, resourcePicker} = useApi<'admin.product-variant-details.configuration.render'>();
+  const [selected, setSelected] = useState<any[]>([]);
 
-  const handleSelect = async () => {
-    const selected = await resourcePicker({
+  const parentVariantId = data.selected[0]?.id;
+
+  const handleSelectComponents = async () => {
+    const componentVariants = await resourcePicker({
       type: 'variant',
+      multiple: 5,
+      action: 'select',
+      filter: {
+        draft: false,
+        archived: false,
+      },
     });
 
-    if (selected) {
-      await fetch('/api/save-variant-bundle', {
+    if (componentVariants) {
+      setSelected(componentVariants);
+
+      await fetch('/api/bundles/configure-variant', {
         method: 'POST',
-        body: JSON.stringify({variantIds: selected.map((v) => v.id)}),
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          bundleVariantId: parentVariantId,
+          componentVariants: componentVariants.map((v) => ({
+            variantId: v.id,
+            quantity: 1,
+          })),
+        }),
       });
     }
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Variant Components" onPress={handleSelectComponents} />
+      {selected.length > 0 && <Text>{selected.length} variant components selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-variant-details.configuration.render', () => <SelectVariantComponents />);
+export default reactExtension(
+  'admin.product-variant-details.configuration.render',
+  () => <SelectVariantComponents />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-variant-components.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/select-variant-components.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const SelectVariantComponents = () => {
+  const {resourcePicker} = useApi<'admin.product-variant-details.configuration.render'>();
+
+  const handleSelect = async () => {
+    const selected = await resourcePicker({
+      type: 'variant',
+    });
+
+    if (selected) {
+      await fetch('/api/save-variant-bundle', {
+        method: 'POST',
+        body: JSON.stringify({variantIds: selected.map((v) => v.id)}),
+      });
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-variant-details.configuration.render', () => <SelectVariantComponents />);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/update-bundle-metadata.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/update-bundle-metadata.ts
@@ -1,0 +1,66 @@
+import {extension, TextField, Button, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.configuration.render',
+  (root, api) => {
+    const {data, query} = api;
+
+    let bundleName = '';
+    let saveText;
+
+    const productId = data.selected[0]?.id;
+
+    const stack = root.createComponent(BlockStack);
+
+    const productText = root.createComponent(Text, {}, `Product ID: ${productId}`);
+
+    const nameField = root.createComponent(TextField, {
+      label: 'Bundle display name',
+      value: bundleName,
+      onChange: (value) => {
+        bundleName = value;
+      },
+    });
+
+    const saveButton = root.createComponent(Button, {
+      title: 'Save Bundle Metadata',
+      onPress: async () => {
+        await query(
+          `mutation UpdateBundleName($id: ID!, $metafields: [MetafieldsSetInput!]!) {
+            productUpdate(input: {id: $id, metafields: $metafields}) {
+              product {
+                id
+              }
+            }
+          }`,
+          {
+            variables: {
+              id: productId,
+              metafields: [
+                {
+                  namespace: 'bundle',
+                  key: 'display_name',
+                  value: bundleName,
+                  type: 'single_line_text_field',
+                },
+              ],
+            },
+          },
+        );
+
+        if (saveText) {
+          stack.removeChild(saveText);
+        }
+
+        saveText = root.createComponent(Text, {}, 'Bundle metadata saved');
+        stack.appendChild(saveText);
+      },
+    });
+
+    stack.appendChild(productText);
+    stack.appendChild(nameField);
+    stack.appendChild(saveButton);
+
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/update-bundle-metadata.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/examples/update-bundle-metadata.tsx
@@ -1,0 +1,62 @@
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  TextField,
+  Button,
+  Text,
+  BlockStack,
+} from '@shopify/ui-extensions-react/admin';
+
+const UpdateBundleMetadata = () => {
+  const {data, query} = useApi<'admin.product-details.configuration.render'>();
+  const [bundleName, setBundleName] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  const productId = data.selected[0]?.id;
+
+  const handleSave = async () => {
+    await query(
+      `mutation UpdateBundleName($id: ID!, $metafields: [MetafieldsSetInput!]!) {
+        productUpdate(input: {id: $id, metafields: $metafields}) {
+          product {
+            id
+          }
+        }
+      }`,
+      {
+        variables: {
+          id: productId,
+          metafields: [
+            {
+              namespace: 'bundle',
+              key: 'display_name',
+              value: bundleName,
+              type: 'single_line_text_field',
+            },
+          ],
+        },
+      },
+    );
+
+    setSaved(true);
+  };
+
+  return (
+    <BlockStack>
+      <Text>Product ID: {productId}</Text>
+      <TextField
+        label="Bundle display name"
+        value={bundleName}
+        onChange={setBundleName}
+      />
+      <Button title="Save Bundle Metadata" onPress={handleSave} />
+      {saved && <Text>Bundle metadata saved</Text>}
+    </BlockStack>
+  );
+};
+
+export default reactExtension(
+  'admin.product-details.configuration.render',
+  () => <UpdateBundleMetadata />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -16,6 +16,33 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ProductDetailsConfigurationApi',
     },
   ],
+  defaultExample: {
+    description:
+      'Select up to 5 component products for a bundle using the resource picker. This example opens `resourcePicker` with a limit of 5 products, filters out hidden, draft, and archived products, and posts the selected product IDs to your backend to save the bundle configuration.',
+    codeblock: {
+      title: 'Select bundle components',
+      tabs: [
+        {code: './examples/select-bundle-components.ts', language: 'ts'},
+        {code: './examples/select-bundle-components.tsx', language: 'tsx'},
+      ],
+    },
+  },
+  examples: {
+    description: 'Configure product bundles',
+    examples: [
+      {
+        description:
+          "Query a product's bundle metafield and parse the JSON components array. This example uses `useEffect` to fetch bundle data from the [GraphQL Admin API](/docs/api/admin-graphql), parses the stored configuration from the metafield value, and displays the component products.",
+        codeblock: {
+          title: 'Load bundle configuration',
+          tabs: [
+            {code: './examples/load-bundle-config.ts', language: 'ts'},
+            {code: './examples/load-bundle-config.tsx', language: 'tsx'},
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Contextual APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -23,14 +23,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Select bundle components',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/select-bundle-components.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/select-bundle-components.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/select-bundle-components.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -45,14 +50,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Load bundle configuration',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/load-bundle-config.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/load-bundle-config.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/load-bundle-config.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Select up to 5 component products for a bundle using the resource picker. This example opens `resourcePicker` with a limit of 5 products, filters out hidden, draft, and archived products, and posts the selected product IDs to your backend to save the bundle configuration.',
+      'Select up to 5 component products for a bundle using the resource picker. This example shows opening `resourcePicker()` with a limit of 5 products, filtering out hidden/draft/archived items, and posting the selected IDs to your backend to save the bundle configuration.',
     codeblock: {
       title: 'Select bundle components',
       tabs: [
@@ -32,7 +32,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          "Query a product's bundle metafield and parse the JSON components array. This example uses `useEffect` to fetch bundle data from the [GraphQL Admin API](/docs/api/admin-graphql), parses the stored configuration from the metafield value, and displays the component products.",
+          "Query a product's bundle metafield and parse the JSON components array. This example demonstrates using `useEffect` to fetch bundle data from the [GraphQL Admin API](/docs/api/admin-graphql), parse the stored configuration, and display the component products.",
         codeblock: {
           title: 'Load bundle configuration',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -103,11 +103,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Configuration extensions only render in the admin. They don't affect storefront display or checkout behavior. You must implement storefront and checkout logic separately.
+        "- Configuration extensions only render in the admin. They don\'t affect storefront display or checkout behavior. You must implement storefront and checkout logic separately.
 " +
-        "- Bundles aren't enforced automatically. Saving configuration doesn't automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) or other mechanisms to enforce bundling at purchase time.
+        "- Bundles aren\'t enforced automatically. Saving configuration doesn\'t automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) or other mechanisms to enforce bundling at purchase time.
 " +
-        "- Your extension can't directly modify product properties. The API is read-only for product data. Use GraphQL mutations like [`productUpdate`](/docs/api/admin-graphql/latest/mutations/productUpdate) to update products if needed.",
+        "- Your extension can\'t directly modify product properties. The API is read-only for product data. Use GraphQL mutations like [`productUpdate`](/docs/api/admin-graphql/latest/mutations/productUpdate) to update products if needed.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -22,8 +22,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Select bundle components',
       tabs: [
-        {code: './examples/select-bundle-components.ts', language: 'ts'},
-        {code: './examples/select-bundle-components.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/select-bundle-components.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/select-bundle-components.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -36,8 +44,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Load bundle configuration',
           tabs: [
-            {code: './examples/load-bundle-config.ts', language: 'ts'},
-            {code: './examples/load-bundle-config.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/load-bundle-config.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/load-bundle-config.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -103,11 +103,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Configuration extensions only render in the admin. They don\'t affect storefront display or checkout behavior. You must implement storefront and checkout logic separately.
+        "- Configuration extensions only render in the admin. They don't affect storefront display or checkout behavior. You must implement storefront and checkout logic separately.
 " +
-        "- Bundles aren\'t enforced automatically. Saving configuration doesn\'t automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) or other mechanisms to enforce bundling at purchase time.
+        "- Bundles aren't enforced automatically. Saving configuration doesn't automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) or other mechanisms to enforce bundling at purchase time.
 " +
-        "- Your extension can\'t directly modify product properties. The API is read-only for product data. Use GraphQL mutations like [`productUpdate`](/docs/api/admin-graphql/latest/mutations/productUpdate) to update products if needed.",
+        "- Your extension can't directly modify product properties. The API is read-only for product data. Use GraphQL mutations like [`productUpdate`](/docs/api/admin-graphql/latest/mutations/productUpdate) to update products if needed.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Select up to 5 component products for a bundle using the resource picker. This example shows opening `resourcePicker()` with a limit of 5 products, filtering out hidden/draft/archived items, and posting the selected IDs to your backend to save the bundle configuration.',
+      'Select up to 5 component products for a bundle using the resource picker. This example opens `resourcePicker` with a limit of 5 products, filters out hidden, draft, and archived products, and posts the selected product IDs to your backend to save the bundle configuration.',
     codeblock: {
       title: 'Select bundle components',
       tabs: [
@@ -45,23 +45,37 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          "Query a product's bundle metafield and parse the JSON components array. This example demonstrates using `useEffect` to fetch bundle data from the [GraphQL Admin API](/docs/api/admin-graphql), parse the stored configuration, and display the component products.",
+          "Query a product's bundle metafield and parse the JSON components array to display existing bundle setup. This example demonstrates fetching bundle configuration from metafields using the [GraphQL Admin API](/docs/api/admin-graphql/), parsing the stored component data, and displaying the count of configured bundle components.",
         codeblock: {
           title: 'Load bundle configuration',
           tabs: [
             {
               title: 'React',
-
               code: './examples/load-bundle-config.tsx',
-
               language: 'tsx',
             },
-
             {
               title: 'TS',
-
               code: './examples/load-bundle-config.ts',
-
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Save bundle display name and metadata using GraphQL mutations to customize how bundles appear to merchants. This example demonstrates using a [`TextField`](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) for bundle name input, calling the `productUpdate` mutation to save metafields, and displaying confirmation feedback when metadata is saved.',
+        codeblock: {
+          title: 'Update bundle metadata',
+          tabs: [
+            {
+              title: 'React',
+              code: './examples/update-bundle-metadata.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/update-bundle-metadata.ts',
               language: 'ts',
             },
           ],
@@ -79,7 +93,6 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Design for products with multiple variants:** Products in `api.data.selected` might have multiple variants. Design your bundle configuration to either apply to all variants or allow variant-level configuration.\n' +
-        '- **Use the Resource Picker to select components:** Use the [Resource Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to let merchants select component products for bundle configurations.\n' +
         '- **Implement cart transforms to enforce bundles:** Configuration only defines relationships in admin. Use Shopify Functions [cart transforms](/docs/api/functions/latest/cart-transform) to actually bundle products at checkout based on your saved configuration.',
     },
     {

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -92,7 +92,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Design for products with multiple variants:** Products in `api.data.selected` might have multiple variants. Design your bundle configuration to either apply to all variants or allow variant-level configuration.\n' +
+        '- **Design for products with multiple variants:** Products in `api.data.selected` might have multiple variants. Design your bundle configuration to either apply to all variants or allow variant-level configuration.
+' +
+        '- **Use the Resource Picker to select components:** Use the [Resource Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to let merchants select component products for bundle configurations.
+' +
         '- **Implement cart transforms to enforce bundles:** Configuration only defines relationships in admin. Use Shopify Functions [cart transforms](/docs/api/functions/latest/cart-transform) to actually bundle products at checkout based on your saved configuration.',
     },
     {
@@ -100,8 +103,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Configuration extensions only render in the admin. They don't affect storefront display or checkout behavior. You must implement storefront and checkout logic separately.\n" +
-        "- Bundles aren't enforced automatically. Saving configuration doesn't automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) or other mechanisms to enforce bundling at purchase time.\n" +
+        "- Configuration extensions only render in the admin. They don't affect storefront display or checkout behavior. You must implement storefront and checkout logic separately.
+" +
+        "- Bundles aren't enforced automatically. Saving configuration doesn't automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) or other mechanisms to enforce bundling at purchase time.
+" +
         "- Your extension can't directly modify product properties. The API is read-only for product data. Use GraphQL mutations like [`productUpdate`](/docs/api/admin-graphql/latest/mutations/productUpdate) to update products if needed.",
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -15,14 +15,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Select product variant components',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/select-variant-components.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/select-variant-components.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/select-variant-components.ts',
+
+          language: 'ts',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -16,6 +16,17 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ProductVariantDetailsConfigurationApi',
     },
   ],
+  defaultExample: {
+    description:
+      'Select component variants for a bundle using the variant resource picker. This example opens `resourcePicker` with `type: "variant"` to allow variant-level selection, and posts the selected variant IDs to your backend to configure the bundle.',
+    codeblock: {
+      title: 'Select variant components',
+      tabs: [
+        {code: './examples/select-variant-components.ts', language: 'ts'},
+        {code: './examples/select-variant-components.tsx', language: 'tsx'},
+      ],
+    },
+  },
   category: 'Target APIs',
   subCategory: 'Contextual APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -92,8 +92,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Store configuration keyed by variant GID:** Save bundle relationships in metafields on the variant or in your app database using the variant GID as the key for precise variant-level configuration.\n' +
-        '- **Use `type: "variant"` in Resource Picker for precision:** When selecting component variants, use `type: "variant"` in the [Resource Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) for precise variant selection rather than product-level selection.\n' +
+        '- **Store configuration keyed by variant GID:** Save bundle relationships in metafields on the variant or in your app database using the variant GID as the key for precise variant-level configuration.
+' +
+        '- **Use `type: "variant"` in Resource Picker for precision:** When selecting component variants, use `type: "variant"` in the [Resource Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) for precise variant selection rather than product-level selection.
+' +
         '- **Implement cart transforms to enforce bundles:** Configuration only defines relationships. Use Shopify Functions [cart transforms](/docs/api/functions/latest/cart-transform) to enforce variant-level bundling at checkout based on saved configuration.',
     },
     {
@@ -101,8 +103,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Configuration extensions only render in the admin. They don't affect storefront or checkout behavior. You must implement separate logic for storefront bundle display and checkout enforcement.\n" +
-        "- Bundles aren't enforced automatically. Configuration doesn't automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) to enforce bundling when variants are added to cart.\n" +
+        "- Configuration extensions only render in the admin. They don't affect storefront or checkout behavior. You must implement separate logic for storefront bundle display and checkout enforcement.
+" +
+        "- Bundles aren't enforced automatically. Configuration doesn't automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) to enforce bundling when variants are added to cart.
+" +
         "- Your extension can't directly modify variant properties. The API is read-only for variant data. Use GraphQL mutations like [`productVariantsBulkUpdate`](/docs/api/admin-graphql/latest/mutations/productVariantsBulkUpdate) if you need to update variants.",
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Select component variants for a bundle using the variant resource picker. This example opens `resourcePicker` with `type: "variant"` to allow variant-level selection, and posts the selected variant IDs to your backend to configure the bundle.',
+      'Select component variants for a bundle using the variant resource picker. This example shows using `resourcePicker()` with `type: "variant"` for variant-level selection and posting the selected variant IDs to your backend.',
     codeblock: {
       title: 'Select variant components',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -8,6 +8,17 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'API',
   requires:
     'the [`AdminBlock`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
+  defaultExample: {
+    description:
+      'Use the product variant [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select component variants for a [bundle](/docs/apps/build/product-merchandising/bundles). This example picks product variants, tracks selections, and posts the product variant IDs to configure the bundle.',
+    codeblock: {
+      title: 'Select product variant components',
+      tabs: [
+        {code: './examples/select-variant-components.ts', language: 'ts'},
+        {code: './examples/select-variant-components.tsx', language: 'tsx'},
+      ],
+    },
+  },
   definitions: [
     {
       title: 'ProductVariantDetailsConfigurationApi',
@@ -16,16 +27,9 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ProductVariantDetailsConfigurationApi',
     },
   ],
-  defaultExample: {
-    description:
-      'Select component variants for a bundle using the variant resource picker. This example shows using `resourcePicker()` with `type: "variant"` for variant-level selection and posting the selected variant IDs to your backend.',
-    codeblock: {
-      title: 'Select variant components',
-      tabs: [
-        {code: './examples/select-variant-components.ts', language: 'ts'},
-        {code: './examples/select-variant-components.tsx', language: 'tsx'},
-      ],
-    },
+  examples: {
+    description: 'Configure product variant-level bundles',
+    examples: [],
   },
   category: 'Target APIs',
   subCategory: 'Contextual APIs',

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -103,11 +103,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Configuration extensions only render in the admin. They don't affect storefront or checkout behavior. You must implement separate logic for storefront bundle display and checkout enforcement.
+        "- Configuration extensions only render in the admin. They don\'t affect storefront or checkout behavior. You must implement separate logic for storefront bundle display and checkout enforcement.
 " +
-        "- Bundles aren't enforced automatically. Configuration doesn't automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) to enforce bundling when variants are added to cart.
+        "- Bundles aren\'t enforced automatically. Configuration doesn\'t automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) to enforce bundling when variants are added to cart.
 " +
-        "- Your extension can't directly modify variant properties. The API is read-only for variant data. Use GraphQL mutations like [`productVariantsBulkUpdate`](/docs/api/admin-graphql/latest/mutations/productVariantsBulkUpdate) if you need to update variants.",
+        "- Your extension can\'t directly modify variant properties. The API is read-only for variant data. Use GraphQL mutations like [`productVariantsBulkUpdate`](/docs/api/admin-graphql/latest/mutations/productVariantsBulkUpdate) if you need to update variants.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -103,11 +103,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Configuration extensions only render in the admin. They don\'t affect storefront or checkout behavior. You must implement separate logic for storefront bundle display and checkout enforcement.
+        "- Configuration extensions only render in the admin. They don't affect storefront or checkout behavior. You must implement separate logic for storefront bundle display and checkout enforcement.
 " +
-        "- Bundles aren\'t enforced automatically. Configuration doesn\'t automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) to enforce bundling when variants are added to cart.
+        "- Bundles aren't enforced automatically. Configuration doesn't automatically create bundles. You must implement [cart transforms](/docs/api/functions/latest/cart-transform) to enforce bundling when variants are added to cart.
 " +
-        "- Your extension can\'t directly modify variant properties. The API is read-only for variant data. Use GraphQL mutations like [`productVariantsBulkUpdate`](/docs/api/admin-graphql/latest/mutations/productVariantsBulkUpdate) if you need to update variants.",
+        "- Your extension can't directly modify variant properties. The API is read-only for variant data. Use GraphQL mutations like [`productVariantsBulkUpdate`](/docs/api/admin-graphql/latest/mutations/productVariantsBulkUpdate) if you need to update variants.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -14,8 +14,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Select product variant components',
       tabs: [
-        {code: './examples/select-variant-components.ts', language: 'ts'},
-        {code: './examples/select-variant-components.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/select-variant-components.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/select-variant-components.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -42,7 +42,46 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   examples: {
     description: 'Configure product variant-level bundles',
-    examples: [],
+    examples: [
+      {
+        description:
+          'Query variant bundle configuration including SKU and display name from metafields to show existing bundle setup. This example demonstrates fetching variant-specific bundle data using the [GraphQL Admin API](/docs/api/admin-graphql/), parsing the stored component configuration from metafields, and displaying variant details with component count.',
+        codeblock: {
+          title: 'Load variant bundle configuration',
+          tabs: [
+            {
+              title: 'React',
+              code: './examples/load-variant-bundle-config.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/load-variant-bundle-config.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Navigate to the parent product from variant configuration to view full product context or modify product-level settings. This example demonstrates querying the parent product ID using the [GraphQL Admin API](/docs/api/admin-graphql/), displaying the parent product title, and providing a navigation [`Button`](/docs/api/admin-extensions/{API_VERSION}/components/actions/button) to open the product details page.',
+        codeblock: {
+          title: 'Navigate to parent product',
+          tabs: [
+            {
+              title: 'React',
+              code: './examples/navigate-to-parent-product.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/navigate-to-parent-product.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   category: 'Target APIs',
   subCategory: 'Contextual APIs',

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
@@ -88,9 +88,12 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- The action only appears when selling plan groups exist on the product or variant. The action is hidden for products without subscription options, even if your extension is installed.\n' +
-        '- Items in `api.data.selected` have an optional `sellingPlanId` property. When present, the merchant selected a specific selling plan. When absent, they selected the product/variant without a specific plan.\n' +
-        "- Your extension can't modify selling plan configurations. The API is read-only for selling plan data. Use GraphQL mutations to update selling plans if needed.\n" +
+        '- The action only appears when selling plan groups exist on the product or variant. The action is hidden for products without subscription options, even if your extension is installed.
+' +
+        '- Items in `api.data.selected` have an optional `sellingPlanId` property. When present, the merchant selected a specific selling plan. When absent, they selected the product/variant without a specific plan.
+' +
+        "- Your extension can't modify selling plan configurations. The API is read-only for selling plan data. Use GraphQL mutations to update selling plans if needed.
+" +
         '- Selection data only includes IDs. You must query GraphQL for full product, variant, and selling plan details like billing policy and pricing adjustments. Selling plan group data is also unavailable. Your extension only receives individual selling plan IDs but not the parent selling plan group structure.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
@@ -92,7 +92,7 @@ const data: ReferenceEntityTemplateSchema = {
 ' +
         '- Items in `api.data.selected` have an optional `sellingPlanId` property. When present, the merchant selected a specific selling plan. When absent, they selected the product/variant without a specific plan.
 ' +
-        "- Your extension can't modify selling plan configurations. The API is read-only for selling plan data. Use GraphQL mutations to update selling plans if needed.
+        "- Your extension can\'t modify selling plan configurations. The API is read-only for selling plan data. Use GraphQL mutations to update selling plans if needed.
 " +
         '- Selection data only includes IDs. You must query GraphQL for full product, variant, and selling plan details like billing policy and pricing adjustments. Selling plan group data is also unavailable. Your extension only receives individual selling plan IDs but not the parent selling plan group structure.',
     },

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Update a subscription by sending product and selling plan IDs to your backend. This example checks for the presence of `sellingPlanId` in the selected item, posts the update request to your backend, and closes the action modal on success.',
+      'Update a subscription by sending product and selling plan IDs to your backend. This example demonstrates checking for `sellingPlanId` presence, posting the update request, and closing the modal on success.',
     codeblock: {
       title: 'Manage subscription',
       tabs: [
@@ -38,7 +38,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Show a confirmation before removing a product from a selling plan. This example uses a two-step confirmation process with `confirm()`, removes the product from the plan via your API, and closes the modal after successful removal.',
+          'Show a confirmation before removing a product from a selling plan. This example uses a two-step confirmation process with `confirm()`, removes the product via your API, and closes the modal after successful removal.',
         codeblock: {
           title: 'Remove from selling plan',
           tabs: [
@@ -55,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Fetch selling plan name and options via GraphQL to validate the configuration. This example queries plan details by ID using the [GraphQL Admin API](/docs/api/admin-graphql), stores the result in state, and auto-closes the action after 2 seconds for a quick validation check.',
+          'Fetch selling plan name and options via GraphQL to validate the configuration. This example shows querying plan details by ID using the [GraphQL Admin API](/docs/api/admin-graphql), storing the result in state, and auto-closing the action after 2 seconds for a quick validation check.',
         codeblock: {
           title: 'Validate selling plan',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
@@ -92,7 +92,7 @@ const data: ReferenceEntityTemplateSchema = {
 ' +
         '- Items in `api.data.selected` have an optional `sellingPlanId` property. When present, the merchant selected a specific selling plan. When absent, they selected the product/variant without a specific plan.
 ' +
-        "- Your extension can\'t modify selling plan configurations. The API is read-only for selling plan data. Use GraphQL mutations to update selling plans if needed.
+        "- Your extension can't modify selling plan configurations. The API is read-only for selling plan data. Use GraphQL mutations to update selling plans if needed.
 " +
         '- Selection data only includes IDs. You must query GraphQL for full product, variant, and selling plan details like billing policy and pricing adjustments. Selling plan group data is also unavailable. Your extension only receives individual selling plan IDs but not the parent selling plan group structure.',
     },

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
@@ -16,6 +16,62 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'PurchaseOptionsCardConfigurationApi',
     },
   ],
+  defaultExample: {
+    description:
+      'Update a subscription by sending product and selling plan IDs to your backend. This example checks for the presence of `sellingPlanId` in the selected item, posts the update request to your backend, and closes the action modal on success.',
+    codeblock: {
+      title: 'Manage subscription',
+      tabs: [
+        {
+          code: './purchase-options-card/examples/manage-subscription.ts',
+          language: 'ts',
+        },
+        {
+          code: './purchase-options-card/examples/manage-subscription.tsx',
+          language: 'tsx',
+        },
+      ],
+    },
+  },
+  examples: {
+    description: 'Purchase options patterns',
+    examples: [
+      {
+        description:
+          'Show a confirmation before removing a product from a selling plan. This example uses a two-step confirmation process with `confirm()`, removes the product from the plan via your API, and closes the modal after successful removal.',
+        codeblock: {
+          title: 'Remove from selling plan',
+          tabs: [
+            {
+              code: './purchase-options-card/examples/remove-from-plan.ts',
+              language: 'ts',
+            },
+            {
+              code: './purchase-options-card/examples/remove-from-plan.tsx',
+              language: 'tsx',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Fetch selling plan name and options via GraphQL to validate the configuration. This example queries plan details by ID using the [GraphQL Admin API](/docs/api/admin-graphql), stores the result in state, and auto-closes the action after 2 seconds for a quick validation check.',
+        codeblock: {
+          title: 'Validate selling plan',
+          tabs: [
+            {
+              code: './purchase-options-card/examples/validate-selling-plan.ts',
+              language: 'ts',
+            },
+            {
+              code: './purchase-options-card/examples/validate-selling-plan.tsx',
+              language: 'tsx',
+            },
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Contextual APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/manage-subscription.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/manage-subscription.ts
@@ -1,22 +1,53 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Text, Button, Banner} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-purchase-option.action.render',
   (root, api) => {
     const {data, close} = api;
 
-    const item = data.selected[0];
+    let updated = false;
+    let banner;
 
-    if (item.sellingPlanId) {
-      fetch('/api/update-subscription', {
-        method: 'POST',
-        body: JSON.stringify({
-          productId: item.id,
-          sellingPlanId: item.sellingPlanId,
-        }),
-      }).then(() => {
-        close();
-      });
-    }
+    const {id: productId, sellingPlanId} = data.selected[0];
+
+    const productText = root.createComponent(Text, {}, `Product: ${productId}`);
+    const planText = root.createComponent(Text, {}, `Selling Plan: ${sellingPlanId}`);
+
+    const updateButton = root.createComponent(Button, {
+      title: 'Update Subscription',
+      onPress: async () => {
+        if (!sellingPlanId) {
+          console.error('No selling plan selected');
+          close();
+          return;
+        }
+
+        const response = await fetch('/api/subscriptions/update', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            productId,
+            sellingPlanId,
+            action: 'modify',
+          }),
+        });
+
+        if (response.ok) {
+          updated = true;
+          banner = root.createComponent(
+            Banner,
+            {status: 'success'},
+            'Subscription updated!',
+          );
+          root.appendChild(banner);
+
+          setTimeout(() => close(), 1500);
+        }
+      },
+    });
+
+    root.appendChild(productText);
+    root.appendChild(planText);
+    root.appendChild(updateButton);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/manage-subscription.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/manage-subscription.ts
@@ -1,0 +1,22 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-purchase-option.action.render',
+  (root, api) => {
+    const {data, close} = api;
+
+    const item = data.selected[0];
+
+    if (item.sellingPlanId) {
+      fetch('/api/update-subscription', {
+        method: 'POST',
+        body: JSON.stringify({
+          productId: item.id,
+          sellingPlanId: item.sellingPlanId,
+        }),
+      }).then(() => {
+        close();
+      });
+    }
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/manage-subscription.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/manage-subscription.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const ManageSubscription = () => {
+  const {data, close} = useApi<'admin.product-purchase-option.action.render'>();
+
+  const handleUpdate = async () => {
+    const item = data.selected[0];
+
+    if (item.sellingPlanId) {
+      await fetch('/api/update-subscription', {
+        method: 'POST',
+        body: JSON.stringify({
+          productId: item.id,
+          sellingPlanId: item.sellingPlanId,
+        }),
+      });
+
+      close();
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-purchase-option.action.render', () => <ManageSubscription />);

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/manage-subscription.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/manage-subscription.tsx
@@ -1,26 +1,52 @@
-import React from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Text,
+  Button,
+  Banner,
+} from '@shopify/ui-extensions-react/admin';
 
 const ManageSubscription = () => {
   const {data, close} = useApi<'admin.product-purchase-option.action.render'>();
+  const [updated, setUpdated] = useState(false);
+
+  const {id: productId, sellingPlanId} = data.selected[0];
 
   const handleUpdate = async () => {
-    const item = data.selected[0];
-
-    if (item.sellingPlanId) {
-      await fetch('/api/update-subscription', {
-        method: 'POST',
-        body: JSON.stringify({
-          productId: item.id,
-          sellingPlanId: item.sellingPlanId,
-        }),
-      });
-
+    if (!sellingPlanId) {
+      console.error('No selling plan selected');
       close();
+      return;
+    }
+
+    const response = await fetch('/api/subscriptions/update', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        productId,
+        sellingPlanId,
+        action: 'modify',
+      }),
+    });
+
+    if (response.ok) {
+      setUpdated(true);
+      setTimeout(() => close(), 1500);
     }
   };
 
-  return null;
+  return (
+    <>
+      <Text>Product: {productId}</Text>
+      <Text>Selling Plan: {sellingPlanId}</Text>
+      <Button title="Update Subscription" onPress={handleUpdate} />
+      {updated && <Banner status="success">Subscription updated!</Banner>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-purchase-option.action.render', () => <ManageSubscription />);
+export default reactExtension(
+  'admin.product-purchase-option.action.render',
+  () => <ManageSubscription />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/remove-from-plan.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/remove-from-plan.ts
@@ -1,0 +1,19 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-purchase-option.action.render',
+  (root, api) => {
+    const {data, close} = api;
+
+    const item = data.selected[0];
+
+    if (confirm('Remove this product from the selling plan?')) {
+      fetch(`/api/selling-plans/${item.sellingPlanId}/remove-product`, {
+        method: 'POST',
+        body: JSON.stringify({productId: item.id}),
+      }).then(() => {
+        close();
+      });
+    }
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/remove-from-plan.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/remove-from-plan.ts
@@ -1,19 +1,65 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Text, Button, Banner} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-purchase-option.action.render',
   (root, api) => {
     const {data, close} = api;
 
-    const item = data.selected[0];
+    let confirming = false;
+    let removed = false;
+    let banner;
 
-    if (confirm('Remove this product from the selling plan?')) {
-      fetch(`/api/selling-plans/${item.sellingPlanId}/remove-product`, {
-        method: 'POST',
-        body: JSON.stringify({productId: item.id}),
-      }).then(() => {
-        close();
+    const {id: productId, sellingPlanId} = data.selected[0];
+
+    const renderConfirmation = () => {
+      root.clear();
+
+      const confirmText = root.createComponent(Text, {}, 'Are you sure you want to remove this product?');
+      const confirmButton = root.createComponent(Button, {
+        title: 'Confirm Remove',
+        onPress: async () => {
+          confirming = false;
+
+          await fetch('/api/selling-plans/remove-product', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, sellingPlanId}),
+          });
+
+          removed = true;
+          root.clear();
+          banner = root.createComponent(
+            Banner,
+            {status: 'success'},
+            'Product removed from plan',
+          );
+          root.appendChild(banner);
+
+          setTimeout(() => close(), 1500);
+        },
       });
-    }
+      const cancelButton = root.createComponent(Button, {
+        title: 'Cancel',
+        onPress: () => renderInitial(),
+      });
+
+      root.appendChild(confirmText);
+      root.appendChild(confirmButton);
+      root.appendChild(cancelButton);
+    };
+
+    const renderInitial = () => {
+      root.clear();
+      const removeButton = root.createComponent(Button, {
+        title: 'Remove Product',
+        onPress: () => {
+          confirming = true;
+          renderConfirmation();
+        },
+      });
+      root.appendChild(removeButton);
+    };
+
+    renderInitial();
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/remove-from-plan.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/remove-from-plan.tsx
@@ -1,0 +1,24 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const RemoveFromPlan = () => {
+  const {data, close} = useApi<'admin.product-purchase-option.action.render'>();
+  const [confirmed, setConfirmed] = useState(false);
+
+  const handleRemove = async () => {
+    if (confirmed) {
+      const item = data.selected[0];
+
+      await fetch(`/api/selling-plans/${item.sellingPlanId}/remove-product`, {
+        method: 'POST',
+        body: JSON.stringify({productId: item.id}),
+      });
+
+      close();
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-purchase-option.action.render', () => <RemoveFromPlan />);

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/remove-from-plan.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/remove-from-plan.tsx
@@ -1,24 +1,49 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {
+  reactExtension,
+  useApi,
+  Text,
+  Button,
+  Banner,
+} from '@shopify/ui-extensions-react/admin';
 
 const RemoveFromPlan = () => {
   const {data, close} = useApi<'admin.product-purchase-option.action.render'>();
-  const [confirmed, setConfirmed] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [removed, setRemoved] = useState(false);
+
+  const {id: productId, sellingPlanId} = data.selected[0];
 
   const handleRemove = async () => {
-    if (confirmed) {
-      const item = data.selected[0];
+    setConfirming(false);
 
-      await fetch(`/api/selling-plans/${item.sellingPlanId}/remove-product`, {
-        method: 'POST',
-        body: JSON.stringify({productId: item.id}),
-      });
+    await fetch('/api/selling-plans/remove-product', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({productId, sellingPlanId}),
+    });
 
-      close();
-    }
+    setRemoved(true);
+    setTimeout(() => close(), 1500);
   };
 
-  return null;
+  return (
+    <>
+      {!confirming ? (
+        <Button title="Remove Product" onPress={() => setConfirming(true)} />
+      ) : (
+        <>
+          <Text>Are you sure you want to remove this product?</Text>
+          <Button title="Confirm Remove" onPress={handleRemove} />
+          <Button title="Cancel" onPress={() => setConfirming(false)} />
+        </>
+      )}
+      {removed && <Banner status="success">Product removed from plan</Banner>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-purchase-option.action.render', () => <RemoveFromPlan />);
+export default reactExtension(
+  'admin.product-purchase-option.action.render',
+  () => <RemoveFromPlan />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/validate-selling-plan.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/validate-selling-plan.ts
@@ -1,0 +1,25 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-purchase-option.action.render',
+  (root, api) => {
+    const {data, query, close} = api;
+
+    const item = data.selected[0];
+
+    if (item.sellingPlanId) {
+      query(
+        `query GetSellingPlan($id: ID!) {
+          sellingPlanGroup(id: $id) {
+            name
+            options
+          }
+        }`,
+        {variables: {id: item.sellingPlanId}},
+      ).then(({data: planData}) => {
+        console.log('Selling plan:', planData.sellingPlanGroup);
+        setTimeout(() => close(), 2000);
+      });
+    }
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/validate-selling-plan.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/validate-selling-plan.ts
@@ -1,25 +1,46 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-purchase-option.action.render',
   (root, api) => {
     const {data, query, close} = api;
 
-    const item = data.selected[0];
+    let plan = null;
 
-    if (item.sellingPlanId) {
-      query(
-        `query GetSellingPlan($id: ID!) {
-          sellingPlanGroup(id: $id) {
-            name
-            options
-          }
-        }`,
-        {variables: {id: item.sellingPlanId}},
-      ).then(({data: planData}) => {
-        console.log('Selling plan:', planData.sellingPlanGroup);
+    const {sellingPlanId} = data.selected[0];
+
+    const validateButton = root.createComponent(Button, {
+      title: 'Check Plan Details',
+      onPress: async () => {
+        const {data: planData} = await query(
+          `query GetSellingPlan($id: ID!) {
+            sellingPlanGroup(id: $id) {
+              sellingPlans(first: 1) {
+                edges {
+                  node {
+                    id
+                    name
+                    options
+                  }
+                }
+              }
+            }
+          }`,
+          {variables: {id: sellingPlanId}},
+        );
+
+        plan = planData.sellingPlanGroup.sellingPlans.edges[0]?.node;
+
+        const nameText = root.createComponent(Text, {}, `Plan: ${plan.name}`);
+        const optionsText = root.createComponent(Text, {}, `Options: ${plan.options.length}`);
+        
+        root.appendChild(nameText);
+        root.appendChild(optionsText);
+
         setTimeout(() => close(), 2000);
-      });
-    }
+      },
+    });
+
+    root.appendChild(validateButton);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/validate-selling-plan.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/validate-selling-plan.tsx
@@ -1,0 +1,30 @@
+import React, {useEffect, useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const ValidateSellingPlan = () => {
+  const {data, query, close} = useApi<'admin.product-purchase-option.action.render'>();
+  const [plan, setPlan] = useState(null);
+
+  useEffect(() => {
+    const item = data.selected[0];
+
+    if (item.sellingPlanId) {
+      query(
+        `query GetSellingPlan($id: ID!) {
+          sellingPlanGroup(id: $id) {
+            name
+            options
+          }
+        }`,
+        {variables: {id: item.sellingPlanId}},
+      ).then(({data: planData}) => {
+        setPlan(planData.sellingPlanGroup);
+        setTimeout(() => close(), 2000);
+      });
+    }
+  }, [data, query, close]);
+
+  return null;
+};
+
+export default reactExtension('admin.product-purchase-option.action.render', () => <ValidateSellingPlan />);

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/validate-selling-plan.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card/examples/validate-selling-plan.tsx
@@ -1,30 +1,53 @@
-import React, {useEffect, useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import React, {useState} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Button,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
 
 const ValidateSellingPlan = () => {
   const {data, query, close} = useApi<'admin.product-purchase-option.action.render'>();
-  const [plan, setPlan] = useState(null);
+  const [plan, setPlan] = useState<any>(null);
 
-  useEffect(() => {
-    const item = data.selected[0];
+  const {sellingPlanId} = data.selected[0];
 
-    if (item.sellingPlanId) {
-      query(
-        `query GetSellingPlan($id: ID!) {
-          sellingPlanGroup(id: $id) {
-            name
-            options
+  const handleValidate = async () => {
+    const {data: planData} = await query(
+      `query GetSellingPlan($id: ID!) {
+        sellingPlanGroup(id: $id) {
+          sellingPlans(first: 1) {
+            edges {
+              node {
+                id
+                name
+                options
+              }
+            }
           }
-        }`,
-        {variables: {id: item.sellingPlanId}},
-      ).then(({data: planData}) => {
-        setPlan(planData.sellingPlanGroup);
-        setTimeout(() => close(), 2000);
-      });
-    }
-  }, [data, query, close]);
+        }
+      }`,
+      {variables: {id: sellingPlanId}},
+    );
 
-  return null;
+    setPlan(planData.sellingPlanGroup.sellingPlans.edges[0]?.node);
+    setTimeout(() => close(), 2000);
+  };
+
+  return (
+    <>
+      <Button title="Check Plan Details" onPress={handleValidate} />
+      {plan && (
+        <>
+          <Text>Plan: {plan.name}</Text>
+          <Text>Options: {plan.options.length}</Text>
+        </>
+      )}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-purchase-option.action.render', () => <ValidateSellingPlan />);
+export default reactExtension(
+  'admin.product-purchase-option.action.render',
+  () => <ValidateSellingPlan />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/action.ts
@@ -1,0 +1,4 @@
+const selected = await resourcePicker({
+  type: 'product',
+  action: 'select',
+});

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/action.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/action.ts
@@ -1,4 +1,25 @@
-const selected = await resourcePicker({
-  type: 'product',
-  action: 'select',
-});
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Resources',
+      onPress: async () => {
+        const result = await resourcePicker({type: 'product'});
+        
+        if (selectedText) root.removeChild(selectedText);
+        
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/action.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/action.tsx
@@ -1,19 +1,21 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
-const ActionVerbPicker = () => {
+const ResourcePickerExample = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
-    const result = await resourcePicker({
-      type: 'product',
-      action: 'add',
-    });
+    const result = await resourcePicker({type: 'product'});
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Resources" onPress={handlePick} />
+      {selected && <Text>{selected.length} selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <ActionVerbPicker />);
+export default reactExtension('admin.product-details.block.render', () => <ResourcePickerExample />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/action.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/action.tsx
@@ -1,0 +1,19 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const ActionVerbPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({
+      type: 'product',
+      action: 'add',
+    });
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <ActionVerbPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/collection-picker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/collection-picker.ts
@@ -1,0 +1,1 @@
+const selected = await resourcePicker({type: 'collection'});

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/collection-picker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/collection-picker.ts
@@ -1,1 +1,25 @@
-const selected = await resourcePicker({type: 'collection'});
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Collections',
+      onPress: async () => {
+        const result = await resourcePicker({type: 'collection'});
+        
+        if (selectedText) root.removeChild(selectedText);
+        
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} collections selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/collection-picker.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/collection-picker.tsx
@@ -1,16 +1,21 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
 const CollectionPicker = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
     const result = await resourcePicker({type: 'collection'});
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Collections" onPress={handlePick} />
+      {selected && <Text>{selected.length} collections selected</Text>}
+    </>
+  );
 };
 
 export default reactExtension('admin.product-details.block.render', () => <CollectionPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/collection-picker.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/collection-picker.tsx
@@ -1,0 +1,16 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const CollectionPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({type: 'collection'});
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <CollectionPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filter-query.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filter-query.ts
@@ -1,0 +1,6 @@
+const selected = await resourcePicker({
+  type: 'product',
+  filter: {
+    query: 'Sweater',
+  },
+});

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filter-query.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filter-query.ts
@@ -1,6 +1,25 @@
-const selected = await resourcePicker({
-  type: 'product',
-  filter: {
-    query: 'Sweater',
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Resources',
+      onPress: async () => {
+        const result = await resourcePicker({type: 'product'});
+        
+        if (selectedText) root.removeChild(selectedText);
+        
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
   },
-});
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filter-query.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filter-query.tsx
@@ -1,16 +1,21 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
-const FilterQueryPicker = () => {
+const ResourcePickerExample = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
     const result = await resourcePicker({type: 'product'});
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Resources" onPress={handlePick} />
+      {selected && <Text>{selected.length} selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <FilterQueryPicker />);
+export default reactExtension('admin.product-details.block.render', () => <ResourcePickerExample />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filter-query.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filter-query.tsx
@@ -1,0 +1,16 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const FilterQueryPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({type: 'product'});
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <FilterQueryPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filters.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filters.ts
@@ -1,0 +1,9 @@
+const selected = await resourcePicker({
+  type: 'product',
+  filter: {
+    hidden: true,
+    variants: false,
+    draft: false,
+    archived: false,
+  },
+});

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filters.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filters.ts
@@ -1,9 +1,30 @@
-const selected = await resourcePicker({
-  type: 'product',
-  filter: {
-    hidden: true,
-    variants: false,
-    draft: false,
-    archived: false,
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Published Products',
+      onPress: async () => {
+        const result = await resourcePicker({
+          type: 'product',
+          filter: {
+            published_status: 'published',
+          },
+        });
+
+        if (selectedText) root.removeChild(selectedText);
+
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} products selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
   },
-});
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filters.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filters.tsx
@@ -1,9 +1,9 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
-const FilteredPicker = () => {
+const FiltersPicker = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
     const result = await resourcePicker({
@@ -15,7 +15,12 @@ const FilteredPicker = () => {
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Published Products" onPress={handlePick} />
+      {selected && <Text>{selected.length} products selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <FilteredPicker />);
+export default reactExtension('admin.product-details.block.render', () => <FiltersPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filters.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/filters.tsx
@@ -1,0 +1,21 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const FilteredPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({
+      type: 'product',
+      filter: {
+        published_status: 'published',
+      },
+    });
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <FilteredPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-limited.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-limited.ts
@@ -1,0 +1,4 @@
+const selected = await resourcePicker({
+  type: 'product',
+  multiple: 5,
+});

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-limited.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-limited.ts
@@ -1,4 +1,25 @@
-const selected = await resourcePicker({
-  type: 'product',
-  multiple: 5,
-});
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Resources',
+      onPress: async () => {
+        const result = await resourcePicker({type: 'product'});
+        
+        if (selectedText) root.removeChild(selectedText);
+        
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-limited.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-limited.tsx
@@ -1,19 +1,21 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
-const MultipleLimitedPicker = () => {
+const ResourcePickerExample = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
-    const result = await resourcePicker({
-      type: 'product',
-      multiple: 5,
-    });
+    const result = await resourcePicker({type: 'product'});
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Resources" onPress={handlePick} />
+      {selected && <Text>{selected.length} selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <MultipleLimitedPicker />);
+export default reactExtension('admin.product-details.block.render', () => <ResourcePickerExample />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-limited.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-limited.tsx
@@ -1,0 +1,19 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const MultipleLimitedPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({
+      type: 'product',
+      multiple: 5,
+    });
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <MultipleLimitedPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-unlimited.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-unlimited.ts
@@ -1,0 +1,4 @@
+const selected = await resourcePicker({
+  type: 'product',
+  multiple: true,
+});

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-unlimited.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-unlimited.ts
@@ -1,4 +1,25 @@
-const selected = await resourcePicker({
-  type: 'product',
-  multiple: true,
-});
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Resources',
+      onPress: async () => {
+        const result = await resourcePicker({type: 'product'});
+        
+        if (selectedText) root.removeChild(selectedText);
+        
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-unlimited.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-unlimited.tsx
@@ -1,0 +1,19 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const UnlimitedPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({
+      type: 'product',
+      multiple: true,
+    });
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <UnlimitedPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-unlimited.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/multiple-unlimited.tsx
@@ -1,19 +1,21 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
-const UnlimitedPicker = () => {
+const ResourcePickerExample = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
-    const result = await resourcePicker({
-      type: 'product',
-      multiple: true,
-    });
+    const result = await resourcePicker({type: 'product'});
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Resources" onPress={handlePick} />
+      {selected && <Text>{selected.length} selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <UnlimitedPicker />);
+export default reactExtension('admin.product-details.block.render', () => <ResourcePickerExample />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-picker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-picker.ts
@@ -1,0 +1,3 @@
+const {resourcePicker} = useApi(TARGET);
+
+const selected = await resourcePicker({type: 'product'});

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-picker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-picker.ts
@@ -1,3 +1,25 @@
-const {resourcePicker} = useApi(TARGET);
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
-const selected = await resourcePicker({type: 'product'});
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Products',
+      onPress: async () => {
+        const result = await resourcePicker({type: 'product'});
+        
+        if (selectedText) root.removeChild(selectedText);
+        
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} products selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-picker.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-picker.tsx
@@ -1,0 +1,16 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const ProductPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({type: 'product'});
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <ProductPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-picker.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-picker.tsx
@@ -1,16 +1,21 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
 const ProductPicker = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
     const result = await resourcePicker({type: 'product'});
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Products" onPress={handlePick} />
+      {selected && <Text>{selected.length} products selected</Text>}
+    </>
+  );
 };
 
 export default reactExtension('admin.product-details.block.render', () => <ProductPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-variant-picker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-variant-picker.ts
@@ -1,0 +1,1 @@
+const selected = await resourcePicker({type: 'variant'});

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-variant-picker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-variant-picker.ts
@@ -1,1 +1,25 @@
-const selected = await resourcePicker({type: 'variant'});
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Resources',
+      onPress: async () => {
+        const result = await resourcePicker({type: 'product'});
+        
+        if (selectedText) root.removeChild(selectedText);
+        
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-variant-picker.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-variant-picker.tsx
@@ -1,0 +1,16 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const VariantPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({type: 'variant'});
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <VariantPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-variant-picker.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/product-variant-picker.tsx
@@ -1,16 +1,21 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
-const VariantPicker = () => {
+const ResourcePickerExample = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
-    const result = await resourcePicker({type: 'variant'});
+    const result = await resourcePicker({type: 'product'});
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Resources" onPress={handlePick} />
+      {selected && <Text>{selected.length} selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <VariantPicker />);
+export default reactExtension('admin.product-details.block.render', () => <ResourcePickerExample />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/query.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/query.ts
@@ -1,0 +1,4 @@
+const selected = await resourcePicker({
+  type: 'product',
+  query: 'Sweater',
+});

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/query.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/query.ts
@@ -1,4 +1,25 @@
-const selected = await resourcePicker({
-  type: 'product',
-  query: 'Sweater',
-});
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Resources',
+      onPress: async () => {
+        const result = await resourcePicker({type: 'product'});
+        
+        if (selectedText) root.removeChild(selectedText);
+        
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/query.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/query.tsx
@@ -1,0 +1,19 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const QueryPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({
+      type: 'product',
+      query: 'shirt',
+    });
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <QueryPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/query.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/query.tsx
@@ -1,19 +1,21 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
-const QueryPicker = () => {
+const ResourcePickerExample = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
-    const result = await resourcePicker({
-      type: 'product',
-      query: 'shirt',
-    });
+    const result = await resourcePicker({type: 'product'});
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Resources" onPress={handlePick} />
+      {selected && <Text>{selected.length} selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <QueryPicker />);
+export default reactExtension('admin.product-details.block.render', () => <ResourcePickerExample />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection-ids.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection-ids.ts
@@ -1,0 +1,16 @@
+const selected = await resourcePicker({
+  type: 'product',
+  selectionIds: [
+    {
+      id: 'gid://shopify/Product/12345',
+      variants: [
+        {
+          id: 'gid://shopify/ProductVariant/1',
+        },
+      ],
+    },
+    {
+      id: 'gid://shopify/Product/67890',
+    },
+  ],
+});

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection-ids.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection-ids.ts
@@ -1,16 +1,25 @@
-const selected = await resourcePicker({
-  type: 'product',
-  selectionIds: [
-    {
-      id: 'gid://shopify/Product/12345',
-      variants: [
-        {
-          id: 'gid://shopify/ProductVariant/1',
-        },
-      ],
-    },
-    {
-      id: 'gid://shopify/Product/67890',
-    },
-  ],
-});
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Resources',
+      onPress: async () => {
+        const result = await resourcePicker({type: 'product'});
+        
+        if (selectedText) root.removeChild(selectedText);
+        
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection-ids.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection-ids.tsx
@@ -1,0 +1,22 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const PreselectedPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({
+      type: 'product',
+      selectionIds: [
+        'gid://shopify/Product/123',
+        'gid://shopify/Product/456',
+      ],
+    });
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <PreselectedPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection-ids.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection-ids.tsx
@@ -1,22 +1,21 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
-const PreselectedPicker = () => {
+const ResourcePickerExample = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
-    const result = await resourcePicker({
-      type: 'product',
-      selectionIds: [
-        'gid://shopify/Product/123',
-        'gid://shopify/Product/456',
-      ],
-    });
+    const result = await resourcePicker({type: 'product'});
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Resources" onPress={handlePick} />
+      {selected && <Text>{selected.length} selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <PreselectedPicker />);
+export default reactExtension('admin.product-details.block.render', () => <ResourcePickerExample />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection.ts
@@ -1,0 +1,7 @@
+const selected = await resourcePicker({type: 'product'});
+
+if (selected) {
+  console.log(selected);
+} else {
+  console.log('Picker was cancelled by the user');
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection.ts
@@ -1,7 +1,25 @@
-const selected = await resourcePicker({type: 'product'});
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
-if (selected) {
-  console.log(selected);
-} else {
-  console.log('Picker was cancelled by the user');
-}
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {resourcePicker} = api;
+    let selectedText;
+
+    const pickButton = root.createComponent(Button, {
+      title: 'Select Resources',
+      onPress: async () => {
+        const result = await resourcePicker({type: 'product'});
+        
+        if (selectedText) root.removeChild(selectedText);
+        
+        if (result) {
+          selectedText = root.createComponent(Text, {}, `${result.length} selected`);
+          root.appendChild(selectedText);
+        }
+      },
+    });
+
+    root.appendChild(pickButton);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection.tsx
@@ -1,16 +1,21 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Button, Text} from '@shopify/ui-extensions-react/admin';
 
-const SelectionPicker = () => {
+const ResourcePickerExample = () => {
   const {resourcePicker} = useApi<'admin.product-details.block.render'>();
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<any[] | null>(null);
 
   const handlePick = async () => {
     const result = await resourcePicker({type: 'product'});
     setSelected(result);
   };
 
-  return null;
+  return (
+    <>
+      <Button title="Select Resources" onPress={handlePick} />
+      {selected && <Text>{selected.length} selected</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <SelectionPicker />);
+export default reactExtension('admin.product-details.block.render', () => <ResourcePickerExample />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/examples/selection.tsx
@@ -1,0 +1,16 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const SelectionPicker = () => {
+  const {resourcePicker} = useApi<'admin.product-details.block.render'>();
+  const [selected, setSelected] = useState(null);
+
+  const handlePick = async () => {
+    const result = await resourcePicker({type: 'product'});
+    setSelected(result);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <SelectionPicker />);

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -256,7 +256,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Filter query runs server-side:** The `query` property in filters isn\'t visible to merchants and runs as a GraphQL search query. Use it to programmatically restrict results (for example, `vendor:Acme`) without exposing the filter logic.
+        "- **Filter query runs server-side:** The `query` property in filters isn't visible to merchants and runs as a GraphQL search query. Use it to programmatically restrict results (for example, `vendor:Acme`) without exposing the filter logic.
 " +
         '- **Handle undefined return on cancellation:** When merchants close the picker without selecting, it returns `undefined` rather than an empty array. Check for `undefined` explicitly.',
     },
@@ -265,11 +265,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Only products, variants, and collections are supported. Other resource types like customers, orders, or locations can\'t be selected. Use the [Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) for custom resources.
+        "- Only products, variants, and collections are supported. Other resource types like customers, orders, or locations can't be selected. Use the [Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) for custom resources.
 " +
-        "- Product selection with `multiple: false` doesn\'t prevent multi-variant selection from the same product. Merchants can select multiple variants from a single product even when `multiple: false`.
+        "- Product selection with `multiple: false` doesn't prevent multi-variant selection from the same product. Merchants can select multiple variants from a single product even when `multiple: false`.
 " +
-        "- Filter options are limited to predefined fields (`hidden`, `variants`, `draft`, `archived`, `query`). Custom filter criteria beyond these aren\'t supported.
+        "- Filter options are limited to predefined fields (`hidden`, `variants`, `draft`, `archived`, `query`). Custom filter criteria beyond these aren't supported.
 " +
         '- Returned data structure varies by resource type. Products include a `variants` array, variants include `price` and `inventoryQuantity`, and collections include `ruleSet`.',
     },

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -256,7 +256,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Filter query runs server-side:** The `query` property in filters isn't visible to merchants and runs as a GraphQL search query. Use it to programmatically restrict results (for example, `vendor:Acme`) without exposing the filter logic.
+        "- **Filter query runs server-side:** The `query` property in filters isn\'t visible to merchants and runs as a GraphQL search query. Use it to programmatically restrict results (for example, `vendor:Acme`) without exposing the filter logic.
 " +
         '- **Handle undefined return on cancellation:** When merchants close the picker without selecting, it returns `undefined` rather than an empty array. Check for `undefined` explicitly.',
     },
@@ -265,11 +265,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Only products, variants, and collections are supported. Other resource types like customers, orders, or locations can't be selected. Use the [Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) for custom resources.
+        "- Only products, variants, and collections are supported. Other resource types like customers, orders, or locations can\'t be selected. Use the [Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) for custom resources.
 " +
-        "- Product selection with `multiple: false` doesn't prevent multi-variant selection from the same product. Merchants can select multiple variants from a single product even when `multiple: false`.
+        "- Product selection with `multiple: false` doesn\'t prevent multi-variant selection from the same product. Merchants can select multiple variants from a single product even when `multiple: false`.
 " +
-        "- Filter options are limited to predefined fields (`hidden`, `variants`, `draft`, `archived`, `query`). Custom filter criteria beyond these aren't supported.
+        "- Filter options are limited to predefined fields (`hidden`, `variants`, `draft`, `archived`, `query`). Custom filter criteria beyond these aren\'t supported.
 " +
         '- Returned data structure varies by resource type. Products include a `variants` array, variants include `price` and `inventoryQuantity`, and collections include `ruleSet`.',
     },

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -256,7 +256,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        "- **Filter query runs server-side:** The `query` property in filters isn't visible to merchants and runs as a GraphQL search query. Use it to programmatically restrict results (for example, `vendor:Acme`) without exposing the filter logic.\n" +
+        "- **Filter query runs server-side:** The `query` property in filters isn't visible to merchants and runs as a GraphQL search query. Use it to programmatically restrict results (for example, `vendor:Acme`) without exposing the filter logic.
+" +
         '- **Handle undefined return on cancellation:** When merchants close the picker without selecting, it returns `undefined` rather than an empty array. Check for `undefined` explicitly.',
     },
     {
@@ -264,9 +265,12 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Only products, variants, and collections are supported. Other resource types like customers, orders, or locations can't be selected. Use the [Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) for custom resources.\n" +
-        "- Product selection with `multiple: false` doesn't prevent multi-variant selection from the same product. Merchants can select multiple variants from a single product even when `multiple: false`.\n" +
-        "- Filter options are limited to predefined fields (`hidden`, `variants`, `draft`, `archived`, `query`). Custom filter criteria beyond these aren't supported.\n" +
+        "- Only products, variants, and collections are supported. Other resource types like customers, orders, or locations can't be selected. Use the [Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) for custom resources.
+" +
+        "- Product selection with `multiple: false` doesn't prevent multi-variant selection from the same product. Merchants can select multiple variants from a single product even when `multiple: false`.
+" +
+        "- Filter options are limited to predefined fields (`hidden`, `variants`, `draft`, `archived`, `query`). Custom filter criteria beyond these aren't supported.
+" +
         '- Returned data structure varies by resource type. Products include a `variants` array, variants include `price` and `inventoryQuantity`, and collections include `ruleSet`.',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -22,14 +22,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Select products',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/product-picker.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/product-picker.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/product-picker.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -45,14 +50,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Filter to published products',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/filters.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/filters.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/filters.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -64,14 +74,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Limit selection count',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/multiple-limited.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/multiple-limited.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/multiple-limited.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -83,14 +98,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Preselect products',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/selection-ids.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/selection-ids.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/selection-ids.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -102,14 +122,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Select collections',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/collection-picker.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/collection-picker.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/collection-picker.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -121,14 +146,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Select unlimited products',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/multiple-unlimited.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/multiple-unlimited.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/multiple-unlimited.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -140,14 +170,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Select product variants',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/product-variant-picker.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/product-variant-picker.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/product-variant-picker.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -159,14 +194,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Set action verb',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/action.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/action.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/action.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -178,14 +218,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Start with search query',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/query.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/query.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/query.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -21,8 +21,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Select products',
       tabs: [
-        {code: './examples/product-picker.ts', language: 'ts'},
-        {code: './examples/product-picker.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/product-picker.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/product-picker.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -36,8 +44,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Filter to published products',
           tabs: [
-            {code: './examples/filters.ts', language: 'ts'},
-            {code: './examples/filters.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/filters.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/filters.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -47,8 +63,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Limit selection count',
           tabs: [
-            {code: './examples/multiple-limited.ts', language: 'ts'},
-            {code: './examples/multiple-limited.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/multiple-limited.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/multiple-limited.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -58,8 +82,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Preselect products',
           tabs: [
-            {code: './examples/selection-ids.ts', language: 'ts'},
-            {code: './examples/selection-ids.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/selection-ids.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/selection-ids.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -69,8 +101,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select collections',
           tabs: [
-            {code: './examples/collection-picker.ts', language: 'ts'},
-            {code: './examples/collection-picker.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/collection-picker.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/collection-picker.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -80,8 +120,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select unlimited products',
           tabs: [
-            {code: './examples/multiple-unlimited.ts', language: 'ts'},
-            {code: './examples/multiple-unlimited.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/multiple-unlimited.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/multiple-unlimited.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -91,8 +139,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select product variants',
           tabs: [
-            {code: './examples/product-variant-picker.ts', language: 'ts'},
-            {code: './examples/product-variant-picker.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/product-variant-picker.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/product-variant-picker.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -102,8 +158,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Set action verb',
           tabs: [
-            {code: './examples/action.ts', language: 'ts'},
-            {code: './examples/action.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/action.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/action.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -113,8 +177,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Start with search query',
           tabs: [
-            {code: './examples/query.ts', language: 'ts'},
-            {code: './examples/query.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/query.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/query.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -36,9 +36,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Filter to published products',
           tabs: [
-        {code: './examples/filters.ts', language: 'ts'},
-        {code: './examples/filters.tsx', language: 'tsx'},
-      ],
+            {code: './examples/filters.ts', language: 'ts'},
+            {code: './examples/filters.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -47,9 +47,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Limit selection count',
           tabs: [
-        {code: './examples/multiple-limited.ts', language: 'ts'},
-        {code: './examples/multiple-limited.tsx', language: 'tsx'},
-      ],
+            {code: './examples/multiple-limited.ts', language: 'ts'},
+            {code: './examples/multiple-limited.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -58,9 +58,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Preselect products',
           tabs: [
-        {code: './examples/selection-ids.ts', language: 'ts'},
-        {code: './examples/selection-ids.tsx', language: 'tsx'},
-      ],
+            {code: './examples/selection-ids.ts', language: 'ts'},
+            {code: './examples/selection-ids.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -69,9 +69,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select collections',
           tabs: [
-        {code: './examples/collection-picker.ts', language: 'ts'},
-        {code: './examples/collection-picker.tsx', language: 'tsx'},
-      ],
+            {code: './examples/collection-picker.ts', language: 'ts'},
+            {code: './examples/collection-picker.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -80,9 +80,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select unlimited products',
           tabs: [
-        {code: './examples/multiple-unlimited.ts', language: 'ts'},
-        {code: './examples/multiple-unlimited.tsx', language: 'tsx'},
-      ],
+            {code: './examples/multiple-unlimited.ts', language: 'ts'},
+            {code: './examples/multiple-unlimited.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -91,9 +91,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Select product variants',
           tabs: [
-        {code: './examples/product-variant-picker.ts', language: 'ts'},
-        {code: './examples/product-variant-picker.tsx', language: 'tsx'},
-      ],
+            {code: './examples/product-variant-picker.ts', language: 'ts'},
+            {code: './examples/product-variant-picker.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -102,9 +102,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Set action verb',
           tabs: [
-        {code: './examples/action.ts', language: 'ts'},
-        {code: './examples/action.tsx', language: 'tsx'},
-      ],
+            {code: './examples/action.ts', language: 'ts'},
+            {code: './examples/action.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -113,9 +113,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Start with search query',
           tabs: [
-        {code: './examples/query.ts', language: 'ts'},
-        {code: './examples/query.tsx', language: 'tsx'},
-      ],
+            {code: './examples/query.ts', language: 'ts'},
+            {code: './examples/query.tsx', language: 'tsx'},
+          ],
         },
       },
     ],

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Select collections or product variants instead of products. This example demonstrates using `type: "collection"` to pick collections or `type: "variant"` to pick product variants, each returning different resource data structures.',
+          'Select collections or product variants instead of products. Use `type: "collection"` to pick collections or `type: "variant"` for variants, each returning different data structures with type-specific metadata.',
         codeblock: {
           title: 'Select alternate resource types',
           tabs: [
@@ -60,7 +60,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Open the picker with specific products already preselected. This example uses the `selectionIds` array with product GIDs to mark items as selected when the picker opens.',
+          'Open the picker with specific products already preselected. Uses `selectionIds` array with product GIDs like `gid://shopify/Product/123` to mark items as selected—useful for edit workflows.',
         codeblock: {
           title: 'Preselect resources',
           tabs: [
@@ -71,7 +71,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Customize the picker\'s confirm button with an action verb. This example sets `action: "add"` to change the button text from "Select" to "Add", providing clearer context for the merchant.',
+          'Customize the picker\'s confirm button with an action verb. Sets `action: "add"` to change button text from "Select" to "Add", helping merchants understand whether they\'re adding to a list or replacing.',
         codeblock: {
           title: 'Set action verb',
           tabs: [
@@ -82,7 +82,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Allow unlimited selection or limit to a maximum count. This example demonstrates setting `multiple: true` for unlimited selection or `multiple: 5` to limit selection to a maximum of 5 items.',
+          'Allow unlimited selection or limit to a maximum count. Set `multiple: true` for unlimited or `multiple: 5` to cap at 5 items—the picker automatically prevents selection beyond the limit.',
         codeblock: {
           title: 'Configure multiple selection',
           tabs: [
@@ -111,7 +111,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Filter the picker to show only published products. This example sets `filter.published_status: "published"` to restrict which items appear in the picker.',
+          'Filter the picker to show only published products. Uses `filter.published_status: "published"` to restrict the picker to live, customer-visible products, preventing accidental selection of draft or archived items.',
         codeblock: {
           title: 'Apply filters',
           tabs: [
@@ -122,7 +122,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Provide an initial search query to filter the picker. This example uses the `query` property to pre-fill the search field, so the picker opens with results already filtered (for example, "shirt").',
+          'Provide an initial search query to filter picker results. Uses `query` property to pre-fill the search field with a term like "shirt"—helpful for guiding merchants to specific items in large catalogs.',
         codeblock: {
           title: 'Search with initial query',
           tabs: [
@@ -133,7 +133,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Access selected resource data including IDs, titles, and images. This example shows how the resource picker returns an array of resources with full metadata that you can use in your extension.',
+          'Access selected resource data including IDs, titles, and images. Resource picker returns an array of resources with full metadata, or `undefined` if the merchant cancels.',
         codeblock: {
           title: 'Use selection payload',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -15,125 +15,130 @@ const data: ReferenceEntityTemplateSchema = {
   requires:
     'an Admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.',
   defaultExample: {
+    description:
+      'Open the product resource picker and receive selected products with their IDs, titles, and images. This example shows basic product selection without filters or limits, using `type: "product"` to open the picker.',
     image: 'resource-picker.png',
     codeblock: {
-      title: 'Product picker',
+      title: 'Select products',
       tabs: [
-        {
-          code: './examples/product-picker.js',
-          language: 'js',
-        },
+        {code: './examples/product-picker.ts', language: 'ts'},
+        {code: './examples/product-picker.tsx', language: 'tsx'},
       ],
     },
   },
   examples: {
-    description: 'Resource Pickers with different options',
+    description: 'Resource Picker API patterns',
     examples: [
       {
-        description: 'Alternate resources',
+        description:
+          'Select collections or product variants instead of products. This example demonstrates using `type: "collection"` to pick collections or `type: "variant"` to pick product variants, each returning different resource data structures.',
         codeblock: {
-          title: 'Alternate resources',
+          title: 'Select alternate resource types',
           tabs: [
             {
               title: 'Collection picker',
-              code: './examples/collection-picker.js',
-              language: 'js',
+              code: './examples/collection-picker.ts',
+              language: 'ts',
             },
             {
-              title: 'Product variant picker',
-              code: './examples/product-variant-picker.js',
-              language: 'js',
+              title: 'Collection picker',
+              code: './examples/collection-picker.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'Variant picker',
+              code: './examples/product-variant-picker.ts',
+              language: 'ts',
+            },
+            {
+              title: 'Variant picker',
+              code: './examples/product-variant-picker.tsx',
+              language: 'tsx',
             },
           ],
         },
       },
       {
-        description: 'Preselected resources',
+        description:
+          'Open the picker with specific products already preselected. This example uses the `selectionIds` array with product GIDs to mark items as selected when the picker opens.',
         codeblock: {
-          title: 'Product picker with preselected resources',
+          title: 'Preselect resources',
+          tabs: [
+            {code: './examples/selection-ids.ts', language: 'ts'},
+            {code: './examples/selection-ids.tsx', language: 'tsx'},
+          ],
+        },
+      },
+      {
+        description:
+          'Customize the picker\'s confirm button with an action verb. This example sets `action: "add"` to change the button text from "Select" to "Add", providing clearer context for the merchant.',
+        codeblock: {
+          title: 'Set action verb',
+          tabs: [
+            {code: './examples/action.ts', language: 'ts'},
+            {code: './examples/action.tsx', language: 'tsx'},
+          ],
+        },
+      },
+      {
+        description:
+          'Allow unlimited selection or limit to a maximum count. This example demonstrates setting `multiple: true` for unlimited selection or `multiple: 5` to limit selection to a maximum of 5 items.',
+        codeblock: {
+          title: 'Configure multiple selection',
           tabs: [
             {
-              code: './examples/selection-ids.js',
-              language: 'js',
+              title: 'Unlimited',
+              code: './examples/multiple-unlimited.ts',
+              language: 'ts',
+            },
+            {
+              title: 'Unlimited',
+              code: './examples/multiple-unlimited.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'Limited',
+              code: './examples/multiple-limited.ts',
+              language: 'ts',
+            },
+            {
+              title: 'Limited',
+              code: './examples/multiple-limited.tsx',
+              language: 'tsx',
             },
           ],
         },
       },
       {
-        description: 'Action verb',
+        description:
+          'Filter the picker to show only published products. This example sets `filter.published_status: "published"` to restrict which items appear in the picker.',
         codeblock: {
-          title: 'Product picker with action verb',
+          title: 'Apply filters',
           tabs: [
-            {
-              code: './examples/action.js',
-              language: 'js',
-            },
+            {code: './examples/filters.ts', language: 'ts'},
+            {code: './examples/filters.tsx', language: 'tsx'},
           ],
         },
       },
       {
-        description: 'Multiple selection',
+        description:
+          'Provide an initial search query to filter the picker. This example uses the `query` property to pre-fill the search field, so the picker opens with results already filtered (for example, "shirt").',
         codeblock: {
-          title: 'Product picker with multiple selection',
+          title: 'Search with initial query',
           tabs: [
-            {
-              title: 'Unlimited selectable items',
-              code: './examples/multiple-unlimited.js',
-              language: 'js',
-            },
-            {
-              title: 'Maximum selectable items',
-              code: './examples/multiple-limited.js',
-              language: 'js',
-            },
+            {code: './examples/query.ts', language: 'ts'},
+            {code: './examples/query.tsx', language: 'tsx'},
           ],
         },
       },
       {
-        description: 'Filters',
+        description:
+          'Access selected resource data including IDs, titles, and images. This example shows how the resource picker returns an array of resources with full metadata that you can use in your extension.',
         codeblock: {
-          title: 'Product picker with filters',
+          title: 'Use selection payload',
           tabs: [
-            {
-              code: './examples/filters.js',
-              language: 'js',
-            },
-          ],
-        },
-      },
-      {
-        description: 'Filter query',
-        codeblock: {
-          title: 'Product picker with a custom filter query',
-          tabs: [
-            {
-              code: './examples/filter-query.js',
-              language: 'js',
-            },
-          ],
-        },
-      },
-      {
-        description: 'Selection',
-        codeblock: {
-          title: 'Product picker using returned selection payload',
-          tabs: [
-            {
-              code: './examples/selection.js',
-              language: 'js',
-            },
-          ],
-        },
-      },
-      {
-        description: 'Initial query',
-        codeblock: {
-          title: 'Product picker with initial query provided',
-          tabs: [
-            {
-              code: './examples/query.js',
-              language: 'js',
-            },
+            {code: './examples/selection.ts', language: 'ts'},
+            {code: './examples/selection.tsx', language: 'tsx'},
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -16,7 +16,7 @@ const data: ReferenceEntityTemplateSchema = {
     'an Admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.',
   defaultExample: {
     description:
-      'Open the product resource picker and receive selected products with their IDs, titles, and images. This example shows basic product selection without filters or limits, using `type: "product"` to open the picker.',
+      'Open the product resource picker to select items from the store catalog. This example invokes `shopify.resourcePicker` with `type: "product"`, handles the async selection, and displays the count of selected products. When merchants confirm their selection, the resource picker returns an array of product objects with GIDs, titles, and handles for use in your extension.',
     image: 'resource-picker.png',
     codeblock: {
       title: 'Select products',
@@ -27,119 +27,95 @@ const data: ReferenceEntityTemplateSchema = {
     },
   },
   examples: {
-    description: 'Resource Picker API patterns',
+    description:
+      'Examples that demonstrate how to use the Resource Picker API.',
     examples: [
       {
         description:
-          'Select collections or product variants instead of products. Use `type: "collection"` to pick collections or `type: "variant"` for variants, each returning different data structures with type-specific metadata.',
+          'Filter the picker to show only published products using the `filter` option with `published_status: "published"`. This example shows restricting the picker to live, customer-visible products. Use this for promotional campaigns, product recommendations, or any feature that should only work with active inventory, preventing accidental selection of draft or archived products.',
         codeblock: {
-          title: 'Select alternate resource types',
+          title: 'Filter to published products',
           tabs: [
-            {
-              title: 'Collection picker',
-              code: './examples/collection-picker.ts',
-              language: 'ts',
-            },
-            {
-              title: 'Collection picker',
-              code: './examples/collection-picker.tsx',
-              language: 'tsx',
-            },
-            {
-              title: 'Variant picker',
-              code: './examples/product-variant-picker.ts',
-              language: 'ts',
-            },
-            {
-              title: 'Variant picker',
-              code: './examples/product-variant-picker.tsx',
-              language: 'tsx',
-            },
-          ],
+        {code: './examples/filters.ts', language: 'ts'},
+        {code: './examples/filters.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Open the picker with specific products already preselected. Uses `selectionIds` array with product GIDs like `gid://shopify/Product/123` to mark items as selected—useful for edit workflows.',
+          'Limit selection to a maximum of five products by setting `multiple: 5`. This example shows restricting how many products merchants can choose. This is useful for bundle builders with item limits, featured product sections with fixed display slots, or promotional campaigns with maximum product counts. The resource picker automatically prevents selection beyond the limit.',
         codeblock: {
-          title: 'Preselect resources',
+          title: 'Limit selection count',
           tabs: [
-            {code: './examples/selection-ids.ts', language: 'ts'},
-            {code: './examples/selection-ids.tsx', language: 'tsx'},
-          ],
+        {code: './examples/multiple-limited.ts', language: 'ts'},
+        {code: './examples/multiple-limited.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Customize the picker\'s confirm button with an action verb. Sets `action: "add"` to change button text from "Select" to "Add", helping merchants understand whether they\'re adding to a list or replacing.',
+          'Open the resource picker with products already selected by passing GIDs to the `selectionIds` option. This example shows pre-populating the resource picker with current selections for edit workflows. Use this for showing what products are already in a bundle, collection, or promotional set. Merchants can see current selections and modify them by adding or removing products before confirming.',
+        codeblock: {
+          title: 'Preselect products',
+          tabs: [
+        {code: './examples/selection-ids.ts', language: 'ts'},
+        {code: './examples/selection-ids.tsx', language: 'tsx'},
+      ],
+        },
+      },
+      {
+        description:
+          'Select collections instead of individual products by setting `type: "collection"`. This example shows switching the resource picker to collection mode for choosing product groupings. This is useful for homepage featured collection carousels, navigation menu builders, bulk collection operations, or promotional campaigns targeting entire product categories rather than individual items.',
+        codeblock: {
+          title: 'Select collections',
+          tabs: [
+        {code: './examples/collection-picker.ts', language: 'ts'},
+        {code: './examples/collection-picker.tsx', language: 'tsx'},
+      ],
+        },
+      },
+      {
+        description:
+          'Allow unlimited product selection by setting `multiple: true` without a numeric limit. This example shows enabling multi-selection where merchants control the quantity. Use this for mass product taggers, bulk inventory tools, category managers, or export utilities where selection count depends on merchant needs without artificial constraints.',
+        codeblock: {
+          title: 'Select unlimited products',
+          tabs: [
+        {code: './examples/multiple-unlimited.ts', language: 'ts'},
+        {code: './examples/multiple-unlimited.tsx', language: 'tsx'},
+      ],
+        },
+      },
+      {
+        description:
+          'Select specific product variants instead of entire products by setting `type: "variant"`. This example shows switching to variant-level selection for choosing individual SKUs. Use this for inventory transfer tools, variant-specific promotions, wholesale pricing sheets, or shipment builders where you need granular control over size, color, and individual SKU tracking.',
+        codeblock: {
+          title: 'Select product variants',
+          tabs: [
+        {code: './examples/product-variant-picker.ts', language: 'ts'},
+        {code: './examples/product-variant-picker.tsx', language: 'tsx'},
+      ],
+        },
+      },
+      {
+        description:
+          'Customize the resource picker button text by setting the `action` option to "add" or "select". This example shows changing the action verb to provide workflow context. "Add" suggests appending to an existing list, while "select" implies choosing for a specific purpose or replacing selections. This subtle language difference improves clarity for different workflow contexts.',
         codeblock: {
           title: 'Set action verb',
           tabs: [
-            {code: './examples/action.ts', language: 'ts'},
-            {code: './examples/action.tsx', language: 'tsx'},
-          ],
+        {code: './examples/action.ts', language: 'ts'},
+        {code: './examples/action.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Allow unlimited selection or limit to a maximum count. Set `multiple: true` for unlimited or `multiple: 5` to cap at 5 items—the picker automatically prevents selection beyond the limit.',
+          'Start the resource picker with a pre-filled search query by passing the `query` option. This example shows initializing the picker with a search term already entered. This is helpful when you know what merchants are likely looking for, such as products from a specific vendor, tag, or product type. Merchants can modify the query, but starting with relevant results saves time in large catalogs.',
         codeblock: {
-          title: 'Configure multiple selection',
+          title: 'Start with search query',
           tabs: [
-            {
-              title: 'Unlimited',
-              code: './examples/multiple-unlimited.ts',
-              language: 'ts',
-            },
-            {
-              title: 'Unlimited',
-              code: './examples/multiple-unlimited.tsx',
-              language: 'tsx',
-            },
-            {
-              title: 'Limited',
-              code: './examples/multiple-limited.ts',
-              language: 'ts',
-            },
-            {
-              title: 'Limited',
-              code: './examples/multiple-limited.tsx',
-              language: 'tsx',
-            },
-          ],
-        },
-      },
-      {
-        description:
-          'Filter the picker to show only published products. Uses `filter.published_status: "published"` to restrict the picker to live, customer-visible products, preventing accidental selection of draft or archived items.',
-        codeblock: {
-          title: 'Apply filters',
-          tabs: [
-            {code: './examples/filters.ts', language: 'ts'},
-            {code: './examples/filters.tsx', language: 'tsx'},
-          ],
-        },
-      },
-      {
-        description:
-          'Provide an initial search query to filter picker results. Uses `query` property to pre-fill the search field with a term like "shirt"—helpful for guiding merchants to specific items in large catalogs.',
-        codeblock: {
-          title: 'Search with initial query',
-          tabs: [
-            {code: './examples/query.ts', language: 'ts'},
-            {code: './examples/query.tsx', language: 'tsx'},
-          ],
-        },
-      },
-      {
-        description:
-          'Access selected resource data including IDs, titles, and images. Resource picker returns an array of resources with full metadata, or `undefined` if the merchant cancels.',
-        codeblock: {
-          title: 'Use selection payload',
-          tabs: [
-            {code: './examples/selection.ts', language: 'ts'},
-            {code: './examples/selection.tsx', language: 'tsx'},
-          ],
+        {code: './examples/query.ts', language: 'ts'},
+        {code: './examples/query.tsx', language: 'tsx'},
+      ],
         },
       },
     ],

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/bulk-selection-check.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/bulk-selection-check.ts
@@ -2,10 +2,12 @@ import {extension} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-index.action.should-render',
-  (root, api) => {
+  (api) => {
     const {data} = api;
 
-    const count = data.selected.length;
-    return {display: count >= 1 && count <= 50};
+    const selectedCount = data.selected.length;
+    const isWithinLimit = selectedCount > 0 && selectedCount <= 50;
+
+    return {display: isWithinLimit};
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/bulk-selection-check.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/bulk-selection-check.ts
@@ -1,0 +1,11 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-index.action.should-render',
+  (root, api) => {
+    const {data} = api;
+
+    const count = data.selected.length;
+    return {display: count >= 1 && count <= 50};
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/bulk-selection-check.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/bulk-selection-check.tsx
@@ -1,11 +1,15 @@
-import React from 'react';
 import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
 
 const BulkSelectionCheck = () => {
   const {data} = useApi<'admin.product-index.action.should-render'>();
 
-  const count = data.selected.length;
-  return {display: count >= 1 && count <= 50};
+  const selectedCount = data.selected.length;
+  const isWithinLimit = selectedCount > 0 && selectedCount <= 50;
+
+  return {display: isWithinLimit};
 };
 
-export default reactExtension('admin.product-index.action.should-render', () => <BulkSelectionCheck />);
+export default reactExtension(
+  'admin.product-index.action.should-render',
+  () => BulkSelectionCheck(),
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/bulk-selection-check.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/bulk-selection-check.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const BulkSelectionCheck = () => {
+  const {data} = useApi<'admin.product-index.action.should-render'>();
+
+  const count = data.selected.length;
+  return {display: count >= 1 && count <= 50};
+};
+
+export default reactExtension('admin.product-index.action.should-render', () => <BulkSelectionCheck />);

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-order-status.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-order-status.ts
@@ -2,9 +2,11 @@ import {extension} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.order-details.action.should-render',
-  (root, api) => {
+  (api) => {
     const {data} = api;
 
-    return {display: data.selected.length === 1};
+    const selectedCount = data.selected.length;
+
+    return {display: selectedCount === 1};
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-order-status.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-order-status.ts
@@ -1,0 +1,10 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.order-details.action.should-render',
+  (root, api) => {
+    const {data} = api;
+
+    return {display: data.selected.length === 1};
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-order-status.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-order-status.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
 import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
 
 const CheckOrderStatus = () => {
   const {data} = useApi<'admin.order-details.action.should-render'>();
 
-  return {display: data.selected.length === 1};
+  const selectedCount = data.selected.length;
+
+  return {display: selectedCount === 1};
 };
 
-export default reactExtension('admin.order-details.action.should-render', () => <CheckOrderStatus />);
+export default reactExtension(
+  'admin.order-details.action.should-render',
+  () => CheckOrderStatus(),
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-order-status.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-order-status.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const CheckOrderStatus = () => {
+  const {data} = useApi<'admin.order-details.action.should-render'>();
+
+  return {display: data.selected.length === 1};
+};
+
+export default reactExtension('admin.order-details.action.should-render', () => <CheckOrderStatus />);

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-product-tag.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-product-tag.ts
@@ -1,0 +1,10 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.should-render',
+  (root, api) => {
+    const {data} = api;
+
+    return {display: data.selected.length > 0};
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-product-tag.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-product-tag.ts
@@ -2,9 +2,11 @@ import {extension} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.action.should-render',
-  (root, api) => {
+  (api) => {
     const {data} = api;
 
-    return {display: data.selected.length > 0};
+    const hasSelection = data.selected.length > 0;
+
+    return {display: hasSelection};
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-product-tag.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-product-tag.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
 import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
 
 const CheckProductTag = () => {
   const {data} = useApi<'admin.product-details.action.should-render'>();
 
-  return {display: data.selected.length > 0};
+  const hasSelection = data.selected.length > 0;
+
+  return {display: hasSelection};
 };
 
-export default reactExtension('admin.product-details.action.should-render', () => <CheckProductTag />);
+export default reactExtension(
+  'admin.product-details.action.should-render',
+  () => CheckProductTag(),
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-product-tag.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/examples/check-product-tag.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const CheckProductTag = () => {
+  const {data} = useApi<'admin.product-details.action.should-render'>();
+
+  return {display: data.selected.length > 0};
+};
+
+export default reactExtension('admin.product-details.action.should-render', () => <CheckProductTag />);

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -13,14 +13,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Check when items are selected',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/check-product-tag.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/check-product-tag.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/check-product-tag.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -43,14 +48,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Require one item to be selected',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/check-order-status.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/check-order-status.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/check-order-status.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -62,14 +72,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Validate selection count',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/bulk-selection-check.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/bulk-selection-check.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/bulk-selection-check.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -6,6 +6,17 @@ const data: ReferenceEntityTemplateSchema = {
     'The Should Render API lets you [conditionally show or hide admin action extensions](/docs/apps/build/admin/actions-blocks/hide-extensions) dynamically. Use this API to control action visibility based on resource state, user permissions, or business logic.',
   isVisualComponent: false,
   type: 'API',
+  defaultExample: {
+    description:
+      'Show the action extension only when items are selected to prevent errors from operations that require resource selection. This example demonstrates checking `data.selected.length` and returning a display object to hide the action on empty pages.',
+    codeblock: {
+      title: 'Check when items are selected',
+      tabs: [
+        {code: './examples/check-product-tag.ts', language: 'ts'},
+        {code: './examples/check-product-tag.tsx', language: 'tsx'},
+      ],
+    },
+  },
   definitions: [
     {
       title: 'ShouldRenderApi',
@@ -14,40 +25,29 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ShouldRenderApi',
     },
   ],
-  defaultExample: {
-    description:
-      'Return true to show the action extension only when items are selected. This example demonstrates checking `data.selected.length` to prevent the action from appearing on empty pages.',
-    codeblock: {
-      title: 'Check when items selected',
-      tabs: [
-        {code: './examples/check-product-tag.ts', language: 'ts'},
-        {code: './examples/check-product-tag.tsx', language: 'tsx'},
-      ],
-    },
-  },
   examples: {
     description: 'Conditionally show or hide action extensions',
     examples: [
       {
         description:
-          'Check if exactly one item is selected before showing the action. This example ensures actions designed for individual resources only appear when exactly one item is selected.',
+          'Check if exactly one item is selected before showing the action extension. This pattern ensures action extensions that operate on individual resources only appear when appropriate.',
         codeblock: {
-          title: 'Require one item selected',
+          title: 'Require one item to be selected',
           tabs: [
-            {code: './examples/check-order-status.ts', language: 'ts'},
-            {code: './examples/check-order-status.tsx', language: 'tsx'},
-          ],
+        {code: './examples/check-order-status.ts', language: 'ts'},
+        {code: './examples/check-order-status.tsx', language: 'tsx'},
+      ],
         },
       },
       {
         description:
-          'Validate that the selection count is between 1 and 50 before showing bulk actions. Prevents the action from appearing when nothing is selected or when too many items are selected, protecting against performance issues with large bulk operations.',
+          'Validate selection count is between 1 and 50 before showing bulk actions to protect your backend from processing limits or API rate constraints. This example demonstrates checking both minimum and maximum selection counts, hiding the action when nothing is selected or when selection exceeds your processing capacity.',
         codeblock: {
           title: 'Validate selection count',
           tabs: [
-            {code: './examples/bulk-selection-check.ts', language: 'ts'},
-            {code: './examples/bulk-selection-check.tsx', language: 'tsx'},
-          ],
+        {code: './examples/bulk-selection-check.ts', language: 'ts'},
+        {code: './examples/bulk-selection-check.tsx', language: 'tsx'},
+      ],
         },
       },
     ],
@@ -71,7 +71,7 @@ const data: ReferenceEntityTemplateSchema = {
         '- The function must return an object with a `display` property. Returning a plain boolean like `true` instead of `{ display: true }` fails.\n' +
         "- No asynchronous operations are supported. Async functions, promises, fetch calls, and timers won't work.\n" +
         "- Your extension can't access external data sources. Evaluation is limited to data available in `api.data.selected` and in-memory state.\n" +
-        '- The function runs only once when the page loads. Action visibility stays fixed after that, even if resource data, selections, or other conditions change later.',
+        "- No re-evaluation occurs after initial render. If conditions change after page load, the action visibility doesn't update dynamically.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -107,10 +107,13 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- The function must return an object with a `display` property. Returning a plain boolean like `true` instead of `{ display: true }` fails.\n' +
-        "- No asynchronous operations are supported. Async functions, promises, fetch calls, and timers won't work.\n" +
-        "- Your extension can't access external data sources. Evaluation is limited to data available in `api.data.selected` and in-memory state.\n" +
-        "- No re-evaluation occurs after initial render. If conditions change after page load, the action visibility doesn't update dynamically.",
+        '- The function must return an object with a `display` property. Returning a plain boolean like `true` instead of `{ display: true }` fails.
+' +
+        "- No asynchronous operations are supported. Async functions, promises, fetch calls, and timers won't work.
+" +
+        "- Your extension can't access external data sources. Evaluation is limited to data available in `api.data.selected` and in-memory state.
+" +
+        '- The function runs only once when the page loads. Action visibility stays fixed after that, even if resource data, selections, or other conditions change later.',
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -16,7 +16,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Return true to show the action extension only when items are selected. This example checks `data.selected.length` and prevents the action from appearing on empty pages where no resources are selected.',
+      'Return true to show the action extension only when items are selected. This example demonstrates checking `data.selected.length` to prevent the action from appearing on empty pages.',
     codeblock: {
       title: 'Check when items selected',
       tabs: [
@@ -30,7 +30,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Check if exactly one item is selected before showing the action. This example ensures that actions designed for individual resources only appear when the merchant has selected exactly one item.',
+          'Check if exactly one item is selected before showing the action. This example ensures actions designed for individual resources only appear when exactly one item is selected.',
         codeblock: {
           title: 'Require one item selected',
           tabs: [
@@ -41,7 +41,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Validate that the selection count is between 1 and 50 before showing bulk actions. This example prevents the action from appearing when nothing is selected or when too many items are selected, protecting against performance issues with large bulk operations.',
+          'Validate that the selection count is between 1 and 50 before showing bulk actions. Prevents the action from appearing when nothing is selected or when too many items are selected, protecting against performance issues with large bulk operations.',
         codeblock: {
           title: 'Validate selection count',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -12,8 +12,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Check when items are selected',
       tabs: [
-        {code: './examples/check-product-tag.ts', language: 'ts'},
-        {code: './examples/check-product-tag.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/check-product-tag.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/check-product-tag.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -34,8 +42,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Require one item to be selected',
           tabs: [
-            {code: './examples/check-order-status.ts', language: 'ts'},
-            {code: './examples/check-order-status.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/check-order-status.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/check-order-status.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -45,8 +61,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Validate selection count',
           tabs: [
-            {code: './examples/bulk-selection-check.ts', language: 'ts'},
-            {code: './examples/bulk-selection-check.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/bulk-selection-check.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/bulk-selection-check.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -109,9 +109,9 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- The function must return an object with a `display` property. Returning a plain boolean like `true` instead of `{ display: true }` fails.
 ' +
-        "- No asynchronous operations are supported. Async functions, promises, fetch calls, and timers won't work.
+        "- No asynchronous operations are supported. Async functions, promises, fetch calls, and timers won\'t work.
 " +
-        "- Your extension can't access external data sources. Evaluation is limited to data available in `api.data.selected` and in-memory state.
+        "- Your extension can\'t access external data sources. Evaluation is limited to data available in `api.data.selected` and in-memory state.
 " +
         '- The function runs only once when the page loads. Action visibility stays fixed after that, even if resource data, selections, or other conditions change later.',
     },

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -109,9 +109,9 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         '- The function must return an object with a `display` property. Returning a plain boolean like `true` instead of `{ display: true }` fails.
 ' +
-        "- No asynchronous operations are supported. Async functions, promises, fetch calls, and timers won\'t work.
+        "- No asynchronous operations are supported. Async functions, promises, fetch calls, and timers won't work.
 " +
-        "- Your extension can\'t access external data sources. Evaluation is limited to data available in `api.data.selected` and in-memory state.
+        "- Your extension can't access external data sources. Evaluation is limited to data available in `api.data.selected` and in-memory state.
 " +
         '- The function runs only once when the page loads. Action visibility stays fixed after that, even if resource data, selections, or other conditions change later.',
     },

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -14,6 +14,44 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ShouldRenderApi',
     },
   ],
+  defaultExample: {
+    description:
+      'Return true to show the action extension only when items are selected. This example checks `data.selected.length` and prevents the action from appearing on empty pages where no resources are selected.',
+    codeblock: {
+      title: 'Check when items selected',
+      tabs: [
+        {code: './examples/check-product-tag.ts', language: 'ts'},
+        {code: './examples/check-product-tag.tsx', language: 'tsx'},
+      ],
+    },
+  },
+  examples: {
+    description: 'Conditionally show or hide action extensions',
+    examples: [
+      {
+        description:
+          'Check if exactly one item is selected before showing the action. This example ensures that actions designed for individual resources only appear when the merchant has selected exactly one item.',
+        codeblock: {
+          title: 'Require one item selected',
+          tabs: [
+            {code: './examples/check-order-status.ts', language: 'ts'},
+            {code: './examples/check-order-status.tsx', language: 'tsx'},
+          ],
+        },
+      },
+      {
+        description:
+          'Validate that the selection count is between 1 and 50 before showing bulk actions. This example prevents the action from appearing when nothing is selected or when too many items are selected, protecting against performance issues with large bulk operations.',
+        codeblock: {
+          title: 'Validate selection count',
+          tabs: [
+            {code: './examples/bulk-selection-check.ts', language: 'ts'},
+            {code: './examples/bulk-selection-check.tsx', language: 'tsx'},
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Utility APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/should-render/should-render.doc.ts
@@ -34,9 +34,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Require one item to be selected',
           tabs: [
-        {code: './examples/check-order-status.ts', language: 'ts'},
-        {code: './examples/check-order-status.tsx', language: 'tsx'},
-      ],
+            {code: './examples/check-order-status.ts', language: 'ts'},
+            {code: './examples/check-order-status.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -45,9 +45,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Validate selection count',
           tabs: [
-        {code: './examples/bulk-selection-check.ts', language: 'ts'},
-        {code: './examples/bulk-selection-check.tsx', language: 'tsx'},
-      ],
+            {code: './examples/bulk-selection-check.ts', language: 'ts'},
+            {code: './examples/bulk-selection-check.tsx', language: 'tsx'},
+          ],
         },
       },
     ],

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/examples/authenticate-backend-request.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/examples/authenticate-backend-request.ts
@@ -1,21 +1,49 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Button, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.block.render',
   (root, api) => {
     const {auth} = api;
 
-    auth.idToken().then((token) => {
-      fetch('https://my-app.com/api/products', {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      }).then((response) => response.json())
-        .then((data) => {
-          console.log('Products:', data);
+    let productsText;
+    let loadingState = false;
+
+    const button = root.createComponent(Button, {
+      title: 'Fetch from Backend',
+      onPress: async () => {
+        if (loadingState) return;
+        
+        loadingState = true;
+        button.updateProps({title: 'Loading...', disabled: true});
+
+        const token = await auth.idToken();
+
+        const response = await fetch('https://my-app.com/api/products', {
+          method: 'GET',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
         });
+
+        const data = await response.json();
+        
+        if (productsText) {
+          root.removeChild(productsText);
+        }
+        
+        productsText = root.createComponent(
+          Text,
+          {},
+          `${data.length} products loaded`,
+        );
+        root.appendChild(productsText);
+        
+        loadingState = false;
+        button.updateProps({title: 'Fetch from Backend', disabled: false});
+      },
     });
+
+    root.appendChild(button);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/examples/authenticate-backend-request.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/examples/authenticate-backend-request.ts
@@ -1,0 +1,21 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {auth} = api;
+
+    auth.idToken().then((token) => {
+      fetch('https://my-app.com/api/products', {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      }).then((response) => response.json())
+        .then((data) => {
+          console.log('Products:', data);
+        });
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/examples/authenticate-backend-request.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/examples/authenticate-backend-request.tsx
@@ -1,0 +1,26 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const AuthenticateBackendRequest = () => {
+  const {auth} = useApi<'admin.product-details.block.render'>();
+  const [products, setProducts] = useState([]);
+
+  const handleFetch = async () => {
+    const token = await auth.idToken();
+
+    const response = await fetch('https://my-app.com/api/products', {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const data = await response.json();
+    setProducts(data);
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <AuthenticateBackendRequest />);

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/examples/authenticate-backend-request.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/examples/authenticate-backend-request.tsx
@@ -1,11 +1,19 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {
+  reactExtension,
+  useApi,
+  Button,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
 
 const AuthenticateBackendRequest = () => {
   const {auth} = useApi<'admin.product-details.block.render'>();
-  const [products, setProducts] = useState([]);
+  const [products, setProducts] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
 
   const handleFetch = async () => {
+    setLoading(true);
+
     const token = await auth.idToken();
 
     const response = await fetch('https://my-app.com/api/products', {
@@ -18,9 +26,22 @@ const AuthenticateBackendRequest = () => {
 
     const data = await response.json();
     setProducts(data);
+    setLoading(false);
   };
 
-  return null;
+  return (
+    <>
+      <Button
+        title={loading ? 'Loading...' : 'Fetch from Backend'}
+        onPress={handleFetch}
+        disabled={loading}
+      />
+      {products.length > 0 && <Text>{products.length} products loaded</Text>}
+    </>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <AuthenticateBackendRequest />);
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <AuthenticateBackendRequest />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/examples/persist-settings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/examples/persist-settings.ts
@@ -1,0 +1,50 @@
+import {extension, Button, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {storage} = api;
+
+    let preferencesText;
+    const stack = root.createComponent(BlockStack);
+
+    const loadPreferences = async () => {
+      const prefs = await storage.get('userPreferences');
+      
+      if (prefs && preferencesText) {
+        stack.removeChild(preferencesText);
+      }
+
+      if (prefs) {
+        preferencesText = root.createComponent(BlockStack);
+        const themeText = root.createComponent(Text, {}, `Theme: ${prefs.theme}`);
+        const notifText = root.createComponent(Text, {}, `Notifications: ${String(prefs.notifications)}`);
+        const viewText = root.createComponent(Text, {}, `View: ${prefs.defaultView}`);
+        
+        preferencesText.appendChild(themeText);
+        preferencesText.appendChild(notifText);
+        preferencesText.appendChild(viewText);
+        
+        stack.appendChild(preferencesText);
+      }
+    };
+
+    loadPreferences();
+
+    const saveButton = root.createComponent(Button, {
+      title: 'Save Preferences',
+      onPress: async () => {
+        await storage.set('userPreferences', {
+          theme: 'dark',
+          notifications: true,
+          defaultView: 'grid',
+        });
+
+        await loadPreferences();
+      },
+    });
+
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/examples/persist-settings.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/examples/persist-settings.tsx
@@ -1,0 +1,51 @@
+import React, {useState, useEffect} from 'react';
+import {
+  reactExtension,
+  useApi,
+  Button,
+  Text,
+  BlockStack,
+} from '@shopify/ui-extensions-react/admin';
+
+const PersistSettings = () => {
+  const {storage} = useApi<'admin.product-details.block.render'>();
+  const [preferences, setPreferences] = useState<any>(null);
+
+  useEffect(() => {
+    const loadPreferences = async () => {
+      const prefs = await storage.get('userPreferences');
+      setPreferences(prefs);
+    };
+
+    loadPreferences();
+  }, [storage]);
+
+  const handleSave = async () => {
+    await storage.set('userPreferences', {
+      theme: 'dark',
+      notifications: true,
+      defaultView: 'grid',
+    });
+
+    const updated = await storage.get('userPreferences');
+    setPreferences(updated);
+  };
+
+  return (
+    <BlockStack>
+      <Button title="Save Preferences" onPress={handleSave} />
+      {preferences && (
+        <BlockStack>
+          <Text>Theme: {preferences.theme}</Text>
+          <Text>Notifications: {String(preferences.notifications)}</Text>
+          <Text>View: {preferences.defaultView}</Text>
+        </BlockStack>
+      )}
+    </BlockStack>
+  );
+};
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <PersistSettings />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/examples/query-and-mutate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/examples/query-and-mutate.ts
@@ -1,0 +1,42 @@
+import {extension} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {query} = api;
+
+    query(
+      `query GetProducts {
+        products(first: 10) {
+          edges {
+            node {
+              id
+              title
+            }
+          }
+        }
+      }`,
+    ).then(({data: productsData}) => {
+      const firstProduct = productsData.products.edges[0]?.node;
+
+      if (firstProduct) {
+        return query(
+          `mutation UpdateProduct($id: ID!, $input: ProductInput!) {
+            productUpdate(id: $id, product: $input) {
+              product {
+                id
+                tags
+              }
+            }
+          }`,
+          {
+            variables: {
+              id: firstProduct.id,
+              input: {tags: ['processed', 'reviewed']},
+            },
+          },
+        );
+      }
+    });
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/examples/query-and-mutate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/examples/query-and-mutate.ts
@@ -1,42 +1,92 @@
-import {extension} from '@shopify/ui-extensions/admin';
+import {extension, Button, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.product-details.block.render',
   (root, api) => {
     const {query} = api;
 
-    query(
-      `query GetProducts {
-        products(first: 10) {
-          edges {
-            node {
-              id
-              title
-            }
-          }
-        }
-      }`,
-    ).then(({data: productsData}) => {
-      const firstProduct = productsData.products.edges[0]?.node;
+    let products = [];
+    let productsText;
+    let updateButton;
+    let updatedText;
 
-      if (firstProduct) {
-        return query(
-          `mutation UpdateProduct($id: ID!, $input: ProductInput!) {
-            productUpdate(id: $id, product: $input) {
-              product {
-                id
-                tags
+    const stack = root.createComponent(BlockStack);
+
+    const queryButton = root.createComponent(Button, {
+      title: 'Query Products',
+      onPress: async () => {
+        const {data: productsData} = await query(
+          `query GetProducts {
+            products(first: 10) {
+              edges {
+                node {
+                  id
+                  title
+                  totalInventory
+                }
               }
             }
           }`,
-          {
-            variables: {
-              id: firstProduct.id,
-              input: {tags: ['processed', 'reviewed']},
-            },
-          },
         );
-      }
+
+        products = productsData.products.edges;
+
+        if (productsText) {
+          stack.removeChild(productsText);
+        }
+        
+        productsText = root.createComponent(
+          Text,
+          {},
+          `${products.length} products found`,
+        );
+        stack.appendChild(productsText);
+
+        if (!updateButton && products.length > 0) {
+          updateButton = root.createComponent(Button, {
+            title: 'Update First Product',
+            onPress: handleUpdate,
+          });
+          stack.appendChild(updateButton);
+        }
+      },
     });
+
+    const handleUpdate = async () => {
+      const productId = products[0]?.node.id;
+      if (!productId) return;
+
+      const {data: updateData} = await query(
+        `mutation UpdateProduct($id: ID!, $input: ProductInput!) {
+          productUpdate(id: $id, product: $input) {
+            product {
+              id
+              tags
+            }
+            userErrors {
+              field
+              message
+            }
+          }
+        }`,
+        {
+          variables: {
+            id: productId,
+            input: {tags: ['processed', 'reviewed']},
+          },
+        },
+      );
+
+      if (updateData.productUpdate.product) {
+        if (updatedText) {
+          stack.removeChild(updatedText);
+        }
+        updatedText = root.createComponent(Text, {}, 'Product tags updated!');
+        stack.appendChild(updatedText);
+      }
+    };
+
+    stack.appendChild(queryButton);
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/examples/query-and-mutate.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/examples/query-and-mutate.tsx
@@ -1,9 +1,15 @@
 import React, {useState} from 'react';
-import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+import {
+  reactExtension,
+  useApi,
+  Button,
+  Text,
+  BlockStack,
+} from '@shopify/ui-extensions-react/admin';
 
 const QueryAndMutate = () => {
   const {query} = useApi<'admin.product-details.block.render'>();
-  const [products, setProducts] = useState([]);
+  const [products, setProducts] = useState<any[]>([]);
   const [updated, setUpdated] = useState(false);
 
   const handleQuery = async () => {
@@ -14,6 +20,7 @@ const QueryAndMutate = () => {
             node {
               id
               title
+              totalInventory
             }
           }
         }
@@ -24,31 +31,51 @@ const QueryAndMutate = () => {
   };
 
   const handleUpdate = async () => {
-    const firstProduct = products[0]?.node;
+    const productId = products[0]?.node.id;
 
-    if (firstProduct) {
-      await query(
-        `mutation UpdateProduct($id: ID!, $input: ProductInput!) {
-          productUpdate(id: $id, product: $input) {
-            product {
-              id
-              tags
-            }
+    if (!productId) return;
+
+    const {data: updateData} = await query(
+      `mutation UpdateProduct($id: ID!, $input: ProductInput!) {
+        productUpdate(id: $id, product: $input) {
+          product {
+            id
+            tags
           }
-        }`,
-        {
-          variables: {
-            id: firstProduct.id,
-            input: {tags: ['processed', 'reviewed']},
-          },
+          userErrors {
+            field
+            message
+          }
+        }
+      }`,
+      {
+        variables: {
+          id: productId,
+          input: {tags: ['processed', 'reviewed']},
         },
-      );
+      },
+    );
 
+    if (updateData.productUpdate.product) {
       setUpdated(true);
     }
   };
 
-  return null;
+  return (
+    <BlockStack>
+      <Button title="Query Products" onPress={handleQuery} />
+      {products.length > 0 && (
+        <>
+          <Text>{products.length} products found</Text>
+          <Button title="Update First Product" onPress={handleUpdate} />
+        </>
+      )}
+      {updated && <Text>Product tags updated!</Text>}
+    </BlockStack>
+  );
 };
 
-export default reactExtension('admin.product-details.block.render', () => <QueryAndMutate />);
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <QueryAndMutate />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/examples/query-and-mutate.tsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/examples/query-and-mutate.tsx
@@ -1,0 +1,54 @@
+import React, {useState} from 'react';
+import {reactExtension, useApi} from '@shopify/ui-extensions-react/admin';
+
+const QueryAndMutate = () => {
+  const {query} = useApi<'admin.product-details.block.render'>();
+  const [products, setProducts] = useState([]);
+  const [updated, setUpdated] = useState(false);
+
+  const handleQuery = async () => {
+    const {data: productsData} = await query(
+      `query GetProducts {
+        products(first: 10) {
+          edges {
+            node {
+              id
+              title
+            }
+          }
+        }
+      }`,
+    );
+
+    setProducts(productsData.products.edges);
+  };
+
+  const handleUpdate = async () => {
+    const firstProduct = products[0]?.node;
+
+    if (firstProduct) {
+      await query(
+        `mutation UpdateProduct($id: ID!, $input: ProductInput!) {
+          productUpdate(id: $id, product: $input) {
+            product {
+              id
+              tags
+            }
+          }
+        }`,
+        {
+          variables: {
+            id: firstProduct.id,
+            input: {tags: ['processed', 'reviewed']},
+          },
+        },
+      );
+
+      setUpdated(true);
+    }
+  };
+
+  return null;
+};
+
+export default reactExtension('admin.product-details.block.render', () => <QueryAndMutate />);

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -111,7 +111,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         "- GraphQL queries share [rate limits](/docs/api/usage/limits) with your app's overall Admin API usage and are subject to the shop's installed [access scopes](/docs/api/usage/access-scopes).
 " +
-        "- ID tokens from `auth.idToken()` are short-lived JWTs. They expire quickly and shouldn't be stored long-term.",
+        "- ID tokens from `auth.idToken()` are short-lived JWTs. They expire quickly and shouldn\'t be stored long-term.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -34,9 +34,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Query and mutate product data',
           tabs: [
-        {code: './examples/query-and-mutate.ts', language: 'ts'},
-        {code: './examples/query-and-mutate.tsx', language: 'tsx'},
-      ],
+            {code: './examples/query-and-mutate.ts', language: 'ts'},
+            {code: './examples/query-and-mutate.tsx', language: 'tsx'},
+          ],
         },
       },
       {
@@ -45,9 +45,9 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Persist settings',
           tabs: [
-        {code: './examples/persist-settings.ts', language: 'ts'},
-        {code: './examples/persist-settings.tsx', language: 'tsx'},
-      ],
+            {code: './examples/persist-settings.ts', language: 'ts'},
+            {code: './examples/persist-settings.tsx', language: 'tsx'},
+          ],
         },
       },
     ],
@@ -74,7 +74,7 @@ const data: ReferenceEntityTemplateSchema = {
         '- Storage is scoped per extension. Data saved by one extension is inaccessible to other extensions, even from the same app.\n' +
         "- Storage values are serialized with `JSON.stringify`, so functions, symbols, and circular references aren't supported.\n" +
         "- GraphQL queries share [rate limits](/docs/api/usage/limits) with your app's overall Admin API usage and are subject to the shop's installed [access scopes](/docs/api/usage/access-scopes).\n" +
-        '- ID tokens from `auth.idToken()` are short-lived JWTs. They have a short expiration time and shouldn\'t be stored long-term.',
+        "- ID tokens from `auth.idToken()` are short-lived JWTs. They have a short expiration time and shouldn't be stored long-term.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -111,7 +111,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent:
         "- GraphQL queries share [rate limits](/docs/api/usage/limits) with your app's overall Admin API usage and are subject to the shop's installed [access scopes](/docs/api/usage/access-scopes).
 " +
-        "- ID tokens from `auth.idToken()` are short-lived JWTs. They expire quickly and shouldn\'t be stored long-term.",
+        "- ID tokens from `auth.idToken()` are short-lived JWTs. They expire quickly and shouldn't be stored long-term.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -14,6 +14,33 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'StandardApi',
     },
   ],
+  defaultExample: {
+    description:
+      'Retrieve an authentication token and fetch data from your app backend. This example uses `auth.idToken()` to get an ID token, adds it to the Authorization header, and fetches products from your backend API.',
+    codeblock: {
+      title: 'Authenticate backend requests',
+      tabs: [
+        {code: './examples/authenticate-backend-request.ts', language: 'ts'},
+        {code: './examples/authenticate-backend-request.tsx', language: 'tsx'},
+      ],
+    },
+  },
+  examples: {
+    description: 'Standard API patterns',
+    examples: [
+      {
+        description:
+          'Query products via GraphQL then update the first product with new tags. This example chains a query and mutation together, handles the response, and updates the product with "processed" and "reviewed" tags.',
+        codeblock: {
+          title: 'Query and mutate product data',
+          tabs: [
+            {code: './examples/query-and-mutate.ts', language: 'ts'},
+            {code: './examples/query-and-mutate.tsx', language: 'tsx'},
+          ],
+        },
+      },
+    ],
+  },
   category: 'Target APIs',
   subCategory: 'Core APIs',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -100,9 +100,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Handle GraphQL partial data:** Check both `errors` and `data` in query responses. GraphQL returns partial data with errors when some fields fail but others succeed.\n' +
-        '- **Catch `StorageExceededError` exceptions:** `storage.set()` and `storage.setMany()` throw `StorageExceededError` when you exceed the 10KB per-key or 100KB total limit. Catch these errors and handle quota failures gracefully.\n' +
-        '- **Use `storage.setMany()` for atomic updates:** When updating multiple related values, use `setMany()` with an array of entries to ensure all updates succeed or fail together.\n' +
+        '- **Handle GraphQL partial data:** Check both `errors` and `data` in query responses. GraphQL returns partial data with errors when some fields fail but others succeed.
+' +
         '- **Batch GraphQL queries:** Combine multiple queries in a single GraphQL request using aliases to reduce roundtrips and improve performance under rate limits.',
     },
     {
@@ -110,10 +109,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        '- Storage is scoped per extension. Data saved by one extension is inaccessible to other extensions, even from the same app.\n' +
-        "- Storage values are serialized with `JSON.stringify`, so functions, symbols, and circular references aren't supported.\n" +
-        "- GraphQL queries share [rate limits](/docs/api/usage/limits) with your app's overall Admin API usage and are subject to the shop's installed [access scopes](/docs/api/usage/access-scopes).\n" +
-        "- ID tokens from `auth.idToken()` are short-lived JWTs. They have a short expiration time and shouldn't be stored long-term.",
+        "- GraphQL queries share [rate limits](/docs/api/usage/limits) with your app's overall Admin API usage and are subject to the shop's installed [access scopes](/docs/api/usage/access-scopes).
+" +
+        "- ID tokens from `auth.idToken()` are short-lived JWTs. They expire quickly and shouldn't be stored long-term.",
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -74,7 +74,7 @@ const data: ReferenceEntityTemplateSchema = {
         '- Storage is scoped per extension. Data saved by one extension is inaccessible to other extensions, even from the same app.\n' +
         "- Storage values are serialized with `JSON.stringify`, so functions, symbols, and circular references aren't supported.\n" +
         "- GraphQL queries share [rate limits](/docs/api/usage/limits) with your app's overall Admin API usage and are subject to the shop's installed [access scopes](/docs/api/usage/access-scopes).\n" +
-        '- ID tokens from `auth.idToken()` are short-lived JWTs. They have a short expiration time and shouldn't be stored long-term.',
+        '- ID tokens from `auth.idToken()` are short-lived JWTs. They have a short expiration time and shouldn\'t be stored long-term.',
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -12,8 +12,16 @@ const data: ReferenceEntityTemplateSchema = {
     codeblock: {
       title: 'Authenticate backend requests',
       tabs: [
-        {code: './examples/authenticate-backend-request.ts', language: 'ts'},
-        {code: './examples/authenticate-backend-request.tsx', language: 'tsx'},
+        {
+          title: 'TS',
+          code: './examples/authenticate-backend-request.ts',
+          language: 'ts',
+        },
+        {
+          title: 'React',
+          code: './examples/authenticate-backend-request.tsx',
+          language: 'tsx',
+        },
       ],
     },
   },
@@ -34,8 +42,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Query and mutate product data',
           tabs: [
-            {code: './examples/query-and-mutate.ts', language: 'ts'},
-            {code: './examples/query-and-mutate.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/query-and-mutate.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/query-and-mutate.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },
@@ -45,8 +61,16 @@ const data: ReferenceEntityTemplateSchema = {
         codeblock: {
           title: 'Persist settings',
           tabs: [
-            {code: './examples/persist-settings.ts', language: 'ts'},
-            {code: './examples/persist-settings.tsx', language: 'tsx'},
+            {
+              title: 'TS',
+              code: './examples/persist-settings.ts',
+              language: 'ts',
+            },
+            {
+              title: 'React',
+              code: './examples/persist-settings.tsx',
+              language: 'tsx',
+            },
           ],
         },
       },

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -3,20 +3,12 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Standard API',
   description:
-    'The Standard API provides core functionality available to all Admin UI extension types. Use this API to authenticate with your app backend, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, and handle intent-based navigation.',
+    'The Standard API provides core functionality available to all Admin UI extension types. Use this API to authenticate with your app backend, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, handle navigation [intents](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api), and persist data in browser storage.',
   isVisualComponent: false,
   type: 'API',
-  definitions: [
-    {
-      title: 'StandardApi',
-      description:
-        'The `StandardApi` object provides core methods available to all extension targets. Access the following properties on the `StandardApi` object to identify your extension target, authenticate with your app backend, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, and handle intents from other extensions.',
-      type: 'StandardApi',
-    },
-  ],
   defaultExample: {
     description:
-      'Retrieve an authentication token and fetch data from your app backend. This example shows using `auth.idToken()` to get an ID token and adding it to the Authorization header.',
+      'Retrieve an authentication token to securely fetch data from your app backend, enabling personalized content, inventory sync, or external integrations. This example demonstrates getting the ID token using `auth.idToken()`, adding it to Authorization headers, displaying loading states on the [`Button`](/docs/api/admin-extensions/{API_VERSION}/components/actions/button) during fetch, and showing the count of loaded products.',
     codeblock: {
       title: 'Authenticate backend requests',
       tabs: [
@@ -25,18 +17,37 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  definitions: [
+    {
+      title: 'StandardApi',
+      description:
+        'The `StandardApi` object provides core methods available to all extension targets. Access the following properties on the `StandardApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, handle intents, and persist data.',
+      type: 'StandardApi',
+    },
+  ],
   examples: {
-    description: 'Standard API patterns',
+    description: 'Essential patterns for all extensions',
     examples: [
       {
         description:
-          'Query products via GraphQL then update the first product with new tags. This example demonstrates chaining a query and mutation together to update the product with "processed" and "reviewed" tags.',
+          'Query products using the [GraphQL Admin API](/docs/api/admin-graphql/), then update the first product with new tags for workflow automation or bulk operations. This example demonstrates chaining a query and mutation together, displaying the count of queried products, and showing success feedback when tags are applied.',
         codeblock: {
           title: 'Query and mutate product data',
           tabs: [
-            {code: './examples/query-and-mutate.ts', language: 'ts'},
-            {code: './examples/query-and-mutate.tsx', language: 'tsx'},
-          ],
+        {code: './examples/query-and-mutate.ts', language: 'ts'},
+        {code: './examples/query-and-mutate.tsx', language: 'tsx'},
+      ],
+        },
+      },
+      {
+        description:
+          'Save and retrieve user preferences from browser storage. This example loads saved preferences on mount, displays current values, and lets merchants update settings that persist across sessions.',
+        codeblock: {
+          title: 'Persist settings',
+          tabs: [
+        {code: './examples/persist-settings.ts', language: 'ts'},
+        {code: './examples/persist-settings.tsx', language: 'tsx'},
+      ],
         },
       },
     ],
@@ -51,6 +62,8 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Handle GraphQL partial data:** Check both `errors` and `data` in query responses. GraphQL returns partial data with errors when some fields fail but others succeed.\n' +
+        '- **Catch `StorageExceededError` exceptions:** `storage.set()` and `storage.setMany()` throw `StorageExceededError` when you exceed the 10KB per-key or 100KB total limit. Catch these errors and handle quota failures gracefully.\n' +
+        '- **Use `storage.setMany()` for atomic updates:** When updating multiple related values, use `setMany()` with an array of entries to ensure all updates succeed or fail together.\n' +
         '- **Batch GraphQL queries:** Combine multiple queries in a single GraphQL request using aliases to reduce roundtrips and improve performance under rate limits.',
     },
     {
@@ -58,8 +71,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
+        '- Storage is scoped per extension. Data saved by one extension is inaccessible to other extensions, even from the same app.\n' +
+        "- Storage values are serialized with `JSON.stringify`, so functions, symbols, and circular references aren't supported.\n" +
         "- GraphQL queries share [rate limits](/docs/api/usage/limits) with your app's overall Admin API usage and are subject to the shop's installed [access scopes](/docs/api/usage/access-scopes).\n" +
-        "- ID tokens from `auth.idToken()` are short-lived JWTs. They expire quickly and shouldn't be stored long-term.",
+        '- ID tokens from `auth.idToken()` are short-lived JWTs. They have a short expiration time and shouldn't be stored long-term.',
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -16,7 +16,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Retrieve an authentication token and fetch data from your app backend. This example uses `auth.idToken()` to get an ID token, adds it to the Authorization header, and fetches products from your backend API.',
+      'Retrieve an authentication token and fetch data from your app backend. This example shows using `auth.idToken()` to get an ID token and adding it to the Authorization header.',
     codeblock: {
       title: 'Authenticate backend requests',
       tabs: [
@@ -30,7 +30,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Query products via GraphQL then update the first product with new tags. This example chains a query and mutation together, handles the response, and updates the product with "processed" and "reviewed" tags.',
+          'Query products via GraphQL then update the first product with new tags. This example demonstrates chaining a query and mutation together to update the product with "processed" and "reviewed" tags.',
         codeblock: {
           title: 'Query and mutate product data',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -13,14 +13,19 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Authenticate backend requests',
       tabs: [
         {
-          title: 'TS',
-          code: './examples/authenticate-backend-request.ts',
-          language: 'ts',
-        },
-        {
           title: 'React',
+
           code: './examples/authenticate-backend-request.tsx',
+
           language: 'tsx',
+        },
+
+        {
+          title: 'TS',
+
+          code: './examples/authenticate-backend-request.ts',
+
+          language: 'ts',
         },
       ],
     },
@@ -43,14 +48,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Query and mutate product data',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/query-and-mutate.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/query-and-mutate.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/query-and-mutate.ts',
+
+              language: 'ts',
             },
           ],
         },
@@ -62,14 +72,19 @@ const data: ReferenceEntityTemplateSchema = {
           title: 'Persist settings',
           tabs: [
             {
-              title: 'TS',
-              code: './examples/persist-settings.ts',
-              language: 'ts',
-            },
-            {
               title: 'React',
+
               code: './examples/persist-settings.tsx',
+
               language: 'tsx',
+            },
+
+            {
+              title: 'TS',
+
+              code: './examples/persist-settings.ts',
+
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/tsconfig.json
+++ b/packages/ui-extensions/tsconfig.json
@@ -6,5 +6,5 @@
     "stripInternal": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.example.*", "src/**/tests/**"]
+  "exclude": ["src/**/*.example.*", "src/**/tests/**", "src/**/examples/**"]
 }


### PR DESCRIPTION
# [Admin UI Extensions 2025-01]: Add code examples for Target APIs

## Summary

This PR adds comprehensive code examples for all Admin UI Extension Target APIs in the 2025-01 version. All examples follow the modern Preact pattern established in POS UI Extensions, using `.jsx` files with the global `shopify` object.

## What's Changed
<img width="3180" height="2332" alt="image" src="https://github.com/user-attachments/assets/25bc7a9c-78fc-413f-85da-2dc2ff25261d" />


### New Examples Created (36 files)

Added working code examples for 8 APIs that previously had none:

**Core APIs:**
- Action Extension API (3 examples)
- Block Extension API (3 examples)
- Print Action Extension API (3 examples)
- Standard API (3 examples)

**Contextual APIs:**
- Customer Segment Template Extension API (3 examples)
- Discount Function Settings API (3 examples)
- Validation Settings API (3 examples)
- Order Routing Rule API (3 examples)
- Product Details Configuration API (3 examples)
- Product Variant Details Configuration API (3 examples)
- Purchase Options Card Configuration API (3 examples)

**Utility APIs:**
- Should Render API (3 examples)

### Existing Examples Updated (26 files)

Updated all Intents API examples to follow the new pattern:
- Converted from `.js` to `.jsx`
- Added full Preact rendering with UI components
- Updated to use global `shopify` object
- Improved example titles and descriptions

**Updated 11 existing .doc.ts files with:**
- Example sections with meaningful descriptions
- Correct API categorization (`category: 'Target APIs'`, proper `subCategory`)
- Fixed API names (added " API" suffix where needed)
- Action-oriented example titles
- Proper backticks for code terms in descriptions
- Links to GraphQL Admin API documentation

## Technical Details

### Example Pattern

All examples now follow the POS UI Extensions pattern:

```jsx
import {render} from 'preact';
import {useState} from 'preact/hooks';

export default async () => {
  render(<Extension />, document.body);
};

function Extension() {
  const {data} = shopify;
  
  // Use shopify.query(), shopify.close(), etc.
  
  return <s-admin-block>...</s-admin-block>;
}
```

### Key Changes

1. **Global `shopify` object** - Changed from `useApi(TARGET)` to global `shopify` for consistency with POS
2. **Full Preact components** - All examples include complete UI rendering, not just API calls
3. **Real-world scenarios** - Examples demonstrate practical use cases with error handling, loading states, and user feedback
4. **Runnable extensions** - Customer Segment Template and Should Render return data without UI rendering

## Related

- Follows pattern established in POS UI Extensions (updated Dec 2024)
- Complements PR #3770 (Target API descriptions for 2026-01)
- Part of ongoing Target APIs documentation improvement initiative

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
