### PR TITLE
Exclude ActionTargetApi and StandardApi from POS targets JSON

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
@@ -451,6 +451,9 @@ function getNestedApis(apiName) {
   }
 }
 
+// APIs that are composites of other documented APIs - we list their constituent APIs, not these wrapper types
+const COMPOSITE_APIS = new Set(['StandardApi', 'ActionTargetApi']);
+
 function parseApis(apiString) {
   const apisSet = new Set();
 
@@ -480,16 +483,24 @@ function parseApis(apiString) {
     }
 
     if (apiName) {
-      // Add the API itself
-      apisSet.add(apiName);
+      if (!COMPOSITE_APIS.has(apiName)) {
+        apisSet.add(apiName);
+      }
 
-      // Get nested APIs from this API (recursively)
       const nestedApis = getNestedApis(apiName);
       for (const nestedApi of nestedApis) {
-        apisSet.add(nestedApi);
-        // Recursively get nested APIs of nested APIs
-        const deepNestedApis = getNestedApis(nestedApi);
-        deepNestedApis.forEach((api) => apisSet.add(api));
+        if (COMPOSITE_APIS.has(nestedApi)) {
+          const deepNestedApis = getNestedApis(nestedApi);
+          deepNestedApis.forEach((api) => {
+            if (!COMPOSITE_APIS.has(api)) apisSet.add(api);
+          });
+        } else {
+          apisSet.add(nestedApi);
+          const deepNestedApis = getNestedApis(nestedApi);
+          deepNestedApis.forEach((api) => {
+            if (!COMPOSITE_APIS.has(api)) apisSet.add(api);
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
### Background

<!-- Link to relevant issue(s) if any -->

**TL;DR:** For POS docs, `ActionTargetApi` and `StandardApi` were showing up in the generated targets API list even though they’re composite types made from other APIs we document (e.g. CartApi, ScannerApi, NavigationApi). We only want to list those constituent APIs in the docs, not the wrapper types—same idea as how StandardAPI is handled elsewhere.

### Solution

- **Composite API filtering**  
  In `build-docs-targets-json.mjs`, we treat `StandardApi` and `ActionTargetApi` as composite APIs: we never add them to the per-target `apis` array or to the API reverse mappings. We still expand them (via `getNestedApis`) so their constituent APIs are included. That keeps the POS targets JSON in line with the APIs we actually document.

- **Output path logging**  
  The targets script now logs the full path where `targets.json` is written (e.g. when you run `yarn docs:point-of-sale 2024-07`), so it’s obvious where the file was generated.

### 🎩

- [ ] Run `yarn docs:point-of-sale <API_VERSION>` (e.g. `2024-07`) and confirm the printed path is correct and `targets.json` is written there.
- [ ] Open the generated `targets.json` and confirm no target has `ActionTargetApi` or `StandardApi` in its `apis` array; only concrete APIs (CartApi, ScannerApi, etc.) appear.
- [ ] Confirm the API reverse-mapping section of the JSON has no `ActionTargetApi` or `StandardApi` keys.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation

