### PR TITLE
[Components content]: Examples for 2025-07

### DIFF
--- a/packages/ui-extensions-react/src/surfaces/admin/components/AdminAction/examples/adminaction-form.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/AdminAction/examples/adminaction-form.example.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {reactExtension, useApi, AdminAction, Button, TextField, Select, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+
+  return (
+    <AdminAction
+      title="Assign warehouse location"
+      primaryAction={
+        <Button
+          onPress={async () => {
+            await fetch('/api/products/assign-warehouse', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId}),
+            });
+            close();
+          }}
+        >
+          Assign to warehouse
+        </Button>
+      }
+      secondaryAction={
+        <Button onPress={() => close()}>Cancel</Button>
+      }
+    >
+      <BlockStack gap>
+        <TextField label="Warehouse SKU" name="warehouseSku" required />
+        <Select
+          label="Target warehouse"
+          name="warehouse"
+          options={[
+            {label: 'East Coast — New York', value: 'nyc'},
+            {label: 'West Coast — Los Angeles', value: 'lax'},
+            {label: 'Central — Chicago', value: 'chi'},
+          ]}
+        />
+      </BlockStack>
+    </AdminAction>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/AdminAction/examples/adminaction-loading.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/AdminAction/examples/adminaction-loading.example.tsx
@@ -1,0 +1,48 @@
+import React, {useState, useEffect} from 'react';
+import {reactExtension, useApi, AdminAction, Button, Text, ProgressIndicator, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close, query} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [product, setProduct] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    query(
+      `query Product($id: ID!) {
+        product(id: $id) { title status totalInventory }
+      }`,
+      {variables: {id: productId}},
+    ).then((result) => {
+      setProduct(result?.data?.product);
+      setLoading(false);
+    });
+  }, [productId, query]);
+
+  return (
+    <AdminAction
+      title="Product details"
+      primaryAction={<Button onPress={() => close()}>Done</Button>}
+    >
+      <BlockStack gap>
+        {loading ? (
+          <ProgressIndicator
+            size="small-200"
+            accessibilityLabel="Loading product details"
+          />
+        ) : product ? (
+          <>
+            <Text fontWeight="bold">{product.title}</Text>
+            <Text>Status: {product.status}</Text>
+            <Text>Inventory: {product.totalInventory} units</Text>
+          </>
+        ) : null}
+      </BlockStack>
+    </AdminAction>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/AdminAction/examples/basic-adminaction.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/AdminAction/examples/basic-adminaction.example.tsx
@@ -1,30 +1,41 @@
-import React from 'react';
-import {
-  reactExtension,
-  AdminAction,
-  Button,
-  Text,
-} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, AdminAction, Button, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+
   return (
     <AdminAction
-      title="My App Action"
+      title="Sync to warehouse"
       primaryAction={
-        <Button onPress={() => {}}>Action</Button>
-      }
-      secondaryAction={
-        <Button onPress={() => {}}>
-          Secondary
+        <Button
+          onPress={async () => {
+            await fetch('/api/products/sync', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId}),
+            });
+            close();
+          }}
+        >
+          Sync product
         </Button>
       }
+      secondaryAction={
+        <Button onPress={() => close()}>Cancel</Button>
+      }
     >
-      <Text>Modal content</Text>
+      <BlockStack gap>
+        <Text>
+          Sync product {productId} to your warehouse management system. This
+          will update inventory counts, pricing, and metadata.
+        </Text>
+      </BlockStack>
     </AdminAction>
   );
 }
 
 export default reactExtension(
-  'Playground',
+  'admin.product-details.action.render',
   () => <App />,
 );

--- a/packages/ui-extensions-react/src/surfaces/admin/components/AdminBlock/examples/adminblock-data.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/AdminBlock/examples/adminblock-data.example.tsx
@@ -1,0 +1,42 @@
+import React, {useState, useEffect} from 'react';
+import {reactExtension, useApi, AdminBlock, Text, ProgressIndicator, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, query} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const [product, setProduct] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    query(
+      `query Product($id: ID!) {
+        product(id: $id) { title totalInventory totalVariants }
+      }`,
+      {variables: {id: productId}},
+    ).then((result) => {
+      setProduct(result?.data?.product);
+      setLoading(false);
+    });
+  }, [productId, query]);
+
+  return (
+    <AdminBlock title="Product analytics">
+      <BlockStack gap>
+        {loading ? (
+          <ProgressIndicator size="small-200" accessibilityLabel="Loading analytics" />
+        ) : product ? (
+          <>
+            <Text fontWeight="bold">{product.title}</Text>
+            <Text>Variants: {product.totalVariants}</Text>
+            <Text>Total inventory: {product.totalInventory}</Text>
+          </>
+        ) : null}
+      </BlockStack>
+    </AdminBlock>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/AdminBlock/examples/adminblock-sections.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/AdminBlock/examples/adminblock-sections.example.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {reactExtension, AdminBlock, Section, Text, Divider, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <AdminBlock title="Product specifications">
+      <BlockStack gap>
+        <Section heading="Compliance">
+          <Text>CE Marking — Approved</Text>
+          <Text>EU distribution cleared</Text>
+        </Section>
+        <Divider />
+        <Section heading="Shipping">
+          <Text>Weight: 2.5 kg</Text>
+          <Text>Dimensions: 30 × 20 × 15 cm</Text>
+        </Section>
+      </BlockStack>
+    </AdminBlock>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/AdminBlock/examples/basic-adminblock.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/AdminBlock/examples/basic-adminblock.example.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
-import {reactExtension, AdminBlock} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, AdminBlock, Text, Badge, InlineStack, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+
   return (
-    <AdminBlock title="My App Block">
-      Block content
+    <AdminBlock title="Warehouse integration">
+      <BlockStack gap>
+        <InlineStack gap>
+          <Text>Sync status:</Text>
+          <Badge tone="success">Connected</Badge>
+        </InlineStack>
+        <Text>Last synced 5 minutes ago</Text>
+        <Text>Warehouse inventory: 247 units across 3 locations</Text>
+      </BlockStack>
     </AdminBlock>
   );
 }
 
-export default reactExtension('Playground', () => <App />);
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/AdminPrintAction/examples/adminprintaction-invoice.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/AdminPrintAction/examples/adminprintaction-invoice.example.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {reactExtension, useApi, AdminPrintAction, Text, ProgressIndicator, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+
+  return (
+    <AdminPrintAction
+      src={`https://your-app.com/print/invoice?product=${productId}&type=wholesale`}
+    >
+      <BlockStack gap>
+        <ProgressIndicator size="small-200" accessibilityLabel="Generating invoice" />
+        <Text>
+          Generating wholesale invoice with pricing and tax details...
+        </Text>
+      </BlockStack>
+    </AdminPrintAction>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/AdminPrintAction/examples/adminprintaction-label.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/AdminPrintAction/examples/adminprintaction-label.example.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {reactExtension, useApi, AdminPrintAction, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const numericId = productId?.split('/').pop();
+
+  return (
+    <AdminPrintAction
+      src={`https://your-app.com/print/shipping-label?product=${numericId}&format=4x6`}
+    >
+      <BlockStack gap>
+        <Text>Preparing shipping label with warehouse barcode...</Text>
+      </BlockStack>
+    </AdminPrintAction>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/AdminPrintAction/examples/basic-adminprintaction.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/AdminPrintAction/examples/basic-adminprintaction.example.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
-import {
-  reactExtension,
-  AdminPrintAction,
-  Text,
-} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, AdminPrintAction, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+
   return (
-    <AdminPrintAction src="https://example.com">
-      <Text>Modal content</Text>
+    <AdminPrintAction
+      src={`https://your-app.com/print/packing-slip?product=${productId}`}
+    >
+      <BlockStack gap>
+        <Text>Generating packing slip for this product...</Text>
+      </BlockStack>
     </AdminPrintAction>
   );
 }
 
 export default reactExtension(
-  'Playground',
+  'admin.product-details.action.render',
   () => <App />,
 );

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Badge/examples/badge-icons.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Badge/examples/badge-icons.example.tsx
@@ -1,0 +1,18 @@
+import {reactExtension, Badge, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Inventory alerts</Text>
+      <Badge tone="success" icon="CircleTickMajor">In stock</Badge>
+      <Badge tone="warning" icon="DiamondAlertMajor">Low stock</Badge>
+      <Badge tone="critical" icon="DiamondAlertMajor">Out of stock</Badge>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Badge/examples/badge-sizes.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Badge/examples/badge-sizes.example.tsx
@@ -1,0 +1,20 @@
+import {reactExtension, Badge, InlineStack, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Sales channels</Text>
+      <InlineStack>
+        <Badge size="small-100" tone="success">Online Store</Badge>
+        <Badge size="small-100" tone="success">POS</Badge>
+        <Badge size="small-100" tone="info">Facebook — pending</Badge>
+      </InlineStack>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Badge/examples/basic-badge.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Badge/examples/basic-badge.example.tsx
@@ -1,13 +1,18 @@
-import {render, Badge} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {reactExtension, Badge, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+
   return (
-    <Badge
-      tone="info"
-    >
-      Fulfilled
-    </Badge>
+    <BlockStack>
+      <Text fontWeight="bold">Order status:</Text>
+      <Badge tone="success">Fulfilled</Badge>
+      <Badge tone="warning">Partially fulfilled</Badge>
+      <Badge tone="critical">Unfulfilled</Badge>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Banner/examples/banner-success.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Banner/examples/banner-success.example.tsx
@@ -1,0 +1,29 @@
+import {useState} from 'react';
+import {reactExtension, useApi, Banner, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const [visible, setVisible] = useState(true);
+
+  if (!visible) return null;
+
+  return (
+    <BlockStack>
+      <Banner
+        title="Product updated successfully"
+        tone="success"
+        dismissible
+        onDismiss={() => setVisible(false)}
+      >
+        Tags and metafields for product {productId} have been synced to your
+        external catalog.
+      </Banner>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Banner/examples/banner-warning.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Banner/examples/banner-warning.example.tsx
@@ -1,0 +1,26 @@
+import {reactExtension, useApi, Banner, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {close} = useApi('admin.product-details.action.render');
+
+  return (
+    <BlockStack>
+      <Banner
+        title="Missing required fields"
+        tone="warning"
+        secondaryAction={
+          <Button onPress={() => close()}>Dismiss</Button>
+        }
+      >
+        The product is missing a weight and shipping dimensions. These fields
+        are required by your fulfillment provider before orders can be
+        processed.
+      </Banner>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Banner/examples/basic-banner.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Banner/examples/basic-banner.example.tsx
@@ -1,16 +1,42 @@
-import React from 'react';
-import {
-  render,
-  Banner,
-  Paragraph,
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, Banner, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const [visible, setVisible] = useState(true);
+
+  if (!visible) return null;
+
   return (
-    <Banner title="Shipping rates changed" dismissible onDismiss={() => console.log('dismissed banner')}>
-      <Paragraph>Your store may be affected</Paragraph>
-    </Banner>
+    <BlockStack>
+      <Banner
+        title="Product sync failed"
+        tone="critical"
+        dismissible
+        onDismiss={() => setVisible(false)}
+        primaryAction={
+          <Button
+            onPress={async () => {
+              await fetch('/api/products/sync', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({productId}),
+              });
+            }}
+          >
+            Retry sync
+          </Button>
+        }
+      >
+        The last sync attempt could not reach your warehouse system. Check your
+        API credentials and try again.
+      </Banner>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/BlockStack/examples/basic-blockstack.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/BlockStack/examples/basic-blockstack.example.tsx
@@ -1,18 +1,20 @@
-import React from 'react';
-import {
-  render,
-  BlockStack,
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {reactExtension, BlockStack, Text, Button} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+
   return (
     <BlockStack gap>
-      <>Child 1</>
-      <>Child 2</>
-      <>Child 3</>
-      <>Child 4</>
+      <Text fontWeight="bold">Warehouse sync</Text>
+      <Text>Last synced 10 minutes ago</Text>
+      <Text>12 variants, 3 locations updated</Text>
+      <Button variant="secondary" onPress={() => console.log('Viewing sync log')}>
+        View sync log
+      </Button>
     </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/BlockStack/examples/blockstack-alignment.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/BlockStack/examples/blockstack-alignment.example.tsx
@@ -1,0 +1,20 @@
+import {reactExtension, BlockStack, Text, Badge, InlineStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack gap inlineAlignment="center">
+      <Text fontWeight="bold">Integration status</Text>
+      <InlineStack gap>
+        <Badge tone="success">Connected</Badge>
+        <Badge tone="info">Auto-sync on</Badge>
+      </InlineStack>
+      <Text>247 products synced</Text>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/BlockStack/examples/blockstack-padding.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/BlockStack/examples/blockstack-padding.example.tsx
@@ -1,0 +1,24 @@
+import {reactExtension, BlockStack, Text, Heading, Divider} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack gap padding="base">
+      <Heading>Product compliance</Heading>
+      <BlockStack gap paddingBlock="base">
+        <Text fontWeight="bold">Safety rating</Text>
+        <Text>UL Listed — Class II</Text>
+      </BlockStack>
+      <Divider />
+      <BlockStack gap paddingBlock="base">
+        <Text fontWeight="bold">Certifications</Text>
+        <Text>CE, FCC, RoHS compliant</Text>
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Box/examples/basic-box.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Box/examples/basic-box.example.tsx
@@ -1,11 +1,20 @@
-import {render, Box} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {reactExtension, Box, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+
   return (
-    <Box padding="base">
-      Box
-    </Box>
+    <BlockStack gap>
+      <Text fontWeight="bold">Warehouse slot</Text>
+      <Box padding="base">
+        <Text fontWeight="bold">Slot A-42</Text>
+        <Text>Aisle A, Rack 4, Shelf 2</Text>
+        <Text>24 units stored</Text>
+      </Box>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Box/examples/box-display.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Box/examples/box-display.example.tsx
@@ -1,0 +1,21 @@
+import {reactExtension, Box, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack gap>
+      <Text fontWeight="bold">Compliance status</Text>
+      <Box display="auto" padding="base">
+        <Text>This product has been reviewed and approved for sale.</Text>
+      </Box>
+      <Box display="none" accessibilityRole="status">
+        <Text>Compliance check passed — accessible to screen readers only.</Text>
+      </Box>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Box/examples/box-sizing.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Box/examples/box-sizing.example.tsx
@@ -1,0 +1,27 @@
+import {reactExtension, Box, Image, Text, InlineStack, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack gap>
+      <InlineStack gap>
+        <Box inlineSize={80} blockSize={80}>
+          <Image
+            source="https://cdn.shopify.com/s/files/placeholder-images/product.png"
+            accessibilityLabel="Product thumbnail"
+          />
+        </Box>
+        <Box>
+          <Text fontWeight="bold">Premium Widget</Text>
+          <Text>SKU: WH-1234</Text>
+          <Text>$49.99</Text>
+        </Box>
+      </InlineStack>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Button/examples/basic-button.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Button/examples/basic-button.example.tsx
@@ -1,15 +1,33 @@
-import {render, Button} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {reactExtension, useApi, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+
   return (
-    <Button
-      onPress={() => {
-        console.log('onPress event');
-      }}
-    >
-      Click here
-    </Button>
+    <BlockStack>
+      <Text>Product: {productId}</Text>
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/sync', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId}),
+          });
+          close();
+        }}
+      >
+        Sync to warehouse
+      </Button>
+      <Button variant="secondary" onPress={() => close()}>
+        Cancel
+      </Button>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Button/examples/button-link.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Button/examples/button-link.example.tsx
@@ -1,0 +1,33 @@
+import {reactExtension, useApi, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const numericId = productId?.split('/').pop();
+
+  return (
+    <BlockStack>
+      <Text>External resources</Text>
+      <Button
+        href={`https://your-store.myshopify.com/products/${numericId}`}
+        target="_blank"
+        variant="secondary"
+        accessibilityLabel="View product on storefront in a new tab"
+      >
+        View on storefront
+      </Button>
+      <Button
+        href="https://help.shopify.com/manual/products"
+        target="_blank"
+        variant="tertiary"
+      >
+        Product documentation
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Button/examples/button-variants.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Button/examples/button-variants.example.tsx
@@ -1,0 +1,44 @@
+import {reactExtension, useApi, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+
+  return (
+    <BlockStack>
+      <Text>Choose an action for this product:</Text>
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch(`/api/products/${productId}/publish`, {method: 'POST'});
+          close();
+        }}
+      >
+        Publish product
+      </Button>
+      <Button
+        variant="tertiary"
+        onPress={async () => {
+          await fetch(`/api/products/${productId}/archive`, {method: 'POST'});
+          close();
+        }}
+      >
+        Archive product
+      </Button>
+      <Button
+        tone="critical"
+        onPress={async () => {
+          await fetch(`/api/products/${productId}`, {method: 'DELETE'});
+          close();
+        }}
+      >
+        Delete product
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Checkbox/examples/basic-checkbox.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Checkbox/examples/basic-checkbox.example.tsx
@@ -1,11 +1,36 @@
-import {render, Checkbox} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, Checkbox, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [syncEnabled, setSyncEnabled] = useState(false);
+
   return (
-    <Checkbox id="checkbox" name="checkbox">
-      Save this information for next time
-    </Checkbox>
+    <BlockStack>
+      <Checkbox
+        label="Enable automatic inventory sync"
+        checked={syncEnabled}
+        onChange={setSyncEnabled}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/sync-settings', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, syncEnabled}),
+          });
+          close();
+        }}
+      >
+        Save settings
+      </Button>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Checkbox/examples/checkbox-error.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Checkbox/examples/checkbox-error.example.tsx
@@ -1,0 +1,41 @@
+import {useState} from 'react';
+import {reactExtension, useApi, Checkbox, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {close} = useApi('admin.product-details.action.render');
+  const [agreed, setAgreed] = useState(false);
+  const [error, setError] = useState(undefined);
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Terms of service</Text>
+      <Checkbox
+        label="I agree to the fulfillment provider terms of service"
+        checked={agreed}
+        error={error}
+        onChange={(value) => {
+          setAgreed(value);
+          setError(undefined);
+        }}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          if (!agreed) {
+            setError('You must agree to the terms before connecting');
+            return;
+          }
+          await fetch('/api/fulfillment/connect', {method: 'POST'});
+          close();
+        }}
+      >
+        Connect provider
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Checkbox/examples/checkbox-multiple.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Checkbox/examples/checkbox-multiple.example.tsx
@@ -1,0 +1,51 @@
+import {useState} from 'react';
+import {reactExtension, useApi, Checkbox, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [channels, setChannels] = useState({
+    online: true,
+    pos: false,
+    wholesale: false,
+  });
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Publish to channels</Text>
+      <Checkbox
+        label="Online Store"
+        checked={channels.online}
+        onChange={(value) => setChannels({...channels, online: value})}
+      />
+      <Checkbox
+        label="Point of Sale"
+        checked={channels.pos}
+        onChange={(value) => setChannels({...channels, pos: value})}
+      />
+      <Checkbox
+        label="Wholesale"
+        checked={channels.wholesale}
+        onChange={(value) => setChannels({...channels, wholesale: value})}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/channels', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, channels}),
+          });
+          close();
+        }}
+      >
+        Update channels
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/ChoiceList/examples/basic-choicelist.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/ChoiceList/examples/basic-choicelist.example.tsx
@@ -1,16 +1,41 @@
-import {render, ChoiceList} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, ChoiceList, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [shippingMethod, setShippingMethod] = useState('standard');
+
   return (
-    <ChoiceList
-      name="Company name"
-      choices={[
-        {label: 'Hidden', id: '1'},
-        {label: 'Optional', id: '2'},
-        {label: 'Required', id: '3'},
-      ]}
-    />
+    <BlockStack>
+      <ChoiceList
+        name="shippingMethod"
+        value={shippingMethod}
+        choices={[
+          {label: 'Standard shipping (5-7 business days)', id: 'standard'},
+          {label: 'Express shipping (2-3 business days)', id: 'express'},
+          {label: 'Overnight delivery', id: 'overnight'},
+        ]}
+        onChange={setShippingMethod}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/shipping-method', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, shippingMethod}),
+          });
+          close();
+        }}
+      >
+        Save shipping method
+      </Button>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/ChoiceList/examples/choicelist-error.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/ChoiceList/examples/choicelist-error.example.tsx
@@ -1,0 +1,50 @@
+import {useState} from 'react';
+import {reactExtension, useApi, ChoiceList, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [region, setRegion] = useState('');
+  const [error, setError] = useState(undefined);
+
+  return (
+    <BlockStack>
+      <ChoiceList
+        name="complianceRegion"
+        value={region}
+        error={error}
+        choices={[
+          {label: 'North America (FDA, FTC)', id: 'na'},
+          {label: 'European Union (CE, REACH)', id: 'eu'},
+          {label: 'Asia-Pacific (JIS, CCC)', id: 'apac'},
+        ]}
+        onChange={(value) => {
+          setRegion(value);
+          setError(undefined);
+        }}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          if (!region) {
+            setError('Select a compliance region before saving');
+            return;
+          }
+          await fetch('/api/products/compliance', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, complianceRegion: region}),
+          });
+          close();
+        }}
+      >
+        Set compliance region
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/ChoiceList/examples/choicelist-multiple.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/ChoiceList/examples/choicelist-multiple.example.tsx
@@ -1,0 +1,45 @@
+import {useState} from 'react';
+import {reactExtension, useApi, ChoiceList, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [tags, setTags] = useState([]);
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Apply product tags</Text>
+      <ChoiceList
+        name="productTags"
+        multiple
+        value={tags}
+        choices={[
+          {label: 'Seasonal', id: 'seasonal'},
+          {label: 'Clearance', id: 'clearance'},
+          {label: 'New arrival', id: 'new-arrival'},
+          {label: 'Best seller', id: 'best-seller'},
+          {label: 'Limited edition', id: 'limited-edition'},
+        ]}
+        onChange={setTags}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/tags', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, tags}),
+          });
+          close();
+        }}
+      >
+        Apply tags
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/ColorPicker/examples/basic-colorpicker.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/ColorPicker/examples/basic-colorpicker.example.tsx
@@ -1,17 +1,33 @@
-import {
-  render,
-  ColorPicker,
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, ColorPicker, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [color, setColor] = useState('#000000');
+
   return (
-    <ColorPicker
-      value="rgba(255 0 0 / 0.5)"
-      onChange={(value) => {
-        console.log({value});
-      }}
-    />
+    <BlockStack>
+      <Text fontWeight="bold">Product accent color</Text>
+      <ColorPicker value={color} onChange={setColor} />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/accent-color', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, color}),
+          });
+          close();
+        }}
+      >
+        Save color
+      </Button>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/ColorPicker/examples/colorpicker-alpha.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/ColorPicker/examples/colorpicker-alpha.example.tsx
@@ -1,0 +1,19 @@
+import {useState} from 'react';
+import {reactExtension, ColorPicker, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const [color, setColor] = useState('rgba(0, 0, 0, 0.5)');
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Overlay color with transparency</Text>
+      <ColorPicker value={color} allowAlpha onChange={setColor} />
+      <Text>Selected: {color}</Text>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/ColorPicker/examples/colorpicker-branding.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/ColorPicker/examples/colorpicker-branding.example.tsx
@@ -1,0 +1,23 @@
+import {useState} from 'react';
+import {reactExtension, ColorPicker, Text, Divider, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const [primary, setPrimary] = useState('#2C6ECB');
+  const [secondary, setSecondary] = useState('#F4F6F8');
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Brand colors for product page</Text>
+      <Text>Primary brand color</Text>
+      <ColorPicker value={primary} onChange={setPrimary} />
+      <Divider />
+      <Text>Secondary brand color</Text>
+      <ColorPicker value={secondary} onChange={setSecondary} />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate-metafields.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate-metafields.example.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {reactExtension, CustomerSegmentTemplate} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  return (
+    <CustomerSegmentTemplate
+      title="Loyalty tier members"
+      description="Customers assigned to a specific loyalty tier through your app. This template uses a custom metafield to filter customers by their current membership level."
+      query='customer.metafields.loyalty.tier = "gold"'
+      dependencies={{
+        customMetafields: ['loyalty.tier'],
+      }}
+      createdOn={new Date('2024-10-01').toISOString()}
+    />
+  );
+}
+
+export default reactExtension(
+  'admin.customers.segmentation-templates.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate-queryinsert.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate-queryinsert.example.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {reactExtension, CustomerSegmentTemplate} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  return (
+    <CustomerSegmentTemplate
+      title="Lapsed customers by region"
+      description={[
+        'Customers who have not placed an order in the last 90 days, filtered by geographic region.',
+        'The displayed query shows an example for US customers. When inserted into the editor, the region filter is left as a placeholder for merchants to customize.',
+      ]}
+      query='days_since_last_order > 90 AND customer_country = "US"'
+      queryToInsert='days_since_last_order > 90 AND customer_country = ""'
+      createdOn={new Date('2024-08-15').toISOString()}
+    />
+  );
+}
+
+export default reactExtension(
+  'admin.customers.segmentation-templates.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate.example.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
-import {reactExtension, CustomerSegmentTemplate} from '@shopify/ui-extensions/admin';
+import {reactExtension, CustomerSegmentTemplate} from '@shopify/ui-extensions-react/admin';
 
 function App() {
   return (
     <CustomerSegmentTemplate
-        title="My Customer Segment Template"
-        description="Description of the segment"
-        query="number_of_orders > 0"
-        createdOn={new Date('2023-01-15').toISOString()}
+      title="High-value repeat buyers"
+      description="Customers who have placed more than 5 orders with a total spend exceeding $500. Use this segment to target loyal customers for VIP promotions and early access campaigns."
+      query="number_of_orders > 5 AND amount_spent > 500"
+      createdOn={new Date('2024-06-01').toISOString()}
     />
   );
 }
 
-export default reactExtension('Playground', () => <App />);
+export default reactExtension(
+  'admin.customers.segmentation-templates.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/DateField/examples/basic-datefield.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/DateField/examples/basic-datefield.example.tsx
@@ -1,19 +1,37 @@
-import React, {useState} from 'react';
-import {
-  render,
-  DateField,
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, DateField, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  const [value, setValue] =
-    useState('2023-11-08');
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [date, setDate] = useState('');
+
   return (
-    <DateField
-      label="DateField"
-      value={value}
-      onChange={setValue}
-    />
+    <BlockStack>
+      <DateField
+        label="Product launch date"
+        name="launchDate"
+        value={date}
+        onChange={setDate}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/launch-date', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, launchDate: date}),
+          });
+          close();
+        }}
+      >
+        Schedule launch
+      </Button>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/DateField/examples/datefield-readonly.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/DateField/examples/datefield-readonly.example.tsx
@@ -1,0 +1,17 @@
+import {reactExtension, DateField, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Important dates</Text>
+      <DateField label="Date created" name="dateCreated" value="2024-01-15" readOnly />
+      <DateField label="Last warehouse sync" name="lastSync" value="2024-03-20" readOnly />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/DateField/examples/datefield-validation.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/DateField/examples/datefield-validation.example.tsx
@@ -1,0 +1,49 @@
+import {useState} from 'react';
+import {reactExtension, useApi, DateField, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [date, setDate] = useState('');
+  const [error, setError] = useState(undefined);
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Product expiry</Text>
+      <DateField
+        label="Expiration date"
+        name="expiryDate"
+        value={date}
+        error={error}
+        onChange={(value) => {
+          setDate(value);
+          const selected = new Date(value);
+          const today = new Date();
+          setError(
+            selected <= today ? 'Expiry date must be in the future' : undefined,
+          );
+        }}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          if (date) {
+            await fetch('/api/products/expiry', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId, expiryDate: date}),
+            });
+            close();
+          }
+        }}
+      >
+        Set expiry date
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/DatePicker/examples/basic-datepicker.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/DatePicker/examples/basic-datepicker.example.tsx
@@ -1,15 +1,33 @@
-import React, { useState } from 'react';
-import {
-  render,
-  DatePicker,
-  type Selected
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, DatePicker, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  const [selected, setSelected] = useState<Selected>('2023-11-08')
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [date, setDate] = useState('');
+
   return (
-    <DatePicker selected={selected} onChange={setSelected} />
+    <BlockStack>
+      <Text fontWeight="bold">Schedule promotion start</Text>
+      <DatePicker selected={date} onChange={setDate} />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/promotion', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, startDate: date}),
+          });
+          close();
+        }}
+      >
+        Schedule promotion
+      </Button>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/DatePicker/examples/multiple-datepicker.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/DatePicker/examples/multiple-datepicker.example.tsx
@@ -1,17 +1,34 @@
-import React from 'react';
-import {
-  render,
-  DatePicker,
-  type Selected,
-} from '@shopify/ui-extensions-react/admin';
-
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, DatePicker, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  const [selected, setSelected] = React.useState<Selected>(['2023-11-08']);
-  
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [dates, setDates] = useState([]);
+
   return (
-    <DatePicker selected={selected} onChange={setSelected} />
+    <BlockStack>
+      <Text fontWeight="bold">Select shipping blackout dates</Text>
+      <Text>Choose dates when this product cannot be shipped.</Text>
+      <DatePicker selected={dates} onChange={setDates} />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/blackout-dates', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, blackoutDates: dates}),
+          });
+          close();
+        }}
+      >
+        Save blackout dates
+      </Button>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/DatePicker/examples/range-datepicker.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/DatePicker/examples/range-datepicker.example.tsx
@@ -1,16 +1,33 @@
-import React from 'react';
-import {
-  render,
-  DatePicker,
-  type Selected
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, DatePicker, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  const [selected, setSelected] = React.useState<Selected>({start: '2023-11-08', end: '2023-11-10' });
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [range, setRange] = useState({start: '', end: ''});
 
   return (
-    <DatePicker selected={selected} onChange={setSelected} />
+    <BlockStack>
+      <Text fontWeight="bold">Set sale period</Text>
+      <DatePicker selected={range} onChange={setRange} />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/sale-period', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, ...range}),
+          });
+          close();
+        }}
+      >
+        Save sale period
+      </Button>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Divider/examples/basic-divider.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Divider/examples/basic-divider.example.tsx
@@ -1,18 +1,19 @@
-import React from 'react';
-import {
-  render,
-  Divider,
-  BlockStack,
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {reactExtension, Divider, Heading, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+
   return (
-    <BlockStack gap>
-      <>First text</>
+    <BlockStack>
+      <Heading>Sync status</Heading>
+      <Text>Last synced 5 minutes ago — all fields up to date.</Text>
       <Divider />
-      <>Second Text</>
+      <Heading size={3}>Recent changes</Heading>
+      <Text>3 metafields updated, 1 tag added in the last 24 hours.</Text>
     </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Divider/examples/divider-inline.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Divider/examples/divider-inline.example.tsx
@@ -1,0 +1,19 @@
+import {reactExtension, Divider, Text, InlineStack, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <InlineStack>
+        <Text fontWeight="bold">$49.99</Text>
+        <Divider direction="block" />
+        <Text>SKU: WH-1234</Text>
+      </InlineStack>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Divider/examples/divider-sections.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Divider/examples/divider-sections.example.tsx
@@ -1,0 +1,21 @@
+import {reactExtension, Divider, TextField, Heading, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Heading>Shipping details</Heading>
+      <TextField label="Weight (kg)" name="weight" />
+      <TextField label="Dimensions (L×W×H cm)" name="dimensions" />
+      <Divider />
+      <Heading>Customs information</Heading>
+      <TextField label="HS tariff code" name="hsCode" />
+      <TextField label="Country of origin" name="countryOfOrigin" />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/EmailField/examples/basic-emailfield.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/EmailField/examples/basic-emailfield.example.tsx
@@ -1,7 +1,38 @@
-import {render, EmailField} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, EmailField, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  return <EmailField label="Enter your email address" />;
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [email, setEmail] = useState('');
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Notification settings</Text>
+      <EmailField
+        label="Low stock notification email"
+        name="notificationEmail"
+        value={email}
+        onChange={setEmail}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/notifications/email', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, email}),
+          });
+          close();
+        }}
+      >
+        Save notification email
+      </Button>
+    </BlockStack>
+  );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/EmailField/examples/emailfield-prefilled.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/EmailField/examples/emailfield-prefilled.example.tsx
@@ -1,0 +1,22 @@
+import {reactExtension, EmailField, TextField, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Fulfillment contact</Text>
+      <TextField label="Contact name" name="contactName" />
+      <EmailField
+        label="Contact email"
+        name="contactEmail"
+        value="fulfillment@example.com"
+      />
+      <EmailField label="CC email (optional)" name="ccEmail" />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/EmailField/examples/emailfield-validation.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/EmailField/examples/emailfield-validation.example.tsx
@@ -1,0 +1,49 @@
+import {useState} from 'react';
+import {reactExtension, useApi, EmailField, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState(undefined);
+
+  return (
+    <BlockStack>
+      <EmailField
+        label="Supplier contact email"
+        name="supplierEmail"
+        required
+        value={email}
+        error={error}
+        onChange={(value) => {
+          setEmail(value);
+          setError(
+            value && !value.includes('@')
+              ? 'Enter a valid email address'
+              : undefined,
+          );
+        }}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          if (email.includes('@')) {
+            await fetch('/api/suppliers/contact', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId, email}),
+            });
+            close();
+          }
+        }}
+      >
+        Save supplier contact
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Form/examples/basic-form.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Form/examples/basic-form.example.tsx
@@ -1,51 +1,31 @@
-import React, { useCallback, useState } from 'react';
-import {
-  reactExtension,
-  Form,
-  TextField,
-} from '@shopify/ui-extensions-react/admin';
-
-export default reactExtension("admin.product-details.block.render", () => <App />);
+import {reactExtension, useApi, Form, TextField, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  const [value, setValue] = useState("");
-  const [error, setError] = useState('');
-
-  const onSubmit = useCallback(
-    async () => {
-      // API call to save the values
-      const res = await fetch('/save', {method:'POST', body: JSON.stringify({name: value})});
-      if (!res.ok) {
-        const json = await res.json();
-        const errors = json.errors.join(',');
-        setError(errors);
-      }
-    },
-    [value]
-  );
-
-  const onReset = useCallback(async () => {
-     // Reset to initial value
-     setValue('')
-     // Clear errors
-     setError('')
-  }, []);
-
-  const onInput = useCallback((nameValue) => {
-    if (!nameValue) {
-      setError("Please enter a name.");
-    }
-  }, [])
-
-  // Field values can only be updated on change when using Remote UI.
-  const onChange = useCallback((nameValue) => {
-    setValue(nameValue);
-  }, [])
-
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
 
   return (
-    <Form id="form" onSubmit={onSubmit} onReset={onReset}>
-      <TextField label="name" value={value} onInput={onInput} onChange={onChange} error={error} />
+    <Form
+      onSubmit={async () => {
+        await fetch('/api/products/metadata', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({productId}),
+        });
+        close();
+      }}
+      onReset={() => close()}
+    >
+      <BlockStack gap>
+        <TextField label="Warehouse SKU" name="warehouseSku" required />
+        <TextField label="Storage location" name="location" />
+        <Button variant="primary">Save product metadata</Button>
+      </BlockStack>
     </Form>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Form/examples/form-reset.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Form/examples/form-reset.example.tsx
@@ -1,0 +1,34 @@
+import {reactExtension, useApi, Form, TextField, Button, InlineStack, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+
+  return (
+    <Form
+      onSubmit={async () => {
+        await fetch('/api/products/shipping', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({productId}),
+        });
+        close();
+      }}
+      onReset={() => close()}
+    >
+      <BlockStack gap>
+        <TextField label="Package weight (kg)" name="weight" />
+        <TextField label="Dimensions (L×W×H cm)" name="dimensions" />
+        <InlineStack gap inlineAlignment="end">
+          <Button variant="tertiary" accessibilityRole="reset">Cancel</Button>
+          <Button variant="primary" accessibilityRole="submit">Save shipping info</Button>
+        </InlineStack>
+      </BlockStack>
+    </Form>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Form/examples/form-sections.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Form/examples/form-sections.example.tsx
@@ -1,0 +1,37 @@
+import {reactExtension, useApi, Form, TextField, EmailField, Section, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+
+  return (
+    <Form
+      onSubmit={async () => {
+        await fetch('/api/fulfillment/setup', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({productId}),
+        });
+        close();
+      }}
+      onReset={() => close()}
+    >
+      <BlockStack gap>
+        <Section heading="Provider details">
+          <TextField label="Provider name" name="providerName" required />
+          <TextField label="API endpoint" name="endpoint" />
+        </Section>
+        <Section heading="Contact information">
+          <TextField label="Contact name" name="contactName" />
+          <EmailField label="Contact email" name="contactEmail" />
+        </Section>
+        <Button variant="primary">Set up provider</Button>
+      </BlockStack>
+    </Form>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/FunctionSettings/examples/basic-functionsettings.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/FunctionSettings/examples/basic-functionsettings.example.tsx
@@ -1,48 +1,35 @@
-import {
-  reactExtension,
-  useApi,
-  FunctionSettings,
-  TextField,
-  Section,
-} from '@shopify/ui-extensions-react/admin';
+import {useState} from 'react';
+import {reactExtension, useApi, FunctionSettings, TextField, Section} from '@shopify/ui-extensions-react/admin';
 
 export default reactExtension(
   'admin.settings.validation.render',
   async (api) => {
-    // Use Direct API access to fetch initial
-    // metafields from the server if we are
-    // rendering against a pre-existing `Validation`
     const initialSettings = api.data.validation
       ? await fetchSettings(api.data.validation.id)
       : {};
-
     return <App settings={initialSettings} />;
-});
+  },
+);
 
 function App({settings}) {
-  const [value, setValue] = useState(settings);
+  const [name, setName] = useState(settings.name || '');
   const [error, setError] = useState();
-
   const {applyMetafieldsChange} = useApi();
 
   return (
-    <FunctionSettings
-      onError={(errors) => {
-        setError(errors[0]?.message);
-      }}
-    >
-      <Section heading="Settings">
+    <FunctionSettings onError={(errors) => setError(errors[0]?.message)}>
+      <Section heading="Validation settings">
         <TextField
-          label="Name"
+          label="Rule name"
           name="name"
-          value={value}
+          value={name}
           error={error}
           onChange={(value) => {
-            setValue(value);
+            setName(value);
             setError(undefined);
             applyMetafieldsChange({
               type: 'updateMetafield',
-              namespace: '$app:my_namespace',
+              namespace: '$app:validation',
               key: 'name',
               value,
               valueType: 'single_line_text_field',

--- a/packages/ui-extensions-react/src/surfaces/admin/components/FunctionSettings/examples/functionsettings-multiple.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/FunctionSettings/examples/functionsettings-multiple.example.tsx
@@ -1,0 +1,75 @@
+import {useState} from 'react';
+import {reactExtension, useApi, FunctionSettings, TextField, NumberField, Section} from '@shopify/ui-extensions-react/admin';
+
+export default reactExtension(
+  'admin.settings.validation.render',
+  async (api) => {
+    const initialSettings = api.data.validation
+      ? await fetchSettings(api.data.validation.id)
+      : {};
+    return <App settings={initialSettings} />;
+  },
+);
+
+function App({settings}) {
+  const [min, setMin] = useState(settings.minQuantity || 1);
+  const [max, setMax] = useState(settings.maxQuantity || 100);
+  const [message, setMessage] = useState(settings.errorMessage || '');
+  const [error, setError] = useState();
+  const {applyMetafieldsChange} = useApi();
+
+  return (
+    <FunctionSettings onError={(errors) => setError(errors[0]?.message)}>
+      <Section heading="Quantity limits">
+        <NumberField
+          label="Minimum order quantity"
+          name="minQuantity"
+          min={1}
+          value={min}
+          error={error}
+          onChange={(value) => {
+            setMin(value);
+            applyMetafieldsChange({
+              type: 'updateMetafield',
+              namespace: '$app:validation',
+              key: 'min_quantity',
+              value: String(value),
+              valueType: 'number_integer',
+            });
+          }}
+        />
+        <NumberField
+          label="Maximum order quantity"
+          name="maxQuantity"
+          min={1}
+          value={max}
+          onChange={(value) => {
+            setMax(value);
+            applyMetafieldsChange({
+              type: 'updateMetafield',
+              namespace: '$app:validation',
+              key: 'max_quantity',
+              value: String(value),
+              valueType: 'number_integer',
+            });
+          }}
+        />
+        <TextField
+          label="Error message shown to customers"
+          name="errorMessage"
+          value={message}
+          onChange={(value) => {
+            setMessage(value);
+            applyMetafieldsChange({
+              type: 'updateMetafield',
+              namespace: '$app:validation',
+              key: 'error_message',
+              value,
+              valueType: 'single_line_text_field',
+            });
+          }}
+        />
+      </Section>
+    </FunctionSettings>
+  );
+}

--- a/packages/ui-extensions-react/src/surfaces/admin/components/FunctionSettings/examples/functionsettings-save.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/FunctionSettings/examples/functionsettings-save.example.tsx
@@ -1,0 +1,69 @@
+import {useState} from 'react';
+import {reactExtension, useApi, FunctionSettings, TextField, ChoiceList, Section, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+export default reactExtension(
+  'admin.settings.validation.render',
+  async (api) => {
+    const initialSettings = api.data.validation
+      ? await fetchSettings(api.data.validation.id)
+      : {};
+    return <App settings={initialSettings} />;
+  },
+);
+
+function App({settings}) {
+  const [title, setTitle] = useState(settings.title || '');
+  const [type, setType] = useState(settings.type || 'percentage');
+  const [error, setError] = useState();
+  const {applyMetafieldsChange} = useApi();
+
+  return (
+    <FunctionSettings
+      onSave={async () => {
+        await fetch('/api/functions/validate-config', {method: 'POST'});
+      }}
+      onError={(errors) => setError(errors[0]?.message)}
+    >
+      <Section heading="Discount configuration">
+        <BlockStack gap>
+          <TextField
+            label="Discount title"
+            name="title"
+            required
+            value={title}
+            error={error}
+            onChange={(value) => {
+              setTitle(value);
+              setError(undefined);
+              applyMetafieldsChange({
+                type: 'updateMetafield',
+                namespace: '$app:discount',
+                key: 'title',
+                value,
+                valueType: 'single_line_text_field',
+              });
+            }}
+          />
+          <ChoiceList
+            name="discountType"
+            value={type}
+            choices={[
+              {label: 'Percentage discount', id: 'percentage'},
+              {label: 'Fixed amount discount', id: 'fixed'},
+            ]}
+            onChange={(value) => {
+              setType(value);
+              applyMetafieldsChange({
+                type: 'updateMetafield',
+                namespace: '$app:discount',
+                key: 'type',
+                value,
+                valueType: 'single_line_text_field',
+              });
+            }}
+          />
+        </BlockStack>
+      </Section>
+    </FunctionSettings>
+  );
+}

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Heading/examples/basic-heading.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Heading/examples/basic-heading.example.tsx
@@ -1,7 +1,18 @@
-import {render, Heading} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {reactExtension, Heading, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  return <Heading>Store name</Heading>;
+
+  return (
+    <BlockStack>
+      <Heading>Product analytics</Heading>
+      <Text>
+        View real-time performance metrics synced from your analytics provider.
+      </Text>
+    </BlockStack>
+  );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Heading/examples/heading-accessible.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Heading/examples/heading-accessible.example.tsx
@@ -1,0 +1,21 @@
+import {reactExtension, Heading, Section, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Section heading="Custom fields">
+        <Heading id="metafields-heading">Metafield values</Heading>
+        <Text>
+          These custom fields are synced with your external product information
+          management system.
+        </Text>
+      </Section>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Heading/examples/heading-sizes.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Heading/examples/heading-sizes.example.tsx
@@ -1,0 +1,22 @@
+import {reactExtension, Heading, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Heading size={2}>Warehouse integration</Heading>
+      <Text>
+        Manage inventory sync and fulfillment settings for this product.
+      </Text>
+      <Heading size={3}>Sync history</Heading>
+      <Text>
+        Last synced 15 minutes ago — 3 variants updated successfully.
+      </Text>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/HeadingGroup/examples/basic-headinggroup.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/HeadingGroup/examples/basic-headinggroup.example.tsx
@@ -1,23 +1,22 @@
-import {
-    render,
-    HeadingGroup,
-    Heading,
-  } from '@shopify/ui-extensions-react/admin';
+import {reactExtension, HeadingGroup, Heading, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
-  render('Playground', () => <App />);
+function App() {
 
-  function App() {
-    return (
-      <>
-        <Heading>Heading &lt;h1&gt;</Heading>
+  return (
+    <BlockStack>
+      <Heading>Warehouse integration</Heading>
+      <HeadingGroup>
+        <Heading>Sync configuration</Heading>
+        <Text>
+          Configure how product data flows between Shopify and your warehouse
+          management system.
+        </Text>
+      </HeadingGroup>
+    </BlockStack>
+  );
+}
 
-        <HeadingGroup>
-          <Heading>Heading &lt;h2&gt;</Heading>
-
-          <HeadingGroup>
-            <Heading>Heading &lt;h3&gt;</Heading>
-          </HeadingGroup>
-        </HeadingGroup>
-      </>
-    );
-  }
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/HeadingGroup/examples/headinggroup-form.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/HeadingGroup/examples/headinggroup-form.example.tsx
@@ -1,0 +1,20 @@
+import {reactExtension, HeadingGroup, Heading, TextField, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Heading>Custom shipping rules</Heading>
+      <HeadingGroup>
+        <Heading>Domestic shipping</Heading>
+        <TextField label="Max package weight (kg)" name="maxWeight" />
+        <TextField label="Handling instructions" name="handling" />
+      </HeadingGroup>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/HeadingGroup/examples/headinggroup-nested.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/HeadingGroup/examples/headinggroup-nested.example.tsx
@@ -1,0 +1,28 @@
+import {reactExtension, HeadingGroup, Heading, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Heading>Product compliance</Heading>
+      <HeadingGroup>
+        <Heading>Safety certifications</Heading>
+        <Text>
+          Certifications required for sale in regulated markets.
+        </Text>
+        <HeadingGroup>
+          <Heading>EU compliance</Heading>
+          <Text>
+            CE marking and REACH regulation status for European Union
+            distribution.
+          </Text>
+        </HeadingGroup>
+      </HeadingGroup>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Icon/examples/basic-icon.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Icon/examples/basic-icon.example.tsx
@@ -1,7 +1,22 @@
-import {render, Icon} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {reactExtension, Icon, Text, InlineStack, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  return <Icon name="AppsMajor" />;
+
+  return (
+    <BlockStack>
+      <InlineStack>
+        <Icon name="CircleTickMajor" accessibilityLabel="Synced" />
+        <Text>Inventory synced</Text>
+      </InlineStack>
+      <InlineStack>
+        <Icon name="CircleAlertMajor" accessibilityLabel="Error" />
+        <Text>Pricing error detected</Text>
+      </InlineStack>
+    </BlockStack>
+  );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Icon/examples/icon-fill.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Icon/examples/icon-fill.example.tsx
@@ -1,0 +1,19 @@
+import {reactExtension, Icon, Text, BlockStack, Box} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">App status</Text>
+      <Box inlineSize={48} blockSize={48}>
+        <Icon name="AppsMajor" size="fill" accessibilityLabel="App connected" />
+      </Box>
+      <Text>Connected to warehouse system</Text>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Icon/examples/icon-tones.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Icon/examples/icon-tones.example.tsx
@@ -1,0 +1,27 @@
+import {reactExtension, Icon, Text, InlineStack, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Compliance checks</Text>
+      <InlineStack>
+        <Icon name="CircleTickMajor" accessibilityLabel="Passed" />
+        <Text>Safety standards — passed</Text>
+      </InlineStack>
+      <InlineStack>
+        <Icon
+          name="CircleAlertMajor"
+          tone="critical"
+          accessibilityLabel="Failed"
+        />
+        <Text>Label requirements — action needed</Text>
+      </InlineStack>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Image/examples/basic-image.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Image/examples/basic-image.example.tsx
@@ -1,9 +1,37 @@
-import {render, Image} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState, useEffect} from 'react';
+import {reactExtension, useApi, Image, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data, query} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const [product, setProduct] = useState(null);
+
+  useEffect(() => {
+    query(
+      `query Product($id: ID!) {
+        product(id: $id) {
+          title
+          featuredImage { url altText }
+        }
+      }`,
+      {variables: {id: productId}},
+    ).then((result) => setProduct(result?.data?.product));
+  }, [productId, query]);
+
+  if (!product?.featuredImage) return null;
+
   return (
-    <Image alt="Pickaxe" source="https://shopify.dev/assets/icons/64/pickaxe-1.png" />
+    <BlockStack>
+      <Image
+        source={product.featuredImage.url}
+        accessibilityLabel={product.featuredImage.altText || product.title}
+      />
+      <Text>{product.title}</Text>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Image/examples/image-decorative.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Image/examples/image-decorative.example.tsx
@@ -1,0 +1,24 @@
+import {reactExtension, Image, Heading, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Image
+        source="https://cdn.shopify.com/s/files/partner-branding/banner.png"
+        accessibilityLabel=""
+        accessibilityRole="decorative"
+      />
+      <Heading>Warehouse connection active</Heading>
+      <Text>
+        Your products are syncing automatically every 15 minutes with your
+        warehouse management system.
+      </Text>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Image/examples/image-loading.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Image/examples/image-loading.example.tsx
@@ -1,0 +1,34 @@
+import {useState} from 'react';
+import {reactExtension, Image, Text, ProgressIndicator, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  return (
+    <BlockStack>
+      {loading && (
+        <ProgressIndicator size="small-100" accessibilityLabel="Loading image" />
+      )}
+      {error ? (
+        <Text>Unable to load product image.</Text>
+      ) : (
+        <Image
+          source="https://cdn.shopify.com/s/files/placeholder-images/product.png"
+          accessibilityLabel="Product preview"
+          loading="lazy"
+          onLoad={() => setLoading(false)}
+          onError={() => {
+            setLoading(false);
+            setError(true);
+          }}
+        />
+      )}
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/InlineStack/examples/basic-inlinestack.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/InlineStack/examples/basic-inlinestack.example.tsx
@@ -1,18 +1,27 @@
-import React from 'react';
-import {
-  render,
-  InlineStack,
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {reactExtension, useApi, InlineStack, Text, Badge, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+
   return (
-    <InlineStack gap>
-      <>Child 1</>
-      <>Child 2</>
-      <>Child 3</>
-      <>Child 4</>
-    </InlineStack>
+    <BlockStack gap>
+      <InlineStack gap>
+        <Text fontWeight="bold">Product:</Text>
+        <Text>{productId || 'Unknown'}</Text>
+        <Badge tone="success">Active</Badge>
+      </InlineStack>
+      <InlineStack gap>
+        <Text fontWeight="bold">SKU:</Text>
+        <Text>WH-1234</Text>
+        <Text fontWeight="bold">Weight:</Text>
+        <Text>2.5 kg</Text>
+      </InlineStack>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/InlineStack/examples/inlinestack-alignment.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/InlineStack/examples/inlinestack-alignment.example.tsx
@@ -1,0 +1,34 @@
+import {reactExtension, useApi, InlineStack, Button, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+
+  return (
+    <BlockStack gap>
+      <Text fontWeight="bold">Confirm action</Text>
+      <Text>Sync product {productId} to all warehouse locations?</Text>
+      <InlineStack gap inlineAlignment="end">
+        <Button variant="tertiary" onPress={() => close()}>Cancel</Button>
+        <Button
+          variant="primary"
+          onPress={async () => {
+            await fetch('/api/products/sync-all', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId}),
+            });
+            close();
+          }}
+        >
+          Sync now
+        </Button>
+      </InlineStack>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/InlineStack/examples/inlinestack-spacing.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/InlineStack/examples/inlinestack-spacing.example.tsx
@@ -1,0 +1,23 @@
+import {reactExtension, InlineStack, Icon, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack gap>
+      <Text fontWeight="bold">Quick stats</Text>
+      <InlineStack gap blockAlignment="center">
+        <Icon name="OrdersMajor" accessibilityLabel="Orders" />
+        <Text>142 orders this month</Text>
+      </InlineStack>
+      <InlineStack gap blockAlignment="center">
+        <Icon name="InventoryMajor" accessibilityLabel="Inventory" />
+        <Text>89 units in stock</Text>
+      </InlineStack>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Link/examples/app-link.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Link/examples/app-link.example.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
-import {
-  render,
-  Link,
-} from '@shopify/ui-extensions-react/admin';
-
-
-render('Playground', () => <App />);
+import {reactExtension, Link, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+
   return (
-    <Link href="app:bar">
-      Link to app path
-    </Link>
+    <BlockStack gap>
+      <Text fontWeight="bold">Manage this product</Text>
+      <Link href="extension://settings">Extension settings</Link>
+      <Link href="extension://dashboard">Sync dashboard</Link>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Link/examples/external-link.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Link/examples/external-link.example.tsx
@@ -1,16 +1,27 @@
-import React from 'react';
-import {
-  render,
-  Link,
-} from '@shopify/ui-extensions-react/admin';
-
-
-render('Playground', () => <App />);
+import {reactExtension, useApi, Link, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const numericId = productId?.split('/').pop();
+
   return (
-    <Link href="https://www.shopify.ca/climate/sustainability-fund">
-      Sustainability fund
-    </Link>
+    <BlockStack gap>
+      <Text fontWeight="bold">External resources</Text>
+      <Link
+        href={`https://your-store.myshopify.com/products/${numericId}`}
+        target="_blank"
+      >
+        View on storefront
+      </Link>
+      <Link href="https://help.shopify.com/manual/products" target="_blank">
+        Shopify product documentation
+      </Link>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Link/examples/shopify-section-link.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Link/examples/shopify-section-link.example.tsx
@@ -1,16 +1,25 @@
-import React from 'react';
-import {
-  render,
-  Link,
-} from '@shopify/ui-extensions-react/admin';
-
-
-render('Playground', () => <App />);
+import {reactExtension, useApi, Link, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const numericId = productId?.split('/').pop();
+
   return (
-    <Link href="shopify://admin/orders">
-      Shop's orders
-    </Link>
+    <BlockStack gap>
+      <Text fontWeight="bold">Admin navigation</Text>
+      <Link href="shopify://admin/orders">View all orders</Link>
+      <Link href={`shopify://admin/products/${numericId}/inventory`}>
+        Manage inventory
+      </Link>
+      <Link href={`shopify://admin/products/${numericId}`} tone="critical">
+        Edit product (admin)
+      </Link>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/MoneyField/examples/basic-moneyfield.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/MoneyField/examples/basic-moneyfield.example.tsx
@@ -1,10 +1,38 @@
-import {render, MoneyField} from '@shopify/ui-extensions-react/admin';
 import {useState} from 'react';
-
-render('Playground', () => <App />);
+import {reactExtension, useApi, MoneyField, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  const [value, setValue] = useState({ amount: 100, currencyCode: 'USD' });
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [cost, setCost] = useState(0);
 
-  return <MoneyField label="Enter an amount" value={value} onChange={setValue} />;
+  return (
+    <BlockStack>
+      <MoneyField
+        label="Cost per item"
+        name="costPrice"
+        currencyCode="USD"
+        value={cost}
+        onChange={setCost}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/cost', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, costPrice: cost}),
+          });
+          close();
+        }}
+      >
+        Save cost price
+      </Button>
+    </BlockStack>
+  );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/MoneyField/examples/moneyfield-currencies.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/MoneyField/examples/moneyfield-currencies.example.tsx
@@ -1,0 +1,18 @@
+import {reactExtension, MoneyField, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Regional pricing</Text>
+      <MoneyField label="US price" name="priceUsd" currencyCode="USD" value={49.99} />
+      <MoneyField label="EU price" name="priceEur" currencyCode="EUR" value={44.99} />
+      <MoneyField label="UK price" name="priceGbp" currencyCode="GBP" value={39.99} />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/MoneyField/examples/moneyfield-validation.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/MoneyField/examples/moneyfield-validation.example.tsx
@@ -1,0 +1,47 @@
+import {useState} from 'react';
+import {reactExtension, useApi, MoneyField, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [price, setPrice] = useState(0);
+  const [error, setError] = useState(undefined);
+
+  return (
+    <BlockStack>
+      <MoneyField
+        label="Wholesale price"
+        name="wholesalePrice"
+        currencyCode="USD"
+        min={0.01}
+        required
+        value={price}
+        error={error}
+        onChange={(value) => {
+          setPrice(value);
+          setError(value <= 0 ? 'Wholesale price must be greater than zero' : undefined);
+        }}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          if (price > 0) {
+            await fetch('/api/products/wholesale-price', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId, wholesalePrice: price}),
+            });
+            close();
+          }
+        }}
+      >
+        Save wholesale price
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/NumberField/examples/basic-numberfield.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/NumberField/examples/basic-numberfield.example.tsx
@@ -1,7 +1,39 @@
-import {render, NumberField} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, NumberField, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  return <NumberField label="Enter a discount amount" />;
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [quantity, setQuantity] = useState(0);
+
+  return (
+    <BlockStack>
+      <NumberField
+        label="Restock quantity"
+        name="quantity"
+        min={1}
+        max={10000}
+        value={quantity}
+        onChange={setQuantity}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/inventory/restock', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, quantity}),
+          });
+          close();
+        }}
+      >
+        Submit restock
+      </Button>
+    </BlockStack>
+  );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/NumberField/examples/numberfield-constraints.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/NumberField/examples/numberfield-constraints.example.tsx
@@ -1,0 +1,35 @@
+import {useState} from 'react';
+import {reactExtension, NumberField, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const [error, setError] = useState(undefined);
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Warehouse slot configuration</Text>
+      <NumberField
+        label="Storage slot number"
+        name="slotNumber"
+        min={1}
+        max={500}
+        step={1}
+        error={error}
+        onChange={(value) => {
+          setError(value > 500 ? 'Slot number cannot exceed 500' : undefined);
+        }}
+      />
+      <NumberField
+        label="Units per pallet"
+        name="unitsPerPallet"
+        min={1}
+        max={200}
+        step={1}
+      />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/NumberField/examples/numberfield-decimal.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/NumberField/examples/numberfield-decimal.example.tsx
@@ -1,0 +1,32 @@
+import {reactExtension, NumberField, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Cost pricing</Text>
+      <NumberField
+        label="Cost per item"
+        name="costPerItem"
+        inputMode="decimal"
+        min={0}
+        step={0.01}
+        suffix="USD"
+      />
+      <NumberField
+        label="Profit margin"
+        name="margin"
+        inputMode="decimal"
+        min={0}
+        max={100}
+        step={0.5}
+        suffix="%"
+      />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Paragraph/examples/basic-paragraph.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Paragraph/examples/basic-paragraph.example.tsx
@@ -1,16 +1,24 @@
-import {
-    render,
-    BlockStack,
-    Paragraph,
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {reactExtension, Paragraph, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-    return (
-        <BlockStack inlineAlignment='center' gap>
-            <Paragraph fontWeight='bold'>Name:</Paragraph>
-            <Paragraph>Jane Doe</Paragraph>
-        </BlockStack>
-    )
+
+  return (
+    <BlockStack>
+      <Paragraph>
+        <Text>Last sync completed at </Text>
+        <Text fontWeight="bold">2:45 PM EST</Text>
+        <Text>
+          . All product tags and metafields were successfully pushed to the
+          warehouse management system.{' '}
+        </Text>
+        <Text fontWeight="bold">24 fields</Text>
+        <Text> updated across 3 variants.</Text>
+      </Paragraph>
+    </BlockStack>
+  );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Paragraph/examples/paragraph-conditional.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Paragraph/examples/paragraph-conditional.example.tsx
@@ -1,0 +1,39 @@
+import {useState, useEffect} from 'react';
+import {reactExtension, useApi, Paragraph, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, query} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const [product, setProduct] = useState(null);
+
+  useEffect(() => {
+    query(
+      `query Product($id: ID!) {
+        product(id: $id) {
+          status
+          title
+        }
+      }`,
+      {variables: {id: productId}},
+    ).then((result) => setProduct(result?.data?.product));
+  }, [productId, query]);
+
+  if (!product || product.status !== 'DRAFT') return null;
+
+  return (
+    <BlockStack>
+      <Paragraph>
+        <Text>
+          "{product.title}" is currently in draft status. Complete the product
+          description, add at least one image, and set pricing before publishing
+          to your storefront.
+        </Text>
+      </Paragraph>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Paragraph/examples/paragraph-with-links.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Paragraph/examples/paragraph-with-links.example.tsx
@@ -1,0 +1,29 @@
+import {reactExtension, Paragraph, Text, Link, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Paragraph>
+        <Text>
+          This product requires special handling during fulfillment. Review the{' '}
+        </Text>
+        <Link
+          href="https://help.shopify.com/manual/fulfillment"
+          target="_blank"
+        >
+          fulfillment guidelines
+        </Link>
+        <Text>
+          {' '}for packaging requirements and carrier restrictions before
+          processing orders.
+        </Text>
+      </Paragraph>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/PasswordField/examples/basic-passwordfield.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/PasswordField/examples/basic-passwordfield.example.tsx
@@ -1,17 +1,37 @@
-import {
-  render,
-  BlockStack,
-  TextField,
-  PasswordField
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, PasswordField, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const [apiKey, setApiKey] = useState('');
+
   return (
     <BlockStack>
-      <TextField label="Enter some text" />
-      <PasswordField label="Enter some text" />
+      <Text fontWeight="bold">Connect warehouse API</Text>
+      <PasswordField
+        label="API key"
+        name="apiKey"
+        value={apiKey}
+        onChange={setApiKey}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/integrations/warehouse', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({apiKey}),
+          });
+          close();
+        }}
+      >
+        Save credentials
+      </Button>
     </BlockStack>
-  )
+  );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/PasswordField/examples/passwordfield-integration.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/PasswordField/examples/passwordfield-integration.example.tsx
@@ -1,0 +1,28 @@
+import {reactExtension, useApi, PasswordField, TextField, EmailField, Button, BlockStack, Heading} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {close} = useApi('admin.product-details.action.render');
+
+  return (
+    <BlockStack>
+      <Heading>Connect fulfillment service</Heading>
+      <TextField label="API endpoint" name="endpoint" />
+      <EmailField label="Account email" name="accountEmail" />
+      <PasswordField label="API token" name="apiToken" />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/fulfillment/connect', {method: 'POST'});
+          close();
+        }}
+      >
+        Connect service
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/PasswordField/examples/passwordfield-validation.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/PasswordField/examples/passwordfield-validation.example.tsx
@@ -1,0 +1,48 @@
+import {useState} from 'react';
+import {reactExtension, useApi, PasswordField, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {close} = useApi('admin.product-details.action.render');
+  const [secret, setSecret] = useState('');
+  const [error, setError] = useState(undefined);
+
+  return (
+    <BlockStack>
+      <PasswordField
+        label="Webhook secret"
+        name="webhookSecret"
+        required
+        value={secret}
+        error={error}
+        onChange={(value) => {
+          setSecret(value);
+          setError(
+            value.length > 0 && value.length < 16
+              ? 'Secret must be at least 16 characters'
+              : undefined,
+          );
+        }}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          if (secret.length >= 16) {
+            await fetch('/api/webhooks/secret', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({secret}),
+            });
+            close();
+          }
+        }}
+      >
+        Save webhook secret
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Pressable/examples/basic-pressable.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Pressable/examples/basic-pressable.example.tsx
@@ -1,20 +1,47 @@
-import {
-  reactExtension,
-  Icon,
-  InlineStack,
-  Pressable,
-  Text,
-} from '@shopify/ui-extensions-react/admin';
+import {reactExtension, useApi, Pressable, Text, Icon, InlineStack, BlockStack} from '@shopify/ui-extensions-react/admin';
 
-reactExtension('Playground', () => <Extension />);
+function App() {
+  const {data} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
 
-function Extension() {
   return (
-    <Pressable padding="base">
-      <InlineStack>
-        <Text>Go to Apps Dashboard</Text>
-        <Icon name="AppsMajor" />
-      </InlineStack>
-    </Pressable>
+    <BlockStack gap>
+      <Text fontWeight="bold">Quick actions</Text>
+      <Pressable
+        padding="base"
+        onPress={async () => {
+          await fetch('/api/products/sync', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId}),
+          });
+        }}
+      >
+        <InlineStack gap blockAlignment="center">
+          <Icon name="RefreshMajor" accessibilityLabel="" />
+          <Text>Sync inventory now</Text>
+        </InlineStack>
+      </Pressable>
+      <Pressable
+        padding="base"
+        onPress={async () => {
+          await fetch('/api/products/export', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId}),
+          });
+        }}
+      >
+        <InlineStack gap blockAlignment="center">
+          <Icon name="ExportMinor" accessibilityLabel="" />
+          <Text>Export product data</Text>
+        </InlineStack>
+      </Pressable>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Pressable/examples/pressable-accessible.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Pressable/examples/pressable-accessible.example.tsx
@@ -1,0 +1,35 @@
+import {reactExtension, Pressable, Text, Badge, InlineStack, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack gap>
+      <Text fontWeight="bold">Warehouse locations</Text>
+      <Pressable
+        padding="base"
+        accessibilityLabel="View New York warehouse details — 142 units in stock"
+        onPress={() => console.log('Card pressed')}
+      >
+        <InlineStack gap blockAlignment="center">
+          <Text>New York</Text>
+          <Badge tone="success">142 units</Badge>
+        </InlineStack>
+      </Pressable>
+      <Pressable
+        padding="base"
+        accessibilityLabel="View Los Angeles warehouse details — 3 units in stock, low stock"
+        onPress={() => console.log('Card pressed')}
+      >
+        <InlineStack gap blockAlignment="center">
+          <Text>Los Angeles</Text>
+          <Badge tone="warning">3 units</Badge>
+        </InlineStack>
+      </Pressable>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Pressable/examples/pressable-link.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Pressable/examples/pressable-link.example.tsx
@@ -1,0 +1,29 @@
+import {reactExtension, useApi, Pressable, Text, Image, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const numericId = productId?.split('/').pop();
+
+  return (
+    <BlockStack gap>
+      <Pressable
+        href={`https://your-store.myshopify.com/products/${numericId}`}
+        target="_blank"
+        padding="base"
+      >
+        <Image
+          source="https://cdn.shopify.com/s/files/placeholder-images/product.png"
+          accessibilityLabel="Product preview"
+        />
+        <Text fontWeight="bold">View on storefront</Text>
+        <Text>Opens the live product page in a new tab</Text>
+      </Pressable>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/ProgressIndicator/examples/basic-progressindicator.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/ProgressIndicator/examples/basic-progressindicator.example.tsx
@@ -1,12 +1,42 @@
-import {
-  reactExtension,
-  ProgressIndicator,
-} from '@shopify/ui-extensions-react/admin';
-
-reactExtension('Playground', () => <App />);
+import {useState, useEffect} from 'react';
+import {reactExtension, useApi, ProgressIndicator, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+  const {data, query} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const [product, setProduct] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    query(
+      `query Product($id: ID!) {
+        product(id: $id) { title totalInventory }
+      }`,
+      {variables: {id: productId}},
+    ).then((result) => {
+      setProduct(result?.data?.product);
+      setLoading(false);
+    });
+  }, [productId, query]);
+
   return (
-    <ProgressIndicator size="small-200" />
+    <BlockStack>
+      {loading ? (
+        <ProgressIndicator
+          size="small-200"
+          accessibilityLabel="Loading product data"
+        />
+      ) : product ? (
+        <>
+          <Text fontWeight="bold">{product.title}</Text>
+          <Text>Total inventory: {product.totalInventory} units</Text>
+        </>
+      ) : null}
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/ProgressIndicator/examples/progressindicator-inline.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/ProgressIndicator/examples/progressindicator-inline.example.tsx
@@ -1,0 +1,23 @@
+import {reactExtension, ProgressIndicator, Text, InlineStack, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Checking eligibility...</Text>
+      <InlineStack>
+        <ProgressIndicator
+          size="small-300"
+          tone="inherit"
+          accessibilityLabel="Checking product eligibility"
+        />
+        <Text>Verifying product meets marketplace requirements</Text>
+      </InlineStack>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/ProgressIndicator/examples/progressindicator-sizes.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/ProgressIndicator/examples/progressindicator-sizes.example.tsx
@@ -1,0 +1,25 @@
+import {reactExtension, ProgressIndicator, Text, Button, BlockStack, InlineStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+
+  return (
+    <BlockStack>
+      <Text>Syncing product data to your warehouse system...</Text>
+      <InlineStack>
+        <ProgressIndicator
+          size="base"
+          accessibilityLabel="Syncing in progress"
+        />
+      </InlineStack>
+      <Button variant="tertiary" onPress={() => close()}>
+        Cancel
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Section/examples/basic-Section.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Section/examples/basic-Section.example.tsx
@@ -1,16 +1,19 @@
-import React from 'react';
-import {
-  render,
-  Section,
-} from '@shopify/ui-extensions-react/admin';
-
-
-render('Playground', () => <App />);
+import {reactExtension, Section, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+
   return (
-    <Section heading="Section heading">
-      Section content
-    </Section>
+    <BlockStack>
+      <Section heading="Inventory details">
+        <Text>Warehouse: East Coast — New York</Text>
+        <Text>Storage slot: A-42</Text>
+        <Text>Units in stock: 247</Text>
+      </Section>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Section/examples/section-accessible.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Section/examples/section-accessible.example.tsx
@@ -1,0 +1,22 @@
+import {reactExtension, Section, TextField, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Section
+        heading="Shipping configuration"
+        accessibilityLabel="Configure shipping dimensions and weight for this product"
+      >
+        <TextField label="Weight (kg)" name="weight" />
+        <TextField label="Length (cm)" name="length" />
+        <TextField label="Width (cm)" name="width" />
+      </Section>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Section/examples/section-nested.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Section/examples/section-nested.example.tsx
@@ -1,0 +1,22 @@
+import {reactExtension, Section, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Section heading="Product compliance">
+        <Text>Regulatory status for product distribution.</Text>
+        <Section heading="Safety certifications">
+          <Text>UL Listed — Class II</Text>
+          <Text>CE Marking — Approved</Text>
+          <Text>FCC Part 15 — Compliant</Text>
+        </Section>
+      </Section>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Select/examples/basic-select.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Select/examples/basic-select.example.tsx
@@ -1,45 +1,43 @@
-import React from 'react';
-import {
-  render,
-  Select,
-} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, Select, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  const [value, setValue] = React.useState('2');
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [warehouse, setWarehouse] = useState('');
 
   return (
-    <Select
-      label="Country"
-      value={value}
-      onChange={setValue}
-      options={[
-        {
-          value: '1',
-          label: 'Australia',
-        },
-        {
-          value: '2',
-          label: 'Canada',
-        },
-        {
-          value: '3',
-          label: 'France',
-        },
-        {
-          value: '4',
-          label: 'Japan',
-        },
-        {
-          value: '5',
-          label: 'Nigeria',
-        },
-        {
-          value: '6',
-          label: 'United States',
-        },
-      ]}
-    />
+    <BlockStack>
+      <Select
+        label="Assign warehouse"
+        name="warehouse"
+        value={warehouse}
+        options={[
+          {label: 'East Coast — New York', value: 'nyc'},
+          {label: 'West Coast — Los Angeles', value: 'lax'},
+          {label: 'Central — Chicago', value: 'chi'},
+          {label: 'International — London', value: 'lon'},
+        ]}
+        onChange={setWarehouse}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/warehouse', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, warehouse}),
+          });
+          close();
+        }}
+      >
+        Assign warehouse
+      </Button>
+    </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Select/examples/select-error.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Select/examples/select-error.example.tsx
@@ -1,0 +1,53 @@
+import {useState} from 'react';
+import {reactExtension, useApi, Select, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [shippingClass, setShippingClass] = useState('');
+  const [error, setError] = useState(undefined);
+
+  return (
+    <BlockStack>
+      <Select
+        label="Shipping class"
+        name="shippingClass"
+        required
+        value={shippingClass}
+        error={error}
+        options={[
+          {label: 'Standard (5-7 days)', value: 'standard'},
+          {label: 'Express (2-3 days)', value: 'express'},
+          {label: 'Overnight', value: 'overnight'},
+          {label: 'Freight', value: 'freight'},
+        ]}
+        onChange={(value) => {
+          setShippingClass(value);
+          setError(undefined);
+        }}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          if (!shippingClass) {
+            setError('Please select a shipping class');
+            return;
+          }
+          await fetch('/api/products/shipping-class', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, shippingClass}),
+          });
+          close();
+        }}
+      >
+        Save shipping class
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Select/examples/select-placeholder.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Select/examples/select-placeholder.example.tsx
@@ -1,0 +1,27 @@
+import {reactExtension, Select, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Product classification</Text>
+      <Select
+        label="Product category"
+        name="category"
+        placeholder="Select a category…"
+        options={[
+          {label: 'Electronics', value: 'electronics'},
+          {label: 'Apparel', value: 'apparel'},
+          {label: 'Home & Garden', value: 'home-garden'},
+          {label: 'Health & Beauty', value: 'health-beauty'},
+          {label: 'Food & Beverage', value: 'food-beverage'},
+        ]}
+      />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Text/examples/basic-text.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Text/examples/basic-text.example.tsx
@@ -1,12 +1,19 @@
-import {render, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {reactExtension, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
+
   return (
-    <BlockStack inlineAlignment="center" gap>
-      <Text fontWeight="bold">Name:</Text>
-      <Text>Jane Doe</Text>
+    <BlockStack>
+      <Text>Current price: </Text>
+      <Text fontWeight="bold">$49.99</Text>
+      <Text fontWeight="bold" fontStyle="italic">
+        Compare at: $64.99
+      </Text>
     </BlockStack>
   );
 }
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Text/examples/text-emphasis.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Text/examples/text-emphasis.example.tsx
@@ -1,0 +1,20 @@
+import {reactExtension, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontStyle="italic" accessibilityRole="emphasis">
+        This product is currently in draft status and not visible to customers.
+      </Text>
+      <Text fontWeight="bold" accessibilityRole="strong">
+        Action required: Complete all required fields before publishing.
+      </Text>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/Text/examples/text-overflow.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/Text/examples/text-overflow.example.tsx
@@ -1,0 +1,20 @@
+import {reactExtension, Text, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Product description</Text>
+      <Text textOverflow="ellipsis">
+        This premium organic cotton t-shirt features a relaxed fit with
+        reinforced stitching, available in twelve colors with custom embroidery
+        options for wholesale orders.
+      </Text>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/TextArea/examples/basic-textarea.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/TextArea/examples/basic-textarea.example.tsx
@@ -1,7 +1,38 @@
-import {render, TextArea} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, TextArea, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  return <TextArea label="Enter a scheduled social media posting" rows={4} />;
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [notes, setNotes] = useState('');
+
+  return (
+    <BlockStack>
+      <TextArea
+        label="Internal notes"
+        name="internalNotes"
+        rows={4}
+        value={notes}
+        onChange={setNotes}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/notes', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, notes}),
+          });
+          close();
+        }}
+      >
+        Save notes
+      </Button>
+    </BlockStack>
+  );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/TextArea/examples/textarea-prefilled.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/TextArea/examples/textarea-prefilled.example.tsx
@@ -1,0 +1,39 @@
+import {useState, useEffect} from 'react';
+import {reactExtension, useApi, TextArea, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, query} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const [instructions, setInstructions] = useState('');
+
+  useEffect(() => {
+    query(
+      `query Product($id: ID!) {
+        product(id: $id) {
+          metafield(namespace: "custom", key: "shipping_instructions") { value }
+        }
+      }`,
+      {variables: {id: productId}},
+    ).then((result) => {
+      setInstructions(result?.data?.product?.metafield?.value || '');
+    });
+  }, [productId, query]);
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Shipping instructions</Text>
+      <TextArea
+        label="Special handling instructions"
+        name="shippingInstructions"
+        rows={3}
+        value={instructions}
+        readOnly
+      />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/TextArea/examples/textarea-validation.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/TextArea/examples/textarea-validation.example.tsx
@@ -1,0 +1,51 @@
+import {useState} from 'react';
+import {reactExtension, useApi, TextArea, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState(undefined);
+
+  return (
+    <BlockStack>
+      <TextArea
+        label="Product description for external catalog"
+        name="catalogDescription"
+        rows={5}
+        maxLength={500}
+        value={description}
+        error={error}
+        onChange={(value) => {
+          setDescription(value);
+          setError(
+            value.length > 500
+              ? 'Description cannot exceed 500 characters'
+              : undefined,
+          );
+        }}
+      />
+      <Text>{description.length} / 500 characters</Text>
+      <Button
+        variant="primary"
+        onPress={async () => {
+          if (description.length <= 500) {
+            await fetch('/api/products/catalog-description', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId, description}),
+            });
+            close();
+          }
+        }}
+      >
+        Save description
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/TextField/examples/basic-textfield.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/TextField/examples/basic-textfield.example.tsx
@@ -1,7 +1,37 @@
-import {render, TextField} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, TextField, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  return <TextField label="Enter some text" />;
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [label, setLabel] = useState('');
+
+  return (
+    <BlockStack>
+      <TextField
+        label="Custom warehouse label"
+        name="warehouseLabel"
+        value={label}
+        onChange={setLabel}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/label', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, label}),
+          });
+          close();
+        }}
+      >
+        Save label
+      </Button>
+    </BlockStack>
+  );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/TextField/examples/textfield-suffix.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/TextField/examples/textfield-suffix.example.tsx
@@ -1,0 +1,22 @@
+import {reactExtension, TextField, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Shipping configuration</Text>
+      <TextField label="Package weight" name="weight" suffix="kg" />
+      <TextField
+        label="Shopify handle"
+        name="handle"
+        suffix=".myshopify.com"
+        readOnly
+      />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/TextField/examples/textfield-validation.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/TextField/examples/textfield-validation.example.tsx
@@ -1,0 +1,56 @@
+import {useState} from 'react';
+import {reactExtension, useApi, TextField, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [sku, setSku] = useState('');
+  const [error, setError] = useState(undefined);
+
+  function validate(value) {
+    if (value.length < 3) {
+      return 'SKU must be at least 3 characters';
+    }
+    if (!/^[A-Z0-9-]+$/i.test(value)) {
+      return 'SKU can only contain letters, numbers, and hyphens';
+    }
+    return undefined;
+  }
+
+  return (
+    <BlockStack>
+      <TextField
+        label="SKU"
+        name="sku"
+        required
+        value={sku}
+        error={error}
+        onChange={(value) => {
+          setSku(value);
+          setError(validate(value));
+        }}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          const validationError = validate(sku);
+          if (!validationError) {
+            await fetch('/api/products/sku', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId, sku}),
+            });
+            close();
+          }
+        }}
+      >
+        Save SKU
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/URLField/examples/basic-urlfield.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/URLField/examples/basic-urlfield.example.tsx
@@ -1,7 +1,38 @@
-import {render, URLField} from '@shopify/ui-extensions-react/admin';
-
-render('Playground', () => <App />);
+import {useState} from 'react';
+import {reactExtension, useApi, URLField, Button, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
 
 function App() {
-  return <URLField label="Enter store url" />;
+  const {data, close} = useApi('admin.product-details.action.render');
+  const productId = data.selected[0]?.id;
+  const [url, setUrl] = useState('');
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">External product source</Text>
+      <URLField
+        label="Source URL"
+        name="sourceUrl"
+        value={url}
+        onChange={setUrl}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          await fetch('/api/products/source', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, sourceUrl: url}),
+          });
+          close();
+        }}
+      >
+        Save source URL
+      </Button>
+    </BlockStack>
+  );
 }
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/URLField/examples/urlfield-prefilled.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/URLField/examples/urlfield-prefilled.example.tsx
@@ -1,0 +1,25 @@
+import {reactExtension, useApi, URLField, BlockStack, Text} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {data} = useApi('admin.product-details.block.render');
+  const productId = data.selected[0]?.id;
+  const numericId = productId?.split('/').pop();
+
+  return (
+    <BlockStack>
+      <Text fontWeight="bold">Product links</Text>
+      <URLField
+        label="Storefront URL"
+        name="storefrontUrl"
+        value={`https://your-store.myshopify.com/products/${numericId}`}
+        readOnly
+      />
+      <URLField label="External catalog URL" name="externalUrl" />
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.block.render',
+  () => <App />,
+);

--- a/packages/ui-extensions-react/src/surfaces/admin/components/URLField/examples/urlfield-validation.example.tsx
+++ b/packages/ui-extensions-react/src/surfaces/admin/components/URLField/examples/urlfield-validation.example.tsx
@@ -1,0 +1,48 @@
+import {useState} from 'react';
+import {reactExtension, useApi, URLField, Button, BlockStack} from '@shopify/ui-extensions-react/admin';
+
+function App() {
+  const {close} = useApi('admin.product-details.action.render');
+  const [endpoint, setEndpoint] = useState('');
+  const [error, setError] = useState(undefined);
+
+  return (
+    <BlockStack>
+      <URLField
+        label="Webhook endpoint URL"
+        name="webhookEndpoint"
+        required
+        value={endpoint}
+        error={error}
+        onChange={(value) => {
+          setEndpoint(value);
+          setError(
+            value && !value.startsWith('https://')
+              ? 'Webhook endpoints must use HTTPS'
+              : undefined,
+          );
+        }}
+      />
+      <Button
+        variant="primary"
+        onPress={async () => {
+          if (endpoint.startsWith('https://')) {
+            await fetch('/api/webhooks/register', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({endpoint}),
+            });
+            close();
+          }
+        }}
+      >
+        Register webhook
+      </Button>
+    </BlockStack>
+  );
+}
+
+export default reactExtension(
+  'admin.product-details.action.render',
+  () => <App />,
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.doc.ts
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'adminaction-default.png',
     codeblock: {
-      title: 'Set the primary and secondary action of the Action modal.',
+      title: 'Configure action modal with buttons',
       tabs: [
         {
           title: 'React',
@@ -30,12 +30,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-adminaction.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Build a form inside an action modal with [TextField](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) and [Select](/docs/api/admin-extensions/{API_VERSION}/components/forms/select) inputs. This example collects a warehouse SKU and location assignment, submitting the form data through the primary action button.',
+        codeblock: {
+          title: 'Build a modal form',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/AdminAction/examples/adminaction-form.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/adminaction-form.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          "Show a [ProgressIndicator](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/progressindicator) while fetching data from the [GraphQL Admin API](/docs/api/admin-graphql/), then replace it with product details. This example queries product information when the modal opens and displays the results after they've loaded.",
+        codeblock: {
+          title: 'Load data into action modal',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/AdminAction/examples/adminaction-loading.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/adminaction-loading.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/examples/adminaction-form.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/examples/adminaction-form.example.ts
@@ -1,0 +1,60 @@
+import {extension, AdminAction, Button, TextField, Select, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+
+    const content = root.createComponent(BlockStack, {gap: true});
+
+    const skuField = root.createComponent(TextField, {
+      label: 'Warehouse SKU',
+      name: 'warehouseSku',
+      required: true,
+    });
+
+    const warehouseSelect = root.createComponent(Select, {
+      label: 'Target warehouse',
+      name: 'warehouse',
+      options: [
+        {label: 'East Coast — New York', value: 'nyc'},
+        {label: 'West Coast — Los Angeles', value: 'lax'},
+        {label: 'Central — Chicago', value: 'chi'},
+      ],
+    });
+
+    content.appendChild(skuField);
+    content.appendChild(warehouseSelect);
+
+    const primaryAction = root.createComponent(
+      Button,
+      {
+        onPress: async () => {
+          await fetch('/api/products/assign-warehouse', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId}),
+          });
+          close();
+        },
+      },
+      'Assign to warehouse',
+    );
+
+    const secondaryAction = root.createComponent(
+      Button,
+      {onPress: () => close()},
+      'Cancel',
+    );
+
+    const action = root.createComponent(AdminAction, {
+      title: 'Assign warehouse location',
+      primaryAction,
+      secondaryAction,
+    });
+
+    action.appendChild(content);
+    root.appendChild(action);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/examples/adminaction-loading.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/examples/adminaction-loading.example.ts
@@ -1,0 +1,49 @@
+import {extension, AdminAction, Button, Text, ProgressIndicator, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  async (root, api) => {
+    const {data, close, query} = api;
+    const productId = data.selected[0]?.id;
+
+    const content = root.createComponent(BlockStack, {gap: true});
+
+    const loader = root.createComponent(ProgressIndicator, {
+      size: 'small-200',
+      accessibilityLabel: 'Loading product details',
+    });
+    content.appendChild(loader);
+
+    const primaryAction = root.createComponent(
+      Button,
+      {onPress: () => close()},
+      'Done',
+    );
+
+    const action = root.createComponent(AdminAction, {
+      title: 'Product details',
+      primaryAction,
+    });
+    action.appendChild(content);
+    root.appendChild(action);
+
+    const result = await query(
+      `query Product($id: ID!) {
+        product(id: $id) { title status totalInventory }
+      }`,
+      {variables: {id: productId}},
+    );
+
+    content.removeChild(loader);
+
+    const product = result?.data?.product;
+    if (product) {
+      const title = root.createComponent(Text, {fontWeight: 'bold'}, product.title);
+      const status = root.createComponent(Text, {}, `Status: ${product.status}`);
+      const inventory = root.createComponent(Text, {}, `Inventory: ${product.totalInventory} units`);
+      content.appendChild(title);
+      content.appendChild(status);
+      content.appendChild(inventory);
+    }
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/examples/basic-adminaction.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/examples/basic-adminaction.example.ts
@@ -1,22 +1,47 @@
-import {extension, AdminAction, Button} from '@shopify/ui-extensions/admin';
+import {extension, AdminAction, Button, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-export default extension('Playground', (root) => {
-  const primaryAction = root.createFragment();
-  const secondaryAction = root.createFragment();
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
 
-  primaryAction.appendChild(
-    root.createComponent(Button, {onPress: () => {}}, 'Action')
-  );
-  secondaryAction.appendChild(
-    root.createComponent(Button, {onPress: () => {}}, 'Secondary')
-  );
+    const content = root.createComponent(BlockStack, {gap: true});
+    const message = root.createComponent(
+      Text,
+      {},
+      `Sync product ${productId} to your warehouse management system. This will update inventory counts, pricing, and metadata.`,
+    );
+    content.appendChild(message);
 
-  const adminAction = root.createComponent(AdminAction, {
-    title: 'My App Action',
-    primaryAction,
-    secondaryAction,
-  }, 'Modal content');
+    const primaryAction = root.createComponent(
+      Button,
+      {
+        onPress: async () => {
+          await fetch('/api/products/sync', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId}),
+          });
+          close();
+        },
+      },
+      'Sync product',
+    );
 
-  root.appendChild(adminAction);
-  root.mount();
-});
+    const secondaryAction = root.createComponent(
+      Button,
+      {onPress: () => close()},
+      'Cancel',
+    );
+
+    const action = root.createComponent(AdminAction, {
+      title: 'Sync to warehouse',
+      primaryAction,
+      secondaryAction,
+    });
+
+    action.appendChild(content);
+    root.appendChild(action);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.doc.ts
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'adminblock-default.png',
     codeblock: {
-      title: 'Simple AdminBlock implementation',
+      title: 'Display warehouse status block',
       tabs: [
         {
           title: 'React',
@@ -30,12 +30,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-adminblock.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Fetch product data from the [GraphQL Admin API](/docs/api/admin-graphql/) and display it inside the block after loading. This example shows a [ProgressIndicator](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/progressindicator) while the query runs, then replaces it with the product title, variant count, and inventory total.',
+        codeblock: {
+          title: 'Load data into block extension',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/AdminBlock/examples/adminblock-data.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/adminblock-data.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Organize block content into themed groups using [Section](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/section) components with headings. This example splits product specifications into compliance and shipping sections separated by a [Divider](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/divider).',
+        codeblock: {
+          title: 'Organize block with sections',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/AdminBlock/examples/adminblock-sections.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/adminblock-sections.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/examples/adminblock-data.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/examples/adminblock-data.example.ts
@@ -1,0 +1,41 @@
+import {extension, AdminBlock, Text, ProgressIndicator, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  async (root, api) => {
+    const {data, query} = api;
+    const productId = data.selected[0]?.id;
+
+    const content = root.createComponent(BlockStack, {gap: true});
+    const loader = root.createComponent(ProgressIndicator, {
+      size: 'small-200',
+      accessibilityLabel: 'Loading analytics',
+    });
+    content.appendChild(loader);
+
+    const block = root.createComponent(AdminBlock, {
+      title: 'Product analytics',
+    });
+    block.appendChild(content);
+    root.appendChild(block);
+
+    const result = await query(
+      `query Product($id: ID!) {
+        product(id: $id) { title totalInventory totalVariants }
+      }`,
+      {variables: {id: productId}},
+    );
+
+    content.removeChild(loader);
+
+    const product = result?.data?.product;
+    if (product) {
+      const title = root.createComponent(Text, {fontWeight: 'bold'}, product.title);
+      const variants = root.createComponent(Text, {}, `Variants: ${product.totalVariants}`);
+      const inventory = root.createComponent(Text, {}, `Total inventory: ${product.totalInventory}`);
+      content.appendChild(title);
+      content.appendChild(variants);
+      content.appendChild(inventory);
+    }
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/examples/adminblock-sections.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/examples/adminblock-sections.example.ts
@@ -1,0 +1,33 @@
+import {extension, AdminBlock, Section, Text, Divider, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const content = root.createComponent(BlockStack, {gap: true});
+
+    const complianceSection = root.createComponent(Section, {heading: 'Compliance'});
+    const cert = root.createComponent(Text, {}, 'CE Marking — Approved');
+    const region = root.createComponent(Text, {}, 'EU distribution cleared');
+    complianceSection.appendChild(cert);
+    complianceSection.appendChild(region);
+
+    const divider = root.createComponent(Divider);
+
+    const shippingSection = root.createComponent(Section, {heading: 'Shipping'});
+    const weight = root.createComponent(Text, {}, 'Weight: 2.5 kg');
+    const dimensions = root.createComponent(Text, {}, 'Dimensions: 30 × 20 × 15 cm');
+    shippingSection.appendChild(weight);
+    shippingSection.appendChild(dimensions);
+
+    content.appendChild(complianceSection);
+    content.appendChild(divider);
+    content.appendChild(shippingSection);
+
+    const block = root.createComponent(AdminBlock, {
+      title: 'Product specifications',
+    });
+    block.appendChild(content);
+    root.appendChild(block);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/examples/basic-adminblock.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/examples/basic-adminblock.example.ts
@@ -1,10 +1,28 @@
-import {extension, AdminBlock, Button} from '@shopify/ui-extensions/admin';
+import {extension, AdminBlock, Text, Badge, InlineStack, BlockStack} from '@shopify/ui-extensions/admin';
 
-export default extension('Playground', (root) => {
-  const adminBlock = root.createComponent(AdminBlock, {
-    title: 'My App Block',
-  }, '5 items active');
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
 
-  root.appendChild(adminBlock);
-  root.mount();
-});
+    const content = root.createComponent(BlockStack, {gap: true});
+
+    const statusRow = root.createComponent(InlineStack, {gap: true});
+    const statusLabel = root.createComponent(Text, {}, 'Sync status:');
+    const statusBadge = root.createComponent(Badge, {tone: 'success'}, 'Connected');
+    statusRow.appendChild(statusLabel);
+    statusRow.appendChild(statusBadge);
+
+    const lastSync = root.createComponent(Text, {}, 'Last synced 5 minutes ago');
+    const inventory = root.createComponent(Text, {}, 'Warehouse inventory: 247 units across 3 locations');
+
+    content.appendChild(statusRow);
+    content.appendChild(lastSync);
+    content.appendChild(inventory);
+
+    const block = root.createComponent(AdminBlock, {
+      title: 'Warehouse integration',
+    });
+    block.appendChild(content);
+    root.appendChild(block);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.doc.ts
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'adminprintaction-default.png',
     codeblock: {
-      title: 'Set the source URL of the print action extension.',
+      title: 'Generate product packing slip',
       tabs: [
         {
           title: 'React',
@@ -30,12 +30,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-adminprintaction.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          "Print a shipping label by passing format parameters in the `src` URL query string. This example constructs a URL with the product's numeric ID and a `4x6` format parameter, letting your print endpoint generate labels in the correct dimensions.",
+        codeblock: {
+          title: 'Print formatted shipping label',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/AdminPrintAction/examples/adminprintaction-label.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/adminprintaction-label.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Show a [ProgressIndicator](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/progressindicator) while your app generates a complex wholesale invoice. This example displays a spinner alongside a status message while the `src` endpoint prepares the invoice document with pricing and tax details.',
+        codeblock: {
+          title: 'Generate wholesale invoice with loading',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/AdminPrintAction/examples/adminprintaction-invoice.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/adminprintaction-invoice.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/examples/adminprintaction-invoice.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/examples/adminprintaction-invoice.example.ts
@@ -1,0 +1,31 @@
+import {extension, AdminPrintAction, Text, ProgressIndicator, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
+
+    const content = root.createComponent(BlockStack, {gap: true});
+
+    const loader = root.createComponent(ProgressIndicator, {
+      size: 'small-200',
+      accessibilityLabel: 'Generating invoice',
+    });
+
+    const message = root.createComponent(
+      Text,
+      {},
+      'Generating wholesale invoice with pricing and tax details...',
+    );
+
+    content.appendChild(loader);
+    content.appendChild(message);
+
+    const printAction = root.createComponent(AdminPrintAction, {
+      src: `https://your-app.com/print/invoice?product=${productId}&type=wholesale`,
+    });
+    printAction.appendChild(content);
+    root.appendChild(printAction);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/examples/adminprintaction-label.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/examples/adminprintaction-label.example.ts
@@ -1,0 +1,24 @@
+import {extension, AdminPrintAction, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
+    const numericId = productId?.split('/').pop();
+
+    const content = root.createComponent(BlockStack, {gap: true});
+    const message = root.createComponent(
+      Text,
+      {},
+      'Preparing shipping label with warehouse barcode...',
+    );
+    content.appendChild(message);
+
+    const printAction = root.createComponent(AdminPrintAction, {
+      src: `https://your-app.com/print/shipping-label?product=${numericId}&format=4x6`,
+    });
+    printAction.appendChild(content);
+    root.appendChild(printAction);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/examples/basic-adminprintaction.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/examples/basic-adminprintaction.example.ts
@@ -1,14 +1,23 @@
-import {extension, AdminPrintAction, Text} from '@shopify/ui-extensions/admin';
+import {extension, AdminPrintAction, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-export default extension('Playground', (root) => {
-  const adminPrintAction = root.createComponent(
-    AdminPrintAction,
-    {
-      src: 'https://example.com',
-    },
-    root.createComponent(Text, {fontWeight: 'bold'}, 'Modal content'),
-  );
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
 
-  root.append(adminPrintAction);
-  root.mount();
-});
+    const content = root.createComponent(BlockStack, {gap: true});
+    const message = root.createComponent(
+      Text,
+      {},
+      'Generating packing slip for this product...',
+    );
+    content.appendChild(message);
+
+    const printAction = root.createComponent(AdminPrintAction, {
+      src: `https://your-app.com/print/packing-slip?product=${productId}`,
+    });
+    printAction.appendChild(content);
+    root.appendChild(printAction);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'badge-default.png',
     codeblock: {
-      title: 'Simple Badge example',
+      title: 'Display order fulfillment status',
       tabs: [
         {
           title: 'React',
@@ -28,12 +28,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-badge.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Pair a status `icon` with `tone` to create scannable inventory alerts in a [block extension](/docs/api/admin-extensions/{API_VERSION}/components/settings-and-templates/adminblock). This example renders badges with contextual icons like `CircleTickMajor` and `DiamondAlertMajor`, giving merchants a compact visual summary of product availability.',
+        codeblock: {
+          title: 'Add icons to stock alerts',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Badge/examples/badge-icons.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/badge-icons.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Display compact sales channel labels alongside product metadata. This example uses `size="small-100"` and renders multiple badges in an [InlineStack](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/inlinestack), using `tone` to differentiate active channels from pending ones.',
+        codeblock: {
+          title: 'Label product sales channels',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Badge/examples/badge-sizes.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/badge-sizes.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/examples/badge-icons.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/examples/badge-icons.example.ts
@@ -1,0 +1,39 @@
+import {extension, Badge, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Inventory alerts',
+    );
+
+    const inStock = root.createComponent(
+      Badge,
+      {tone: 'success', icon: 'CircleTickMajor'},
+      'In stock',
+    );
+
+    const lowStock = root.createComponent(
+      Badge,
+      {tone: 'warning', icon: 'DiamondAlertMajor'},
+      'Low stock',
+    );
+
+    const outOfStock = root.createComponent(
+      Badge,
+      {tone: 'critical', icon: 'DiamondAlertMajor'},
+      'Out of stock',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(inStock);
+    stack.appendChild(lowStock);
+    stack.appendChild(outOfStock);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/examples/badge-sizes.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/examples/badge-sizes.example.ts
@@ -1,0 +1,43 @@
+import {extension, Badge, InlineStack, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Sales channels',
+    );
+
+    const channels = root.createComponent(InlineStack);
+
+    const online = root.createComponent(
+      Badge,
+      {size: 'small-100', tone: 'success'},
+      'Online Store',
+    );
+
+    const pos = root.createComponent(
+      Badge,
+      {size: 'small-100', tone: 'success'},
+      'POS',
+    );
+
+    const pending = root.createComponent(
+      Badge,
+      {size: 'small-100', tone: 'info'},
+      'Facebook — pending',
+    );
+
+    channels.appendChild(online);
+    channels.appendChild(pos);
+    channels.appendChild(pending);
+
+    stack.appendChild(heading);
+    stack.appendChild(channels);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/examples/basic-badge.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/examples/basic-badge.example.ts
@@ -1,11 +1,39 @@
-import {extend, Badge} from '@shopify/ui-extensions/admin';
+import {extension, Badge, BlockStack, Text} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const badge = root.createComponent(
-    Badge,
-    {tone: 'info'},
-    'Fulfilled',
-  );
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
 
-  root.appendChild(badge);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const label = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Order status:',
+    );
+
+    const fulfilled = root.createComponent(
+      Badge,
+      {tone: 'success'},
+      'Fulfilled',
+    );
+
+    const partial = root.createComponent(
+      Badge,
+      {tone: 'warning'},
+      'Partially fulfilled',
+    );
+
+    const unfulfilled = root.createComponent(
+      Badge,
+      {tone: 'critical'},
+      'Unfulfilled',
+    );
+
+    stack.appendChild(label);
+    stack.appendChild(fulfilled);
+    stack.appendChild(partial);
+    stack.appendChild(unfulfilled);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'banner-default.png',
     codeblock: {
-      title: 'Simple Banner example',
+      title: 'Warn about API sync failure',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-banner.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Show a `success` banner after completing a product update to give merchants immediate visual confirmation. This example renders a dismissible banner with a message that includes the product ID, so merchants know exactly which resource was updated.',
+        codeblock: {
+          title: 'Confirm successful product update',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Banner/examples/banner-success.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/banner-success.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Show `warning` validation issues at the top of an [action modal](/docs/api/admin-extensions/{API_VERSION}/components/settings-and-templates/adminaction) before merchants submit. This example combines a banner with `secondaryAction` to let merchants review or dismiss the warning before proceeding.',
+        codeblock: {
+          title: 'Display form validation warnings',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Banner/examples/banner-warning.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/banner-warning.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/examples/banner-success.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/examples/banner-success.example.ts
@@ -1,0 +1,27 @@
+import {extension, Banner, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
+
+    const stack = root.createComponent(BlockStack);
+
+    const banner = root.createComponent(
+      Banner,
+      {
+        title: 'Product updated successfully',
+        tone: 'success',
+        dismissible: true,
+        onDismiss: () => {
+          stack.removeChild(banner);
+        },
+      },
+      `Tags and metafields for product ${productId} have been synced to your external catalog.`,
+    );
+
+    stack.appendChild(banner);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/examples/banner-warning.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/examples/banner-warning.example.ts
@@ -1,0 +1,29 @@
+import {extension, Banner, Button, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {close} = api;
+
+    const stack = root.createComponent(BlockStack);
+
+    const dismissButton = root.createComponent(
+      Button,
+      {onPress: () => close()},
+      'Dismiss',
+    );
+
+    const banner = root.createComponent(
+      Banner,
+      {
+        title: 'Missing required fields',
+        tone: 'warning',
+        secondaryAction: dismissButton,
+      },
+      'The product is missing a weight and shipping dimensions. These fields are required by your fulfillment provider before orders can be processed.',
+    );
+
+    stack.appendChild(banner);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/examples/basic-banner.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/examples/basic-banner.example.ts
@@ -1,11 +1,42 @@
-import {extend, Banner} from '@shopify/ui-extensions/admin';
+import {extension, Banner, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const banner = root.createComponent(Banner, {
-    title: 'Shipping rates changed',
-    dismissible: true,
-    onDismiss: () => console.log('dismissed banner')
-  }, 'Your store may be affected');
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
 
-  root.appendChild(banner);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const retryButton = root.createComponent(
+      Button,
+      {
+        onPress: async () => {
+          await fetch('/api/products/sync', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId}),
+          });
+        },
+      },
+      'Retry sync',
+    );
+
+    const banner = root.createComponent(
+      Banner,
+      {
+        title: 'Product sync failed',
+        tone: 'critical',
+        dismissible: true,
+        onDismiss: () => {
+          stack.removeChild(banner);
+        },
+        primaryAction: retryButton,
+      },
+      'The last sync attempt could not reach your warehouse system. Check your API credentials and try again.',
+    );
+
+    stack.appendChild(banner);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/BlockStack/BlockStack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/BlockStack/BlockStack.doc.ts
@@ -16,13 +16,12 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'BlockStackProps',
     },
   ],
-  related: [],
   category: 'UI components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'blockstack-default.png',
     codeblock: {
-      title: 'Laying out elements in a column',
+      title: 'Stack extension content vertically',
       tabs: [
         {
           title: 'React',
@@ -30,14 +29,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-blockstack.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Center a status display within the extension using `inlineAlignment="center"` on the `BlockStack`. This example centers an [InlineStack](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/inlinestack) of [Badge](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/badge) indicators, creating a focused status row.',
+        codeblock: {
+          title: 'Center-align block content',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/BlockStack/examples/blockstack-alignment.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/blockstack-alignment.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Separate compliance sections with spacing and a divider inside a block layout. This example applies `padding` and `paddingBlock` on nested `BlockStack` components, separated by a [Divider](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/divider).',
+        codeblock: {
+          title: 'Add padding between sections',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/BlockStack/examples/blockstack-padding.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/blockstack-padding.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',
@@ -53,6 +94,7 @@ const data: ReferenceEntityTemplateSchema = {
 - BlockStack doesn't render any visible background, border, or shadow. It is purely a layout container. For visual styling, wrap it in a [Box](/docs/api/admin-extensions/{API_VERSION}/ui-components/layout-and-structure/box) or [Section](/docs/api/admin-extensions/{API_VERSION}/ui-components/layout-and-structure/section).`,
     },
   ],
+  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/BlockStack/examples/basic-blockstack.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/BlockStack/examples/basic-blockstack.example.ts
@@ -1,24 +1,24 @@
-import {
-  extension,
-  BlockStack,
-} from '@shopify/ui-extensions/admin';
+import {extension, BlockStack, Text, Button} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'Playground',
+  'admin.product-details.block.render',
   (root) => {
-    const blockStack = root.createComponent(
-      BlockStack,
-      {
-        gap: true,
-      },
-      [
-        root.createText('Child 1'),
-        root.createText('Child 2'),
-        root.createText('Child 3'),
-        root.createText('Child 4'),
-      ],
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const title = root.createComponent(Text, {fontWeight: 'bold'}, 'Warehouse sync');
+    const status = root.createComponent(Text, {}, 'Last synced 10 minutes ago');
+    const detail = root.createComponent(Text, {}, '12 variants, 3 locations updated');
+    const action = root.createComponent(
+      Button,
+      {variant: 'secondary', onPress: () => console.log('Viewing sync log')},
+      'View sync log',
     );
 
-    root.appendChild(blockStack);
+    stack.appendChild(title);
+    stack.appendChild(status);
+    stack.appendChild(detail);
+    stack.appendChild(action);
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/BlockStack/examples/blockstack-alignment.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/BlockStack/examples/blockstack-alignment.example.ts
@@ -1,0 +1,27 @@
+import {extension, BlockStack, Text, Badge, InlineStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack, {
+      gap: true,
+      inlineAlignment: 'center',
+    });
+
+    const title = root.createComponent(Text, {fontWeight: 'bold'}, 'Integration status');
+
+    const badges = root.createComponent(InlineStack, {gap: true});
+    const connectedBadge = root.createComponent(Badge, {tone: 'success'}, 'Connected');
+    const syncBadge = root.createComponent(Badge, {tone: 'info'}, 'Auto-sync on');
+    badges.appendChild(connectedBadge);
+    badges.appendChild(syncBadge);
+
+    const count = root.createComponent(Text, {}, '247 products synced');
+
+    stack.appendChild(title);
+    stack.appendChild(badges);
+    stack.appendChild(count);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/BlockStack/examples/blockstack-padding.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/BlockStack/examples/blockstack-padding.example.ts
@@ -1,0 +1,40 @@
+import {extension, BlockStack, Text, Heading, Divider} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const outer = root.createComponent(BlockStack, {
+      gap: true,
+      padding: 'base',
+    });
+
+    const heading = root.createComponent(Heading, {}, 'Product compliance');
+
+    const section1 = root.createComponent(BlockStack, {
+      gap: true,
+      paddingBlock: 'base',
+    });
+    const label1 = root.createComponent(Text, {fontWeight: 'bold'}, 'Safety rating');
+    const value1 = root.createComponent(Text, {}, 'UL Listed — Class II');
+    section1.appendChild(label1);
+    section1.appendChild(value1);
+
+    const divider = root.createComponent(Divider);
+
+    const section2 = root.createComponent(BlockStack, {
+      gap: true,
+      paddingBlock: 'base',
+    });
+    const label2 = root.createComponent(Text, {fontWeight: 'bold'}, 'Certifications');
+    const value2 = root.createComponent(Text, {}, 'CE, FCC, RoHS compliant');
+    section2.appendChild(label2);
+    section2.appendChild(value2);
+
+    outer.appendChild(heading);
+    outer.appendChild(section1);
+    outer.appendChild(divider);
+    outer.appendChild(section2);
+    root.appendChild(outer);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'box-default.png',
     codeblock: {
-      title: 'Use Box to build your layout',
+      title: 'Create a padded content container',
       tabs: [
         {
           title: 'React',
@@ -28,14 +28,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-box.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Constrain an [Image](/docs/api/admin-extensions/{API_VERSION}/components/media-and-visuals/image) to a fixed size using `inlineSize` and `blockSize` props. This example creates a thumbnail container alongside product details in an [InlineStack](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/inlinestack), preventing the image from stretching beyond its bounds.',
+        codeblock: {
+          title: 'Constrain image dimensions',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Box/examples/box-sizing.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/box-sizing.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Hide supplementary content from the visible layout while keeping it in the DOM. This example uses `display="none"` on a `Box` with `accessibilityRole="status"` to remove a compliance message visually without deleting it from the page.',
+        codeblock: {
+          title: 'Control visibility with display',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Box/examples/box-display.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/box-display.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/examples/basic-box.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/examples/basic-box.example.ts
@@ -1,11 +1,27 @@
-import {extend, Box} from '@shopify/ui-extensions/admin';
+import {extension, Box, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const box = root.createComponent(
-    Box,
-    {padding: 'base'},
-    'Box',
-  );
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
 
-  root.appendChild(box);
-});
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const heading = root.createComponent(Text, {fontWeight: 'bold'}, 'Warehouse slot');
+
+    const card = root.createComponent(Box, {
+      padding: 'base',
+    });
+
+    const slot = root.createComponent(Text, {fontWeight: 'bold'}, 'Slot A-42');
+    const location = root.createComponent(Text, {}, 'Aisle A, Rack 4, Shelf 2');
+    const status = root.createComponent(Text, {}, '24 units stored');
+
+    card.appendChild(slot);
+    card.appendChild(location);
+    card.appendChild(status);
+
+    stack.appendChild(heading);
+    stack.appendChild(card);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/examples/box-display.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/examples/box-display.example.ts
@@ -1,0 +1,34 @@
+import {extension, Box, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const heading = root.createComponent(Text, {fontWeight: 'bold'}, 'Compliance status');
+
+    const visibleBox = root.createComponent(Box, {
+      display: 'auto',
+      padding: 'base',
+    });
+    const visibleText = root.createComponent(Text, {}, 'This product has been reviewed and approved for sale.');
+    visibleBox.appendChild(visibleText);
+
+    const hiddenBox = root.createComponent(Box, {
+      display: 'none',
+      accessibilityRole: 'status',
+    });
+    const hiddenText = root.createComponent(
+      Text,
+      {},
+      'Compliance check passed — accessible to screen readers only.',
+    );
+    hiddenBox.appendChild(hiddenText);
+
+    stack.appendChild(heading);
+    stack.appendChild(visibleBox);
+    stack.appendChild(hiddenBox);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/examples/box-sizing.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/examples/box-sizing.example.ts
@@ -1,0 +1,35 @@
+import {extension, Box, Image, Text, InlineStack, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const row = root.createComponent(InlineStack, {gap: true});
+
+    const imageBox = root.createComponent(Box, {
+      inlineSize: 80,
+      blockSize: 80,
+    });
+    const image = root.createComponent(Image, {
+      source: 'https://cdn.shopify.com/s/files/placeholder-images/product.png',
+      accessibilityLabel: 'Product thumbnail',
+    });
+    imageBox.appendChild(image);
+
+    const detailBox = root.createComponent(Box);
+    const title = root.createComponent(Text, {fontWeight: 'bold'}, 'Premium Widget');
+    const sku = root.createComponent(Text, {}, 'SKU: WH-1234');
+    const price = root.createComponent(Text, {}, '$49.99');
+    detailBox.appendChild(title);
+    detailBox.appendChild(sku);
+    detailBox.appendChild(price);
+
+    row.appendChild(imageBox);
+    row.appendChild(detailBox);
+
+    stack.appendChild(row);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'button-default.png',
     codeblock: {
-      title: 'Add a simple button to your app.',
+      title: 'Sync product to backend',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-button.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Present publish, archive, and delete actions for a product using `variant` and `tone` props to communicate intent. This example uses `primary` for the main action, `tertiary` for a low-emphasis option, and `critical` tone for the destructive delete.',
+        codeblock: {
+          title: 'Set button variants and tones',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Button/examples/button-variants.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/button-variants.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Link to the product storefront page and documentation using `href` and `target` props. This example renders buttons as external links that open in new tabs, and uses `accessibilityLabel` to provide screen reader context.',
+        codeblock: {
+          title: 'Open external links',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Button/examples/button-link.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/button-link.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/examples/basic-button.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/examples/basic-button.example.ts
@@ -1,11 +1,39 @@
-import {extend, Button} from '@shopify/ui-extensions/admin';
+import {extension, Button, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const button = root.createComponent(
-    Button,
-    {onPress: () => console.log('onPress event')},
-    'Click here',
-  );
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
 
-  root.appendChild(button);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const info = root.createComponent(
+      Text,
+      {},
+      `Product: ${productId}`,
+    );
+
+    const saveButton = root.createComponent(Button, {
+      variant: 'primary',
+      onPress: async () => {
+        await fetch('/api/products/sync', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({productId}),
+        });
+        close();
+      },
+    }, 'Sync to warehouse');
+
+    const cancelButton = root.createComponent(Button, {
+      variant: 'secondary',
+      onPress: () => close(),
+    }, 'Cancel');
+
+    stack.appendChild(info);
+    stack.appendChild(saveButton);
+    stack.appendChild(cancelButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/examples/button-link.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/examples/button-link.example.ts
@@ -1,0 +1,36 @@
+import {extension, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
+    const numericId = productId?.split('/').pop();
+
+    const stack = root.createComponent(BlockStack);
+
+    const label = root.createComponent(
+      Text,
+      {},
+      'External resources',
+    );
+
+    const storefrontLink = root.createComponent(Button, {
+      href: `https://your-store.myshopify.com/products/${numericId}`,
+      target: '_blank',
+      variant: 'secondary',
+      accessibilityLabel: 'View product on storefront in a new tab',
+    }, 'View on storefront');
+
+    const docsLink = root.createComponent(Button, {
+      href: 'https://help.shopify.com/manual/products',
+      target: '_blank',
+      variant: 'tertiary',
+    }, 'Product documentation');
+
+    stack.appendChild(label);
+    stack.appendChild(storefrontLink);
+    stack.appendChild(docsLink);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/examples/button-variants.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/examples/button-variants.example.ts
@@ -1,0 +1,47 @@
+import {extension, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {},
+      'Choose an action for this product:',
+    );
+
+    const publishButton = root.createComponent(Button, {
+      variant: 'primary',
+      onPress: async () => {
+        await fetch(`/api/products/${productId}/publish`, {method: 'POST'});
+        close();
+      },
+    }, 'Publish product');
+
+    const archiveButton = root.createComponent(Button, {
+      variant: 'tertiary',
+      onPress: async () => {
+        await fetch(`/api/products/${productId}/archive`, {method: 'POST'});
+        close();
+      },
+    }, 'Archive product');
+
+    const deleteButton = root.createComponent(Button, {
+      tone: 'critical',
+      onPress: async () => {
+        await fetch(`/api/products/${productId}`, {method: 'DELETE'});
+        close();
+      },
+    }, 'Delete product');
+
+    stack.appendChild(heading);
+    stack.appendChild(publishButton);
+    stack.appendChild(archiveButton);
+    stack.appendChild(deleteButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'checkbox-default.png',
     codeblock: {
-      title: 'Add a simple Checkbox',
+      title: 'Toggle feature settings',
       tabs: [
         {
           title: 'React',
@@ -29,14 +29,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-checkbox.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Require merchants to agree to terms before connecting a service using the `error` prop for validation. This example shows an inline error when the merchant attempts to submit without checking the box, which requires explicit consent before proceeding.',
+        codeblock: {
+          title: 'Validate required agreement',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Checkbox/examples/checkbox-error.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/checkbox-error.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Present multiple independent options as a group of checkboxes for channel publishing. This example renders three checkboxes (Online Store, Point of Sale, and Wholesale), letting merchants select any combination of sales channels for a product.',
+        codeblock: {
+          title: 'Select multiple channel options',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Checkbox/examples/checkbox-multiple.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/checkbox-multiple.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/examples/basic-checkbox.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/examples/basic-checkbox.example.ts
@@ -1,11 +1,40 @@
-import {extend, Checkbox} from '@shopify/ui-extensions/admin';
+import {extension, Checkbox, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const checkbox = root.createComponent(
-    Checkbox,
-    {id: 'checkbox', name: 'checkbox'},
-    'Save this information for next time',
-  );
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let syncEnabled = false;
 
-  root.appendChild(checkbox);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const checkbox = root.createComponent(Checkbox, {
+      label: 'Enable automatic inventory sync',
+      checked: syncEnabled,
+      onChange: (value) => {
+        syncEnabled = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/sync-settings', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, syncEnabled}),
+          });
+          close();
+        },
+      },
+      'Save settings',
+    );
+
+    stack.appendChild(checkbox);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/examples/checkbox-error.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/examples/checkbox-error.example.ts
@@ -1,0 +1,47 @@
+import {extension, Checkbox, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {close} = api;
+    let agreed = false;
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Terms of service',
+    );
+
+    const checkbox = root.createComponent(Checkbox, {
+      label: 'I agree to the fulfillment provider terms of service',
+      checked: agreed,
+      onChange: (value) => {
+        agreed = value;
+        checkbox.updateProps({error: undefined});
+      },
+    });
+
+    const connectButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          if (!agreed) {
+            checkbox.updateProps({error: 'You must agree to the terms before connecting'});
+            return;
+          }
+          await fetch('/api/fulfillment/connect', {method: 'POST'});
+          close();
+        },
+      },
+      'Connect provider',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(checkbox);
+    stack.appendChild(connectButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/examples/checkbox-multiple.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/examples/checkbox-multiple.example.ts
@@ -1,0 +1,59 @@
+import {extension, Checkbox, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    const channels = {online: true, pos: false, wholesale: false};
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Publish to channels',
+    );
+
+    const onlineCheckbox = root.createComponent(Checkbox, {
+      label: 'Online Store',
+      checked: channels.online,
+      onChange: (value) => { channels.online = value; },
+    });
+
+    const posCheckbox = root.createComponent(Checkbox, {
+      label: 'Point of Sale',
+      checked: channels.pos,
+      onChange: (value) => { channels.pos = value; },
+    });
+
+    const wholesaleCheckbox = root.createComponent(Checkbox, {
+      label: 'Wholesale',
+      checked: channels.wholesale,
+      onChange: (value) => { channels.wholesale = value; },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/channels', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, channels}),
+          });
+          close();
+        },
+      },
+      'Update channels',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(onlineCheckbox);
+    stack.appendChild(posCheckbox);
+    stack.appendChild(wholesaleCheckbox);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'choicelist-default.png',
     codeblock: {
-      title: 'Simple ChoiceList example',
+      title: 'Choose a shipping method',
       tabs: [
         {
           title: 'React',
@@ -29,14 +29,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-choicelist.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Enable multi-select with the `multiple` prop to let merchants pick several options at once. This example renders checkboxes for product tags like "Seasonal" and "Best seller", collecting an array of selected values to save as product metadata.',
+        codeblock: {
+          title: 'Select multiple product tags',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/ChoiceList/examples/choicelist-multiple.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/choicelist-multiple.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Validate that a selection has been made before submission using the `error` prop. This example shows an inline error when merchants attempt to save without selecting a compliance region, so a region is always chosen before the data reaches your backend.',
+        codeblock: {
+          title: 'Validate required selection',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/ChoiceList/examples/choicelist-error.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/choicelist-error.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/examples/basic-choicelist.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/examples/basic-choicelist.example.ts
@@ -1,23 +1,45 @@
-import {
-  extension,
-  ChoiceList,
-} from '@shopify/ui-extensions/admin';
+import {extension, ChoiceList, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'Playground',
-  (root) => {
-    const blockStack = root.createComponent(
-      ChoiceList,
-      {
-        name: 'Company name',
-        choices: [
-            {label: 'Hidden', id: '1'},
-            {label: 'Optional', id: '2'},
-            {label: 'Required', id: '3'},
-        ]
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let shippingMethod = 'standard';
+
+    const stack = root.createComponent(BlockStack);
+
+    const choiceList = root.createComponent(ChoiceList, {
+      name: 'shippingMethod',
+      value: shippingMethod,
+      choices: [
+        {label: 'Standard shipping (5-7 business days)', id: 'standard'},
+        {label: 'Express shipping (2-3 business days)', id: 'express'},
+        {label: 'Overnight delivery', id: 'overnight'},
+      ],
+      onChange: (value) => {
+        shippingMethod = value;
       },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/shipping-method', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, shippingMethod}),
+          });
+          close();
+        },
+      },
+      'Save shipping method',
     );
 
-    root.appendChild(blockStack);
+    stack.appendChild(choiceList);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/examples/choicelist-error.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/examples/choicelist-error.example.ts
@@ -1,0 +1,50 @@
+import {extension, ChoiceList, Button, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let complianceRegion = '';
+
+    const stack = root.createComponent(BlockStack);
+
+    const choiceList = root.createComponent(ChoiceList, {
+      name: 'complianceRegion',
+      value: complianceRegion,
+      choices: [
+        {label: 'North America (FDA, FTC)', id: 'na'},
+        {label: 'European Union (CE, REACH)', id: 'eu'},
+        {label: 'Asia-Pacific (JIS, CCC)', id: 'apac'},
+      ],
+      onChange: (value) => {
+        complianceRegion = value;
+        choiceList.updateProps({error: undefined});
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          if (!complianceRegion) {
+            choiceList.updateProps({error: 'Select a compliance region before saving'});
+            return;
+          }
+          await fetch('/api/products/compliance', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, complianceRegion}),
+          });
+          close();
+        },
+      },
+      'Set compliance region',
+    );
+
+    stack.appendChild(choiceList);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/examples/choicelist-multiple.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/examples/choicelist-multiple.example.ts
@@ -1,0 +1,55 @@
+import {extension, ChoiceList, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let tags = [];
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Apply product tags',
+    );
+
+    const choiceList = root.createComponent(ChoiceList, {
+      name: 'productTags',
+      multiple: true,
+      value: tags,
+      choices: [
+        {label: 'Seasonal', id: 'seasonal'},
+        {label: 'Clearance', id: 'clearance'},
+        {label: 'New arrival', id: 'new-arrival'},
+        {label: 'Best seller', id: 'best-seller'},
+        {label: 'Limited edition', id: 'limited-edition'},
+      ],
+      onChange: (value) => {
+        tags = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/tags', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, tags}),
+          });
+          close();
+        },
+      },
+      'Apply tags',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(choiceList);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'colorpicker-default.png',
     codeblock: {
-      title: 'Simple ColorPicker example',
+      title: 'Select product accent color',
       tabs: [
         {
           title: 'React',
@@ -29,14 +29,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-colorpicker.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Enable the alpha (transparency) channel by setting `allowAlpha` to `true`. This example lets merchants pick an overlay color with adjustable opacity, returning a hex color string with alpha (for example, `#RRGGBBAA`) for use on product pages.',
+        codeblock: {
+          title: 'Enable alpha transparency selection',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/ColorPicker/examples/colorpicker-alpha.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/colorpicker-alpha.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Present multiple color pickers for a complete brand color configuration. This example renders primary and secondary brand color pickers separated by a [Divider](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/divider), letting merchants define a full product page color scheme.',
+        codeblock: {
+          title: 'Configure brand color palette',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/ColorPicker/examples/colorpicker-branding.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/colorpicker-branding.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/examples/basic-colorpicker.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/examples/basic-colorpicker.example.ts
@@ -1,19 +1,46 @@
-import {
-  extension,
-  ColorPicker,
-} from '@shopify/ui-extensions/admin';
+import {extension, ColorPicker, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'Playground',
-  (root) => {
-    const blockStack = root.createComponent(
-      ColorPicker,
-      {
-        value: "rgba(255 0 0 / 0.5)",
-        label: ""
-      },
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let color = '#000000';
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Product accent color',
     );
 
-    root.appendChild(blockStack);
+    const picker = root.createComponent(ColorPicker, {
+      value: color,
+      onChange: (value) => {
+        color = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/accent-color', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, color}),
+          });
+          close();
+        },
+      },
+      'Save color',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(picker);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/examples/colorpicker-alpha.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/examples/colorpicker-alpha.example.ts
@@ -1,0 +1,30 @@
+import {extension, ColorPicker, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Overlay color with transparency',
+    );
+
+    const picker = root.createComponent(ColorPicker, {
+      value: 'rgba(0, 0, 0, 0.5)',
+      allowAlpha: true,
+      onChange: (value) => {
+        preview.replaceChildren(`Selected: ${value}`);
+      },
+    });
+
+    const preview = root.createComponent(Text, {}, 'Selected: rgba(0, 0, 0, 0.5)');
+
+    stack.appendChild(heading);
+    stack.appendChild(picker);
+    stack.appendChild(preview);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/examples/colorpicker-branding.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/examples/colorpicker-branding.example.ts
@@ -1,0 +1,37 @@
+import {extension, ColorPicker, Text, Divider, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Brand colors for product page',
+    );
+
+    const primaryLabel = root.createComponent(Text, {}, 'Primary brand color');
+    const primaryPicker = root.createComponent(ColorPicker, {
+      value: '#2C6ECB',
+      onChange: (color) => console.log('Selected:', color),
+    });
+
+    const divider = root.createComponent(Divider);
+
+    const secondaryLabel = root.createComponent(Text, {}, 'Secondary brand color');
+    const secondaryPicker = root.createComponent(ColorPicker, {
+      value: '#F4F6F8',
+      onChange: (color) => console.log('Selected:', color),
+    });
+
+    stack.appendChild(heading);
+    stack.appendChild(primaryLabel);
+    stack.appendChild(primaryPicker);
+    stack.appendChild(divider);
+    stack.appendChild(secondaryLabel);
+    stack.appendChild(secondaryPicker);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/CustomerSegmentTemplate.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/CustomerSegmentTemplate.doc.ts
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'customersegmenttemplate-default',
     codeblock: {
-      title: 'Simple CustomerSegmentTemplate implementation',
+      title: 'Create a repeat buyer segment template',
       tabs: [
         {
           title: 'React',
@@ -30,12 +30,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/customersegmenttemplate.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Use `queryToInsert` to provide a different query than what is displayed in the template preview. This example shows a complete query with a US region filter in the template card, but inserts a version with an empty region placeholder so merchants can customize the filter for their market.',
+        codeblock: {
+          title: 'Customize the inserted query',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate-queryinsert.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/customersegmenttemplate-queryinsert.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Declare custom metafield dependencies using the `dependencies` prop so the segment editor knows which metafields your query references. This example filters customers by a `loyalty.tier` custom metafield, enabling the editor to validate the query and show relevant autocomplete suggestions.',
+        codeblock: {
+          title: 'Declare metafield dependencies',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate-metafields.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/customersegmenttemplate-metafields.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate-metafields.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate-metafields.example.ts
@@ -1,0 +1,18 @@
+import {extension, CustomerSegmentTemplate} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.customers.segmentation-templates.render',
+  (root, {i18n}) => {
+    const template = root.createComponent(CustomerSegmentTemplate, {
+      title: 'Loyalty tier members',
+      description: 'Customers assigned to a specific loyalty tier through your app. This template uses a custom metafield to filter customers by their current membership level.',
+      query: 'customer.metafields.loyalty.tier = "gold"',
+      dependencies: {
+        customMetafields: ['loyalty.tier'],
+      },
+      createdOn: new Date('2024-10-01').toISOString(),
+    });
+
+    root.appendChild(template);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate-queryinsert.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate-queryinsert.example.ts
@@ -1,0 +1,19 @@
+import {extension, CustomerSegmentTemplate} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.customers.segmentation-templates.render',
+  (root, {i18n}) => {
+    const template = root.createComponent(CustomerSegmentTemplate, {
+      title: 'Lapsed customers by region',
+      description: [
+        'Customers who have not placed an order in the last 90 days, filtered by geographic region.',
+        'The displayed query shows an example for US customers. When inserted into the editor, the region filter is left as a placeholder for merchants to customize.',
+      ],
+      query: 'days_since_last_order > 90 AND customer_country = "US"',
+      queryToInsert: 'days_since_last_order > 90 AND customer_country = ""',
+      createdOn: new Date('2024-08-15').toISOString(),
+    });
+
+    root.appendChild(template);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/examples/customersegmenttemplate.example.ts
@@ -4,14 +4,12 @@ export default extension(
   'admin.customers.segmentation-templates.render',
   (root, {i18n}) => {
     const template = root.createComponent(CustomerSegmentTemplate, {
-      title: i18n.translate('template.title'),
-      description: i18n.translate('template.description'),
-      query: "number_of_orders > 0'",
-      createdOn: new Date('2023-01-15').toISOString(),
+      title: 'High-value repeat buyers',
+      description: 'Customers who have placed more than 5 orders with a total spend exceeding $500. Use this segment to target loyal customers for VIP promotions and early access campaigns.',
+      query: 'number_of_orders > 5 AND amount_spent > 500',
+      createdOn: new Date('2024-06-01').toISOString(),
     });
 
     root.appendChild(template);
-
-    root.mount();
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
@@ -16,13 +16,12 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'DateFieldProps',
     },
   ],
-  related: [],
   category: 'UI components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'datefield-default.png',
     codeblock: {
-      title: 'Add a single-date DateField',
+      title: 'Schedule product launch date',
       tabs: [
         {
           title: 'React',
@@ -30,14 +29,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-datefield.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          "Validate that a selected date is in the future using the `error` prop. This example checks the expiration date against today's date on each change and displays an inline error for past dates, so merchants can only set valid expiry windows.",
+        codeblock: {
+          title: 'Validate future date selection',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/DateField/examples/datefield-validation.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/datefield-validation.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Display historical dates as read-only reference fields using the `readOnly` prop. This example shows the product creation date and last warehouse sync date as non-editable fields, providing merchants with timeline context in a [block extension](/docs/api/admin-extensions/{API_VERSION}/components/settings-and-templates/adminblock).',
+        codeblock: {
+          title: 'Display read-only date references',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/DateField/examples/datefield-readonly.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/datefield-readonly.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',
@@ -54,6 +95,7 @@ const data: ReferenceEntityTemplateSchema = {
 - DateField doesn't support time selection. If you need date and time, you must combine DateField with a separate time input.`,
     },
   ],
+  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/basic-datefield.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/basic-datefield.example.ts
@@ -1,14 +1,40 @@
-import {extend, DateField} from '@shopify/ui-extensions/admin';
+import {extension, DateField, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const dateField = root.createComponent(
-    DateField,
-    {
-      label: 'Date',
-      value: '2023-11-08',
-    },
-    'DateField',
-  );
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let launchDate = '';
 
-  root.appendChild(dateField);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(DateField, {
+      label: 'Product launch date',
+      name: 'launchDate',
+      onChange: (value) => {
+        launchDate = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/launch-date', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, launchDate}),
+          });
+          close();
+        },
+      },
+      'Schedule launch',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/datefield-readonly.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/datefield-readonly.example.ts
@@ -1,0 +1,34 @@
+import {extension, DateField, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Important dates',
+    );
+
+    const createdField = root.createComponent(DateField, {
+      label: 'Date created',
+      name: 'dateCreated',
+      value: '2024-01-15',
+      readOnly: true,
+    });
+
+    const lastSyncField = root.createComponent(DateField, {
+      label: 'Last warehouse sync',
+      name: 'lastSync',
+      value: '2024-03-20',
+      readOnly: true,
+    });
+
+    stack.appendChild(heading);
+    stack.appendChild(createdField);
+    stack.appendChild(lastSyncField);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/datefield-validation.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/datefield-validation.example.ts
@@ -1,0 +1,56 @@
+import {extension, DateField, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let expiryDate = '';
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Product expiry',
+    );
+
+    const field = root.createComponent(DateField, {
+      label: 'Expiration date',
+      name: 'expiryDate',
+      onChange: (value) => {
+        expiryDate = value;
+        const selected = new Date(value);
+        const today = new Date();
+        if (selected <= today) {
+          field.updateProps({error: 'Expiry date must be in the future'});
+        } else {
+          field.updateProps({error: undefined});
+        }
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          if (expiryDate) {
+            await fetch('/api/products/expiry', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId, expiryDate}),
+            });
+            close();
+          }
+        },
+      },
+      'Set expiry date',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'datepicker-default.png',
     codeblock: {
-      title: 'Add a single-date DatePicker',
+      title: 'Schedule promotion start date',
       tabs: [
         {
           title: 'React',
@@ -29,9 +29,9 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-datepicker.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
@@ -40,9 +40,10 @@ const data: ReferenceEntityTemplateSchema = {
     description: '',
     examples: [
       {
-        description: 'Use this when merchants need to select multiple dates.',
+        description:
+          "Enable multi-date selection by passing an array to `selected` to let merchants pick multiple individual dates. This example collects shipping blackout dates (specific days when a product can't be shipped) and saves them as an array to your fulfillment backend.",
         codeblock: {
-          title: 'Add a multi-date DatePicker',
+          title: 'Select multiple blackout dates',
           tabs: [
             {
               title: 'React',
@@ -50,17 +51,18 @@ const data: ReferenceEntityTemplateSchema = {
               language: 'tsx',
             },
             {
-              title: 'JS',
+              title: 'TS',
               code: './examples/multiple-datepicker.example.ts',
-              language: 'js',
+              language: 'ts',
             },
           ],
         },
       },
       {
-        description: 'Use this when merchants need to select a range of dates.',
+        description:
+          'Select a date range by passing an object with `start` and `end` properties to `selected`. This example lets merchants define a sale period by picking start and end dates on the calendar, then saves the range to configure time-limited pricing.',
         codeblock: {
-          title: 'Add a range DatePicker',
+          title: 'Define a sale date range',
           tabs: [
             {
               title: 'React',
@@ -68,9 +70,9 @@ const data: ReferenceEntityTemplateSchema = {
               language: 'tsx',
             },
             {
-              title: 'JS',
+              title: 'TS',
               code: './examples/range-datepicker.example.ts',
-              language: 'js',
+              language: 'ts',
             },
           ],
         },

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/examples/basic-datepicker.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/examples/basic-datepicker.example.ts
@@ -1,11 +1,46 @@
-import {extend, DatePicker} from '@shopify/ui-extensions/admin';
+import {extension, DatePicker, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const datePicker = root.createComponent(
-    DatePicker,
-    {},
-    'DatePicker',
-  );
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let selectedDate = '';
 
-  root.appendChild(datePicker);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Schedule promotion start',
+    );
+
+    const picker = root.createComponent(DatePicker, {
+      selected: selectedDate,
+      onChange: (value) => {
+        selectedDate = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/promotion', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, startDate: selectedDate}),
+          });
+          close();
+        },
+      },
+      'Schedule promotion',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(picker);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/examples/multiple-datepicker.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/examples/multiple-datepicker.example.ts
@@ -1,11 +1,53 @@
-import {extend, DatePicker} from '@shopify/ui-extensions/admin';
+import {extension, DatePicker, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const datePicker = root.createComponent(
-    DatePicker,
-    { selected: ['2023-11-08'] },
-    'DatePicker',
-  );
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let blackoutDates = [];
 
-  root.appendChild(datePicker);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Select shipping blackout dates',
+    );
+
+    const description = root.createComponent(
+      Text,
+      {},
+      'Choose dates when this product cannot be shipped.',
+    );
+
+    const picker = root.createComponent(DatePicker, {
+      selected: blackoutDates,
+      onChange: (value) => {
+        blackoutDates = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/blackout-dates', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, blackoutDates}),
+          });
+          close();
+        },
+      },
+      'Save blackout dates',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(description);
+    stack.appendChild(picker);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/examples/range-datepicker.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/examples/range-datepicker.example.ts
@@ -1,11 +1,46 @@
-import {extend, DatePicker} from '@shopify/ui-extensions/admin';
+import {extension, DatePicker, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const datePicker = root.createComponent(
-    DatePicker,
-    { selected: {start: '2023-11-08', end: '2023-11-10' } },
-    'DatePicker',
-  );
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let dateRange = {start: '', end: ''};
 
-  root.appendChild(datePicker);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Set sale period',
+    );
+
+    const picker = root.createComponent(DatePicker, {
+      selected: dateRange,
+      onChange: (value) => {
+        dateRange = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/sale-period', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, ...dateRange}),
+          });
+          close();
+        },
+      },
+      'Save sale period',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(picker);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'divider-default.png',
     codeblock: {
-      title: 'Simple Divider example',
+      title: 'Separate content sections',
       tabs: [
         {
           title: 'React',
@@ -29,14 +29,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-divider.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Render a vertical divider between inline elements using `direction="block"`. This example separates a product price from its SKU inside an [InlineStack](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/inlinestack), creating a compact metadata row.',
+        codeblock: {
+          title: 'Add vertical inline dividers',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Divider/examples/divider-inline.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/divider-inline.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Break a multi-section form into visually distinct groups using dividers between [TextField](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) clusters. This example separates shipping details from customs information in an [action modal](/docs/api/admin-extensions/{API_VERSION}/components/settings-and-templates/adminaction), making it easier for merchants to find fields.',
+        codeblock: {
+          title: 'Divide form groups',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Divider/examples/divider-sections.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/divider-sections.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/examples/basic-divider.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/examples/basic-divider.example.ts
@@ -1,17 +1,24 @@
-import {
-    extension,
-    Divider,
-  } from '@shopify/ui-extensions/admin';
+import {extension, Divider, Heading, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-  export default extension(
-    'Playground',
-    (root) => {
-      const divier = root.createComponent(Divider);
-      const firstText = root.createText('First Text');
-      const secondText = root.createText('Second Text');
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
 
-      root.appendChild(firstText);
-      root.appendChild(divier);
-      root.appendChild(secondText);
-    },
-  );
+    const stack = root.createComponent(BlockStack);
+
+    const title = root.createComponent(Heading, {}, 'Sync status');
+    const status = root.createComponent(Text, {}, 'Last synced 5 minutes ago — all fields up to date.');
+
+    const divider = root.createComponent(Divider);
+
+    const historyTitle = root.createComponent(Heading, {size: 3}, 'Recent changes');
+    const history = root.createComponent(Text, {}, '3 metafields updated, 1 tag added in the last 24 hours.');
+
+    stack.appendChild(title);
+    stack.appendChild(status);
+    stack.appendChild(divider);
+    stack.appendChild(historyTitle);
+    stack.appendChild(history);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/examples/divider-inline.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/examples/divider-inline.example.ts
@@ -1,0 +1,30 @@
+import {extension, Divider, Text, InlineStack, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const row = root.createComponent(InlineStack);
+
+    const price = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      '$49.99',
+    );
+
+    const divider = root.createComponent(Divider, {
+      direction: 'block',
+    });
+
+    const sku = root.createComponent(Text, {}, 'SKU: WH-1234');
+
+    row.appendChild(price);
+    row.appendChild(divider);
+    row.appendChild(sku);
+
+    stack.appendChild(row);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/examples/divider-sections.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/examples/divider-sections.example.ts
@@ -1,0 +1,40 @@
+import {extension, Divider, TextField, Heading, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const shippingTitle = root.createComponent(Heading, {}, 'Shipping details');
+    const weightField = root.createComponent(TextField, {
+      label: 'Weight (kg)',
+      name: 'weight',
+    });
+    const dimensionsField = root.createComponent(TextField, {
+      label: 'Dimensions (L×W×H cm)',
+      name: 'dimensions',
+    });
+
+    const divider = root.createComponent(Divider);
+
+    const customsTitle = root.createComponent(Heading, {}, 'Customs information');
+    const hsCodeField = root.createComponent(TextField, {
+      label: 'HS tariff code',
+      name: 'hsCode',
+    });
+    const originField = root.createComponent(TextField, {
+      label: 'Country of origin',
+      name: 'countryOfOrigin',
+    });
+
+    stack.appendChild(shippingTitle);
+    stack.appendChild(weightField);
+    stack.appendChild(dimensionsField);
+    stack.appendChild(divider);
+    stack.appendChild(customsTitle);
+    stack.appendChild(hsCodeField);
+    stack.appendChild(originField);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'emailfield-default.png',
     codeblock: {
-      title: 'Simple EmailField example',
+      title: 'Collect notification email',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-emailfield.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Validate email format on each keystroke using the `error` prop and `required` attribute. This example checks for the presence of an `@` symbol as the merchant types and displays an inline error message, preventing invalid email addresses from being saved.',
+        codeblock: {
+          title: 'Validate email format inline',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/EmailField/examples/emailfield-validation.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/emailfield-validation.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Pre-fill an email field with a default value using the `value` prop for edit workflows. This example combines an `EmailField` with a [TextField](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) to build a complete fulfillment contact form, with a primary email pre-populated and an optional CC field.',
+        codeblock: {
+          title: 'Pre-fill contact form fields',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/EmailField/examples/emailfield-prefilled.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/emailfield-prefilled.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/examples/basic-emailfield.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/examples/basic-emailfield.example.ts
@@ -1,9 +1,47 @@
-import {extend, EmailField} from '@shopify/ui-extensions/admin';
+import {extension, EmailField, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const emailField = root.createComponent(EmailField, {
-    label: 'Enter your email address',
-  });
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let email = '';
 
-  root.appendChild(emailField);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Notification settings',
+    );
+
+    const field = root.createComponent(EmailField, {
+      label: 'Low stock notification email',
+      name: 'notificationEmail',
+      onChange: (value) => {
+        email = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/notifications/email', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, email}),
+          });
+          close();
+        },
+      },
+      'Save notification email',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/examples/emailfield-prefilled.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/examples/emailfield-prefilled.example.ts
@@ -1,0 +1,38 @@
+import {extension, EmailField, TextField, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Fulfillment contact',
+    );
+
+    const nameField = root.createComponent(TextField, {
+      label: 'Contact name',
+      name: 'contactName',
+    });
+
+    const emailField = root.createComponent(EmailField, {
+      label: 'Contact email',
+      name: 'contactEmail',
+      value: 'fulfillment@example.com',
+      disabled: false,
+    });
+
+    const ccField = root.createComponent(EmailField, {
+      label: 'CC email (optional)',
+      name: 'ccEmail',
+    });
+
+    stack.appendChild(heading);
+    stack.appendChild(nameField);
+    stack.appendChild(emailField);
+    stack.appendChild(ccField);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/examples/emailfield-validation.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/examples/emailfield-validation.example.ts
@@ -1,0 +1,48 @@
+import {extension, EmailField, Button, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let supplierEmail = '';
+
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(EmailField, {
+      label: 'Supplier contact email',
+      name: 'supplierEmail',
+      required: true,
+      onChange: (value) => {
+        supplierEmail = value;
+        if (value && !value.includes('@')) {
+          field.updateProps({error: 'Enter a valid email address'});
+        } else {
+          field.updateProps({error: undefined});
+        }
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          if (supplierEmail.includes('@')) {
+            await fetch('/api/suppliers/contact', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId, email: supplierEmail}),
+            });
+            close();
+          }
+        },
+      },
+      'Save supplier contact',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/Form.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/Form.doc.ts
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'form-default.png',
     codeblock: {
-      title: 'Simple form implementation',
+      title: 'Submit product metadata form',
       tabs: [
         {
           title: 'React',
@@ -28,12 +28,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-form.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Handle cancellation with the `onReset` callback to close the modal without saving. This example pairs submit and reset actions using [InlineStack](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/inlinestack) to right-align the cancel and save buttons, following standard dialog patterns.',
+        codeblock: {
+          title: 'Handle form submit and cancel',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Form/examples/form-reset.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/form-reset.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Organize complex forms with [Section](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/section) components to group related fields together. This example splits a fulfillment provider setup into "Provider details" and "Contact information" sections, making long forms easier to scan.',
+        codeblock: {
+          title: 'Organize form with sections',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Form/examples/form-sections.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/form-sections.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/examples/basic-form.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/examples/basic-form.example.ts
@@ -1,43 +1,48 @@
-import {
-  extend,
-  Form,
-  TextField,
-} from '@shopify/ui-extensions/admin';
+import {extension, Form, TextField, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('admin.product-details.block.render', (root) => {
-  let name = '';
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
 
-  const textField = root.createComponent(
-    TextField,
-    {
-      label: 'name',
-      value: name,
-      onChange: (value) => {
-        textField.updateProps({value});
-        name = value;
+    const form = root.createComponent(Form, {
+      onSubmit: async () => {
+        await fetch('/api/products/metadata', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({productId}),
+        });
+        close();
       },
-    }
-  );
+      onReset: () => {
+        close();
+      },
+    });
 
-  const onSubmit = async () => {
-    // API call to save the values
-    const res = await fetch('/save', {method:'POST', body: JSON.stringify({name})});
-    if (!res.ok) {
-      const json = await res.json();
-      // The Host can catch these errors and do something with them.
-      throw Error(`There were errors: ${json.errors.join(',')}`);
-    }
-  };
+    const stack = root.createComponent(BlockStack, {gap: true});
 
-  const onReset = async () => {
-    name = '';
-  };
+    const skuField = root.createComponent(TextField, {
+      label: 'Warehouse SKU',
+      name: 'warehouseSku',
+      required: true,
+    });
 
-  const form = root.createComponent(
-    Form,
-    {onSubmit, onReset}
-  );
+    const locationField = root.createComponent(TextField, {
+      label: 'Storage location',
+      name: 'location',
+    });
 
-  form.appendChild(textField);
-  root.appendChild(form);
-});
+    const submitButton = root.createComponent(
+      Button,
+      {variant: 'primary'},
+      'Save product metadata',
+    );
+
+    stack.appendChild(skuField);
+    stack.appendChild(locationField);
+    stack.appendChild(submitButton);
+    form.appendChild(stack);
+    root.appendChild(form);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/examples/form-reset.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/examples/form-reset.example.ts
@@ -1,0 +1,55 @@
+import {extension, Form, TextField, Button, InlineStack, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+
+    const form = root.createComponent(Form, {
+      onSubmit: async () => {
+        await fetch('/api/products/shipping', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({productId}),
+        });
+        close();
+      },
+      onReset: () => {
+        close();
+      },
+    });
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const weightField = root.createComponent(TextField, {
+      label: 'Package weight (kg)',
+      name: 'weight',
+    });
+
+    const dimensionsField = root.createComponent(TextField, {
+      label: 'Dimensions (L×W×H cm)',
+      name: 'dimensions',
+    });
+
+    const actions = root.createComponent(InlineStack, {gap: true, inlineAlignment: 'end'});
+    const resetButton = root.createComponent(
+      Button,
+      {variant: 'tertiary', accessibilityRole: 'reset'},
+      'Cancel',
+    );
+    const submitButton = root.createComponent(
+      Button,
+      {variant: 'primary', accessibilityRole: 'submit'},
+      'Save shipping info',
+    );
+    actions.appendChild(resetButton);
+    actions.appendChild(submitButton);
+
+    stack.appendChild(weightField);
+    stack.appendChild(dimensionsField);
+    stack.appendChild(actions);
+    form.appendChild(stack);
+    root.appendChild(form);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/examples/form-sections.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/examples/form-sections.example.ts
@@ -1,0 +1,45 @@
+import {extension, Form, TextField, EmailField, Section, Button, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+
+    const form = root.createComponent(Form, {
+      onSubmit: async () => {
+        await fetch('/api/fulfillment/setup', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({productId}),
+        });
+        close();
+      },
+      onReset: () => {
+        close();
+      },
+    });
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const providerSection = root.createComponent(Section, {heading: 'Provider details'});
+    const nameField = root.createComponent(TextField, {label: 'Provider name', name: 'providerName', required: true});
+    const endpointField = root.createComponent(TextField, {label: 'API endpoint', name: 'endpoint'});
+    providerSection.appendChild(nameField);
+    providerSection.appendChild(endpointField);
+
+    const contactSection = root.createComponent(Section, {heading: 'Contact information'});
+    const contactName = root.createComponent(TextField, {label: 'Contact name', name: 'contactName'});
+    const contactEmail = root.createComponent(EmailField, {label: 'Contact email', name: 'contactEmail'});
+    contactSection.appendChild(contactName);
+    contactSection.appendChild(contactEmail);
+
+    const submitButton = root.createComponent(Button, {variant: 'primary'}, 'Set up provider');
+
+    stack.appendChild(providerSection);
+    stack.appendChild(contactSection);
+    stack.appendChild(submitButton);
+    form.appendChild(stack);
+    root.appendChild(form);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.doc.ts
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'form-default.png',
     codeblock: {
-      title: 'Simple function settings form implementation',
+      title: 'Configure function validation settings',
       tabs: [
         {
           title: 'React',
@@ -30,12 +30,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-functionsettings.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Collect multiple metafield values in a single settings form using [NumberField](/docs/api/admin-extensions/{API_VERSION}/components/forms/numberfield) and [TextField](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) components. This example manages minimum quantity, maximum quantity, and a custom error message, writing each change to its own metafield key through `applyMetafieldsChange`.',
+        codeblock: {
+          title: 'Manage multiple metafield settings',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/FunctionSettings/examples/functionsettings-multiple.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/functionsettings-multiple.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Use the `onSave` callback to notify your backend when the admin saves changes. This example configures a discount function with a title and type [ChoiceList](/docs/api/admin-extensions/{API_VERSION}/components/forms/choicelist), calling your validation endpoint during save and surfacing any errors through `onError`.',
+        codeblock: {
+          title: 'Validate settings on save',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/FunctionSettings/examples/functionsettings-save.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/functionsettings-save.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/examples/basic-functionsettings.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/examples/basic-functionsettings.example.ts
@@ -1,29 +1,21 @@
-import {
-  extension,
-  FunctionSettings,
-  TextField,
-  Section,
-} from '@shopify/ui-extensions/admin';
+import {extension, FunctionSettings, TextField, Section} from '@shopify/ui-extensions/admin';
 
 export default extension(
   'admin.settings.validation.render',
   async (root, api) => {
-    // Use Direct API access to fetch initial
-    // metafields from the server if we are
-    // rendering against a pre-existing `Validation`
     const initialSettings = api.data.validation
       ? await fetchSettings(api.data.validation.id)
       : {};
 
-    const textField = root.createComponent(TextField, {
-      value: initialSettings.name,
-      label: 'Name',
+    const nameField = root.createComponent(TextField, {
+      value: initialSettings.name || '',
+      label: 'Rule name',
       name: 'name',
       onChange(value) {
-        textField.updateProps({value, error: undefined});
+        nameField.updateProps({value, error: undefined});
         api.applyMetafieldsChange({
           type: 'updateMetafield',
-          namespace: '$app:my_namespace',
+          namespace: '$app:validation',
           key: 'name',
           value,
           valueType: 'single_line_text_field',
@@ -32,16 +24,17 @@ export default extension(
     });
 
     const section = root.createComponent(Section, {
-      heading: 'Settings',
+      heading: 'Validation settings',
     });
 
     const settings = root.createComponent(FunctionSettings, {
       onError(errors) {
-        textField.updateProps({error: errors[0]?.message});
+        nameField.updateProps({error: errors[0]?.message});
       },
     });
 
-    section.append(textField);
-    settings.append(section);
+    section.appendChild(nameField);
+    settings.appendChild(section);
+    root.appendChild(settings);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/examples/functionsettings-multiple.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/examples/functionsettings-multiple.example.ts
@@ -1,0 +1,77 @@
+import {extension, FunctionSettings, TextField, NumberField, Section} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.settings.validation.render',
+  async (root, api) => {
+    const initialSettings = api.data.validation
+      ? await fetchSettings(api.data.validation.id)
+      : {};
+
+    const minField = root.createComponent(NumberField, {
+      value: initialSettings.minQuantity || 1,
+      label: 'Minimum order quantity',
+      name: 'minQuantity',
+      min: 1,
+      onChange(value) {
+        minField.updateProps({value});
+        api.applyMetafieldsChange({
+          type: 'updateMetafield',
+          namespace: '$app:validation',
+          key: 'min_quantity',
+          value: String(value),
+          valueType: 'number_integer',
+        });
+      },
+    });
+
+    const maxField = root.createComponent(NumberField, {
+      value: initialSettings.maxQuantity || 100,
+      label: 'Maximum order quantity',
+      name: 'maxQuantity',
+      min: 1,
+      onChange(value) {
+        maxField.updateProps({value});
+        api.applyMetafieldsChange({
+          type: 'updateMetafield',
+          namespace: '$app:validation',
+          key: 'max_quantity',
+          value: String(value),
+          valueType: 'number_integer',
+        });
+      },
+    });
+
+    const messageField = root.createComponent(TextField, {
+      value: initialSettings.errorMessage || '',
+      label: 'Error message shown to customers',
+      name: 'errorMessage',
+      onChange(value) {
+        messageField.updateProps({value});
+        api.applyMetafieldsChange({
+          type: 'updateMetafield',
+          namespace: '$app:validation',
+          key: 'error_message',
+          value,
+          valueType: 'single_line_text_field',
+        });
+      },
+    });
+
+    const section = root.createComponent(Section, {
+      heading: 'Quantity limits',
+    });
+
+    const settings = root.createComponent(FunctionSettings, {
+      onError(errors) {
+        const firstError = errors[0]?.message;
+        minField.updateProps({error: firstError});
+      },
+    });
+
+    section.appendChild(minField);
+    section.appendChild(maxField);
+    section.appendChild(messageField);
+    settings.appendChild(section);
+    root.appendChild(settings);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/examples/functionsettings-save.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/examples/functionsettings-save.example.ts
@@ -1,0 +1,65 @@
+import {extension, FunctionSettings, TextField, ChoiceList, Section, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.settings.validation.render',
+  async (root, api) => {
+    const initialSettings = api.data.validation
+      ? await fetchSettings(api.data.validation.id)
+      : {};
+
+    const titleField = root.createComponent(TextField, {
+      value: initialSettings.title || '',
+      label: 'Discount title',
+      name: 'title',
+      required: true,
+      onChange(value) {
+        titleField.updateProps({value, error: undefined});
+        api.applyMetafieldsChange({
+          type: 'updateMetafield',
+          namespace: '$app:discount',
+          key: 'title',
+          value,
+          valueType: 'single_line_text_field',
+        });
+      },
+    });
+
+    const typeChoice = root.createComponent(ChoiceList, {
+      name: 'discountType',
+      value: initialSettings.type || 'percentage',
+      choices: [
+        {label: 'Percentage discount', id: 'percentage'},
+        {label: 'Fixed amount discount', id: 'fixed'},
+      ],
+      onChange(value) {
+        api.applyMetafieldsChange({
+          type: 'updateMetafield',
+          namespace: '$app:discount',
+          key: 'type',
+          value,
+          valueType: 'single_line_text_field',
+        });
+      },
+    });
+
+    const section = root.createComponent(Section, {
+      heading: 'Discount configuration',
+    });
+
+    const settings = root.createComponent(FunctionSettings, {
+      onSave: async () => {
+        await fetch('/api/functions/validate-config', {method: 'POST'});
+      },
+      onError(errors) {
+        titleField.updateProps({error: errors[0]?.message});
+      },
+    });
+
+    const content = root.createComponent(BlockStack, {gap: true});
+    content.appendChild(titleField);
+    content.appendChild(typeChoice);
+    section.appendChild(content);
+    settings.appendChild(section);
+    root.appendChild(settings);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'heading-default.png',
     codeblock: {
-      title: 'Simple Heading example',
+      title: 'Label extension sections',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-heading.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          "Control heading size using the `size` prop to create visual hierarchy. This example renders a size-2 heading for the extension title and a size-3 sub-heading for a detail section, mirroring the Shopify admin's native content structure.",
+        codeblock: {
+          title: 'Create hierarchical content sections',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Heading/examples/heading-sizes.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/heading-sizes.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Create accessible section labels using the `id` prop inside a [Section](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/section) component. This example nests a heading within a section to maintain proper document outline so screen readers announce the section context correctly.',
+        codeblock: {
+          title: 'Build accessible section labels',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Heading/examples/heading-accessible.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/heading-accessible.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/examples/basic-heading.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/examples/basic-heading.example.ts
@@ -1,7 +1,24 @@
-import {extend, Heading} from '@shopify/ui-extensions/admin';
+import {extension, Heading, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const heading = root.createComponent(Heading, undefined, 'Headings are cool');
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+    const stack = root.createComponent(BlockStack);
 
-  root.appendChild(heading);
-});
+    const heading = root.createComponent(
+      Heading,
+      {},
+      'Product analytics',
+    );
+
+    const detail = root.createComponent(
+      Text,
+      {},
+      'View real-time performance metrics synced from your analytics provider.',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(detail);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/examples/heading-accessible.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/examples/heading-accessible.example.ts
@@ -1,0 +1,32 @@
+import {extension, Heading, Section, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const section = root.createComponent(
+      Section,
+      {heading: 'Custom fields'},
+    );
+
+    const heading = root.createComponent(
+      Heading,
+      {id: 'metafields-heading'},
+      'Metafield values',
+    );
+
+    const description = root.createComponent(
+      Text,
+      {},
+      'These custom fields are synced with your external product information management system.',
+    );
+
+    section.appendChild(heading);
+    section.appendChild(description);
+
+    stack.appendChild(section);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/examples/heading-sizes.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/examples/heading-sizes.example.ts
@@ -1,0 +1,39 @@
+import {extension, Heading, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const primary = root.createComponent(
+      Heading,
+      {size: 2},
+      'Warehouse integration',
+    );
+
+    const section = root.createComponent(
+      Text,
+      {},
+      'Manage inventory sync and fulfillment settings for this product.',
+    );
+
+    const sub = root.createComponent(
+      Heading,
+      {size: 3},
+      'Sync history',
+    );
+
+    const detail = root.createComponent(
+      Text,
+      {},
+      'Last synced 15 minutes ago — 3 variants updated successfully.',
+    );
+
+    stack.appendChild(primary);
+    stack.appendChild(section);
+    stack.appendChild(sub);
+    stack.appendChild(detail);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/HeadingGroup/HeadingGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/HeadingGroup/HeadingGroup.doc.ts
@@ -13,7 +13,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'headinggroup-default.png',
     codeblock: {
-      title: 'Simple HeadingGroup example',
+      title: 'Group related heading content',
       tabs: [
         {
           title: 'React',
@@ -21,9 +21,9 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-headinggroup.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },

--- a/packages/ui-extensions/src/surfaces/admin/components/HeadingGroup/examples/basic-headinggroup.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/HeadingGroup/examples/basic-headinggroup.example.ts
@@ -1,20 +1,36 @@
-import {
-    extend,
-    HeadingGroup,
-    Heading,
-    BlockStack,
-  } from '@shopify/ui-extensions/admin';
+import {extension, HeadingGroup, Heading, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-  extend('Playground', (root) => {
-    const headingGroup = root.createComponent(BlockStack, undefined, [
-      root.createComponent(Heading, undefined, 'Heading <h1>'),
-      root.createComponent(HeadingGroup, undefined, [
-        root.createComponent(Heading, undefined, 'Heading <h2>'),
-        root.createComponent(HeadingGroup, undefined, [
-          root.createComponent(Heading, undefined, 'Heading <h3>'),
-        ]),
-      ]),
-    ]);
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
 
-    root.appendChild(headingGroup);
-  });
+    const stack = root.createComponent(BlockStack);
+
+    const h1 = root.createComponent(
+      Heading,
+      {},
+      'Warehouse integration',
+    );
+
+    const group = root.createComponent(HeadingGroup);
+
+    const h2 = root.createComponent(
+      Heading,
+      {},
+      'Sync configuration',
+    );
+
+    const detail = root.createComponent(
+      Text,
+      {},
+      'Configure how product data flows between Shopify and your warehouse management system.',
+    );
+
+    group.appendChild(h2);
+    group.appendChild(detail);
+
+    stack.appendChild(h1);
+    stack.appendChild(group);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/HeadingGroup/examples/headinggroup-form.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/HeadingGroup/examples/headinggroup-form.example.ts
@@ -1,0 +1,33 @@
+import {extension, HeadingGroup, Heading, TextField, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const title = root.createComponent(Heading, {}, 'Custom shipping rules');
+
+    const formGroup = root.createComponent(HeadingGroup);
+
+    const formTitle = root.createComponent(Heading, {}, 'Domestic shipping');
+
+    const weightField = root.createComponent(TextField, {
+      label: 'Max package weight (kg)',
+      name: 'maxWeight',
+    });
+
+    const handlingField = root.createComponent(TextField, {
+      label: 'Handling instructions',
+      name: 'handling',
+    });
+
+    formGroup.appendChild(formTitle);
+    formGroup.appendChild(weightField);
+    formGroup.appendChild(handlingField);
+
+    stack.appendChild(title);
+    stack.appendChild(formGroup);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/HeadingGroup/examples/headinggroup-nested.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/HeadingGroup/examples/headinggroup-nested.example.ts
@@ -1,0 +1,38 @@
+import {extension, HeadingGroup, Heading, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const title = root.createComponent(Heading, {}, 'Product compliance');
+
+    const outerGroup = root.createComponent(HeadingGroup);
+    const sectionTitle = root.createComponent(Heading, {}, 'Safety certifications');
+    const sectionText = root.createComponent(
+      Text,
+      {},
+      'Certifications required for sale in regulated markets.',
+    );
+
+    const innerGroup = root.createComponent(HeadingGroup);
+    const subTitle = root.createComponent(Heading, {}, 'EU compliance');
+    const subText = root.createComponent(
+      Text,
+      {},
+      'CE marking and REACH regulation status for European Union distribution.',
+    );
+
+    innerGroup.appendChild(subTitle);
+    innerGroup.appendChild(subText);
+
+    outerGroup.appendChild(sectionTitle);
+    outerGroup.appendChild(sectionText);
+    outerGroup.appendChild(innerGroup);
+
+    stack.appendChild(title);
+    stack.appendChild(outerGroup);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
@@ -26,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'icon-default.png',
     codeblock: {
-      title: 'Simple Icon example',
+      title: 'Show action status indicators',
       tabs: [
         {
           title: 'React',
@@ -34,12 +34,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-icon.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Apply the `critical` tone to icons that represent failures or items requiring attention. This example shows passing and failing compliance checks, using the default tone for passes and `tone="critical"` for failures so merchants can spot problems at a glance.',
+        codeblock: {
+          title: 'Apply critical tone to warning icons',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Icon/examples/icon-tones.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/icon-tones.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Scale an icon to match its parent container for larger displays like status badges or app logos. This example places an icon with `size="fill"` inside a fixed-size [Box](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/box), allowing it to scale proportionally.',
+        codeblock: {
+          title: 'Fill a container with an icon',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Icon/examples/icon-fill.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/icon-fill.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/examples/basic-icon.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/examples/basic-icon.example.ts
@@ -1,7 +1,31 @@
-import {extend, Icon} from '@shopify/ui-extensions/admin';
+import {extension, Icon, Text, InlineStack, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const icon = root.createComponent(Icon, {name: 'AppsMajor'});
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
 
-  root.appendChild(icon);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const syncRow = root.createComponent(InlineStack);
+    const syncIcon = root.createComponent(Icon, {
+      name: 'CircleTickMajor',
+      accessibilityLabel: 'Synced',
+    });
+    const syncText = root.createComponent(Text, {}, 'Inventory synced');
+    syncRow.appendChild(syncIcon);
+    syncRow.appendChild(syncText);
+
+    const alertRow = root.createComponent(InlineStack);
+    const alertIcon = root.createComponent(Icon, {
+      name: 'CircleAlertMajor',
+      accessibilityLabel: 'Error',
+    });
+    const alertText = root.createComponent(Text, {}, 'Pricing error detected');
+    alertRow.appendChild(alertIcon);
+    alertRow.appendChild(alertText);
+
+    stack.appendChild(syncRow);
+    stack.appendChild(alertRow);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/examples/icon-fill.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/examples/icon-fill.example.ts
@@ -1,0 +1,39 @@
+import {extension, Icon, Text, BlockStack, Box} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const label = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'App status',
+    );
+
+    const iconContainer = root.createComponent(Box, {
+      inlineSize: 48,
+      blockSize: 48,
+    });
+
+    const appIcon = root.createComponent(Icon, {
+      name: 'AppsMajor',
+      size: 'fill',
+      accessibilityLabel: 'App connected',
+    });
+
+    iconContainer.appendChild(appIcon);
+
+    const status = root.createComponent(
+      Text,
+      {},
+      'Connected to warehouse system',
+    );
+
+    stack.appendChild(label);
+    stack.appendChild(iconContainer);
+    stack.appendChild(status);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/examples/icon-tones.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/examples/icon-tones.example.ts
@@ -1,0 +1,39 @@
+import {extension, Icon, Text, InlineStack, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Compliance checks',
+    );
+
+    const passRow = root.createComponent(InlineStack);
+    const passIcon = root.createComponent(Icon, {
+      name: 'CircleTickMajor',
+      accessibilityLabel: 'Passed',
+    });
+    const passText = root.createComponent(Text, {}, 'Safety standards — passed');
+    passRow.appendChild(passIcon);
+    passRow.appendChild(passText);
+
+    const failRow = root.createComponent(InlineStack);
+    const failIcon = root.createComponent(Icon, {
+      name: 'CircleAlertMajor',
+      tone: 'critical',
+      accessibilityLabel: 'Failed',
+    });
+    const failText = root.createComponent(Text, {}, 'Label requirements — action needed');
+    failRow.appendChild(failIcon);
+    failRow.appendChild(failText);
+
+    stack.appendChild(heading);
+    stack.appendChild(passRow);
+    stack.appendChild(failRow);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'image-default.png',
     codeblock: {
-      title: 'Simple Image example',
+      title: 'Display product featured image',
       tabs: [
         {
           title: 'React',
@@ -28,14 +28,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-image.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Handle image loading and error states using `onLoad` and `onError` callbacks. This example shows a [ProgressIndicator](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/progressindicator) while the image loads and displays an error message if the image fails to load, preventing broken image placeholders.',
+        codeblock: {
+          title: 'Handle image loading states',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Image/examples/image-loading.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/image-loading.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Mark non-essential images as decorative using `accessibilityRole="decorative"` with an empty `accessibilityLabel`. This example renders a partner branding banner that screen readers skip, keeping the focus on meaningful content.',
+        codeblock: {
+          title: 'Add decorative branding images',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Image/examples/image-decorative.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/image-decorative.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/examples/basic-image.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/examples/basic-image.example.ts
@@ -1,10 +1,41 @@
-import {extend, Image} from '@shopify/ui-extensions/admin';
+import {extension, Image, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const image = root.createComponent(Image, {
-    alt: 'Pickaxe',
-    source: 'https://shopify.dev/assets/icons/64/pickaxe-1.png',
-  });
+export default extension(
+  'admin.product-details.block.render',
+  async (root, api) => {
+    const {data, query} = api;
+    const productId = data.selected[0]?.id;
 
-  root.appendChild(image);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const result = await query(
+      `query Product($id: ID!) {
+        product(id: $id) {
+          title
+          featuredImage { url altText }
+        }
+      }`,
+      {variables: {id: productId}},
+    );
+
+    const product = result?.data?.product;
+
+    if (product?.featuredImage) {
+      const image = root.createComponent(Image, {
+        source: product.featuredImage.url,
+        accessibilityLabel: product.featuredImage.altText || product.title,
+      });
+
+      const caption = root.createComponent(
+        Text,
+        {},
+        product.title,
+      );
+
+      stack.appendChild(image);
+      stack.appendChild(caption);
+    }
+
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/examples/image-decorative.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/examples/image-decorative.example.ts
@@ -1,0 +1,32 @@
+import {extension, Image, Heading, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const banner = root.createComponent(Image, {
+      source: 'https://cdn.shopify.com/s/files/partner-branding/banner.png',
+      accessibilityLabel: '',
+      accessibilityRole: 'decorative',
+    });
+
+    const heading = root.createComponent(
+      Heading,
+      {},
+      'Warehouse connection active',
+    );
+
+    const description = root.createComponent(
+      Text,
+      {},
+      'Your products are syncing automatically every 15 minutes with your warehouse management system.',
+    );
+
+    stack.appendChild(banner);
+    stack.appendChild(heading);
+    stack.appendChild(description);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/examples/image-loading.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/examples/image-loading.example.ts
@@ -1,0 +1,36 @@
+import {extension, Image, Text, ProgressIndicator, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const loader = root.createComponent(ProgressIndicator, {
+      size: 'small-100',
+      accessibilityLabel: 'Loading image',
+    });
+    stack.appendChild(loader);
+
+    const image = root.createComponent(Image, {
+      source: 'https://cdn.shopify.com/s/files/placeholder-images/product.png',
+      accessibilityLabel: 'Product preview',
+      loading: 'lazy',
+      onLoad: () => {
+        stack.removeChild(loader);
+      },
+      onError: () => {
+        stack.removeChild(loader);
+        const error = root.createComponent(
+          Text,
+          {},
+          'Unable to load product image.',
+        );
+        stack.appendChild(error);
+      },
+    });
+
+    stack.appendChild(image);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/InlineStack/InlineStack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InlineStack/InlineStack.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'inlinestack-default.png',
     codeblock: {
-      title: 'Laying out elements in a row',
+      title: 'Arrange metadata in rows',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-inlinestack.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Right-align action buttons using `inlineAlignment="end"`. This example positions cancel and confirm [Button](/docs/api/admin-extensions/{API_VERSION}/components/actions/button) components at the trailing edge of an [action modal](/docs/api/admin-extensions/{API_VERSION}/components/settings-and-templates/adminaction), following standard dialog patterns.',
+        codeblock: {
+          title: 'Right-align action buttons',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/InlineStack/examples/inlinestack-alignment.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/inlinestack-alignment.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Vertically center [Icon](/docs/api/admin-extensions/{API_VERSION}/components/media-and-visuals/icon) and text pairs using `blockAlignment="center"`. This example places order and inventory icons inline with their stat labels, so they stay aligned regardless of icon and text height differences.',
+        codeblock: {
+          title: 'Center-align icon and text pairs',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/InlineStack/examples/inlinestack-spacing.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/inlinestack-spacing.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/InlineStack/examples/basic-inlinestack.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InlineStack/examples/basic-inlinestack.example.ts
@@ -1,18 +1,33 @@
-import {extension, InlineStack} from '@shopify/ui-extensions/admin';
+import {extension, InlineStack, Text, Badge, BlockStack} from '@shopify/ui-extensions/admin';
 
-export default extension('Playground', (root) => {
-  const inlineStack = root.createComponent(
-    InlineStack,
-    {
-      gap: true,
-    },
-    [
-      root.createText('Child 1'),
-      root.createText('Child 2'),
-      root.createText('Child 3'),
-      root.createText('Child 4'),
-    ],
-  );
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
 
-  root.appendChild(inlineStack);
-});
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const row = root.createComponent(InlineStack, {gap: true});
+    const label = root.createComponent(Text, {fontWeight: 'bold'}, 'Product:');
+    const id = root.createComponent(Text, {}, productId || 'Unknown');
+    const badge = root.createComponent(Badge, {tone: 'success'}, 'Active');
+    row.appendChild(label);
+    row.appendChild(id);
+    row.appendChild(badge);
+
+    const metaRow = root.createComponent(InlineStack, {gap: true});
+    const skuLabel = root.createComponent(Text, {fontWeight: 'bold'}, 'SKU:');
+    const skuValue = root.createComponent(Text, {}, 'WH-1234');
+    const weightLabel = root.createComponent(Text, {fontWeight: 'bold'}, 'Weight:');
+    const weightValue = root.createComponent(Text, {}, '2.5 kg');
+    metaRow.appendChild(skuLabel);
+    metaRow.appendChild(skuValue);
+    metaRow.appendChild(weightLabel);
+    metaRow.appendChild(weightValue);
+
+    stack.appendChild(row);
+    stack.appendChild(metaRow);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/InlineStack/examples/inlinestack-alignment.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InlineStack/examples/inlinestack-alignment.example.ts
@@ -1,0 +1,48 @@
+import {extension, InlineStack, Button, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const heading = root.createComponent(Text, {fontWeight: 'bold'}, 'Confirm action');
+    const message = root.createComponent(Text, {}, `Sync product ${productId} to all warehouse locations?`);
+
+    const actions = root.createComponent(InlineStack, {
+      gap: true,
+      inlineAlignment: 'end',
+    });
+
+    const cancelButton = root.createComponent(
+      Button,
+      {variant: 'tertiary', onPress: () => close()},
+      'Cancel',
+    );
+    const confirmButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/sync-all', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId}),
+          });
+          close();
+        },
+      },
+      'Sync now',
+    );
+
+    actions.appendChild(cancelButton);
+    actions.appendChild(confirmButton);
+
+    stack.appendChild(heading);
+    stack.appendChild(message);
+    stack.appendChild(actions);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/InlineStack/examples/inlinestack-spacing.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InlineStack/examples/inlinestack-spacing.example.ts
@@ -1,0 +1,34 @@
+import {extension, InlineStack, Icon, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const heading = root.createComponent(Text, {fontWeight: 'bold'}, 'Quick stats');
+
+    const stat1 = root.createComponent(InlineStack, {
+      gap: true,
+      blockAlignment: 'center',
+    });
+    const icon1 = root.createComponent(Icon, {name: 'OrdersMajor', accessibilityLabel: 'Orders'});
+    const text1 = root.createComponent(Text, {}, '142 orders this month');
+    stat1.appendChild(icon1);
+    stat1.appendChild(text1);
+
+    const stat2 = root.createComponent(InlineStack, {
+      gap: true,
+      blockAlignment: 'center',
+    });
+    const icon2 = root.createComponent(Icon, {name: 'InventoryMajor', accessibilityLabel: 'Inventory'});
+    const text2 = root.createComponent(Text, {}, '89 units in stock');
+    stat2.appendChild(icon2);
+    stat2.appendChild(text2);
+
+    stack.appendChild(heading);
+    stack.appendChild(stat1);
+    stack.appendChild(stat2);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'link-default.png',
     codeblock: {
-      title: 'Link to an app page',
+      title: 'Navigate to app pages',
       tabs: [
         {
           title: 'React',
@@ -28,12 +28,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/app-link.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Open external URLs in new tabs using `target="_blank"`. This example links to the product\'s storefront page and Shopify documentation, building the storefront URL from the product ID in `data.selected`.',
+        codeblock: {
+          title: 'Open external links in new tabs',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Link/examples/external-link.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/external-link.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Navigate to Shopify admin pages using the `shopify://` protocol. This example links to the orders list, the product\'s inventory page, and the product editor, using `tone="critical"` on the edit link to draw attention to it.',
+        codeblock: {
+          title: 'Link to Shopify admin sections',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Link/examples/shopify-section-link.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/shopify-section-link.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {
@@ -53,68 +96,6 @@ const data: ReferenceEntityTemplateSchema = {
 - The \`onClick\` callback fires before navigation occurs. If the callback throws an error, navigation might still proceed. You can't use \`onClick\` to conditionally prevent navigation.`,
     },
   ],
-  examples: {
-    description: '',
-    examples: [
-      {
-        description: 'Link to an external URL',
-        image: 'external-link.png',
-        codeblock: {
-          tabs: [
-            {
-              title: 'React',
-              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Link/examples/external-link.example.tsx',
-              language: 'typescript',
-            },
-            {
-              title: 'JS',
-              code: './examples/external-link.example.ts',
-              language: 'typescript',
-            },
-          ],
-          title: 'External Link',
-        },
-      },
-      {
-        description: 'Link to a relative URL',
-        image: 'relative-link.png',
-        codeblock: {
-          tabs: [
-            {
-              title: 'React',
-              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Link/examples/relative-link.example.tsx',
-              language: 'typescript',
-            },
-            {
-              title: 'JS',
-              code: './examples/relative-link.example.ts',
-              language: 'typescript',
-            },
-          ],
-          title: 'Relative Link',
-        },
-      },
-      {
-        description: 'Link to a Shopify admin page',
-        image: 'shopify-section-link.png',
-        codeblock: {
-          tabs: [
-            {
-              title: 'React',
-              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Link/examples/shopify-section-link.example.tsx',
-              language: 'typescript',
-            },
-            {
-              title: 'JS',
-              code: './examples/shopify-section-link.example.ts',
-              language: 'typescript',
-            },
-          ],
-          title: 'Shopify Section Link',
-        },
-      },
-    ],
-  },
   related: [],
 };
 

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/examples/app-link.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/examples/app-link.example.ts
@@ -1,17 +1,28 @@
-import {
-  extension,
-  Link,
-} from '@shopify/ui-extensions/admin';
+import {extension, Link, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'Playground',
+  'admin.product-details.block.render',
   (root) => {
-    const link = root.createComponent(
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const heading = root.createComponent(Text, {fontWeight: 'bold'}, 'Manage this product');
+
+    const settingsLink = root.createComponent(
       Link,
-      {href: 'app://baz'},
-      'Link to app path',
+      {href: 'extension://settings'},
+      'Extension settings',
     );
 
-    root.appendChild(link);
+    const dashboardLink = root.createComponent(
+      Link,
+      {href: 'extension://dashboard'},
+      'Sync dashboard',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(settingsLink);
+    stack.appendChild(dashboardLink);
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/examples/external-link.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/examples/external-link.example.ts
@@ -1,17 +1,37 @@
-import {
-  extension,
-  Link,
-} from '@shopify/ui-extensions/admin';
+import {extension, Link, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'Playground',
-  (root) => {
-    const link = root.createComponent(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
+    const numericId = productId?.split('/').pop();
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const heading = root.createComponent(Text, {fontWeight: 'bold'}, 'External resources');
+
+    const storefrontLink = root.createComponent(
       Link,
-      {href: 'https://www.shopify.ca/climate/sustainability-fund'},
-      'Sustainability fund',
+      {
+        href: `https://your-store.myshopify.com/products/${numericId}`,
+        target: '_blank',
+      },
+      'View on storefront',
     );
 
-    root.appendChild(link);
+    const docsLink = root.createComponent(
+      Link,
+      {
+        href: 'https://help.shopify.com/manual/products',
+        target: '_blank',
+      },
+      'Shopify product documentation',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(storefrontLink);
+    stack.appendChild(docsLink);
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/examples/shopify-section-link.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/examples/shopify-section-link.example.ts
@@ -1,17 +1,41 @@
-import {
-  extension,
-  Link,
-} from '@shopify/ui-extensions/admin';
+import {extension, Link, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'Playground',
-  (root) => {
-    const link = root.createComponent(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
+    const numericId = productId?.split('/').pop();
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const heading = root.createComponent(Text, {fontWeight: 'bold'}, 'Admin navigation');
+
+    const ordersLink = root.createComponent(
       Link,
       {href: 'shopify://admin/orders'},
-      "Shop's orders",
+      'View all orders',
     );
 
-    root.appendChild(link);
+    const inventoryLink = root.createComponent(
+      Link,
+      {href: `shopify://admin/products/${numericId}/inventory`},
+      'Manage inventory',
+    );
+
+    const criticalLink = root.createComponent(
+      Link,
+      {
+        href: `shopify://admin/products/${numericId}`,
+        tone: 'critical',
+      },
+      'Edit product (admin)',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(ordersLink);
+    stack.appendChild(inventoryLink);
+    stack.appendChild(criticalLink);
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'moneyfield-default.png',
     codeblock: {
-      title: 'Simple MoneyField example',
+      title: 'Set product cost price',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-moneyfield.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Display multiple money fields with different `currencyCode` values for regional pricing. This example renders USD, EUR, and GBP price fields in a [BlockStack](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/blockstack), each automatically formatted with the correct currency symbol and decimal precision for their locale.',
+        codeblock: {
+          title: 'Configure regional currency pricing',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/MoneyField/examples/moneyfield-currencies.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/moneyfield-currencies.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          "Enforce minimum price constraints using `min` and the `error` prop for inline validation. This example prevents merchants from setting a wholesale price at zero or below, displaying an error until they've entered a valid amount.",
+        codeblock: {
+          title: 'Validate minimum price amount',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/MoneyField/examples/moneyfield-validation.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/moneyfield-validation.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/examples/basic-moneyfield.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/examples/basic-moneyfield.example.ts
@@ -1,9 +1,41 @@
-import {extend, MoneyFIeld} from '@shopify/ui-extensions/admin';
+import {extension, MoneyField, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const urlField = root.createComponent(MoneyFIeld, {
-    label: 'Enter amount',
-  });
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let costPrice = 0;
 
-  root.appendChild(urlField);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(MoneyField, {
+      label: 'Cost per item',
+      name: 'costPrice',
+      currencyCode: 'USD',
+      onChange: (value) => {
+        costPrice = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/cost', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, costPrice}),
+          });
+          close();
+        },
+      },
+      'Save cost price',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/examples/moneyfield-currencies.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/examples/moneyfield-currencies.example.ts
@@ -1,0 +1,42 @@
+import {extension, MoneyField, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Regional pricing',
+    );
+
+    const usdField = root.createComponent(MoneyField, {
+      label: 'US price',
+      name: 'priceUsd',
+      currencyCode: 'USD',
+      value: 49.99,
+    });
+
+    const eurField = root.createComponent(MoneyField, {
+      label: 'EU price',
+      name: 'priceEur',
+      currencyCode: 'EUR',
+      value: 44.99,
+    });
+
+    const gbpField = root.createComponent(MoneyField, {
+      label: 'UK price',
+      name: 'priceGbp',
+      currencyCode: 'GBP',
+      value: 39.99,
+    });
+
+    stack.appendChild(heading);
+    stack.appendChild(usdField);
+    stack.appendChild(eurField);
+    stack.appendChild(gbpField);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/examples/moneyfield-validation.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/examples/moneyfield-validation.example.ts
@@ -1,0 +1,50 @@
+import {extension, MoneyField, Button, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let wholesalePrice = 0;
+
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(MoneyField, {
+      label: 'Wholesale price',
+      name: 'wholesalePrice',
+      currencyCode: 'USD',
+      min: 0.01,
+      required: true,
+      onChange: (value) => {
+        wholesalePrice = value;
+        if (value <= 0) {
+          field.updateProps({error: 'Wholesale price must be greater than zero'});
+        } else {
+          field.updateProps({error: undefined});
+        }
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          if (wholesalePrice > 0) {
+            await fetch('/api/products/wholesale-price', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId, wholesalePrice}),
+            });
+            close();
+          }
+        },
+      },
+      'Save wholesale price',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'numberfield-default.png',
     codeblock: {
-      title: 'Simple NumberField example',
+      title: 'Set inventory restock quantity',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-numberfield.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Collect fractional values like cost pricing and profit margins from merchants. This example uses `inputMode="decimal"` and combines `step` with `suffix` to guide merchants through entering currency amounts and percentages with the correct precision.',
+        codeblock: {
+          title: 'Configure decimal pricing fields',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/NumberField/examples/numberfield-decimal.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/numberfield-decimal.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Enforce warehouse-specific limits using `min`, `max`, and `step` constraints with inline `error` feedback. This example validates slot numbers against a maximum capacity and shows an error when the value exceeds the allowed range.',
+        codeblock: {
+          title: 'Enforce numeric constraints with errors',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/NumberField/examples/numberfield-constraints.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/numberfield-constraints.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
 
   subSections: [

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/examples/basic-numberfield.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/examples/basic-numberfield.example.ts
@@ -1,9 +1,42 @@
-import {extend, NumberField} from '@shopify/ui-extensions/admin';
+import {extension, NumberField, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const discountField = root.createComponent(NumberField, {
-    label: 'Enter the discount amount',
-  });
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let quantity = 0;
 
-  root.appendChild(discountField);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(NumberField, {
+      label: 'Restock quantity',
+      name: 'quantity',
+      min: 1,
+      max: 10000,
+      onChange: (value) => {
+        quantity = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/inventory/restock', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, quantity}),
+          });
+          close();
+        },
+      },
+      'Submit restock',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/examples/numberfield-constraints.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/examples/numberfield-constraints.example.ts
@@ -1,0 +1,46 @@
+import {extension, NumberField, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Warehouse slot configuration',
+    );
+
+    const slotField = root.createComponent(NumberField, {
+      label: 'Storage slot number',
+      name: 'slotNumber',
+      min: 1,
+      max: 500,
+      step: 1,
+      error: undefined,
+      onChange: (value) => {
+        if (value > 500) {
+          slotField.updateProps({
+            error: 'Slot number cannot exceed 500',
+          });
+        } else {
+          slotField.updateProps({error: undefined});
+        }
+      },
+    });
+
+    const palletField = root.createComponent(NumberField, {
+      label: 'Units per pallet',
+      name: 'unitsPerPallet',
+      min: 1,
+      max: 200,
+      step: 1,
+    });
+
+    stack.appendChild(heading);
+    stack.appendChild(slotField);
+    stack.appendChild(palletField);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/examples/numberfield-decimal.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/examples/numberfield-decimal.example.ts
@@ -1,0 +1,39 @@
+import {extension, NumberField, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Cost pricing',
+    );
+
+    const costField = root.createComponent(NumberField, {
+      label: 'Cost per item',
+      name: 'costPerItem',
+      inputMode: 'decimal',
+      min: 0,
+      step: 0.01,
+      suffix: 'USD',
+    });
+
+    const marginField = root.createComponent(NumberField, {
+      label: 'Profit margin',
+      name: 'margin',
+      inputMode: 'decimal',
+      min: 0,
+      max: 100,
+      step: 0.5,
+      suffix: '%',
+    });
+
+    stack.appendChild(heading);
+    stack.appendChild(costField);
+    stack.appendChild(marginField);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'paragraph-default.png',
     codeblock: {
-      title: 'Simple Paragraph example',
+      title: 'Display product sync summary',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-paragraph.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Present fulfillment instructions that include an inline [Link](/docs/api/admin-extensions/{API_VERSION}/components/actions/link) to external documentation. This example shows how to nest interactive elements inside a paragraph to provide contextual help alongside instructional text.',
+        codeblock: {
+          title: 'Embed inline links in help text',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Paragraph/examples/paragraph-with-links.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/paragraph-with-links.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Show or hide guidance based on product status retrieved from the [GraphQL Admin API](/docs/api/admin-graphql/). This example queries the product status and conditionally renders a paragraph with publishing instructions when the product is in draft, helping merchants understand what steps remain.',
+        codeblock: {
+          title: 'Show conditional help text',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Paragraph/examples/paragraph-conditional.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/paragraph-conditional.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/examples/basic-paragraph.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/examples/basic-paragraph.example.ts
@@ -1,10 +1,46 @@
-import {extend, Paragraph, BlockStack} from '@shopify/ui-extensions/admin';
+import {extension, Paragraph, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const paragraph = root.createComponent(BlockStack, {inlineAlignment: 'center', gap: true}, [
-    root.createComponent(Paragraph, {fontWeight: 'bold'}, 'Name:'),
-    root.createComponent(Paragraph, {}, 'Jane Doe'),
-  ]);
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
 
-  root.appendChild(paragraph);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const paragraph = root.createComponent(Paragraph);
+
+    const intro = root.createComponent(
+      Text,
+      {},
+      'Last sync completed at ',
+    );
+    const time = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      '2:45 PM EST',
+    );
+    const detail = root.createComponent(
+      Text,
+      {},
+      '. All product tags and metafields were successfully pushed to the warehouse management system. ',
+    );
+    const count = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      '24 fields',
+    );
+    const suffix = root.createComponent(
+      Text,
+      {},
+      ' updated across 3 variants.',
+    );
+
+    paragraph.appendChild(intro);
+    paragraph.appendChild(time);
+    paragraph.appendChild(detail);
+    paragraph.appendChild(count);
+    paragraph.appendChild(suffix);
+
+    stack.appendChild(paragraph);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/examples/paragraph-conditional.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/examples/paragraph-conditional.example.ts
@@ -1,0 +1,38 @@
+import {extension, Paragraph, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  async (root, api) => {
+    const {data, query} = api;
+    const productId = data.selected[0]?.id;
+
+    const stack = root.createComponent(BlockStack);
+
+    const result = await query(
+      `query Product($id: ID!) {
+        product(id: $id) {
+          status
+          title
+        }
+      }`,
+      {variables: {id: productId}},
+    );
+
+    const product = result?.data?.product;
+
+    if (product?.status === 'DRAFT') {
+      const helpText = root.createComponent(Paragraph);
+
+      const message = root.createComponent(
+        Text,
+        {},
+        `"${product.title}" is currently in draft status. Complete the product description, add at least one image, and set pricing before publishing to your storefront.`,
+      );
+
+      helpText.appendChild(message);
+      stack.appendChild(helpText);
+    }
+
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/examples/paragraph-with-links.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/examples/paragraph-with-links.example.ts
@@ -1,0 +1,39 @@
+import {extension, Paragraph, Text, Link, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const paragraph = root.createComponent(Paragraph);
+
+    const intro = root.createComponent(
+      Text,
+      {},
+      'This product requires special handling during fulfillment. Review the ',
+    );
+
+    const link = root.createComponent(
+      Link,
+      {
+        href: 'https://help.shopify.com/manual/fulfillment',
+        target: '_blank',
+      },
+      'fulfillment guidelines',
+    );
+
+    const suffix = root.createComponent(
+      Text,
+      {},
+      ' for packaging requirements and carrier restrictions before processing orders.',
+    );
+
+    paragraph.appendChild(intro);
+    paragraph.appendChild(link);
+    paragraph.appendChild(suffix);
+
+    stack.appendChild(paragraph);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'passwordfield-default.png',
     codeblock: {
-      title: 'Simple PasswordField example',
+      title: 'Enter API credentials securely',
       tabs: [
         {
           title: 'React',
@@ -29,14 +29,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-passwordfield.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Enforce minimum length requirements on sensitive inputs using the `error` prop. This example validates that a webhook secret is at least 16 characters, displaying an inline error until the requirement is met to prevent merchants from saving weak secrets.',
+        codeblock: {
+          title: 'Validate secret length requirements',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/PasswordField/examples/passwordfield-validation.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/passwordfield-validation.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Combine `PasswordField` with [TextField](/docs/api/admin-extensions/{API_VERSION}/components/forms/textfield) and [EmailField](/docs/api/admin-extensions/{API_VERSION}/components/forms/emailfield) to build a complete service connection form. This example collects an API endpoint, account email, and token in a single modal to connect a fulfillment provider.',
+        codeblock: {
+          title: 'Build a service connection form',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/PasswordField/examples/passwordfield-integration.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/passwordfield-integration.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/examples/basic-passwordfield.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/examples/basic-passwordfield.example.ts
@@ -1,14 +1,46 @@
-import {extend, TextField, PasswordField, BlockStack} from '@shopify/ui-extensions/admin';
+import {extension, PasswordField, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const blockStack = root.createComponent(BlockStack, {}, [
-    root.createComponent(TextField, {
-      label: 'Username',
-    }),
-    root.createComponent(PasswordField, {
-      label: 'Password',
-    }),
-  ]);
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    let apiKey = '';
 
-  root.appendChild(blockStack);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Connect warehouse API',
+    );
+
+    const field = root.createComponent(PasswordField, {
+      label: 'API key',
+      name: 'apiKey',
+      onChange: (value) => {
+        apiKey = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/integrations/warehouse', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({apiKey}),
+          });
+          close();
+        },
+      },
+      'Save credentials',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/examples/passwordfield-integration.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/examples/passwordfield-integration.example.ts
@@ -1,0 +1,50 @@
+import {extension, PasswordField, TextField, EmailField, Button, BlockStack, Heading} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {close} = api;
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Heading,
+      {},
+      'Connect fulfillment service',
+    );
+
+    const endpointField = root.createComponent(TextField, {
+      label: 'API endpoint',
+      name: 'endpoint',
+    });
+
+    const emailField = root.createComponent(EmailField, {
+      label: 'Account email',
+      name: 'accountEmail',
+    });
+
+    const tokenField = root.createComponent(PasswordField, {
+      label: 'API token',
+      name: 'apiToken',
+    });
+
+    const connectButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/fulfillment/connect', {method: 'POST'});
+          close();
+        },
+      },
+      'Connect service',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(endpointField);
+    stack.appendChild(emailField);
+    stack.appendChild(tokenField);
+    stack.appendChild(connectButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/examples/passwordfield-validation.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/examples/passwordfield-validation.example.ts
@@ -1,0 +1,47 @@
+import {extension, PasswordField, Button, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {close} = api;
+    let secret = '';
+
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(PasswordField, {
+      label: 'Webhook secret',
+      name: 'webhookSecret',
+      required: true,
+      onChange: (value) => {
+        secret = value;
+        if (value.length > 0 && value.length < 16) {
+          field.updateProps({error: 'Secret must be at least 16 characters'});
+        } else {
+          field.updateProps({error: undefined});
+        }
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          if (secret.length >= 16) {
+            await fetch('/api/webhooks/secret', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({secret}),
+            });
+            close();
+          }
+        },
+      },
+      'Save webhook secret',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Pressable/Pressable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Pressable/Pressable.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'pressable-default.png',
     codeblock: {
-      title: 'Simple pressable example',
+      title: 'Build custom action rows',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-pressable.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          "Use `href` and `target` props to make a `Pressable` behave as a link, wrapping rich content like [Image](/docs/api/admin-extensions/{API_VERSION}/components/media-and-visuals/image) and text. This example creates a clickable card that opens the product's storefront page in a new tab.",
+        codeblock: {
+          title: 'Create a clickable product card',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Pressable/examples/pressable-link.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/pressable-link.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Label custom tappable areas for screen readers using `accessibilityLabel`. This example renders warehouse location rows with [Badge](/docs/api/admin-extensions/{API_VERSION}/components/feedback-and-status-indicators/badge) indicators, where each row announces its stock level and location name to assistive technology.',
+        codeblock: {
+          title: 'Add accessible interactive regions',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Pressable/examples/pressable-accessible.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/pressable-accessible.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Pressable/examples/basic-pressable.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Pressable/examples/basic-pressable.example.ts
@@ -1,25 +1,52 @@
-import {
-  extension,
-  Icon,
-  InlineStack,
-  Pressable,
-  Text,
-} from '@shopify/ui-extensions/admin';
+import {extension, Pressable, Text, Icon, InlineStack, BlockStack} from '@shopify/ui-extensions/admin';
 
-extension('Playground', (root) => {
-  const pressable = root.createComponent(
-    Pressable,
-    {
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const heading = root.createComponent(Text, {fontWeight: 'bold'}, 'Quick actions');
+
+    const syncAction = root.createComponent(Pressable, {
       padding: 'base',
-      onPress: () => console.log('onPress event'),
-    },
-    [
-      root.createComponent(InlineStack, {}, [
-        root.createComponent(Text, {}, 'Go to App Dashboard'),
-        root.createComponent(Icon, {name: 'AppsMajor'}),
-      ]),
-    ],
-  );
+      onPress: async () => {
+        await fetch('/api/products/sync', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({productId}),
+        });
+      },
+    });
+    const syncRow = root.createComponent(InlineStack, {gap: true, blockAlignment: 'center'});
+    const syncIcon = root.createComponent(Icon, {name: 'RefreshMajor', accessibilityLabel: ''});
+    const syncText = root.createComponent(Text, {}, 'Sync inventory now');
+    syncRow.appendChild(syncIcon);
+    syncRow.appendChild(syncText);
+    syncAction.appendChild(syncRow);
 
-  root.appendChild(pressable);
-});
+    const exportAction = root.createComponent(Pressable, {
+      padding: 'base',
+      onPress: async () => {
+        await fetch('/api/products/export', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({productId}),
+        });
+      },
+    });
+    const exportRow = root.createComponent(InlineStack, {gap: true, blockAlignment: 'center'});
+    const exportIcon = root.createComponent(Icon, {name: 'ExportMinor', accessibilityLabel: ''});
+    const exportText = root.createComponent(Text, {}, 'Export product data');
+    exportRow.appendChild(exportIcon);
+    exportRow.appendChild(exportText);
+    exportAction.appendChild(exportRow);
+
+    stack.appendChild(heading);
+    stack.appendChild(syncAction);
+    stack.appendChild(exportAction);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Pressable/examples/pressable-accessible.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Pressable/examples/pressable-accessible.example.ts
@@ -1,0 +1,40 @@
+import {extension, Pressable, Text, Badge, InlineStack, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const heading = root.createComponent(Text, {fontWeight: 'bold'}, 'Warehouse locations');
+
+    const location1 = root.createComponent(Pressable, {
+      padding: 'base',
+      accessibilityLabel: 'View New York warehouse details — 142 units in stock',
+      onPress: () => console.log('Card pressed'),
+    });
+    const row1 = root.createComponent(InlineStack, {gap: true, blockAlignment: 'center'});
+    const name1 = root.createComponent(Text, {}, 'New York');
+    const badge1 = root.createComponent(Badge, {tone: 'success'}, '142 units');
+    row1.appendChild(name1);
+    row1.appendChild(badge1);
+    location1.appendChild(row1);
+
+    const location2 = root.createComponent(Pressable, {
+      padding: 'base',
+      accessibilityLabel: 'View Los Angeles warehouse details — 3 units in stock, low stock',
+      onPress: () => console.log('Card pressed'),
+    });
+    const row2 = root.createComponent(InlineStack, {gap: true, blockAlignment: 'center'});
+    const name2 = root.createComponent(Text, {}, 'Los Angeles');
+    const badge2 = root.createComponent(Badge, {tone: 'warning'}, '3 units');
+    row2.appendChild(name2);
+    row2.appendChild(badge2);
+    location2.appendChild(row2);
+
+    stack.appendChild(heading);
+    stack.appendChild(location1);
+    stack.appendChild(location2);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Pressable/examples/pressable-link.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Pressable/examples/pressable-link.example.ts
@@ -1,0 +1,32 @@
+import {extension, Pressable, Text, Image, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
+    const numericId = productId?.split('/').pop();
+
+    const stack = root.createComponent(BlockStack, {gap: true});
+
+    const card = root.createComponent(Pressable, {
+      href: `https://your-store.myshopify.com/products/${numericId}`,
+      target: '_blank',
+      padding: 'base',
+    });
+
+    const image = root.createComponent(Image, {
+      source: 'https://cdn.shopify.com/s/files/placeholder-images/product.png',
+      accessibilityLabel: 'Product preview',
+    });
+    const title = root.createComponent(Text, {fontWeight: 'bold'}, 'View on storefront');
+    const description = root.createComponent(Text, {}, 'Opens the live product page in a new tab');
+
+    card.appendChild(image);
+    card.appendChild(title);
+    card.appendChild(description);
+
+    stack.appendChild(card);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/ProgressIndicator/ProgressIndicator.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ProgressIndicator/ProgressIndicator.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'progressindicator-default.png',
     codeblock: {
-      title: 'Simple spinner example',
+      title: 'Show loading during API query',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-progressindicator.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Show a prominent loading indicator while a sync is in progress inside an [action modal](/docs/api/admin-extensions/{API_VERSION}/components/settings-and-templates/adminaction). This example pairs a `base`-sized indicator with a status message and a cancel [Button](/docs/api/admin-extensions/{API_VERSION}/components/actions/button), keeping merchants informed and in control.',
+        codeblock: {
+          title: 'Display sync progress in action modal',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/ProgressIndicator/examples/progressindicator-sizes.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/progressindicator-sizes.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Place a compact `small-300` spinner inline with status text using `tone="inherit"` to match the surrounding text color. This example renders the indicator alongside a description inside an [InlineStack](/docs/api/admin-extensions/{API_VERSION}/components/layout-and-structure/inlinestack), creating a subtle loading cue.',
+        codeblock: {
+          title: 'Add inline loading indicator',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/ProgressIndicator/examples/progressindicator-inline.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/progressindicator-inline.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/ProgressIndicator/examples/basic-progressindicator.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ProgressIndicator/examples/basic-progressindicator.example.ts
@@ -1,18 +1,43 @@
-import {
-  extension,
-  ProgressIndicator,
-} from '@shopify/ui-extensions/admin';
+import {extension, ProgressIndicator, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'Playground',
-  (root) => {
-    const progressIndicator = root.createComponent(
-      ProgressIndicator,
-      {
-        size: 'small-200',
-      },
+  'admin.product-details.block.render',
+  async (root, api) => {
+    const {data, query} = api;
+    const productId = data.selected[0]?.id;
+
+    const stack = root.createComponent(BlockStack);
+
+    const loader = root.createComponent(ProgressIndicator, {
+      size: 'small-200',
+      accessibilityLabel: 'Loading product data',
+    });
+    stack.appendChild(loader);
+    root.appendChild(stack);
+
+    const result = await query(
+      `query Product($id: ID!) {
+        product(id: $id) { title totalInventory }
+      }`,
+      {variables: {id: productId}},
     );
 
-    root.appendChild(progressIndicator);
+    stack.removeChild(loader);
+
+    const product = result?.data?.product;
+    if (product) {
+      const title = root.createComponent(
+        Text,
+        {fontWeight: 'bold'},
+        product.title,
+      );
+      const inventory = root.createComponent(
+        Text,
+        {},
+        `Total inventory: ${product.totalInventory} units`,
+      );
+      stack.appendChild(title);
+      stack.appendChild(inventory);
+    }
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/ProgressIndicator/examples/progressindicator-inline.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ProgressIndicator/examples/progressindicator-inline.example.ts
@@ -1,0 +1,36 @@
+import {extension, ProgressIndicator, Text, InlineStack, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Checking eligibility...',
+    );
+
+    const row = root.createComponent(InlineStack);
+
+    const indicator = root.createComponent(ProgressIndicator, {
+      size: 'small-300',
+      tone: 'inherit',
+      accessibilityLabel: 'Checking product eligibility',
+    });
+
+    const label = root.createComponent(
+      Text,
+      {},
+      'Verifying product meets marketplace requirements',
+    );
+
+    row.appendChild(indicator);
+    row.appendChild(label);
+
+    stack.appendChild(heading);
+    stack.appendChild(row);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/ProgressIndicator/examples/progressindicator-sizes.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ProgressIndicator/examples/progressindicator-sizes.example.ts
@@ -1,0 +1,37 @@
+import {extension, ProgressIndicator, Text, Button, BlockStack, InlineStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+
+    const stack = root.createComponent(BlockStack);
+
+    const message = root.createComponent(
+      Text,
+      {},
+      'Syncing product data to your warehouse system...',
+    );
+
+    const spinnerRow = root.createComponent(InlineStack);
+    const spinner = root.createComponent(ProgressIndicator, {
+      size: 'base',
+      accessibilityLabel: 'Syncing in progress',
+    });
+    spinnerRow.appendChild(spinner);
+
+    const cancelButton = root.createComponent(
+      Button,
+      {
+        variant: 'tertiary',
+        onPress: () => close(),
+      },
+      'Cancel',
+    );
+
+    stack.appendChild(message);
+    stack.appendChild(spinnerRow);
+    stack.appendChild(cancelButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'section-default.png',
     codeblock: {
-      title: 'Section to an app page',
+      title: 'Group content with a heading',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-Section.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Nest sections to create multi-level content grouping with automatic heading level adjustment. This example places a "Safety certifications" section inside a "Product compliance" parent section, with heading levels adapting to reflect the hierarchy.',
+        codeblock: {
+          title: 'Nest sections for content hierarchy',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Section/examples/section-nested.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/section-nested.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Provide screen readers with a more descriptive section context than the visible heading alone using `accessibilityLabel`. This example labels a shipping configuration section with form fields, so assistive technology announces the full purpose of the form group.',
+        codeblock: {
+          title: 'Add accessible section descriptions',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Section/examples/section-accessible.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/section-accessible.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/examples/basic-Section.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/examples/basic-Section.example.ts
@@ -1,19 +1,24 @@
-import {
-  extend,
-  Section,
-} from '@shopify/ui-extensions/admin';
+import {extension, Section, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-export default extend(
-  'Playground',
+export default extension(
+  'admin.product-details.block.render',
   (root) => {
-    const section = root.createComponent(
-      Section,
-      {
-        heading: 'Section heading',
-      },
-      'Section content'
-    );
 
-    root.appendChild(section);
+    const stack = root.createComponent(BlockStack);
+
+    const section = root.createComponent(Section, {
+      heading: 'Inventory details',
+    });
+
+    const warehouse = root.createComponent(Text, {}, 'Warehouse: East Coast — New York');
+    const slot = root.createComponent(Text, {}, 'Storage slot: A-42');
+    const quantity = root.createComponent(Text, {}, 'Units in stock: 247');
+
+    section.appendChild(warehouse);
+    section.appendChild(slot);
+    section.appendChild(quantity);
+
+    stack.appendChild(section);
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/examples/section-accessible.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/examples/section-accessible.example.ts
@@ -1,0 +1,34 @@
+import {extension, Section, TextField, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const shippingSection = root.createComponent(Section, {
+      heading: 'Shipping configuration',
+      accessibilityLabel: 'Configure shipping dimensions and weight for this product',
+    });
+
+    const weight = root.createComponent(TextField, {
+      label: 'Weight (kg)',
+      name: 'weight',
+    });
+    const length = root.createComponent(TextField, {
+      label: 'Length (cm)',
+      name: 'length',
+    });
+    const width = root.createComponent(TextField, {
+      label: 'Width (cm)',
+      name: 'width',
+    });
+
+    shippingSection.appendChild(weight);
+    shippingSection.appendChild(length);
+    shippingSection.appendChild(width);
+
+    stack.appendChild(shippingSection);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/examples/section-nested.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/examples/section-nested.example.ts
@@ -1,0 +1,37 @@
+import {extension, Section, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const outer = root.createComponent(Section, {
+      heading: 'Product compliance',
+    });
+
+    const intro = root.createComponent(
+      Text,
+      {},
+      'Regulatory status for product distribution.',
+    );
+
+    const inner = root.createComponent(Section, {
+      heading: 'Safety certifications',
+    });
+
+    const cert1 = root.createComponent(Text, {}, 'UL Listed — Class II');
+    const cert2 = root.createComponent(Text, {}, 'CE Marking — Approved');
+    const cert3 = root.createComponent(Text, {}, 'FCC Part 15 — Compliant');
+
+    inner.appendChild(cert1);
+    inner.appendChild(cert2);
+    inner.appendChild(cert3);
+
+    outer.appendChild(intro);
+    outer.appendChild(inner);
+
+    stack.appendChild(outer);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -16,13 +16,12 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'SelectProps',
     },
   ],
-  related: [],
   category: 'UI components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'select-default.png',
     codeblock: {
-      title: 'Simple Select example',
+      title: 'Assign warehouse location',
       tabs: [
         {
           title: 'React',
@@ -30,14 +29,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-select.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Guide merchants to make a selection by adding a `placeholder` that appears before any option is chosen. This example uses a placeholder message in a product classification dropdown, making it clear that a selection is expected.',
+        codeblock: {
+          title: 'Add placeholder prompt text',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Select/examples/select-placeholder.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/select-placeholder.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Validate that a `required` select field has a value before submission using the `error` prop. This example shows an inline error when merchants attempt to save without choosing a shipping class, preventing incomplete data from reaching your backend.',
+        codeblock: {
+          title: 'Validate required selection on submit',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Select/examples/select-error.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/select-error.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',
@@ -59,6 +100,7 @@ const data: ReferenceEntityTemplateSchema = {
 - Dynamic loading of options as the user scrolls isn't supported.`,
     },
   ],
+  related: [],
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/examples/basic-select.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/examples/basic-select.example.ts
@@ -1,47 +1,46 @@
-import {
-  extension,
-  Select,
-} from '@shopify/ui-extensions/admin';
+import {extension, Select, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
 export default extension(
-  'Playground',
-  (root) => {
-    let value = '2';
-    const select = root.createComponent(Select, {
-      value,
-      label: 'Country',
-      onChange(nextValue) {
-        value = nextValue;
-        select.updateProps({value});
-      },
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let warehouse = '';
+
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(Select, {
+      label: 'Assign warehouse',
+      name: 'warehouse',
       options: [
-        {
-          value: '1',
-          label: 'Australia',
-        },
-        {
-          value: '2',
-          label: 'Canada',
-        },
-        {
-          value: '3',
-          label: 'France',
-        },
-        {
-          value: '4',
-          label: 'Japan',
-        },
-        {
-          value: '5',
-          label: 'Nigeria',
-        },
-        {
-          value: '6',
-          label: 'United States',
-        },
+        {label: 'East Coast — New York', value: 'nyc'},
+        {label: 'West Coast — Los Angeles', value: 'lax'},
+        {label: 'Central — Chicago', value: 'chi'},
+        {label: 'International — London', value: 'lon'},
       ],
+      onChange: (value) => {
+        warehouse = value;
+      },
     });
 
-    root.appendChild(select);
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/warehouse', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, warehouse}),
+          });
+          close();
+        },
+      },
+      'Assign warehouse',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
   },
 );

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/examples/select-error.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/examples/select-error.example.ts
@@ -1,0 +1,52 @@
+import {extension, Select, Button, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let shippingClass = '';
+
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(Select, {
+      label: 'Shipping class',
+      name: 'shippingClass',
+      required: true,
+      options: [
+        {label: 'Standard (5-7 days)', value: 'standard'},
+        {label: 'Express (2-3 days)', value: 'express'},
+        {label: 'Overnight', value: 'overnight'},
+        {label: 'Freight', value: 'freight'},
+      ],
+      onChange: (value) => {
+        shippingClass = value;
+        field.updateProps({error: undefined});
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          if (!shippingClass) {
+            field.updateProps({error: 'Please select a shipping class'});
+            return;
+          }
+          await fetch('/api/products/shipping-class', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, shippingClass}),
+          });
+          close();
+        },
+      },
+      'Save shipping class',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/examples/select-placeholder.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/examples/select-placeholder.example.ts
@@ -1,0 +1,32 @@
+import {extension, Select, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Product classification',
+    );
+
+    const field = root.createComponent(Select, {
+      label: 'Product category',
+      name: 'category',
+      placeholder: 'Select a category…',
+      options: [
+        {label: 'Electronics', value: 'electronics'},
+        {label: 'Apparel', value: 'apparel'},
+        {label: 'Home & Garden', value: 'home-garden'},
+        {label: 'Health & Beauty', value: 'health-beauty'},
+        {label: 'Food & Beverage', value: 'food-beverage'},
+      ],
+    });
+
+    stack.appendChild(heading);
+    stack.appendChild(field);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'text-default.png',
     codeblock: {
-      title: 'Simple Text example',
+      title: 'Highlight product pricing',
       tabs: [
         {
           title: 'React',
@@ -28,12 +28,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-text.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Communicate product status warnings with proper screen reader semantics using `fontStyle` and `accessibilityRole`. This example marks a draft status notice with `emphasis` and an action-required message with `strong`, so assistive technology conveys the visual urgency correctly.',
+        codeblock: {
+          title: 'Emphasize text for screen readers',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Text/examples/text-emphasis.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/text-emphasis.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Prevent long product descriptions from breaking your layout using `textOverflow="ellipsis"`. This example truncates content that exceeds its container width, keeping the block extension UI compact while still displaying the beginning of the text.',
+        codeblock: {
+          title: 'Truncate long descriptions',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/Text/examples/text-overflow.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/text-overflow.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/examples/basic-text.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/examples/basic-text.example.ts
@@ -1,10 +1,31 @@
-import {extend, Text, BlockStack} from '@shopify/ui-extensions/admin';
+import {extension, Text, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const text = root.createComponent(BlockStack, {inlineAlignment: 'center', gap: true}, [
-    root.createComponent(Text, {fontWeight: 'bold'}, 'Name:'),
-    root.createComponent(Text, {}, 'Jane Doe'),
-  ]);
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+    const stack = root.createComponent(BlockStack);
 
-  root.appendChild(text);
-});
+    const label = root.createComponent(
+      Text,
+      {},
+      'Current price: ',
+    );
+
+    const price = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      '$49.99',
+    );
+
+    const compare = root.createComponent(
+      Text,
+      {fontWeight: 'bold', fontStyle: 'italic'},
+      'Compare at: $64.99',
+    );
+
+    stack.appendChild(label);
+    stack.appendChild(price);
+    stack.appendChild(compare);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/examples/text-emphasis.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/examples/text-emphasis.example.ts
@@ -1,0 +1,31 @@
+import {extension, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const status = root.createComponent(
+      Text,
+      {
+        fontStyle: 'italic',
+        accessibilityRole: 'emphasis',
+      },
+      'This product is currently in draft status and not visible to customers.',
+    );
+
+    const note = root.createComponent(
+      Text,
+      {
+        fontWeight: 'bold',
+        accessibilityRole: 'strong',
+      },
+      'Action required: Complete all required fields before publishing.',
+    );
+
+    stack.appendChild(status);
+    stack.appendChild(note);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/examples/text-overflow.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/examples/text-overflow.example.ts
@@ -1,0 +1,25 @@
+import {extension, Text, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const label = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Product description',
+    );
+
+    const description = root.createComponent(
+      Text,
+      {textOverflow: 'ellipsis'},
+      'This premium organic cotton t-shirt features a relaxed fit with reinforced stitching, available in twelve colors with custom embroidery options for wholesale orders.',
+    );
+
+    stack.appendChild(label);
+    stack.appendChild(description);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'textarea-default.png',
     codeblock: {
-      title: 'Simple TextArea example',
+      title: 'Collect internal product notes',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-textarea.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Enforce a character limit using `maxLength` with a live counter and inline `error` feedback. This example tracks the description length on each keystroke and shows an error when the limit is exceeded, helping merchants keep descriptions within the allowed length.',
+        codeblock: {
+          title: 'Validate description length',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/TextArea/examples/textarea-validation.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/textarea-validation.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          "Pre-fill a text area with existing metafield data from the [GraphQL Admin API](/docs/api/admin-graphql/) and display it as read-only. This example queries the product's shipping instructions metafield and renders the value in a `readOnly` text area for reference.",
+        codeblock: {
+          title: 'Display existing metafield content',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/TextArea/examples/textarea-prefilled.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/textarea-prefilled.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
 
   subSections: [

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/examples/basic-textarea.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/examples/basic-textarea.example.ts
@@ -1,10 +1,41 @@
-import {extend, TextArea} from '@shopify/ui-extensions/admin';
+import {extension, TextArea, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const textArea = root.createComponent(TextArea, {
-    label: 'Enter a scheduled social media posting',
-    rows: 5,
-  });
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let notes = '';
 
-  root.appendChild(textArea);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(TextArea, {
+      label: 'Internal notes',
+      name: 'internalNotes',
+      rows: 4,
+      onChange: (value) => {
+        notes = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/notes', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, notes}),
+          });
+          close();
+        },
+      },
+      'Save notes',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/examples/textarea-prefilled.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/examples/textarea-prefilled.example.ts
@@ -1,0 +1,40 @@
+import {extension, TextArea, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  async (root, api) => {
+    const {data, query} = api;
+    const productId = data.selected[0]?.id;
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Shipping instructions',
+    );
+
+    const result = await query(
+      `query Product($id: ID!) {
+        product(id: $id) {
+          metafield(namespace: "custom", key: "shipping_instructions") { value }
+        }
+      }`,
+      {variables: {id: productId}},
+    );
+
+    const existing = result?.data?.product?.metafield?.value || '';
+
+    const field = root.createComponent(TextArea, {
+      label: 'Special handling instructions',
+      name: 'shippingInstructions',
+      rows: 3,
+      value: existing,
+      readOnly: true,
+    });
+
+    stack.appendChild(heading);
+    stack.appendChild(field);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/examples/textarea-validation.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/examples/textarea-validation.example.ts
@@ -1,0 +1,53 @@
+import {extension, TextArea, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let description = '';
+
+    const stack = root.createComponent(BlockStack);
+
+    const charCount = root.createComponent(Text, {}, '0 / 500 characters');
+
+    const field = root.createComponent(TextArea, {
+      label: 'Product description for external catalog',
+      name: 'catalogDescription',
+      rows: 5,
+      maxLength: 500,
+      onChange: (value) => {
+        description = value;
+        charCount.replaceChildren(`${value.length} / 500 characters`);
+        if (value.length > 500) {
+          field.updateProps({error: 'Description cannot exceed 500 characters'});
+        } else {
+          field.updateProps({error: undefined});
+        }
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          if (description.length <= 500) {
+            await fetch('/api/products/catalog-description', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId, description}),
+            });
+            close();
+          }
+        },
+      },
+      'Save description',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(charCount);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'textfield-default.png',
     codeblock: {
-      title: 'Simple TextField example',
+      title: 'Collect product metadata',
       tabs: [
         {
           title: 'React',
@@ -29,14 +29,56 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-textfield.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
   },
-
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Validate SKU format on each keystroke using the `error` prop and `onChange` callback. This example checks minimum length and character restrictions as the merchant types, displaying inline error messages that prevent invalid data from being submitted.',
+        codeblock: {
+          title: 'Validate input with error messages',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/TextField/examples/textfield-validation.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/textfield-validation.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          "Display a unit or domain label after the editable portion of the field with the `suffix` prop. This example adds `kg` to a weight field and `.myshopify.com` to a handle field, making the implied format visible so merchants don't need to type it.",
+        codeblock: {
+          title: 'Add suffix labels to fields',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/TextField/examples/textfield-suffix.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/textfield-suffix.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/examples/basic-textfield.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/examples/basic-textfield.example.ts
@@ -1,9 +1,40 @@
-import {extend, TextField} from '@shopify/ui-extensions/admin';
+import {extension, TextField, Button, BlockStack} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const textfield = root.createComponent(TextField, {
-    label: 'Enter some text',
-  });
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let customLabel = '';
 
-  root.appendChild(textfield);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(TextField, {
+      label: 'Custom warehouse label',
+      name: 'warehouseLabel',
+      onChange: (value) => {
+        customLabel = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/label', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, label: customLabel}),
+          });
+          close();
+        },
+      },
+      'Save label',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/examples/textfield-suffix.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/examples/textfield-suffix.example.ts
@@ -1,0 +1,33 @@
+import {extension, TextField, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root) => {
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Shipping configuration',
+    );
+
+    const weightField = root.createComponent(TextField, {
+      label: 'Package weight',
+      name: 'weight',
+      suffix: 'kg',
+    });
+
+    const handleField = root.createComponent(TextField, {
+      label: 'Shopify handle',
+      name: 'handle',
+      suffix: '.myshopify.com',
+      readOnly: true,
+    });
+
+    stack.appendChild(heading);
+    stack.appendChild(weightField);
+    stack.appendChild(handleField);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/examples/textfield-validation.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/examples/textfield-validation.example.ts
@@ -1,0 +1,50 @@
+import {extension, TextField, Button, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let skuValue = '';
+
+    const stack = root.createComponent(BlockStack);
+
+    const skuField = root.createComponent(TextField, {
+      label: 'SKU',
+      name: 'sku',
+      required: true,
+      onChange: (value) => {
+        skuValue = value;
+        if (value.length < 3) {
+          skuField.updateProps({error: 'SKU must be at least 3 characters'});
+        } else if (!/^[A-Z0-9-]+$/i.test(value)) {
+          skuField.updateProps({error: 'SKU can only contain letters, numbers, and hyphens'});
+        } else {
+          skuField.updateProps({error: undefined});
+        }
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          if (skuValue.length >= 3) {
+            await fetch('/api/products/sku', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({productId, sku: skuValue}),
+            });
+            close();
+          }
+        },
+      },
+      'Save SKU',
+    );
+
+    stack.appendChild(skuField);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'urlfield-default.png',
     codeblock: {
-      title: 'Simple URLField example',
+      title: 'Set external product source URL',
       tabs: [
         {
           title: 'React',
@@ -29,12 +29,55 @@ const data: ReferenceEntityTemplateSchema = {
           language: 'tsx',
         },
         {
-          title: 'JS',
+          title: 'TS',
           code: './examples/basic-urlfield.example.ts',
-          language: 'js',
+          language: 'ts',
         },
       ],
     },
+  },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Validate that a webhook endpoint uses HTTPS using the `error` prop and `required` attribute. This example checks the URL protocol on each keystroke and displays an inline error for non-HTTPS URLs, so merchants can only register secure webhook endpoints.',
+        codeblock: {
+          title: 'Validate webhook endpoint protocol',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/URLField/examples/urlfield-validation.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/urlfield-validation.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          "Pre-populate a URL field with the product's storefront address using `data.selected` and the `readOnly` prop. This example shows the product storefront URL as a reference alongside an editable field for the external catalog link.",
+        codeblock: {
+          title: 'Pre-fill product storefront link',
+          tabs: [
+            {
+              title: 'React',
+              code: '../../../../../../ui-extensions-react/src/surfaces/admin/components/URLField/examples/urlfield-prefilled.example.tsx',
+              language: 'tsx',
+            },
+            {
+              title: 'TS',
+              code: './examples/urlfield-prefilled.example.ts',
+              language: 'ts',
+            },
+          ],
+        },
+      },
+    ],
   },
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/basic-urlfield.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/basic-urlfield.example.ts
@@ -1,9 +1,47 @@
-import {extend, URLField} from '@shopify/ui-extensions/admin';
+import {extension, URLField, Button, BlockStack, Text} from '@shopify/ui-extensions/admin';
 
-extend('Playground', (root) => {
-  const urlField = root.createComponent(URLField, {
-    label: 'Enter store url',
-  });
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {data, close} = api;
+    const productId = data.selected[0]?.id;
+    let sourceUrl = '';
 
-  root.appendChild(urlField);
-});
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'External product source',
+    );
+
+    const field = root.createComponent(URLField, {
+      label: 'Source URL',
+      name: 'sourceUrl',
+      onChange: (value) => {
+        sourceUrl = value;
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          await fetch('/api/products/source', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({productId, sourceUrl}),
+          });
+          close();
+        },
+      },
+      'Save source URL',
+    );
+
+    stack.appendChild(heading);
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/urlfield-prefilled.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/urlfield-prefilled.example.ts
@@ -1,0 +1,35 @@
+import {extension, URLField, BlockStack, Text} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.block.render',
+  (root, api) => {
+    const {data} = api;
+    const productId = data.selected[0]?.id;
+    const numericId = productId?.split('/').pop();
+
+    const stack = root.createComponent(BlockStack);
+
+    const heading = root.createComponent(
+      Text,
+      {fontWeight: 'bold'},
+      'Product links',
+    );
+
+    const storefrontField = root.createComponent(URLField, {
+      label: 'Storefront URL',
+      name: 'storefrontUrl',
+      value: `https://your-store.myshopify.com/products/${numericId}`,
+      readOnly: true,
+    });
+
+    const externalField = root.createComponent(URLField, {
+      label: 'External catalog URL',
+      name: 'externalUrl',
+    });
+
+    stack.appendChild(heading);
+    stack.appendChild(storefrontField);
+    stack.appendChild(externalField);
+    root.appendChild(stack);
+  },
+);

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/urlfield-validation.example.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/urlfield-validation.example.ts
@@ -1,0 +1,47 @@
+import {extension, URLField, Button, BlockStack} from '@shopify/ui-extensions/admin';
+
+export default extension(
+  'admin.product-details.action.render',
+  (root, api) => {
+    const {close} = api;
+    let endpoint = '';
+
+    const stack = root.createComponent(BlockStack);
+
+    const field = root.createComponent(URLField, {
+      label: 'Webhook endpoint URL',
+      name: 'webhookEndpoint',
+      required: true,
+      onChange: (value) => {
+        endpoint = value;
+        if (value && !value.startsWith('https://')) {
+          field.updateProps({error: 'Webhook endpoints must use HTTPS'});
+        } else {
+          field.updateProps({error: undefined});
+        }
+      },
+    });
+
+    const saveButton = root.createComponent(
+      Button,
+      {
+        variant: 'primary',
+        onPress: async () => {
+          if (endpoint.startsWith('https://')) {
+            await fetch('/api/webhooks/register', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({endpoint}),
+            });
+            close();
+          }
+        },
+      },
+      'Register webhook',
+    );
+
+    stack.appendChild(field);
+    stack.appendChild(saveButton);
+    root.appendChild(stack);
+  },
+);


### PR DESCRIPTION
## Summary

Rewrites all code examples and descriptions for the 36 admin UI extension components in the 2025-07 API version. The existing examples were minimal placeholders (single-prop demos, missing descriptions, no real use cases). This PR replaces them with examples that show devs how to use each component in realistic extension scearios.

## What changed

**Example code (216 files):** Each component now has 3 examples, each with a `.ts` (imperative) and `.tsx` (React) version. Examples use real extension targets like `admin.product-details.action.render` and `block.render`, and demonstrate actual patterns developers need — querying the GraphQL Admin API, posting to backend endpoints, handling form submission, validating input, and working with `data.selected`, `close()`, and `navigation`.

**Documentation (36 `.doc.ts` files + 65 React `.doc.ts` files):** Every `defaultExample` and `examples` section has been updated with:
- Action-oriented titles (5 words or fewer)
- Two-sentence descriptions following the Shopify dev docs style guide: first sentence explains the business use case, second sentence covers the technical implementation
- Links to related components and APIs where they help the reader (1-2 per description)

**Prop validation:** All props used in examples have been validated against the actual 2025-07 TypeScript type definitions to ensure no example references a prop, value, or component that doesn't exist in this version.

### CSAT feedback

This PR closes the following feedback issues: