### PR TITLE
[2024-07] Make API headings consistent in POS UI and Admin UI

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ActionApi` object provides methods for presenting modal interfaces. Access these methods through `api.action` to launch full-screen modal experiences.',
+        'The `ActionApi` object provides methods for presenting modal interfaces. Access these properties through `api.action` to launch full-screen modal experiences.',
       type: 'ActionApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -13,7 +13,7 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'ActionApi',
+      title: 'Methods',
       description:
         'The `ActionApi` object provides methods for presenting modal interfaces. Access these methods through `api.action` to launch full-screen modal experiences.',
       type: 'ActionApiContent',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/action-api.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `ActionApi` object provides methods for presenting modal interfaces. Access these properties through `api.action` to launch full-screen modal experiences.',
+        'The `ActionApi` object provides properties for presenting modal interfaces. Access these properties through `api.action` to launch full-screen modal experiences.',
       type: 'ActionApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `CartApi` object provides access to cart management methods and subscribable cart state. Access these properties through `api.cart` to build cart-aware extensions that respond to real-time cart updates.',
+        'The `CartApi` object provides access to cart management and subscribable cart state. Access these properties through `api.cart` to build cart-aware extensions that respond to real-time cart updates.',
       type: 'CartApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `CartApi` object provides access to cart management methods and subscribable cart state. Access these methods through `api.cart` to build cart-aware extensions that respond to real-time cart updates.',
+        'The `CartApi` object provides access to cart management methods and subscribable cart state. Access these properties through `api.cart` to build cart-aware extensions that respond to real-time cart updates.',
       type: 'CartApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/cart-api.doc.ts
@@ -13,7 +13,7 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'CartApi',
+      title: 'Methods',
       description:
         'The `CartApi` object provides access to cart management methods and subscribable cart state. Access these methods through `api.cart` to build cart-aware extensions that respond to real-time cart updates.',
       type: 'CartApiContent',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'ConnectivityApi',
+      title: 'Methods',
       description:
         'The `ConnectivityApi` object provides methods for monitoring network connectivity. Access these methods through `api.connectivity` to check connection status and subscribe to connectivity changes.',
       type: 'ConnectivityApiContent',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -12,9 +12,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ConnectivityApi` object provides methods for monitoring network connectivity. Access these methods through `api.connectivity` to check connection status and subscribe to connectivity changes.',
+        'The `ConnectivityApi` object provides methods for monitoring network connectivity. Access these properties through `api.connectivity` to check connection status and subscribe to connectivity changes.',
       type: 'ConnectivityApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/connectivity-api.doc.ts
@@ -14,7 +14,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `ConnectivityApi` object provides methods for monitoring network connectivity. Access these properties through `api.connectivity` to check connection status and subscribe to connectivity changes.',
+        'The `ConnectivityApi` object provides properties for monitoring network connectivity. Access these properties through `api.connectivity` to check connection status and subscribe to connectivity changes.',
       type: 'ConnectivityApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `CustomerApi` object provides access to customer data. Access these methods through `api.customer` to interact with the current customer context.',
+        'The `CustomerApi` object provides access to customer data. Access these properties through `api.customer` to interact with the current customer context.',
       type: 'CustomerApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/customer-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'CustomerApi',
+      title: 'Methods',
       description:
-        'The `CustomerApi` object provides access to customer data. Access this property through `api.customer` to interact with the current customer context.',
+        'The `CustomerApi` object provides access to customer data. Access these methods through `api.customer` to interact with the current customer context.',
       type: 'CustomerApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -12,9 +12,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `DeviceApi` object provides access to device information and capabilities. Access these methods through `api.device` to retrieve device details and check device characteristics.',
+        'The `DeviceApi` object provides access to device information and capabilities. Access these properties through `api.device` to retrieve device details and check device characteristics.',
       type: 'DeviceApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/device-api.doc.ts
@@ -12,9 +12,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'DeviceApi',
+      title: 'Methods',
       description:
-        'The `DeviceApi` object provides access to device information and capabilities. Access these properties and methods through `api.device` to retrieve device details and check device characteristics.',
+        'The `DeviceApi` object provides access to device information and capabilities. Access these methods through `api.device` to retrieve device details and check device characteristics.',
       type: 'DeviceApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
