### PR TITLE
handle ActionTargetAPi

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* eslint-disable no-console */
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
@@ -56,7 +58,7 @@ function parseComponentTypesFromFiles() {
     path.join(basePath, 'SmartGridComponents.ts'),
   );
   if (smartGridComponents) {
-    componentTypesMap['SmartGridComponents'] = smartGridComponents;
+    componentTypesMap.SmartGridComponents = smartGridComponents;
   }
 
   // Parse ActionExtensionComponents
@@ -64,7 +66,7 @@ function parseComponentTypesFromFiles() {
     path.join(basePath, 'ActionExtensionComponents.ts'),
   );
   if (actionComponents) {
-    componentTypesMap['ActionExtensionComponents'] = actionComponents;
+    componentTypesMap.ActionExtensionComponents = actionComponents;
   }
 
   // Parse BlockExtensionComponents
@@ -72,7 +74,7 @@ function parseComponentTypesFromFiles() {
     path.join(basePath, 'BlockExtensionComponents.ts'),
   );
   if (blockComponents) {
-    componentTypesMap['BlockExtensionComponents'] = blockComponents;
+    componentTypesMap.BlockExtensionComponents = blockComponents;
   }
 
   // Parse ReceiptComponents
@@ -80,7 +82,7 @@ function parseComponentTypesFromFiles() {
     path.join(basePath, 'ReceiptComponents.ts'),
   );
   if (receiptComponents) {
-    componentTypesMap['ReceiptComponents'] = receiptComponents;
+    componentTypesMap.ReceiptComponents = receiptComponents;
   }
 
   // Parse StandardComponents (for BasicComponents which excludes 'Tile')
@@ -88,10 +90,10 @@ function parseComponentTypesFromFiles() {
     path.join(basePath, 'StandardComponents.ts'),
   );
   if (standardComponents) {
-    componentTypesMap['StandardComponents'] = standardComponents;
+    componentTypesMap.StandardComponents = standardComponents;
     // BasicComponents = Exclude<StandardComponents, 'Tile'>
-    componentTypesMap['BasicComponents'] = standardComponents.filter(
-      (c) => c !== 'Tile',
+    componentTypesMap.BasicComponents = standardComponents.filter(
+      (component) => component !== 'Tile',
     );
     // Update global allComponents
     allComponents = standardComponents.sort();
@@ -186,7 +188,7 @@ function parseTargetsFile() {
 
 function getNestedApis(apiName) {
   // Check if we've already parsed this API
-  if (apiDefinitionsCache.hasOwnProperty(apiName)) {
+  if (Object.prototype.hasOwnProperty.call(apiDefinitionsCache, apiName)) {
     return apiDefinitionsCache[apiName];
   }
 
@@ -305,7 +307,7 @@ function getNestedApis(apiName) {
     }
 
     // Find the end position (semicolon at the correct nesting level)
-    let startPos = startMatch.index + startMatch[0].length;
+    const startPos = startMatch.index + startMatch[0].length;
     let endPos = startPos;
     let braceDepth = 0;
     let angleDepth = 0;
@@ -346,19 +348,22 @@ function getNestedApis(apiName) {
   }
 }
 
+// APIs that are composites of other documented APIs - we list their constituent APIs, not these wrapper types
+const COMPOSITE_APIS = new Set(['StandardApi', 'ActionTargetApi']);
+
 function parseApis(apiString) {
   const apisSet = new Set();
 
   // Remove any comments
-  apiString = apiString
+  const cleanedApiString = apiString
     .replace(/\/\/[^\n]*/g, '')
     .replace(/\/\*[\s\S]*?\*\//g, '');
 
   // Split by & and extract API names
-  const parts = apiString
+  const parts = cleanedApiString
     .split('&')
-    .map((s) => s.trim())
-    .filter((s) => s);
+    .map((part) => part.trim())
+    .filter((part) => part);
 
   for (const part of parts) {
     // Match StandardApi<'...'> or just ApiName
@@ -375,16 +380,24 @@ function parseApis(apiString) {
     }
 
     if (apiName) {
-      // Add the API itself
-      apisSet.add(apiName);
+      if (!COMPOSITE_APIS.has(apiName)) {
+        apisSet.add(apiName);
+      }
 
-      // Get nested APIs from this API (recursively)
       const nestedApis = getNestedApis(apiName);
       for (const nestedApi of nestedApis) {
-        apisSet.add(nestedApi);
-        // Recursively get nested APIs of nested APIs
-        const deepNestedApis = getNestedApis(nestedApi);
-        deepNestedApis.forEach((api) => apisSet.add(api));
+        if (COMPOSITE_APIS.has(nestedApi)) {
+          const deepNestedApis = getNestedApis(nestedApi);
+          deepNestedApis.forEach((api) => {
+            if (!COMPOSITE_APIS.has(api)) apisSet.add(api);
+          });
+        } else {
+          apisSet.add(nestedApi);
+          const deepNestedApis = getNestedApis(nestedApi);
+          deepNestedApis.forEach((api) => {
+            if (!COMPOSITE_APIS.has(api)) apisSet.add(api);
+          });
+        }
       }
     }
   }
@@ -394,11 +407,11 @@ function parseApis(apiString) {
 
 function parseComponents(componentString, componentTypesMap) {
   // Remove whitespace and newlines
-  componentString = componentString.replace(/\s+/g, ' ').trim();
+  const cleanedComponentString = componentString.replace(/\s+/g, ' ').trim();
 
   // Check if it directly references one of our parsed component types
   for (const [typeName, components] of Object.entries(componentTypesMap)) {
-    if (componentString.includes(typeName)) {
+    if (cleanedComponentString.includes(typeName)) {
       return components;
     }
   }
@@ -466,3 +479,4 @@ if (!fs.existsSync(outputDir)) {
   fs.mkdirSync(outputDir, {recursive: true});
 }
 fs.writeFileSync(outputPath, JSON.stringify(extendedJson, null, 2));
+console.log('✅ Generated targets.json at:', outputPath);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
@@ -81,7 +81,7 @@ process.on('exit', () => {
     if (existsSync(tempComponentDefs)) {
       require('fs').unlinkSync(tempComponentDefs);
     }
-  } catch (e) {
+  } catch (cleanupError) {
     // Ignore cleanup errors on exit
   }
 });
@@ -162,20 +162,28 @@ try {
     replaceValue: 'any',
   });
   await generateExtensionsDocs();
-  
-  // Generate targets.json
+
+  // Generate targets.json (script logs output path)
   console.log('Generating targets.json...');
   try {
     const {execSync} = await import('child_process');
-    execSync(`node ${path.join(docsPath, 'build-docs-targets-json.mjs')} ${EXTENSIONS_API_VERSION}`, {
-      stdio: 'inherit',
-      cwd: rootPath,
-    });
-    console.log('✅ Generated targets.json');
+    execSync(
+      `node ${path.join(
+        docsPath,
+        'build-docs-targets-json.mjs',
+      )} ${EXTENSIONS_API_VERSION}`,
+      {
+        stdio: 'inherit',
+        cwd: rootPath,
+      },
+    );
   } catch (targetsError) {
-    console.warn('Warning: Failed to generate targets.json:', targetsError.message);
+    console.warn(
+      'Warning: Failed to generate targets.json:',
+      targetsError.message,
+    );
   }
-  
+
   await copyGeneratedToShopifyDev({
     generatedDocsPath,
     shopifyDevPath,


### PR DESCRIPTION

### Background

<!-- Link to relevant issue(s) if any -->

**TL;DR:** For POS docs, `ActionTargetApi` and `StandardApi` were showing up in the generated targets API list even though they’re composite types made from other APIs we document (e.g. CartApi, ScannerApi, NavigationApi). We only want to list those constituent APIs in the docs, not the wrapper types—same idea as how StandardAPI is handled elsewhere.

### Solution

- **Composite API filtering**  
  In `build-docs-targets-json.mjs`, we treat `StandardApi` and `ActionTargetApi` as composite APIs: we never add them to the per-target `apis` array or to the API reverse mappings. We still expand them (via `getNestedApis`) so their constituent APIs are included. That keeps the POS targets JSON in line with the APIs we actually document.

- **Output path logging**  
  The targets script now logs the full path where `targets.json` is written (e.g. when you run `yarn docs:point-of-sale 2025-07`), so it’s obvious where the file was generated.

### 🎩

- [ ] Run `yarn docs:point-of-sale <API_VERSION>` (e.g. `2025-07`) and confirm the printed path is correct and `targets.json` is written there.
- [ ] Open the generated `targets.json` and confirm no target has `ActionTargetApi` or `StandardApi` in its `apis` array; only concrete APIs (CartApi, ScannerApi, etc.) appear.
- [ ] Confirm the API reverse-mapping section of the JSON has no `ActionTargetApi` or `StandardApi` keys.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation

