### PR TITLE
fix broken script for 2023-04

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
@@ -42,3 +42,26 @@ targets_exit=$?
 if [ $targets_exit -ne 0 ]; then
   fail_and_exit $targets_exit
 fi
+
+# Make sure https://shopify.dev URLs are relative so they work in Spin (same as checkout)
+if [ -f ./$DOCS_PATH/generated/generated_docs_data.json ]; then
+  sed -i.bak 's|https://shopify.dev||gi' ./$DOCS_PATH/generated/generated_docs_data.json 2>/dev/null || true
+  rm -f ./$DOCS_PATH/generated/generated_docs_data.json.bak
+fi
+
+# Copy the generated docs (including targets.json) to shopify-dev when repo is present as sibling
+if [ -d ../../../shopify-dev ]; then
+  DEST_DIR="../../../shopify-dev/areas/platforms/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION"
+  mkdir -p "$DEST_DIR"
+  cp ./$DOCS_PATH/generated/* "$DEST_DIR/"
+  if [ "$API_VERSION" != "unstable" ]; then
+    sed -i.bak "s|/docs/api/admin-extensions/unstable|/docs/api/admin-extensions/$API_VERSION|gi" "$DEST_DIR/generated_docs_data.json" 2>/dev/null || true
+    rm -f "$DEST_DIR/generated_docs_data.json.bak"
+  fi
+  echo "Copied admin docs and targets.json to shopify-dev at $DEST_DIR"
+  if [ -n "$SPIN_SHOPIFY_DEV_SERVICE_FQDN" ]; then
+    echo "Docs: https://$SPIN_SHOPIFY_DEV_SERVICE_FQDN/docs/api/admin-extensions"
+  fi
+else
+  echo "Not copying to shopify-dev (not found at ../../../shopify-dev)."
+fi

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -126,15 +126,12 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Link to Product Page',
                 language: 'tsx',
-                code: '<Link to="shopify:admin/products/1234567890" />',
+                code: './examples/link-shopify-admin.tsx',
               },
               {
                 title: 'Fetch data',
                 language: 'ts',
-                code: `fetch("shopify:admin/api/graphql.json", {
-  method: "POST",
-  body: JSON.stringify(simpleProductQuery),
-});`,
+                code: './examples/fetch-shopify-admin.ts',
               },
             ],
           },
@@ -149,7 +146,7 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Link to Product Page',
                 language: 'tsx',
-                code: '<Link to="app:settings/advanced" />',
+                code: './examples/link-app.tsx',
               },
             ],
           },
@@ -164,7 +161,7 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Trigger Action Extension from a Block extension',
                 language: 'tsx',
-                code: '<Link to={`extension:${extension.handle}/${extensionTarget}`} />',
+                code: './examples/link-extension.tsx',
               },
             ],
           },
@@ -179,7 +176,7 @@ const data: LandingTemplateSchema = {
               {
                 title: 'Link to route in your extension',
                 language: 'tsx',
-                code: '<Link to={`/reviews/${product.id}`} />',
+                code: './examples/link-relative.tsx',
               },
             ],
           },

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/admin-extensions.doc.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-template-curly-in-string */
 import {LandingTemplateSchema} from '@shopify/generate-docs';
 
 const data: LandingTemplateSchema = {

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/fetch-shopify-admin.ts
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/fetch-shopify-admin.ts
@@ -1,0 +1,4 @@
+fetch("shopify:admin/api/graphql.json", {
+  method: "POST",
+  body: JSON.stringify(simpleProductQuery),
+});

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-app.tsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-app.tsx
@@ -1,0 +1,1 @@
+<Link to="app:settings/advanced" />

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-extension.tsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-extension.tsx
@@ -1,0 +1,1 @@
+<Link to={`extension:${extension.handle}/${extensionTarget}`} />

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-relative.tsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-relative.tsx
@@ -1,0 +1,1 @@
+<Link to={`/reviews/${product.id}`} />

--- a/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-shopify-admin.tsx
+++ b/packages/ui-extensions/docs/surfaces/admin/staticPages/examples/link-shopify-admin.tsx
@@ -1,0 +1,1 @@
+<Link to="shopify:admin/products/1234567890" />


### PR DESCRIPTION
**Admin docs build fixes**

- **generate-docs “Unable to find code file”**  
  The Custom Protocols section used inline `code` strings; generate-docs treats `code` as file paths. Added five example files under `staticPages/examples/` (link-shopify-admin, fetch-shopify-admin, link-app, link-extension, link-relative) and pointed the doc at them so the build succeeds.

- **Copy to shopify-dev**  
  After a successful build, the script now copies `docs/surfaces/admin/generated/` (including `targets.json`) into shopify-dev at `templated_apis/admin_extensions/<API_VERSION>/` when shopify-dev is present at `../../../shopify-dev`. Strips `https://shopify.dev` from `generated_docs_data.json` for Spin and rewrites `/unstable` to the version for stable builds.

- **Script behavior**  
  Build script already takes `API_VERSION` as the first argument (e.g. `yarn docs:admin 2023-04`) and defines `fail_and_exit`; no change to that. Copy step runs only when the docs build and targets generation succeed.