@@ -10,9 +10,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'DraftOrderApi',
+      title: 'Methods',
       description:
-        'The `DraftOrderApi` object provides access to draft order data. Access this property through `api.draftOrder` to interact with the current draft order context.',
+        'The `DraftOrderApi` object provides access to draft order data. Access these methods through `api.draftOrder` to interact with the current draft order context.',
       type: 'DraftOrderApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/draft-order-api.doc.ts
@@ -10,9 +10,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `DraftOrderApi` object provides access to draft order data. Access these methods through `api.draftOrder` to interact with the current draft order context.',
+        'The `DraftOrderApi` object provides access to draft order data. Access these properties through `api.draftOrder` to interact with the current draft order context.',
       type: 'DraftOrderApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -12,9 +12,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `LocaleApi` object provides access to current locale information and change notifications. Access these methods through `api.locale` to retrieve and monitor locale data.',
+        'The `LocaleApi` object provides access to current locale information and change notifications. Access these properties through `api.locale` to retrieve and monitor locale data.',
       type: 'LocaleApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/locale-api.doc.ts
@@ -12,9 +12,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'LocaleApi',
+      title: 'Methods',
       description:
-        'The `LocaleApi` object provides access to current locale information and change notifications. Access these properties through `api.locale` to retrieve and monitor locale data.',
+        'The `LocaleApi` object provides access to current locale information and change notifications. Access these methods through `api.locale` to retrieve and monitor locale data.',
       type: 'LocaleApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'NavigationApi',
+      title: 'Methods',
       description:
-        'The global `navigation` object provides web-standard navigation functionality. Access these properties and methods directly through the global `navigation` object to manage navigation within modal interfaces.',
+        'The global `navigation` object provides web-standard navigation functionality. Access these methods directly through the global `navigation` object to manage navigation within modal interfaces.',
       type: 'NavigationApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The global `navigation` object provides web-standard navigation functionality. Access these methods directly through the global `navigation` object to manage navigation within modal interfaces.',
+        'The global `navigation` object provides web-standard navigation functionality. Access these properties directly through the global `navigation` object to manage navigation within modal interfaces.',
       type: 'NavigationApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `OrderApi` object provides access to order data. Access these methods through `api.order` to interact with the current order context.',
+        'The `OrderApi` object provides access to order data. Access these properties through `api.order` to interact with the current order context.',
       type: 'OrderApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/order-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'OrderApi',
+      title: 'Methods',
       description:
-        'The `OrderApi` object provides access to order data. Access this property through `api.order` to interact with the current order context.',
+        'The `OrderApi` object provides access to order data. Access these methods through `api.order` to interact with the current order context.',
       type: 'OrderApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ProductApi` object provides access to product data. Access these methods through `api.product` to interact with the current product context.',
+        'The `ProductApi` object provides access to product data. Access these properties through `api.product` to interact with the current product context.',
       type: 'ProductApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'ProductApi',
+      title: 'Methods',
       description:
-        'The `ProductApi` object provides access to product data. Access this property through `api.product` to interact with the current product context.',
+        'The `ProductApi` object provides access to product data. Access these methods through `api.product` to interact with the current product context.',
       type: 'ProductApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -16,7 +16,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `ProductSearchApi` object provides methods for searching and fetching product data. Access these properties through `api.productSearch` to perform product searches and lookups.',
+        'The `ProductSearchApi` object provides properties for searching and fetching product data. Access these properties through `api.productSearch` to perform product searches and lookups.',
       type: 'ProductSearchApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -14,7 +14,7 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'ProductSearchApi',
+      title: 'Methods',
       description:
         'The `ProductSearchApi` object provides methods for searching and fetching product data. Access these methods through `api.productSearch` to perform product searches and lookups.',
       type: 'ProductSearchApiContent',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/product-search-api.doc.ts
@@ -14,9 +14,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ProductSearchApi` object provides methods for searching and fetching product data. Access these methods through `api.productSearch` to perform product searches and lookups.',
+        'The `ProductSearchApi` object provides methods for searching and fetching product data. Access these properties through `api.productSearch` to perform product searches and lookups.',
       type: 'ProductSearchApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ScannerApi` object provides access to scanning functionality and scanner source information. Access these methods through `api.scanner` to monitor scan events and available scanner sources.',
+        'The `ScannerApi` object provides access to scanning functionality and scanner source information. Access these properties through `api.scanner` to monitor scan events and available scanner sources.',
       type: 'ScannerApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/scanner-api.doc.ts
@@ -13,9 +13,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'ScannerApi',
+      title: 'Methods',
       description:
-        'The `ScannerApi` object provides access to scanning functionality and scanner source information. Access these properties through `api.scanner` to monitor scan events and available scanner sources.',
+        'The `ScannerApi` object provides access to scanning functionality and scanner source information. Access these methods through `api.scanner` to monitor scan events and available scanner sources.',
       type: 'ScannerApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -14,7 +14,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `SessionApi` object provides access to current session information and authentication methods. Access these properties through `api.session` to retrieve shop data and generate secure tokens. These methods enable secure API calls while maintaining user privacy and [app permissions](https://help.shopify.com/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).',
+        'The `SessionApi` object provides access to current session information and authentication. Access these properties through `api.session` to retrieve shop data and generate secure tokens. These properties enable secure API calls while maintaining user privacy and [app permissions](https://help.shopify.com/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).',
       type: 'SessionApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -12,9 +12,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `SessionApi` object provides access to current session information and authentication methods. Access these methods through `api.session` to retrieve shop data and generate secure tokens. These methods enable secure API calls while maintaining user privacy and [app permissions](https://help.shopify.com/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).',
+        'The `SessionApi` object provides access to current session information and authentication methods. Access these properties through `api.session` to retrieve shop data and generate secure tokens. These methods enable secure API calls while maintaining user privacy and [app permissions](https://help.shopify.com/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).',
       type: 'SessionApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/session-api.doc.ts
@@ -12,9 +12,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'SessionApi',
+      title: 'Methods',
       description:
-        'The `SessionApi` object provides access to current session information and authentication methods. Access these properties and methods through `api.session` to retrieve shop data and generate secure tokens. These methods enable secure API calls while maintaining user privacy and [app permissions](https://help.shopify.com/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).',
+        'The `SessionApi` object provides access to current session information and authentication methods. Access these methods through `api.session` to retrieve shop data and generate secure tokens. These methods enable secure API calls while maintaining user privacy and [app permissions](https://help.shopify.com/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).',
       type: 'SessionApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'ToastApi',
+      title: 'Methods',
       description:
         'The `ToastApi` object provides methods for displaying temporary notification messages. Access these methods through `api.toast` to show user feedback and status updates.',
       type: 'ToastApiContent',

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -12,9 +12,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'APIs',
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ToastApi` object provides methods for displaying temporary notification messages. Access these methods through `api.toast` to show user feedback and status updates.',
+        'The `ToastApi` object provides methods for displaying temporary notification messages. Access these properties through `api.toast` to show user feedback and status updates.',
       type: 'ToastApiContent',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/toast-api.doc.ts
@@ -14,7 +14,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `ToastApi` object provides methods for displaying temporary notification messages. Access these properties through `api.toast` to show user feedback and status updates.',
+        'The `ToastApi` object provides properties for displaying temporary notification messages. Access these properties through `api.toast` to show user feedback and status updates.',
       type: 'ToastApiContent',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -25,8 +25,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.\n' +
-        "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [`Button`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
+        '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.',
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -10,9 +10,9 @@ const data: ReferenceEntityTemplateSchema = {
     'the [`AdminAction`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminaction) component.',
   definitions: [
     {
-      title: 'ActionExtensionApi',
+      title: 'Methods',
       description:
-        'The `ActionExtensionApi` object provides methods for action extensions that render in modal overlays. Access the following properties on the `ActionExtensionApi` object to interact with the current context, control the modal, and display picker dialogs.',
+        'The `ActionExtensionApi` object provides methods for action extensions that render in modal overlays. Access the following methods on the `ActionExtensionApi` object to interact with the current context, control the modal, and display picker dialogs.',
       type: 'ActionExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ActionExtensionApi` object provides methods for action extensions that render in modal overlays. Access the following methods on the `ActionExtensionApi` object to interact with the current context, control the modal, and display picker dialogs.',
