### PR TITLE
[2025-04] Fix relative paths in `purchase-options-card-action` doc

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.ts
@@ -16,12 +16,12 @@ const data: ReferenceEntityTemplateSchema = {
       tabs: [
         {
           title: 'React',
-          code: './purchase-options-card/examples/manage-subscription.tsx',
+          code: '../purchase-options-card/examples/manage-subscription.tsx',
           language: 'tsx',
         },
         {
           title: 'TS',
-          code: './purchase-options-card/examples/manage-subscription.ts',
+          code: '../purchase-options-card/examples/manage-subscription.ts',
           language: 'ts',
         },
       ],
@@ -46,12 +46,12 @@ const data: ReferenceEntityTemplateSchema = {
           tabs: [
             {
               title: 'React',
-              code: './purchase-options-card/examples/remove-from-plan.tsx',
+              code: '../purchase-options-card/examples/remove-from-plan.tsx',
               language: 'tsx',
             },
             {
               title: 'TS',
-              code: './purchase-options-card/examples/remove-from-plan.ts',
+              code: '../purchase-options-card/examples/remove-from-plan.ts',
               language: 'ts',
             },
           ],
@@ -65,12 +65,12 @@ const data: ReferenceEntityTemplateSchema = {
           tabs: [
             {
               title: 'React',
-              code: './purchase-options-card/examples/validate-selling-plan.tsx',
+              code: '../purchase-options-card/examples/validate-selling-plan.tsx',
               language: 'tsx',
             },
             {
               title: 'TS',
-              code: './purchase-options-card/examples/validate-selling-plan.ts',
+              code: '../purchase-options-card/examples/validate-selling-plan.ts',
               language: 'ts',
             },
           ],


### PR DESCRIPTION
## This PR: 
- Fixes some relative paths in Admin UI extensions version 2025-04 that were causing rendering issues in the dev docs:

```
Error: Unable to find code file, './purchase-options-card/examples/manage-subscription.tsx', in the doc file: 'src/surfaces/admin/api/purchase-options-card-action/purchase-options-card-action.doc.js'.
    at /Users/michellevinci/src/github.com/Shopify/ui-extensions/node_modules/@shopify/generate-docs/dist/generate-docs/src/assembler/contentModifications/createCodeTabs.js19
    at Array.map (<anonymous>)
    at createCodeTabs (/Users/michellevinci/src/github.com/Shopify/ui-extensions/node_modules/@shopify/generate-docs/dist/generate-docs/src/assembler/contentModifications/createCodeTabs.js:33:71)
    at addExamplesToDocs (/Users/michellevinci/src/github.com/Shopify/ui-extensions/node_modules/@shopify/generate-docs/dist/generate-docs/src/assembler/docModifications/addExamplesToDocs.js58)
    at /Users/michellevinci/src/github.com/Shopify/ui-extensions/node_modules/@shopify/generate-docs/dist/generate-docs/src/assembler/docModifications/addGeneratedContentToDocs.js51
    at Array.forEach (<anonymous>)
    at addGeneratedContentToDocs (/Users/michellevinci/src/github.com/Shopify/ui-extensions/node_modules/@shopify/generate-docs/dist/generate-docs/src/assembler/docModifications/addGeneratedContentToDocs.js:8:18)
    at parseDocFiles (/Users/michellevinci/src/github.com/Shopify/ui-extensions/node_modules/@shopify/generate-docs/dist/generate-docs/src/assembler/assembler.js63)
    at async Promise.all (index 1
```