### PR TITLE
chore: update all paths in build-docs scripts 2026-04-rc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -26,7 +26,7 @@ const generatedDocsPath = path.join(docsPath, 'generated');
 const shopifyDevPath = path.join(rootPath, '../../../shopify-dev');
 const shopifyDevDBPath = path.join(
   shopifyDevPath,
-  'db/data/docs/templated_apis',
+  'areas/platforms/shopify-dev/db/data/docs/templated_apis',
 );
 
 const shopifyDevExists = existsSync(shopifyDevPath);
@@ -511,7 +511,7 @@ try {
     path.join(docsPath, 'screenshots'),
     path.join(
       shopifyDevPath,
-      'content-v2/assets/images/templated-apis-screenshots/admin',
+      'areas/platforms/shopify-dev/content/assets/images/templated-apis-screenshots/admin',
     ),
     {recursive: true},
   );

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -99,21 +99,21 @@ fi
 copy_generated_docs_to_shopify_dev() {
 # Copy the generated docs to shopify-dev
 if [ -d $SHOPIFY_DEV_PATH ]; then
-  mkdir -p $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
-  cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
+  mkdir -p $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
+  cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
 
   # Replace 'latest' with the exact API version in relative doc links
   for file in generated_docs_data.json generated_static_pages.json; do
     run_sed \
       "s/\/docs\/api\/checkout-ui-extensions\/latest/\/docs\/api\/checkout-ui-extensions\/$API_VERSION/gi" \
-      "$SHOPIFY_DEV_PATH/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/$file"
+      "$SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/$file"
     sed_exit=$?
     if [ $sed_exit -ne 0 ]; then
       fail_and_exit $sed_exit
     fi
   done
 
-  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/content-v2/assets/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
+  rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/content/assets/images/templated-apis-screenshots/checkout-ui-extensions/$API_VERSION
   echo "Docs: https://shopify-dev.shop.dev/docs/api/checkout-ui-extensions"
 else
   echo "Not copying docs to shopify-dev because it was not found at $SHOPIFY_DEV_PATH."

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
@@ -25,7 +25,7 @@ const generatedDocsPath = path.join(docsPath, 'generated');
 const shopifyDevPath = path.join(rootPath, '../../../shopify-dev');
 const shopifyDevDBPath = path.join(
   shopifyDevPath,
-  'db/data/docs/templated_apis',
+  'areas/platforms/shopify-dev/db/data/docs/templated_apis',
 );
 
 const generatedDocsDataFile = 'generated_docs_data.json';
@@ -85,7 +85,7 @@ const generateExtensionsDocs = async () => {
     path.join(docsPath, 'screenshots'),
     path.join(
       shopifyDevPath,
-      'content-v2/assets/images/templated-apis-screenshots/customer-account-ui-extensions',
+      'areas/platforms/shopify-dev/content/assets/images/templated-apis-screenshots/customer-account-ui-extensions',
       EXTENSIONS_API_VERSION,
     ),
     {recursive: true},

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
@@ -33,7 +33,7 @@ const generatedDocsPath = path.join(docsPath, 'generated');
 const shopifyDevPath = await resolveShopifyDevPath(rootPath);
 const shopifyDevDBPath = path.join(
   shopifyDevPath,
-  'db/data/docs/templated_apis',
+  'areas/platforms/shopify-dev/db/data/docs/templated_apis',
 );
 
 const generatedDocsDataFile = 'generated_docs_data.json';
@@ -145,7 +145,7 @@ const generateExtensionsDocs = async () => {
     path.join(docsPath, 'screenshots'),
     path.join(
       shopifyDevPath,
-      'content-v2/assets/images/templated-apis-screenshots/pos-ui-extensions',
+      'areas/platforms/shopify-dev/content/assets/images/templated-apis-screenshots/pos-ui-extensions',
       EXTENSIONS_API_VERSION,
     ),
     {recursive: true},


### PR DESCRIPTION
### Background

Due to the [monorepo restructure](https://github.com/Shopify/shopify-dev/pull/67845) of shopify-dev, we need to update the paths in build-docs

### Solution

Updated paths for the new `areas/platforms/shopify-dev` directory
Updated images paths for the new `content/assets..` path, which serves images from the CDN.

### 🎩

- review changes

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
