### PR TITLE
[2023-10] Make API headings consistent in Admin UI

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ActionExtensionApi` object provides methods for action extensions that render in modal overlays. Access the following methods on the `ActionExtensionApi` object to interact with the current context and control the modal.',
+        'The `ActionExtensionApi` object provides methods for action extensions that render in modal overlays. Access the following properties on the `ActionExtensionApi` object to interact with the current context and control the modal.',
       type: 'ActionExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'ActionExtensionApi',
+      title: 'Methods',
       description:
-        'The `ActionExtensionApi` object provides methods for action extensions that render in modal overlays. Access the following properties on the `ActionExtensionApi` object to interact with the current context and control the modal.',
+        'The `ActionExtensionApi` object provides methods for action extensions that render in modal overlays. Access the following methods on the `ActionExtensionApi` object to interact with the current context and control the modal.',
       type: 'ActionExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `ActionExtensionApi` object provides methods for action extensions that render in modal overlays. Access the following properties on the `ActionExtensionApi` object to interact with the current context and control the modal.',
+        'The `ActionExtensionApi` object provides properties for action extensions that render in modal overlays. Access the following properties on the `ActionExtensionApi` object to interact with the current context and control the modal.',
       type: 'ActionExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -88,8 +88,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent:
-        '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.\n' +
-        "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [`Button`](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
+        '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.',
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following methods on the `BlockExtensionApi` object to interact with the current context and navigate to other extensions.',
+        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following properties on the `BlockExtensionApi` object to interact with the current context and navigate to other extensions.',
       type: 'BlockExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following properties on the `BlockExtensionApi` object to interact with the current context and navigate to other extensions.',
+        'The `BlockExtensionApi` object provides properties for block extensions that render inline content on admin pages. Access the following properties on the `BlockExtensionApi` object to interact with the current context and navigate to other extensions.',
       type: 'BlockExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'BlockExtensionApi',
+      title: 'Methods',
       description:
-        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following properties on the `BlockExtensionApi` object to interact with the current context and navigate to other extensions.',
+        'The `BlockExtensionApi` object provides methods for block extensions that render inline content on admin pages. Access the following methods on the `BlockExtensionApi` object to interact with the current context and navigate to other extensions.',
       type: 'BlockExtensionApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'CustomerSegmentTemplateApi',
+      title: 'Methods',
       description:
-        'The `CustomerSegmentTemplateApi` object includes tools for creating segment templates and translating content. Access the following properties on the `CustomerSegmentTemplateApi` object in the `admin.customers.segmentation-templates.render` target.',
+        'The `CustomerSegmentTemplateApi` object includes tools for creating segment templates and translating content. Access the following methods on the `CustomerSegmentTemplateApi` object in the `admin.customers.segmentation-templates.render` target.',
       type: 'CustomerSegmentTemplateApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/customer-segment-template/customer-segment-template.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `CustomerSegmentTemplateApi` object includes tools for creating segment templates and translating content. Access the following methods on the `CustomerSegmentTemplateApi` object in the `admin.customers.segmentation-templates.render` target.',
+        'The `CustomerSegmentTemplateApi` object includes tools for creating segment templates and translating content. Access the following properties on the `CustomerSegmentTemplateApi` object in the `admin.customers.segmentation-templates.render` target.',
       type: 'CustomerSegmentTemplateApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `ProductDetailsConfigurationApi` object provides access to product configuration data and methods. Access the following properties on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
+        'The `ProductDetailsConfigurationApi` object provides access to product configuration data. Access the following properties on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
       type: 'ProductDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ProductDetailsConfigurationApi` object provides access to product configuration data and methods. Access the following methods on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
+        'The `ProductDetailsConfigurationApi` object provides access to product configuration data and methods. Access the following properties on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
       type: 'ProductDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'ProductDetailsConfigurationApi',
+      title: 'Methods',
       description:
-        'The `ProductDetailsConfigurationApi` object provides access to product configuration data and methods. Access the following properties on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
+        'The `ProductDetailsConfigurationApi` object provides access to product configuration data and methods. Access the following methods on the `ProductDetailsConfigurationApi` object to interact with the current product context, navigate within the admin, and select resources in the `admin.product-details.configuration.render` target.',
       type: 'ProductDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data and methods. Access the following properties on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
+        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data. Access the following properties on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
       type: 'ProductVariantDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'ProductVariantDetailsConfigurationApi',
+      title: 'Methods',
       description:
-        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data and methods. Access the following properties on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
+        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data and methods. Access the following methods on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
       type: 'ProductVariantDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data and methods. Access the following methods on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
+        'The `ProductVariantDetailsConfigurationApi` object provides access to product variant configuration data and methods. Access the following properties on the `ProductVariantDetailsConfigurationApi` object to interact with the current product variant context, navigate within the admin, and select resources in the `admin.product-variant-details.configuration.render` target.',
       type: 'ProductVariantDetailsConfigurationApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -27,9 +27,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'Methods',
+      title: 'Properties',
       description:
-        'The `StandardApi` object provides core methods available to all extension targets. Access the following methods on the `StandardApi` object to identify your extension target, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, navigate to other admin pages, and handle intents from other extensions.',
+        'The `StandardApi` object provides core methods available to all extension targets. Access the following properties on the `StandardApi` object to identify your extension target, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, navigate to other admin pages, and handle intents from other extensions.',
       type: 'StandardApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -29,7 +29,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'The `StandardApi` object provides core methods available to all extension targets. Access the following properties on the `StandardApi` object to identify your extension target, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, navigate to other admin pages, and handle intents from other extensions.',
+        'The `StandardApi` object provides core properties available to all extension targets. Access the following properties on the `StandardApi` object to identify your extension target, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, navigate to other admin pages, and handle intents from other extensions.',
       type: 'StandardApi',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -27,9 +27,9 @@ const data: ReferenceEntityTemplateSchema = {
   },
   definitions: [
     {
-      title: 'StandardApi',
+      title: 'Methods',
       description:
-        'The `StandardApi` object provides core methods available to all extension targets. Access the following properties on the `StandardApi` object to identify your extension target, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, navigate to other admin pages, and handle intents from other extensions.',
+        'The `StandardApi` object provides core methods available to all extension targets. Access the following methods on the `StandardApi` object to identify your extension target, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, navigate to other admin pages, and handle intents from other extensions.',
       type: 'StandardApi',
     },
   ],


### PR DESCRIPTION
## This PR:
- Standardizes the API docs section headings for Admin UI to use "Properties" consistently
- Revises a few Admin UI API docs for clarity

> **Note**: 
> POS doesn't exist in this version.