### PR TITLE
2023 07 admin path

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
@@ -1,6 +1,13 @@
 DOCS_PATH=docs/surfaces/admin
 SRC_PATH=src/surfaces/admin
 
+# Version for shopify-dev path (e.g. 2023-07). Use env or 2nd arg: API_VERSION=2023-07 yarn docs:admin
+API_VERSION=${API_VERSION:-${2:-unstable}}
+if [ "$API_VERSION" = "unstable" ]; then
+  echo "Building admin docs for 'unstable'. Set API_VERSION=2023-07 (or pass as 2nd arg) to copy to a versioned path in shopify-dev."
+else
+  echo "Building admin docs for '$API_VERSION'."
+fi
 
 # COMPILE_COMPONENT_DOCS="yarn tsc --project ./docs/surfaces/${surface}/tsconfig.docs.json --types react --moduleResolution node  --target esNext  --module CommonJS && generate-docs --input ./src/surfaces/${surface}/components/* ./src/surfaces/${surface}/api/* --typesInput ./src --output ./docs/surfaces/${surface}/generated && rm -rf ../../src/surfaces/${surface}/**/**/*.doc.js"
 # COMPILE_API_DOCS="yarn tsc --project ./docs/${surface}/tsconfig.docs.json --types react --moduleResolution node  --target esNext  --module CommonJS && generate-docs --input ./src/surfaces/${surface}/components/* --typesInput ./src --output ./docs/surfaces/${surface}/generated && rm -rf ./src/surfaces/${surface}/components/**/*.doc.js"
@@ -22,5 +29,28 @@ node ./$DOCS_PATH/build-docs-targets-json.mjs
 find ./ -name '*.doc*.js' -exec rm -r {} \;
 
 if [ $build_exit -ne 0 ]; then
-  fail_and_exit $build_exit
+  exit $build_exit
+fi
+
+# Make sure https://shopify.dev URLs are relative so they work in Spin (same as checkout)
+if [ -f ./$DOCS_PATH/generated/generated_docs_data.json ]; then
+  sed -i.bak 's|https://shopify.dev||gi' ./$DOCS_PATH/generated/generated_docs_data.json 2>/dev/null || true
+  rm -f ./$DOCS_PATH/generated/generated_docs_data.json.bak
+fi
+
+# Copy the generated docs to shopify-dev (when repo is present as sibling, e.g. in Spin)
+if [ -d ../../../shopify-dev ]; then
+  DEST_DIR="../../../shopify-dev/areas/platforms/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION"
+  mkdir -p "$DEST_DIR"
+  cp ./$DOCS_PATH/generated/* "$DEST_DIR/"
+  if [ "$API_VERSION" != "unstable" ]; then
+    sed -i.bak "s|/docs/api/admin-extensions/unstable|/docs/api/admin-extensions/$API_VERSION|gi" "$DEST_DIR/generated_docs_data.json" 2>/dev/null || true
+    rm -f "$DEST_DIR/generated_docs_data.json.bak"
+  fi
+  echo "Copied admin docs to shopify-dev at $DEST_DIR"
+  if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
+    echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/admin-extensions"
+  fi
+else
+  echo "Not copying to shopify-dev (not found at ../../../shopify-dev)."
 fi

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-template-curly-in-string */
 import {LandingTemplateSchema} from '@shopify/generate-docs';
 
 const data: LandingTemplateSchema = {

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -126,15 +126,12 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Link to Product Page',
                 language: 'tsx',
-                code: '<Link to="shopify:admin/products/1234567890" />',
+                code: './examples/link-shopify-admin.tsx',
               },
               {
                 title: 'Fetch data',
                 language: 'ts',
-                code: `fetch("shopify:admin/api/graphql.json", {
-  method: "POST",
-  body: JSON.stringify(simpleProductQuery),
-});`,
+                code: './examples/fetch-shopify-admin.ts',
               },
             ],
           },
@@ -149,7 +146,7 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Link to Product Page',
                 language: 'tsx',
-                code: '<Link to="app:settings/advanced" />',
+                code: './examples/link-app.tsx',
               },
             ],
           },
@@ -164,7 +161,7 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Trigger Action Extension from a Block extension',
                 language: 'tsx',
-                code: '<Link to={`extension:${extension.handle}/${extensionTarget}`} />',
+                code: './examples/link-extension.tsx',
               },
             ],
           },
@@ -179,7 +176,7 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Link to route in your app',
                 language: 'tsx',
-                code: '<Link to={`/reviews/${product.id}`} />',
+                code: './examples/link-relative.tsx',
               },
             ],
           },

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/fetch-shopify-admin.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/fetch-shopify-admin.ts
@@ -1,0 +1,4 @@
+fetch("shopify:admin/api/graphql.json", {
+  method: "POST",
+  body: JSON.stringify(simpleProductQuery),
+});

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-app.tsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-app.tsx
@@ -1,0 +1,1 @@
+<Link to="app:settings/advanced" />

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-extension.tsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-extension.tsx
@@ -1,0 +1,1 @@
+<Link to={`extension:${extension.handle}/${extensionTarget}`} />

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-relative.tsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-relative.tsx
@@ -1,0 +1,1 @@
+<Link to={`/reviews/${product.id}`} />

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-shopify-admin.tsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-shopify-admin.tsx
@@ -1,0 +1,1 @@
+<Link to="shopify:admin/products/1234567890" />


### PR DESCRIPTION
## PR summary: Admin docs build fixes and shopify-dev copy

### What changed

**1. Admin docs build script (`docs/surfaces/admin/build-docs.sh`)**
- Replaced undefined `fail_and_exit` with `exit $build_exit` so the script exits with the right status when the doc build fails.
- **Copy to shopify-dev:** After a successful build, generated docs are copied into the shopify-dev repo when it exists at `../../../shopify-dev` (same pattern as checkout docs).
- Destination: `shopify-dev/.../templated_apis/admin_extensions/<API_VERSION>/`. Version is controlled by `API_VERSION` or the second script argument (default `unstable`).
- Strip `https://shopify.dev` from `generated_docs_data.json` before copy so links work in Spin; for non-`unstable` versions, replace `/unstable` with the version in doc links.

**2. generate-docs “Unable to find code file” fix**
- `generate-docs` treats every `code` field as a file path. The Custom Protocols section used inline snippets (e.g. `'<Link to="shopify:admin/..." />'`), which were interpreted as paths and failed.
- **Fix:** Added five small example files under `staticPages/examples/` and pointed the doc at them:
  - `link-shopify-admin.tsx`, `fetch-shopify-admin.ts`, `link-app.tsx`, `link-extension.tsx`, `link-relative.tsx`
- Updated `admin-extensions.doc.ts` so all Custom Protocols codeblocks use these file paths instead of inline code strings.

### Result

- `yarn docs:admin` (and `API_VERSION=2023-07 yarn docs:admin`) completes successfully.
- When shopify-dev is present as a sibling repo, admin docs are copied into it and appear on shopify.dev.

