### PR TITLE
Cherry-pick  to 2025-04

### DIFF
--- a/.changeset/cherry-pick-c0eefd7-e5706f74.md
+++ b/.changeset/cherry-pick-c0eefd7-e5706f74.md
@@ -1,0 +1,5 @@
+---
+"@shopify/ui-extensions": patch
+---
+
+update `Screen.onReceiveParams` with clarifying description.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/render/components/Screen/Screen.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/render/components/Screen/Screen.ts
@@ -62,7 +62,7 @@ export interface ScreenProps {
    */
   overrideNavigateBack?: () => void;
   /**
-   * A callback function triggered when the navigation event completes and the screen receives parameters passed during navigation.
+   * A callback function triggered when the navigation event completes with any passed parameters. Runs when screen is mounted (with `undefined`).
    */
   onReceiveParams?: (params: any) => void;
 }


### PR DESCRIPTION
Paired with, https://github.com/Shopify/ui-extensions/pull/3819
Cherry-pick of c0eefd76294e06687433c34e13e844fcfdd772d2 to 

**Original commit:** update  with clarifying description.
