### PR TITLE
chore: update all paths in build-docs fast/watch scripts 2025-10

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-fast.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-fast.sh
@@ -50,9 +50,9 @@ fi
 # Copy generated docs to shopify-dev
 copy_generated_docs_to_shopify_dev() {
   if [ -d $SHOPIFY_DEV_PATH ]; then
-    mkdir -p $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
-    cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
-    echo "✓ Copied docs to shopify-dev: $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/checkout_extensions/$API_VERSION"
+    mkdir -p $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
+    cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
+    echo "✓ Copied docs to shopify-dev: $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION"
   else
     echo "Not copying docs to shopify-dev because it was not found at $SHOPIFY_DEV_PATH."
   fi

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-watch.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-watch.sh
@@ -51,8 +51,8 @@ build_docs() {
   # Copy generated docs to shopify-dev
   copy_generated_docs_to_shopify_dev() {
     if [ -d $SHOPIFY_DEV_PATH ]; then
-      mkdir -p $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
-      cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
+      mkdir -p $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
+      cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
       echo "✓ Copied docs to shopify-dev"
     fi
   }


### PR DESCRIPTION
### Background

Due to the [monorepo restructure](https://github.com/Shopify/shopify-dev/pull/67845) of shopify-dev, we need to update the paths in build-docs

### Solution

Updated paths for the new areas/platforms/shopify-dev directory

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
