### PR TITLE
[2026-01] Add deprecation warning to checkout metafield read API

### DIFF
--- a/.changeset/sixty-parrots-hunt.md
+++ b/.changeset/sixty-parrots-hunt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add deprecation warning to checkout metafield read API in Checkout UI Extensions

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,5 +60,12 @@ module.exports = {
         'promise/catch-or-return': 'off',
       },
     },
+    {
+      files: ['packages/ui-extensions/src/surfaces/checkout/preact/*.ts'],
+      rules: {
+        // Support use of deprecated hooks until removal
+        'import/no-deprecated': 'off',
+      },
+    },
   ],
 };

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/metafields.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/metafields.doc.ts
@@ -29,13 +29,14 @@ const data: ReferenceEntityTemplateSchema = {
     },
     {
       title: 'useMetafield',
-      description: 'Returns a single filtered `Metafield` or `undefined`.',
+      description:
+        'Returns a single filtered `Metafield` or `undefined`.\n > Caution: `useMetafield` is deprecated. Use `useAppMetafields` with cart metafields instead.',
       type: 'UseMetafieldGeneratedType',
     },
     {
       title: 'useMetafields',
       description:
-        'Returns the current array of `metafields` applied to the checkout. You can optionally filter the list.',
+        'Returns the current array of `metafields` applied to the checkout. You can optionally filter the list.\n > Caution: `useMetafields` is deprecated. Use `useAppMetafields` with cart metafields instead.',
       type: 'UseMetafieldsGeneratedType',
     },
     {

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
@@ -102,6 +102,11 @@ export interface AddressAutocompleteStandardApi<
    *
    * Once the order is created, you can query these metafields using the
    * [GraphQL Admin API](https://shopify.dev/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)
+   *
+   * > Caution:
+   * `metafields` is deprecated. Use `appMetafields` with cart metafields instead.
+   *
+   * @deprecated Use `appMetafields` with cart metafields instead.
    */
   metafields: Metafield[];
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -641,8 +641,10 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * Once the order is created, you can query these metafields using the
    * [GraphQL Admin API](https://shopify.dev/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)
    *
-   * > Tip:
-   * > Cart metafields are only available on carts created via the Storefront API version `2023-04` or later.
+   * > Caution:
+   * `metafields` is deprecated. Use `appMetafields` with cart metafields instead.
+   *
+   * @deprecated Use `appMetafields` with cart metafields instead.
    */
   metafields: SubscribableSignalLike<Metafield[]>;
 

--- a/packages/ui-extensions/src/surfaces/checkout/preact/metafield.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/preact/metafield.ts
@@ -11,6 +11,7 @@ interface MetafieldFilter {
 /**
  * Returns a single filtered `Metafield` or `undefined`.
  * @arg {MetafieldFilter} - filter the list of returned metafields to a single metafield
+ * @deprecated `useMetafield` is deprecated. Use `useAppMetafields` with cart metafields instead.
  */
 export function useMetafield(filters: MetafieldFilter): Metafield | undefined {
   const {namespace, key} = filters;

--- a/packages/ui-extensions/src/surfaces/checkout/preact/metafields.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/preact/metafields.ts
@@ -20,6 +20,7 @@ interface MetafieldsFilters {
  * Returns the current array of `metafields` applied to the checkout.
  * You can optionally filter the list.
  * @arg {MetafieldsFilters} - filter the list of returned metafields
+ * @deprecated `useMetafields` is deprecated. Use `useAppMetafields` with cart metafields instead.
  */
 export function useMetafields<
   Target extends RenderExtensionTarget = RenderExtensionTarget,


### PR DESCRIPTION
### Background

Add `@deprecated` warning to checkout metafield read API for `2026-01`.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