+        'The `ActionExtensionApi` object provides methods for action extensions that render in modal overlays. Access the following properties on the `ActionExtensionApi` object to interact with the current context, control the modal, and display picker dialogs.',
       type: 'ActionExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `ActionExtensionApi` object provides methods for action extensions that render in modal overlays. Access the following properties on the `ActionExtensionApi` object to interact with the current context, control the modal, and display picker dialogs.',
+        'The `ActionExtensionApi` object provides properties for action extensions that render in modal overlays. Access the following properties on the `ActionExtensionApi` object to interact with the current context, control the modal, and display picker dialogs.',
       type: 'ActionExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following methods on the `BlockExtensionApi` object to interact with the current context, navigate to other extensions, and display picker dialogs.',
+        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following properties on the `BlockExtensionApi` object to interact with the current context, navigate to other extensions, and display picker dialogs.',
       type: 'BlockExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -10,9 +10,9 @@ const data: ReferenceEntityTemplateSchema = {
     'the [`AdminBlock`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
   definitions: [
     {
-      title: 'BlockExtensionApi',
+      title: 'Methods',
       description:
-        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following properties on the `BlockExtensionApi` object to interact with the current context, navigate to other extensions, and display picker dialogs.',
+        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following methods on the `BlockExtensionApi` object to interact with the current context, navigate to other extensions, and display picker dialogs.',
       type: 'BlockExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following properties on the `BlockExtensionApi` object to interact with the current context, navigate to other extensions, and display picker dialogs.',
+        'The `BlockExtensionApi` object provides properties for block extensions that render inline content on admin pages. Access the following properties on the `BlockExtensionApi` object to interact with the current context, navigate to other extensions, and display picker dialogs.',
       type: 'BlockExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -10,7 +10,7 @@ const data: ReferenceEntityTemplateSchema = {
     'the [`FunctionSettings`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
   definitions: [
     {
-      title: 'applyMetafieldChange',
+      title: 'Methods',
       description:
         'Applies a [metafield](/docs/apps/build/metafields) change to the validation settings. Use this method to update or remove metafields that store validation function configuration data. The method accepts a change object specifying the operation type, metafield key, namespace, value, and [value type](/docs/apps/build/metafields/list-of-data-types). Returns a promise that resolves to indicate success or provides an error message if the operation fails.',
       type: 'ApplyMetafieldChange',

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -29,7 +29,7 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
         'Applies a [metafield](/docs/apps/build/metafields) change to the validation settings. Use this method to update or remove metafields that store validation function configuration data. The method accepts a change object specifying the operation type, metafield key, namespace, value, and [value type](/docs/apps/build/metafields/list-of-data-types). Returns a promise that resolves to indicate success or provides an error message if the operation fails.',
       type: 'ApplyMetafieldChange',

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -29,7 +29,7 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Properties',
+      title: 'applyMetafieldChange',
       description:
         'Applies a [metafield](/docs/apps/build/metafields) change to the validation settings. Use this method to update or remove metafields that store validation function configuration data. The method accepts a change object specifying the operation type, metafield key, namespace, value, and [value type](/docs/apps/build/metafields/list-of-data-types). Returns a promise that resolves to indicate success or provides an error message if the operation fails.',
       type: 'ApplyMetafieldChange',

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -10,9 +10,9 @@ const data: ReferenceEntityTemplateSchema = {
     'the [`CustomerSegmentTemplate`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/customersegmenttemplate) component.',
   definitions: [
     {
-      title: 'CustomerSegmentTemplateApi',
+      title: 'Methods',
       description:
-        'The `CustomerSegmentTemplateApi` object includes tools for creating segment templates and translating content. Access the following properties on the `CustomerSegmentTemplateApi` object in the `admin.customers.segmentation-templates.render` target.',
+        'The `CustomerSegmentTemplateApi` object includes tools for creating segment templates and translating content. Access the following methods on the `CustomerSegmentTemplateApi` object in the `admin.customers.segmentation-templates.render` target.',
       type: 'CustomerSegmentTemplateApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `CustomerSegmentTemplateApi` object includes tools for creating segment templates and translating content. Access the following methods on the `CustomerSegmentTemplateApi` object in the `admin.customers.segmentation-templates.render` target.',
+        'The `CustomerSegmentTemplateApi` object includes tools for creating segment templates and translating content. Access the following properties on the `CustomerSegmentTemplateApi` object in the `admin.customers.segmentation-templates.render` target.',
       type: 'CustomerSegmentTemplateApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Customer Segment Template Extension API',
   description:
-    'The Customer Segment Template Extension API lets you [build a customer segment template extension](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension). Merchants can use your templates to quickly set up [customer segments](/docs/apps/build/marketing-analytics/customer-segments) based on custom criteria.',
+    'The Customer Segment Template Extension API lets you [build a customer segment template extension](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension). Merchants can use your templates to set up [customer segments](/docs/apps/build/marketing-analytics/customer-segments) based on custom criteria.',
   isVisualComponent: false,
   type: 'API',
   requires:

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `OrderRoutingRuleApi` object provides access to order routing rule data and configuration methods. Access the following properties on the `OrderRoutingRuleApi` object to interact with the current order routing rule context in the `admin.settings.order-routing-rule.render` target.',
+        'The `OrderRoutingRuleApi` object provides access to order routing rule data and configuration. Access the following properties on the `OrderRoutingRuleApi` object to interact with the current order routing rule context in the `admin.settings.order-routing-rule.render` target.',
       type: 'OrderRoutingRuleApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -10,9 +10,9 @@ const data: ReferenceEntityTemplateSchema = {
     'the [`FunctionSettings`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
   definitions: [
     {
-      title: 'OrderRoutingRuleApi',
+      title: 'Methods',
       description:
-        'The `OrderRoutingRuleApi` object provides access to order routing rule data and configuration methods. Access the following properties on the `OrderRoutingRuleApi` object to interact with the current order routing rule context in the `admin.settings.order-routing-rule.render` target.',
+        'The `OrderRoutingRuleApi` object provides access to order routing rule data and configuration methods. Access the following methods on the `OrderRoutingRuleApi` object to interact with the current order routing rule context in the `admin.settings.order-routing-rule.render` target.',
       type: 'OrderRoutingRuleApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `OrderRoutingRuleApi` object provides access to order routing rule data and configuration methods. Access the following methods on the `OrderRoutingRuleApi` object to interact with the current order routing rule context in the `admin.settings.order-routing-rule.render` target.',
+        'The `OrderRoutingRuleApi` object provides access to order routing rule data and configuration methods. Access the following properties on the `OrderRoutingRuleApi` object to interact with the current order routing rule context in the `admin.settings.order-routing-rule.render` target.',
       type: 'OrderRoutingRuleApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `PrintActionExtensionApi` object provides methods for print action extensions that generate custom printable documents. Access the following methods on the `PrintActionExtensionApi` object to access selected resources and display picker dialogs for print configuration.',
+        'The `PrintActionExtensionApi` object provides methods for print action extensions that generate custom printable documents. Access the following properties on the `PrintActionExtensionApi` object to access selected resources and display picker dialogs for print configuration.',
       type: 'PrintActionExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `PrintActionExtensionApi` object provides methods for print action extensions that generate custom printable documents. Access the following properties on the `PrintActionExtensionApi` object to access selected resources and display picker dialogs for print configuration.',
+        'The `PrintActionExtensionApi` object provides properties for print action extensions that generate custom printable documents. Access the following properties on the `PrintActionExtensionApi` object to access selected resources and display picker dialogs for print configuration.',
       type: 'PrintActionExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -10,9 +10,9 @@ const data: ReferenceEntityTemplateSchema = {
     'the [`AdminPrintAction`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminprintaction) component.',
   definitions: [
     {
-      title: 'PrintActionExtensionApi',
+      title: 'Methods',
       description:
-        'The `PrintActionExtensionApi` object provides methods for print action extensions that generate custom printable documents. Access the following properties on the `PrintActionExtensionApi` object to access selected resources and display picker dialogs for print configuration.',
+        'The `PrintActionExtensionApi` object provides methods for print action extensions that generate custom printable documents. Access the following methods on the `PrintActionExtensionApi` object to access selected resources and display picker dialogs for print configuration.',
       type: 'PrintActionExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `ProductDetailsConfigurationApi` object provides access to product configuration data and methods. Access the following properties on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
+        'The `ProductDetailsConfigurationApi` object provides access to product configuration data. Access the following properties on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
       type: 'ProductDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ProductDetailsConfigurationApi` object provides access to product configuration data and methods. Access the following methods on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
+        'The `ProductDetailsConfigurationApi` object provides access to product configuration data and methods. Access the following properties on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
       type: 'ProductDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -10,9 +10,9 @@ const data: ReferenceEntityTemplateSchema = {
     'the [`AdminBlock`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
   definitions: [
     {
-      title: 'ProductDetailsConfigurationApi',
+      title: 'Methods',
       description:
-        'The `ProductDetailsConfigurationApi` object provides access to product configuration data and methods. Access the following properties on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
+        'The `ProductDetailsConfigurationApi` object provides access to product configuration data and methods. Access the following methods on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
       type: 'ProductDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data and methods. Access the following properties on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
+        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data. Access the following properties on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
       type: 'ProductVariantDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data and methods. Access the following methods on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
+        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data and methods. Access the following properties on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
       type: 'ProductVariantDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -10,9 +10,9 @@ const data: ReferenceEntityTemplateSchema = {
     'the [`AdminBlock`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
   definitions: [
     {
-      title: 'ProductVariantDetailsConfigurationApi',
+      title: 'Methods',
       description:
-        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data and methods. Access the following properties on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
+        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data and methods. Access the following methods on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
       type: 'ProductVariantDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -190,8 +190,8 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
-      description: `The \`ResourcePickerOptions\` object defines how the resource picker behaves, including which resource type to display, selection limits, filters, and preselected items. Access the following methods on the \`ResourcePickerOptions\` object to configure the resource picker's appearance and functionality.`,
+      title: 'Properties',
+      description: `The \`ResourcePickerOptions\` object defines how the resource picker behaves, including which resource type to display, selection limits, filters, and preselected items. Access the following properties on the \`ResourcePickerOptions\` object to configure the resource picker's appearance and functionality.`,
       type: 'ResourcePickerOptions',
     },
     {

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -137,8 +137,8 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'ResourcePickerOptions',
-      description: `The \`ResourcePickerOptions\` object defines how the resource picker behaves, including which resource type to display, selection limits, filters, and preselected items. Access the following properties on the \`ResourcePickerOptions\` object to configure the resource picker's appearance and functionality.`,
+      title: 'Methods',
+      description: `The \`ResourcePickerOptions\` object defines how the resource picker behaves, including which resource type to display, selection limits, filters, and preselected items. Access the following methods on the \`ResourcePickerOptions\` object to configure the resource picker's appearance and functionality.`,
       type: 'ResourcePickerOptions',
     },
     {

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -8,9 +8,9 @@ const data: ReferenceEntityTemplateSchema = {
   type: 'API',
   definitions: [
     {
-      title: 'StandardApi',
+      title: 'Methods',
       description:
-        'The `StandardApi` object provides core methods available to all extension targets. Access the following properties on the `StandardApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), and translate content.',
+        'The `StandardApi` object provides core methods available to all extension targets. Access the following methods on the `StandardApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), and translate content.',
       type: 'StandardApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -27,9 +27,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `StandardApi` object provides core methods available to all extension targets. Access the following methods on the `StandardApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), and translate content.',
+        'The `StandardApi` object provides core methods available to all extension targets. Access the following properties on the `StandardApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), and translate content.',
       type: 'StandardApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -29,7 +29,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `StandardApi` object provides core methods available to all extension targets. Access the following properties on the `StandardApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), and translate content.',
+        'The `StandardApi` object provides core properties available to all extension targets. Access the following properties on the `StandardApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), and translate content.',
       type: 'StandardApi',
     },
   ],


### PR DESCRIPTION
## This PR:
- Standardizes the API docs section headings for POS UI and Admin UI to use "Properties" consistently
- Revises a few Admin UI API docs for clarity