### PR TITLE
2023-10 target docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
@@ -1,0 +1,882 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+console.log('✅ Module loaded, starting script...');
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const EXTENSIONS_API_VERSION = process.argv[2] || 'unstable';
+
+// Configuration for admin surface
+const config = {
+  basePath: path.join(__dirname, '../../../src/surfaces/admin'),
+  outputPath: path.join(__dirname, 'generated/targets.json'),
+  componentTypesPath: 'components',
+  hasComponentTypes: true,
+};
+
+// All components will be populated from StandardComponents
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+// Cache for checkout components
+let checkoutComponentsCache = null;
+
+/**
+ * Parse components from checkout's shared.ts file
+ */
+function parseCheckoutComponents() {
+  // Return cached value if available
+  if (checkoutComponentsCache !== null) {
+    return checkoutComponentsCache;
+  }
+
+  try {
+    // Always look in the checkout surface directory
+    const checkoutBasePath = path.join(
+      __dirname,
+      '../../../src/surfaces/checkout',
+    );
+    const sharedPath = path.join(checkoutBasePath, 'shared.ts');
+    const componentsPath = path.join(checkoutBasePath, 'components.ts');
+
+    // First try to parse from shared.ts (legacy format with SUPPORTED_COMPONENTS)
+    if (fs.existsSync(sharedPath)) {
+      const content = fs.readFileSync(sharedPath, 'utf-8');
+
+      // Look for SUPPORTED_COMPONENTS array
+      const supportedMatch = content.match(
+        /export const SUPPORTED_COMPONENTS\s*=\s*\[([\s\S]*?)\]\s*as const/,
+      );
+
+      if (supportedMatch) {
+        const arrayContent = supportedMatch[1];
+        // Extract all quoted strings
+        const components = arrayContent.match(/'([^']+)'/g);
+        if (components) {
+          checkoutComponentsCache = components.map((c) => c.replace(/'/g, ''));
+          return checkoutComponentsCache;
+        }
+      }
+    }
+
+    // If SUPPORTED_COMPONENTS not found, try to parse from components.ts
+    if (fs.existsSync(componentsPath)) {
+      const content = fs.readFileSync(componentsPath, 'utf-8');
+
+      // Match export statements like: export {ComponentName} from './components/ComponentName/ComponentName';
+      const exportMatches = content.matchAll(
+        /export\s*\{\s*(\w+)\s*\}\s*from/g,
+      );
+      const components = [];
+
+      for (const match of exportMatches) {
+        const componentName = match[1];
+        // Filter out Props types and other exports
+        if (
+          !componentName.endsWith('Props') &&
+          !componentName.includes('Type') &&
+          componentName.charAt(0) === componentName.charAt(0).toUpperCase()
+        ) {
+          components.push(componentName);
+        }
+      }
+
+      if (components.length > 0) {
+        checkoutComponentsCache = components;
+        return checkoutComponentsCache;
+      }
+    }
+
+    if (!fs.existsSync(sharedPath) && !fs.existsSync(componentsPath)) {
+      checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
+      return checkoutComponentsCache;
+    }
+
+    checkoutComponentsCache = ['[CheckoutComponentsParseError]'];
+    return checkoutComponentsCache;
+  } catch (error) {
+    console.error('Error parsing checkout components:', error);
+    checkoutComponentsCache = ['[CheckoutComponentsError]'];
+    return checkoutComponentsCache;
+  }
+}
+
+/**
+ * Parse components from the local components.ts file
+ */
+function parseLocalComponents() {
+  try {
+    const componentsPath = path.join(config.basePath, 'components.ts');
+
+    if (!fs.existsSync(componentsPath)) {
+      console.warn('components.ts not found at:', componentsPath);
+      return [];
+    }
+
+    const content = fs.readFileSync(componentsPath, 'utf-8');
+
+    // Match export statements like: export {ComponentName} from './components/ComponentName/ComponentName';
+    const exportMatches = content.matchAll(/export\s*\{\s*(\w+)\s*\}\s*from/g);
+    const components = [];
+
+    for (const match of exportMatches) {
+      const componentName = match[1];
+      // Filter out Props types and other exports
+      if (
+        !componentName.endsWith('Props') &&
+        !componentName.includes('Type') &&
+        componentName.charAt(0) === componentName.charAt(0).toUpperCase()
+      ) {
+        components.push(componentName);
+      }
+    }
+
+    return components;
+  } catch (error) {
+    console.error('Error parsing local components:', error);
+    return [];
+  }
+}
+
+/**
+ * Parse a string union type from a component file and resolve type references
+ * e.g., export type SmartGridComponents = 'Tile';
+ * or: export type BlockExtensionComponents = StandardComponents | 'AdminBlock';
+ * or: export type StandardComponents = AnyComponent | 'Avatar' | ... (with AnyComponent imported)
+ */
+function parseStringUnionType(filePath, componentTypesMap = {}) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    // Extract all quoted component names from the file (but not from import statements)
+    // Remove import lines first
+    const contentWithoutImports = content.replace(/^import.*?;$/gm, '');
+    const componentNames = contentWithoutImports.match(/'([^']+)'/g);
+    const quotedComponents = componentNames
+      ? componentNames.map((name) => name.replace(/'/g, ''))
+      : [];
+
+    // Check if the type references other types (like StandardComponents or AnyComponent)
+    // Look for patterns like: StandardComponents | 'OtherComponent'
+    const typeRefPattern = /export type \w+ =\s*([\s\S]*?);/;
+    const typeDefMatch = content.match(typeRefPattern);
+
+    if (typeDefMatch) {
+      const typeDef = typeDefMatch[1];
+      // Find references to other types (capitalized words that aren't in quotes)
+      const typeRefs = typeDef.match(/\b([A-Z]\w+(?:Components?)?)\b/g);
+
+      if (typeRefs) {
+        const allComponents = [...quotedComponents];
+
+        for (const typeRef of typeRefs) {
+          // Check if this is AnyComponent (imported from checkout)
+          if (typeRef === 'AnyComponent') {
+            // Add all checkout components
+            const checkoutComponents = parseCheckoutComponents();
+            allComponents.push(...checkoutComponents);
+          }
+          // If this type reference exists in our map, include its components
+          else if (componentTypesMap[typeRef]) {
+            allComponents.push(...componentTypesMap[typeRef]);
+          }
+        }
+
+        // Remove duplicates
+        return [...new Set(allComponents)];
+      }
+    }
+
+    return quotedComponents.length > 0 ? quotedComponents : null;
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from files in the components directory
+ * Uses a two-pass approach:
+ * 1. First pass: Parse all component types that only contain quoted strings
+ * 2. Second pass: Parse types that reference other types (like StandardComponents)
+ */
+function parseComponentTypesFromFiles() {
+  if (!config.hasComponentTypes || !config.componentTypesPath) {
+    return {};
+  }
+
+  const componentsPath = path.join(config.basePath, config.componentTypesPath);
+  const componentTypesMap = {};
+
+  try {
+    // Look for all TypeScript files in the components directory
+    const files = fs.readdirSync(componentsPath);
+    const tsFiles = files.filter(
+      (file) => file.endsWith('.ts') && !file.endsWith('.d.ts'),
+    );
+
+    // First pass: Parse files with only quoted strings
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, {});
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+
+        // If this is StandardComponents, use it as the base
+        if (componentTypeName === 'StandardComponents') {
+          allComponents = components.sort();
+        }
+      }
+    }
+
+    // Second pass: Re-parse files that might reference other types
+    // This allows types like BlockExtensionComponents = StandardComponents | 'AdminBlock'
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, componentTypesMap);
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+      }
+    }
+  } catch (error) {
+    console.error('Error parsing component types:', error.message);
+  }
+
+  return componentTypesMap;
+}
+
+/**
+ * Check if a target has @private JSDoc tag
+ */
+function hasPrivateTag(content, matchIndex) {
+  // Look backwards from the match to find the JSDoc comment
+  const beforeMatch = content.substring(0, matchIndex);
+
+  // Find the last JSDoc comment before this target
+  const jsDocMatches = [...beforeMatch.matchAll(/\/\*\*[\s\S]*?\*\//g)];
+
+  if (jsDocMatches.length === 0) {
+    return false;
+  }
+
+  const lastJsDoc = jsDocMatches[jsDocMatches.length - 1];
+  const jsDocEnd = lastJsDoc.index + lastJsDoc[0].length;
+
+  // Check if there's only whitespace between the JSDoc and our match
+  const between = beforeMatch.substring(jsDocEnd);
+  if (!/^\s*$/.test(between)) {
+    return false;
+  }
+
+  // Check if the JSDoc contains @private
+  return lastJsDoc[0].includes('@private');
+}
+
+/**
+ * Parse inline component type definitions from extension-targets.ts
+ * e.g., type CustomerSegmentTemplateComponent = AnyComponentBuilder<Pick<Components, 'CustomerSegmentTemplate' | 'InternalCustomerSegmentTemplate'>>
+ */
+function parseInlineComponentTypes(content, componentTypesMap) {
+  // Match type definitions with Pick
+  const pickTypeRegex =
+    /type\s+(\w+)\s*=\s*AnyComponentBuilder<\s*Pick<\s*Components\s*,\s*([\s\S]*?)>\s*>/g;
+  let match;
+
+  while ((match = pickTypeRegex.exec(content)) !== null) {
+    const typeName = match[1];
+    const pickedUnion = match[2].trim();
+    const components = parseUnionOfStrings(pickedUnion);
+    if (components.length > 0) {
+      componentTypesMap[typeName] = components;
+    }
+  }
+
+  // Match type definitions with Omit
+  const omitTypeRegex =
+    /type\s+(\w+)\s*=\s*AnyComponentBuilder<\s*Omit<\s*Components\s*,\s*([\s\S]*?)>\s*>/g;
+
+  while ((match = omitTypeRegex.exec(content)) !== null) {
+    const typeName = match[1];
+    const omittedUnion = match[2].trim();
+    const omittedComponents = parseUnionOfStrings(omittedUnion);
+
+    // Get all components and filter out the omitted ones
+    if (allComponents.length > 0) {
+      componentTypesMap[typeName] = allComponents.filter(
+        (c) => !omittedComponents.includes(c),
+      );
+    }
+  }
+}
+
+function parseTargetsFile() {
+  console.log('Starting parseTargetsFile...');
+  const targetsFilePath = path.join(config.basePath, 'extension-targets.ts');
+
+  console.log('Reading targets file:', targetsFilePath);
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse and populate allComponents from the local components.ts file
+  if (allComponents.length === 0) {
+    console.log('Parsing local components...');
+    const localComponents = parseLocalComponents();
+    console.log(`Found ${localComponents.length} local components`);
+    if (localComponents.length > 0) {
+      allComponents = localComponents.sort();
+    }
+  }
+
+  // Parse component type definitions from files
+  console.log('Parsing component types from files...');
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  // Parse inline component type definitions from extension-targets.ts
+  parseInlineComponentTypes(content, componentTypesMap);
+  console.log(
+    `Found ${Object.keys(componentTypesMap).length} component type mappings`,
+  );
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'CustomerAccountExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  console.log('Looking for interface targets...');
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match && match[1].includes('RenderExtension<')) {
+      console.log(`Parsing targets from ${interfaceName}...`);
+      parseTargetsFromInterfaceBody(
+        match[1],
+        targets,
+        componentTypesMap,
+        content,
+      );
+    }
+  }
+
+  console.log(`Found ${Object.keys(targets).length} targets total`);
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(
+  interfaceBody,
+  targets,
+  componentTypesMap,
+  fullContent,
+) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+
+    // Find position in full content to check for @private
+    if (fullContent) {
+      const targetInContent = fullContent.indexOf(`'${targetName}':`);
+      if (
+        targetInContent !== -1 &&
+        hasPrivateTag(fullContent, targetInContent)
+      ) {
+        continue; // Skip private targets
+      }
+    }
+
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (apiDefinitionsCache.hasOwnProperty(apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Try to find the API file in the surface's api directory
+  const apiDir = path.join(config.basePath, 'api');
+
+  if (!fs.existsSync(apiDir)) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Convert API name to potential file paths
+  // e.g., StandardApi -> standard-api, CartApi -> cart-api
+  const kebabName = apiName
+    .replace(/Api$/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+  // Try multiple possible locations
+  const possiblePaths = [
+    path.join(apiDir, `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}`, `${kebabName}.ts`),
+    path.join(apiDir, kebabName.replace(/-/g, ''), `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}-api`, `${kebabName}-api.ts`),
+    path.join(apiDir, `${kebabName}-api.ts`),
+    path.join(apiDir, `standard-api`, `standard-api.ts`),
+  ];
+
+  let content = null;
+  for (const apiFilePath of possiblePaths) {
+    try {
+      if (fs.existsSync(apiFilePath)) {
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      }
+    } catch (error) {
+      // Continue to next path
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    let startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const generalMatch = part.match(/(\w+Api)\b/);
+      if (generalMatch) {
+        apiName = generalMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+/**
+ * Parse a TypeScript component type expression
+ * Handles various patterns: type refs, unions, Exclude, AllowedComponents, etc.
+ */
+function parseComponents(componentString, componentTypesMap) {
+  // Normalize whitespace
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle union types like "AllComponents | OrderRoutingComponents"
+  if (componentString.includes('|') && !componentString.includes("'")) {
+    const unionParts = componentString.split('|').map((p) => p.trim());
+    const allComponentsFromUnion = new Set();
+
+    for (const part of unionParts) {
+      const partComponents = parseComponents(part, componentTypesMap);
+      partComponents.forEach((c) => allComponentsFromUnion.add(c));
+    }
+
+    return [...allComponentsFromUnion];
+  }
+
+  // Handle AnyComponentBuilder<Pick<Components, 'Comp1' | 'Comp2'>>
+  const pickMatch = componentString.match(
+    /AnyComponentBuilder<\s*Pick<\s*Components\s*,\s*([^>]+)>\s*>/,
+  );
+  if (pickMatch) {
+    const pickedUnion = pickMatch[1].trim();
+    return parseUnionOfStrings(pickedUnion);
+  }
+
+  // Handle AnyComponentBuilder<Omit<Components, 'Comp1' | 'Comp2'>>
+  const omitMatch = componentString.match(
+    /AnyComponentBuilder<\s*Omit<\s*Components\s*,\s*([^>]+)>\s*>/,
+  );
+  if (omitMatch) {
+    const omittedUnion = omitMatch[1].trim();
+    const omittedComponents = parseUnionOfStrings(omittedUnion);
+
+    // Get all components and filter out the omitted ones
+    if (allComponents.length > 0) {
+      return allComponents.filter((c) => !omittedComponents.includes(c));
+    }
+    // Fallback: try to get from checkout components if allComponents not set
+    const checkoutComponents = parseCheckoutComponents();
+    return checkoutComponents.filter((c) => !omittedComponents.includes(c));
+  }
+
+  // Handle plain AnyComponentBuilder<Components>
+  const anyComponentBuilderMatch = componentString.match(
+    /AnyComponentBuilder<\s*Components\s*>/,
+  );
+  if (anyComponentBuilderMatch) {
+    if (allComponents.length > 0) {
+      return allComponents;
+    }
+    return parseCheckoutComponents();
+  }
+
+  // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
+  const checkoutExceptMatch = componentString.match(
+    /AnyCheckoutComponentExcept<([^>]+)>/,
+  );
+  if (checkoutExceptMatch) {
+    const excludedUnion = checkoutExceptMatch[1];
+    // Get all checkout components
+    const allCheckoutComponents = parseCheckoutComponents();
+    // Parse the union of excluded components
+    const excludedComponents = parseUnionOfStrings(excludedUnion);
+    // Filter out the excluded components
+    return allCheckoutComponents.filter((c) => !excludedComponents.includes(c));
+  }
+
+  // Handle Exclude<BaseType, ExcludedComponent>
+  const excludeMatch = componentString.match(/Exclude<(\w+),\s*'([^']+)'>/);
+  if (excludeMatch) {
+    const baseType = excludeMatch[1];
+    const excluded = excludeMatch[2];
+    const baseComponents = resolveComponentType(baseType, componentTypesMap);
+    return baseComponents.filter((c) => c !== excluded);
+  }
+
+  // Handle AllowedComponents<ComponentType>
+  const allowedMatch = componentString.match(/AllowedComponents<([^>]+)>/);
+  if (allowedMatch) {
+    const innerType = allowedMatch[1].trim();
+    return resolveComponentType(innerType, componentTypesMap);
+  }
+
+  // Check if it's a direct type reference
+  const result = resolveComponentType(componentString, componentTypesMap);
+  if (result.length > 0) {
+    return result;
+  }
+
+  // Default to all components if we have them
+  if (allComponents.length > 0) {
+    return allComponents;
+  }
+
+  return ['[Unknown]'];
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'" or "| 'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Resolve a component type name to a list of component names
+ */
+function resolveComponentType(typeName, componentTypesMap) {
+  typeName = typeName.trim();
+
+  // Check if it's in our component types map
+  if (componentTypesMap[typeName]) {
+    return componentTypesMap[typeName];
+  }
+
+  // Handle special checkout types
+  if (
+    typeName === 'AnyCheckoutComponent' ||
+    typeName === 'AnyComponent' ||
+    typeName === 'AnyThankYouComponent'
+  ) {
+    return parseCheckoutComponents();
+  }
+
+  // Check if it's a quoted string literal
+  const quotedMatch = typeName.match(/^'([^']+)'$/);
+  if (quotedMatch) {
+    return [quotedMatch[1]];
+  }
+
+  return [];
+}
+
+function createCombinedMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for admin surface');
+  console.log(`📁 Base path: ${config.basePath}`);
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the combined JSON with reverse mappings
+  const combinedJson = createCombinedMapping(targetsJson);
+
+  // Write to output file
+  const outputDir = path.dirname(config.outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, {recursive: true});
+  }
+  fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
+
+  console.log('✅ Generated combined targets JSON at:', config.outputPath);
+
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(combinedJson).filter(
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api'),
+  ).length;
+  const componentEntries = Object.keys(combinedJson).filter(
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api'),
+  ).length;
+
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(combinedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
@@ -7,8 +7,6 @@ console.log('✅ Module loaded, starting script...');
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const EXTENSIONS_API_VERSION = process.argv[2] || 'unstable';
-
 // Configuration for admin surface
 const config = {
   basePath: path.join(__dirname, '../../../src/surfaces/admin'),

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
@@ -49,6 +49,14 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
+# Generate targets.json
+echo "Generating targets.json..."
+node ./$DOCS_PATH/build-docs-targets-json.mjs $API_VERSION
+targets_exit=$?
+if [ $targets_exit -ne 0 ]; then
+  fail_and_exit $targets_exit
+fi
+
 if [ -d ~/src/github.com/Shopify/shopify-dev ]; then
   echo "Copying docs to shopify-dev..."
   

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
@@ -5,15 +5,6 @@ import {fileURLToPath} from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const API_VERSION = process.argv[2];
-
-if (!API_VERSION) {
-  console.error('Error: API_VERSION is required.');
-  console.error('Usage: node build-docs-targets-json.mjs <API_VERSION>');
-  console.error('Example: node build-docs-targets-json.mjs 2025-10');
-  process.exit(1);
-}
-
 // All checkout components
 let allComponents = [];
 

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
@@ -1,0 +1,477 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const API_VERSION = process.argv[2];
+
+if (!API_VERSION) {
+  console.error('Error: API_VERSION is required.');
+  console.error('Usage: node build-docs-targets-json.mjs <API_VERSION>');
+  console.error('Example: node build-docs-targets-json.mjs 2025-10');
+  process.exit(1);
+}
+
+// All checkout components
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+/**
+ * Parse components from the local components.ts file
+ */
+function parseLocalComponents() {
+  try {
+    const componentsPath = path.join(
+      __dirname,
+      '../../../src/surfaces/checkout/components.ts',
+    );
+
+    if (!fs.existsSync(componentsPath)) {
+      console.warn('components.ts not found at:', componentsPath);
+      return [];
+    }
+
+    const content = fs.readFileSync(componentsPath, 'utf-8');
+
+    // Match export statements like: export {ComponentName} from './components/ComponentName/ComponentName';
+    const exportMatches = content.matchAll(/export\s*\{\s*(\w+)\s*\}\s*from/g);
+    const components = [];
+
+    for (const match of exportMatches) {
+      const componentName = match[1];
+      // Filter out Props types and other exports
+      if (
+        !componentName.endsWith('Props') &&
+        !componentName.includes('Type') &&
+        componentName.charAt(0) === componentName.charAt(0).toUpperCase()
+      ) {
+        components.push(componentName);
+      }
+    }
+
+    return components;
+  } catch (error) {
+    console.error('Error parsing local components:', error);
+    return [];
+  }
+}
+
+/**
+ * Parse component types - checkout doesn't have separate component type files
+ */
+function parseComponentTypesFromFiles() {
+  // Checkout doesn't have separate component type files
+  // Component types are defined inline in targets.ts or shared.ts
+  return {};
+}
+
+/**
+ * Check if a target has @private JSDoc tag
+ */
+function hasPrivateTag(content, matchIndex) {
+  // Look backwards from the match to find the JSDoc comment
+  const beforeMatch = content.substring(0, matchIndex);
+
+  // Find the last JSDoc comment before this target
+  const jsDocMatches = [...beforeMatch.matchAll(/\/\*\*[\s\S]*?\*\//g)];
+
+  if (jsDocMatches.length === 0) {
+    return false;
+  }
+
+  const lastJsDoc = jsDocMatches[jsDocMatches.length - 1];
+  const jsDocEnd = lastJsDoc.index + lastJsDoc[0].length;
+
+  // Check if there's only whitespace between the JSDoc and our match
+  const between = beforeMatch.substring(jsDocEnd);
+  if (!/^\s*$/.test(between)) {
+    return false;
+  }
+
+  // Check if the JSDoc contains @private
+  return lastJsDoc[0].includes('@private');
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(
+    __dirname,
+    '../../../src/surfaces/checkout/targets.ts',
+  );
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse and populate allComponents from the local components.ts file if not already set
+  if (allComponents.length === 0) {
+    const localComponents = parseLocalComponents();
+    if (localComponents.length > 0) {
+      allComponents = localComponents.sort();
+    }
+  }
+
+  // Parse component type definitions
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'ExtensionTargets',
+    'RunnableExtensionTargets',
+  ];
+
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match) {
+      if (match[1].includes('RenderExtension<')) {
+        parseTargetsFromInterfaceBody(
+          match[1],
+          targets,
+          componentTypesMap,
+          content,
+        );
+      }
+      if (match[1].includes('RunnableExtension<')) {
+        parseRunnableTargetsFromInterfaceBody(match[1], targets, content);
+      }
+    }
+  }
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+/**
+ * Parse RunnableExtension targets (no components, just APIs)
+ */
+function parseRunnableTargetsFromInterfaceBody(
+  interfaceBody,
+  targets,
+  fullContent,
+) {
+  const targetRegex = /'([^']+)':\s*RunnableExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+
+    // Find position in full content to check for @private
+    const targetInContent = fullContent.indexOf(`'${targetName}':`);
+    if (targetInContent !== -1 && hasPrivateTag(fullContent, targetInContent)) {
+      continue; // Skip private targets
+    }
+
+    let runnableExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    runnableExtensionContent = runnableExtensionContent
+      .replace(/\/\/[^\n]*/g, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // Split by comma to separate API and Output type
+    const parts = splitByTopLevelComma(runnableExtensionContent);
+
+    if (parts.length >= 1) {
+      const apiString = parts[0].trim();
+      const apis = parseApis(apiString);
+
+      targets[targetName] = {
+        components: [], // RunnableExtension targets don't render components
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function parseTargetsFromInterfaceBody(
+  interfaceBody,
+  targets,
+  componentTypesMap,
+  fullContent,
+) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+
+    // Find position in full content to check for @private
+    if (fullContent) {
+      const targetInContent = fullContent.indexOf(`'${targetName}':`);
+      if (
+        targetInContent !== -1 &&
+        hasPrivateTag(fullContent, targetInContent)
+      ) {
+        continue; // Skip private targets
+      }
+    }
+
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  apiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = apiString
+    .split('&')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const fallbackMatch = part.match(/(\w+Api)\b/);
+      if (fallbackMatch) {
+        apiName = fallbackMatch[1];
+      }
+    }
+
+    if (apiName) {
+      apisSet.add(apiName);
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+function parseComponents(componentString, componentTypesMap) {
+  // Remove whitespace and newlines
+  componentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyComponent (checkout's main component type)
+  if (componentString === 'AnyComponent') {
+    return allComponents;
+  }
+
+  // Handle AllowedComponents<'Comp1' | 'Comp2'>
+  const allowedMatch = componentString.match(
+    /AllowedComponents<\s*([^>]+)\s*>/,
+  );
+  if (allowedMatch) {
+    const allowedUnion = allowedMatch[1].trim();
+    return parseUnionOfStrings(allowedUnion);
+  }
+
+  // Handle AnyComponentExcept<'Comp1' | 'Comp2'>
+  const exceptMatch = componentString.match(
+    /AnyComponentExcept<\s*([^>]+)\s*>/,
+  );
+  if (exceptMatch) {
+    const exceptedUnion = exceptMatch[1].trim();
+    const exceptedComponents = parseUnionOfStrings(exceptedUnion);
+    return allComponents.filter((c) => !exceptedComponents.includes(c));
+  }
+
+  // Check if it directly references one of our parsed component types
+  for (const [typeName, components] of Object.entries(componentTypesMap)) {
+    if (componentString.includes(typeName)) {
+      return components;
+    }
+  }
+
+  // Default to all components if no match
+  return allComponents;
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+function createReverseMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for checkout surface');
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the extended JSON with reverse mappings
+  const extendedJson = createReverseMapping(targetsJson);
+
+  // Write to output file
+  const outputPath = path.join(__dirname, 'generated/targets.json');
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, {recursive: true});
+  }
+  fs.writeFileSync(outputPath, JSON.stringify(extendedJson, null, 2));
+
+  console.log('✅ Generated targets JSON at:', outputPath);
+
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(extendedJson).filter(
+    (key) =>
+      extendedJson[key].targets && !targetsJson[key] && key.endsWith('Api'),
+  ).length;
+  const componentEntries = Object.keys(extendedJson).filter(
+    (key) =>
+      extendedJson[key].targets && !targetsJson[key] && !key.endsWith('Api'),
+  ).length;
+
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(extendedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -38,7 +38,7 @@ fi
 
 # Make sure https://shopify.dev URLs are relative so they work in Spin.
 # See https://github.com/Shopify/generate-docs/issues/181
-sed -i 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data.json
+sed -i '' 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data.json
 sed_exit=$?
 if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
@@ -57,7 +57,7 @@ if [ -d ../../../shopify-dev ]; then
     mkdir -p ../../../shopify-dev/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
     cp ./$DOCS_PATH/generated/* ../../../shopify-dev/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
     # Replace 'unstable' with the exact API version in relative doc links
-    sed -i \
+    sed -i '' \
       "s/\/docs\/api\/checkout-ui-extensions\/unstable/\/docs\/api\/checkout-ui-extensions\/$API_VERSION/gi" \
       ../../../shopify-dev/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/generated_docs_data.json
     sed_exit=$?

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -44,6 +44,14 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
+# Generate targets.json
+echo "Generating targets.json..."
+node ./$DOCS_PATH/build-docs-targets-json.mjs $API_VERSION
+targets_exit=$?
+if [ $targets_exit -ne 0 ]; then
+  fail_and_exit $targets_exit
+fi
+
 # Copy the generated docs to shopify-dev
 if [ -d ../../../shopify-dev ]; then
     mkdir -p ../../../shopify-dev/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION


### PR DESCRIPTION
### Background

Part of: https://github.com/Shopify/temp-project-mover-Archetypically-20260312105649/issues/14

We want to parse target information for the dev docs for each surface.

### Solution

Added scripts for admin and checkout surfaces to pull target information into a format that shopify-dev needs to display that information.

**Note:** This is the 2023-10 API version branch. Only admin and checkout surfaces exist on this branch (no point-of-sale or customer-account as separate surfaces).

The scripts handle:

- **`@private` JSDoc tags**: Targets marked with `@private` are excluded from the generated output
- **`Pick<>` / `Omit<>` types**: Correctly resolved to their component lists
- **API parsing**: Extracts API types from `RenderExtension<Api, Components>` definitions
- **Reverse mappings**: Generates API → targets and Component → targets mappings

Key differences for 2023-10:

- Admin uses `extension-targets.ts` with `ExtensionTargets` interface
- Checkout uses `targets.ts` with `ExtensionTargets` interface
- Checkout has both new `.` naming (e.g., `purchase.checkout.block.render`) and deprecated `::` naming (e.g., `Checkout::Dynamic::Render`)
- Admin has its own 28 components (not shared with checkout)
- Customer-account order status targets exist in checkout surface (deprecated, moved to separate surface in later versions)

### 🎩

Run the docs generation scripts (which now include targets.json generation):

```bash
# 1. Admin surface (16 targets, 28 components)
yarn docs:admin 2023-10

# 2. Checkout surface (52 targets, 47 components)
yarn docs:checkout 2023-10
```

Verify that:

- **Admin**: 16 targets generated (1 `@private` excluded: `Playground`)
- **Checkout**: 52 targets generated (multiple `@private` excluded including gift card and payment method targets)
- Admin targets have 28 admin-specific components (AdminAction, AdminBlock, etc.)
- Checkout targets have 47 checkout components (Banner, BlockLayout, etc.)
- Each target has `components` and `apis` arrays
- Reverse mappings exist for APIs and Components

### Checklist

- [x] I have :tophat:'d these changes
