### PR TITLE
scripts for 2026-04

### DIFF
--- a/packages/ui-extensions/docs/shared/build-docs-type-resolver.mjs
+++ b/packages/ui-extensions/docs/shared/build-docs-type-resolver.mjs
@@ -1,0 +1,406 @@
+/* eslint-disable no-console */
+/* eslint-env node */
+/**
+ * Shared type resolver for build-docs-targets-json scripts
+ *
+ * This module provides utilities for parsing TypeScript type definitions
+ * and resolving component types, including handling of:
+ * - String literals: 'ComponentName'
+ * - Type references: TypeName
+ * - Union types: A | B | C
+ * - Exclude types: Exclude<Base, Excluded>
+ * - Array types: (typeof ARRAY)[number]
+ * - @private JSDoc tags for excluding private components
+ */
+
+import fs from 'fs';
+
+/**
+ * Creates a type resolver instance for a specific surface
+ * @param {string} sharedTsPath - Path to the shared.ts file for the surface
+ * @returns {Object} Type resolver with methods for resolving types
+ */
+export function createTypeResolver(sharedTsPath) {
+  // Cache for type definitions parsed from shared.ts
+  let typeDefinitionsCache = null;
+  const resolvedTypesCache = {};
+  // Set of type names that are marked with @private JSDoc tag
+  let privateTypesCache = null;
+
+  /**
+   * Parse all type definitions from shared.ts
+   * Returns a map of type name -> type definition string
+   * Also detects @private JSDoc tags to identify private types
+   */
+  function parseTypeDefinitions() {
+    if (typeDefinitionsCache !== null) {
+      return typeDefinitionsCache;
+    }
+
+    typeDefinitionsCache = {};
+    privateTypesCache = new Set();
+
+    try {
+      if (!fs.existsSync(sharedTsPath)) {
+        return typeDefinitionsCache;
+      }
+
+      const content = fs.readFileSync(sharedTsPath, 'utf-8');
+
+      // Parse const arrays (like SUPPORTED_COMPONENTS) - store as resolved arrays
+      const constArrayRegex =
+        /export const (\w+)\s*=\s*\[([\s\S]*?)\]\s*as const/g;
+      let constMatch;
+      while ((constMatch = constArrayRegex.exec(content)) !== null) {
+        const constName = constMatch[1];
+        const arrayContent = constMatch[2];
+        const components = arrayContent.match(/'([^']+)'/g);
+        if (components) {
+          typeDefinitionsCache[constName] = components.map((component) =>
+            component.replace(/'/g, ''),
+          );
+        }
+      }
+
+      // Parse all type definitions: export type TypeName = Definition;
+      // Also check for @private JSDoc comments preceding the type
+      const typeRegex = /export type (\w+)(?:<[^>]+>)?\s*=\s*/g;
+      let match;
+
+      while ((match = typeRegex.exec(content)) !== null) {
+        const typeName = match[1];
+        const startPos = match.index + match[0].length;
+
+        // Check for @private in JSDoc comment before this type definition
+        // Look backwards from the match to find a preceding JSDoc comment
+        const beforeMatch = content.substring(0, match.index);
+        const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+        if (lastJsDocEnd !== -1) {
+          // Check if there's no other code between the JSDoc and this type
+          const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+          if (between === '') {
+            // Find the start of this JSDoc comment
+            const jsDocStart = beforeMatch.lastIndexOf('/**');
+            if (jsDocStart !== -1) {
+              const jsDocContent = beforeMatch.substring(
+                jsDocStart,
+                lastJsDocEnd + 2,
+              );
+              // Check if this JSDoc contains @private tag
+              if (jsDocContent.includes('@private')) {
+                privateTypesCache.add(typeName);
+              }
+            }
+          }
+        }
+
+        // Find the end of the type definition (semicolon at depth 0)
+        let endPos = startPos;
+        let depth = 0;
+        let inString = false;
+
+        for (let i = startPos; i < content.length; i++) {
+          const char = content[i];
+          const prevChar = i > 0 ? content[i - 1] : '';
+
+          if (char === "'" && prevChar !== '\\') {
+            inString = !inString;
+          }
+
+          if (!inString) {
+            if (char === '<' || char === '(' || char === '{' || char === '[') {
+              depth++;
+            } else if (
+              char === '>' ||
+              char === ')' ||
+              char === '}' ||
+              char === ']'
+            ) {
+              depth--;
+            } else if (char === ';' && depth === 0) {
+              endPos = i;
+              break;
+            }
+          }
+        }
+
+        const definition = content.substring(startPos, endPos).trim();
+        typeDefinitionsCache[typeName] = definition;
+      }
+
+      return typeDefinitionsCache;
+    } catch (error) {
+      console.warn('Warning: Failed to parse type definitions:', error.message);
+      return typeDefinitionsCache;
+    }
+  }
+
+  /**
+   * Check if a type is marked as @private
+   */
+  function isPrivateType(typeName) {
+    // Ensure type definitions are parsed (which also populates privateTypesCache)
+    parseTypeDefinitions();
+    return privateTypesCache && privateTypesCache.has(typeName);
+  }
+
+  /**
+   * Get the components from @private types (to exclude them from other types)
+   */
+  function getPrivateComponents() {
+    parseTypeDefinitions();
+    const privateComponents = [];
+    if (privateTypesCache) {
+      for (const typeName of privateTypesCache) {
+        const resolved = resolveTypeInternal(typeName, false); // Don't filter private when getting private components
+        privateComponents.push(...resolved);
+      }
+    }
+    return privateComponents;
+  }
+
+  /**
+   * Internal type resolver - can optionally skip filtering of @private components
+   * @param {string} typeExpr - The type expression to resolve
+   * @param {boolean} filterPrivate - Whether to filter out @private components (default: true)
+   */
+  function resolveTypeInternal(typeExpr, filterPrivate = true) {
+    if (!typeExpr) return [];
+
+    const trimmedTypeExpr = typeExpr.trim();
+
+    // Check cache first (but only for filtered results)
+    const cacheKey = filterPrivate
+      ? trimmedTypeExpr
+      : `__unfiltered__${trimmedTypeExpr}`;
+    if (resolvedTypesCache[cacheKey]) {
+      return [...resolvedTypesCache[cacheKey]];
+    }
+
+    const typeDefs = parseTypeDefinitions();
+    let result = [];
+
+    // Handle string literal: 'ComponentName'
+    const stringLiteralMatch = trimmedTypeExpr.match(/^'([^']+)'$/);
+    if (stringLiteralMatch) {
+      result = [stringLiteralMatch[1]];
+      resolvedTypesCache[cacheKey] = result;
+      return [...result];
+    }
+
+    // IMPORTANT: Check for unions FIRST before other patterns
+    // This ensures we don't match partial patterns within a union
+    if (trimmedTypeExpr.includes('|')) {
+      const parts = splitByTopLevelPipe(typeExpr);
+      // Only treat as union if we actually got multiple parts
+      if (parts.filter((part) => part.trim()).length > 1) {
+        for (const part of parts) {
+          const trimmed = part.trim();
+          if (trimmed) {
+            result.push(...resolveTypeInternal(trimmed, filterPrivate));
+          }
+        }
+        // Deduplicate
+        result = [...new Set(result)];
+        resolvedTypesCache[cacheKey] = result;
+        return [...result];
+      }
+    }
+
+    // Handle (typeof ARRAY_NAME)[number] - anchored to match entire expression
+    const typeofMatch = trimmedTypeExpr.match(/^\(typeof (\w+)\)\[number\]$/);
+    if (typeofMatch) {
+      const arrayName = typeofMatch[1];
+      if (Array.isArray(typeDefs[arrayName])) {
+        result = [...typeDefs[arrayName]];
+        resolvedTypesCache[cacheKey] = result;
+        return [...result];
+      }
+    }
+
+    // Handle Exclude<BaseType, ExcludedType>
+    const excludeMatch = trimmedTypeExpr.match(/^Exclude<(.+)>$/);
+    if (excludeMatch) {
+      const innerContent = excludeMatch[1];
+      const parts = splitByTopLevelComma(innerContent);
+      if (parts.length >= 2) {
+        const baseType = parts[0].trim();
+        const excludedType = parts[1].trim();
+
+        const baseComponents = resolveTypeInternal(baseType, filterPrivate);
+        const excludedComponents = resolveTypeInternal(
+          excludedType,
+          filterPrivate,
+        );
+
+        result = baseComponents.filter(
+          (component) => !excludedComponents.includes(component),
+        );
+        resolvedTypesCache[cacheKey] = result;
+        return [...result];
+      }
+    }
+
+    // Handle type reference (look up in definitions and resolve recursively)
+    if (/^\w+$/.test(trimmedTypeExpr)) {
+      // If this type itself is marked @private, return empty (unless we're not filtering)
+      if (filterPrivate && isPrivateType(trimmedTypeExpr)) {
+        resolvedTypesCache[cacheKey] = [];
+        return [];
+      }
+
+      const definition = typeDefs[trimmedTypeExpr];
+      if (Array.isArray(definition)) {
+        // It's a pre-resolved array (like SUPPORTED_COMPONENTS)
+        result = [...definition];
+      } else if (typeof definition === 'string') {
+        // Recursively resolve the definition
+        result = resolveTypeInternal(definition, filterPrivate);
+      }
+      resolvedTypesCache[cacheKey] = result;
+      return [...result];
+    }
+
+    // If we can't resolve it, return empty
+    resolvedTypesCache[cacheKey] = result;
+    return [...result];
+  }
+
+  /**
+   * Resolve a type expression to component strings
+   * Automatically excludes components from types marked with @private JSDoc tag
+   * @param {string} typeExpr - The type expression to resolve
+   * @returns {string[]} Array of component names
+   */
+  function resolveType(typeExpr) {
+    // Get result with private components filtered out
+    let result = resolveTypeInternal(typeExpr, true);
+
+    // Also filter out any components that come from @private types
+    const privateComponents = getPrivateComponents();
+    if (privateComponents.length > 0) {
+      result = result.filter(
+        (component) => !privateComponents.includes(component),
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * Resolve a type expression WITHOUT filtering @private components
+   * Use this for AllowedComponents<> which explicitly allows private components
+   * @param {string} typeExpr - The type expression to resolve
+   * @returns {string[]} Array of component names
+   */
+  function resolveTypeUnfiltered(typeExpr) {
+    return resolveTypeInternal(typeExpr, false);
+  }
+
+  /**
+   * Get the parsed type definitions (for debugging or advanced use)
+   */
+  function getTypeDefinitions() {
+    return parseTypeDefinitions();
+  }
+
+  /**
+   * Get the set of private type names
+   */
+  function getPrivateTypeNames() {
+    parseTypeDefinitions();
+    return privateTypesCache ? new Set(privateTypesCache) : new Set();
+  }
+
+  return {
+    resolveType,
+    resolveTypeUnfiltered,
+    getTypeDefinitions,
+    getPrivateTypeNames,
+    getPrivateComponents,
+    isPrivateType,
+  };
+}
+
+/**
+ * Split a string by top-level pipe (|) characters, respecting nesting
+ */
+export function splitByTopLevelPipe(str) {
+  const parts = [];
+  let current = '';
+  let depth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<' || char === '(' || char === '{' || char === '[') {
+      depth++;
+      current += char;
+    } else if (char === '>' || char === ')' || char === '}' || char === ']') {
+      depth--;
+      current += char;
+    } else if (char === '|' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+/**
+ * Split a string by top-level comma (,) characters, respecting nesting
+ */
+export function splitByTopLevelComma(str) {
+  const parts = [];
+  let current = '';
+  let angleDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    if (char === '<') {
+      angleDepth++;
+      current += char;
+    } else if (char === '>') {
+      angleDepth--;
+      current += char;
+    } else if (char === '{') {
+      braceDepth++;
+      current += char;
+    } else if (char === '}') {
+      braceDepth--;
+      current += char;
+    } else if (char === '(') {
+      parenDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenDepth--;
+      current += char;
+    } else if (
+      char === ',' &&
+      angleDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0
+    ) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs-targets-json.mjs
@@ -1,0 +1,726 @@
+/* eslint-disable no-console */
+/* eslint-env node */
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {
+  createTypeResolver,
+  splitByTopLevelComma,
+} from '../../shared/build-docs-type-resolver.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Find the generated_docs_data.json file to determine output location
+function findGeneratedDocsPath() {
+  const generatedDir = path.join(__dirname, 'generated');
+
+  // Look for generated_docs_data.json recursively
+  function findFile(dir) {
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+      const fullPath = path.join(dir, file);
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory()) {
+        const result = findFile(fullPath);
+        if (result) return result;
+      } else if (file === 'generated_docs_data.json') {
+        return path.dirname(fullPath);
+      }
+    }
+    return null;
+  }
+
+  const docsPath = findFile(generatedDir);
+  return docsPath || generatedDir; // Fallback to generated root if not found
+}
+
+// Configuration for admin surface
+const config = {
+  basePath: path.join(__dirname, '../../../src/surfaces/admin'),
+  outputPath: path.join(findGeneratedDocsPath(), 'targets.json'),
+  componentTypesPath: 'components',
+  hasComponentTypes: true,
+};
+
+// All components will be populated from StandardComponents
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+// Create type resolver for checkout's shared.ts (to resolve AnyComponent, etc.)
+const checkoutSharedPath = path.join(
+  __dirname,
+  '../../../src/surfaces/checkout/shared.ts',
+);
+const checkoutTypeResolver = createTypeResolver(checkoutSharedPath);
+
+// Cache for checkout components (resolved via type resolver, excluding @private)
+let checkoutComponentsCache = null;
+
+/**
+ * Parse components from checkout's shared.ts file
+ * Uses the shared type resolver to properly handle @private types
+ */
+function parseCheckoutComponents() {
+  // Return cached value if available
+  if (checkoutComponentsCache !== null) {
+    return checkoutComponentsCache;
+  }
+
+  try {
+    // Use the type resolver to get AnyComponent (which excludes @private)
+    checkoutComponentsCache = checkoutTypeResolver.resolveType('AnyComponent');
+
+    if (checkoutComponentsCache.length === 0) {
+      // Fallback: try to get just SUPPORTED_COMPONENTS
+      const typeDefs = checkoutTypeResolver.getTypeDefinitions();
+      if (Array.isArray(typeDefs.SUPPORTED_COMPONENTS)) {
+        checkoutComponentsCache = [...typeDefs.SUPPORTED_COMPONENTS];
+      } else {
+        checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
+      }
+    }
+
+    return checkoutComponentsCache;
+  } catch (error) {
+    checkoutComponentsCache = ['[CheckoutComponentsError]'];
+    return checkoutComponentsCache;
+  }
+}
+
+/**
+ * Parse a string union type from a component file and resolve type references
+ * e.g., export type SmartGridComponents = 'Tile';
+ * or: export type BlockExtensionComponents = StandardComponents | 'AdminBlock';
+ * or: export type StandardComponents = AnyComponent | 'Avatar' | ... (with AnyComponent imported)
+ */
+function parseStringUnionType(filePath, componentTypesMap = {}) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    // Extract all quoted component names from the file (but not from import statements)
+    // Remove import lines first
+    const contentWithoutImports = content.replace(/^import.*?;$/gm, '');
+    const componentNames = contentWithoutImports.match(/'([^']+)'/g);
+    const quotedComponents = componentNames
+      ? componentNames.map((name) => name.replace(/'/g, ''))
+      : [];
+
+    // Check if the type references other types (like StandardComponents or AnyComponent)
+    // Look for patterns like: StandardComponents | 'OtherComponent'
+    const typeRefPattern = /export type \w+ =\s*([\s\S]*?);/;
+    const typeDefMatch = content.match(typeRefPattern);
+
+    if (typeDefMatch) {
+      const typeDef = typeDefMatch[1];
+      // Find references to other types (capitalized words that aren't in quotes)
+      const typeRefs = typeDef.match(/\b([A-Z]\w+(?:Components?)?)\b/g);
+
+      if (typeRefs) {
+        const components = [...quotedComponents];
+
+        for (const typeRef of typeRefs) {
+          // Check if this is AnyComponent (imported from checkout)
+          if (typeRef === 'AnyComponent') {
+            // Add all checkout components
+            const checkoutComponents = parseCheckoutComponents();
+            components.push(...checkoutComponents);
+          }
+          // If this type reference exists in our map, include its components
+          else if (componentTypesMap[typeRef]) {
+            components.push(...componentTypesMap[typeRef]);
+          }
+        }
+
+        // Remove duplicates
+        return [...new Set(components)];
+      }
+    }
+
+    return quotedComponents.length > 0 ? quotedComponents : null;
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from files in the components directory
+ * Uses a two-pass approach:
+ * 1. First pass: Parse all component types that only contain quoted strings
+ * 2. Second pass: Parse types that reference other types (like StandardComponents)
+ */
+function parseComponentTypesFromFiles() {
+  if (!config.hasComponentTypes || !config.componentTypesPath) {
+    return {};
+  }
+
+  const componentsPath = path.join(config.basePath, config.componentTypesPath);
+  const componentTypesMap = {};
+
+  try {
+    // Look for all TypeScript files in the components directory
+    const files = fs.readdirSync(componentsPath);
+    const tsFiles = files.filter(
+      (file) => file.endsWith('.ts') && !file.endsWith('.d.ts'),
+    );
+
+    // First pass: Parse files with only quoted strings
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, {});
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+
+        // If this is StandardComponents, use it as the base
+        if (componentTypeName === 'StandardComponents') {
+          allComponents = components.sort();
+        }
+      }
+    }
+
+    // Second pass: Re-parse files that might reference other types
+    // This allows types like BlockExtensionComponents = StandardComponents | 'AdminBlock'
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, componentTypesMap);
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+      }
+    }
+  } catch (error) {
+    console.error('Error parsing component types:', error.message);
+  }
+
+  return componentTypesMap;
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(config.basePath, 'extension-targets.ts');
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse component type definitions
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension or RunnableExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'CustomerAccountExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match) {
+      // Parse RenderExtension targets (have components)
+      if (match[1].includes('RenderExtension<')) {
+        parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+      }
+      // Parse RunnableExtension targets (no components, like should-render)
+      if (match[1].includes('RunnableExtension<')) {
+        parseRunnableTargetsFromInterfaceBody(match[1], targets);
+      }
+    }
+  }
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(
+  interfaceBody,
+  targets,
+  componentTypesMap,
+) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    // Look backwards from the match to find a preceding JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      // Check if there's no other target between the JSDoc and this target
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      // If the text between JSDoc end and target is empty (or just whitespace), the JSDoc belongs to this target
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          // Skip this target if it's marked @private
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+/**
+ * Parse RunnableExtension targets from an interface body
+ * These targets don't have components (they return data, not UI)
+ */
+function parseRunnableTargetsFromInterfaceBody(interfaceBody, targets) {
+  // Parse each RunnableExtension target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RunnableExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
+    let runnableExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    runnableExtensionContent = runnableExtensionContent
+      .replace(/\/\/[^\n]*/g, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // Split by comma to separate API and Output type
+    const parts = splitByTopLevelComma(runnableExtensionContent);
+
+    if (parts.length >= 1) {
+      const apiString = parts[0].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // RunnableExtension targets don't have components - they return data
+      targets[targetName] = {
+        components: [],
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (Object.prototype.hasOwnProperty.call(apiDefinitionsCache, apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Try to find the API file in the surface's api directory
+  const apiDir = path.join(config.basePath, 'api');
+
+  if (!fs.existsSync(apiDir)) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Convert API name to potential file paths
+  // e.g., StandardApi -> standard-api, CartApi -> cart-api
+  const kebabName = apiName
+    .replace(/Api$/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+  // Try multiple possible locations
+  const possiblePaths = [
+    path.join(apiDir, `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}`, `${kebabName}.ts`),
+    path.join(apiDir, kebabName.replace(/-/g, ''), `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}-api`, `${kebabName}-api.ts`),
+    path.join(apiDir, `${kebabName}-api.ts`),
+    path.join(apiDir, `standard-api`, `standard-api.ts`),
+  ];
+
+  let content = null;
+  for (const apiFilePath of possiblePaths) {
+    try {
+      if (fs.existsSync(apiFilePath)) {
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      }
+    } catch (error) {
+      // Continue to next path
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    const startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  const trimmedApiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = trimmedApiString
+    .split('&')
+    .map((part) => part.trim())
+    .filter((part) => part);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const generalMatch = part.match(/(\w+Api)\b/);
+      if (generalMatch) {
+        apiName = generalMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+/**
+ * Parse a TypeScript component type expression
+ * Handles various patterns: type refs, unions, Exclude, AllowedComponents, etc.
+ */
+function parseComponents(componentString, componentTypesMap) {
+  // Normalize whitespace
+  const trimmedComponentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
+  const checkoutExceptMatch = trimmedComponentString.match(
+    /AnyCheckoutComponentExcept<([^>]+)>/,
+  );
+  if (checkoutExceptMatch) {
+    const excludedUnion = checkoutExceptMatch[1];
+    // Get all checkout components
+    const allCheckoutComponents = parseCheckoutComponents();
+    // Parse the union of excluded components
+    const excludedComponents = parseUnionOfStrings(excludedUnion);
+    // Filter out the excluded components
+    return allCheckoutComponents.filter(
+      (component) => !excludedComponents.includes(component),
+    );
+  }
+
+  // Handle Exclude<BaseType, ExcludedComponent>
+  const excludeMatch = trimmedComponentString.match(
+    /Exclude<(\w+),\s*'([^']+)'>/,
+  );
+  if (excludeMatch) {
+    const baseType = excludeMatch[1];
+    const excluded = excludeMatch[2];
+    const baseComponents = resolveComponentType(baseType, componentTypesMap);
+    return baseComponents.filter((component) => component !== excluded);
+  }
+
+  // Handle AllowedComponents<ComponentType>
+  const allowedMatch = trimmedComponentString.match(
+    /AllowedComponents<([^>]+)>/,
+  );
+  if (allowedMatch) {
+    const innerType = allowedMatch[1].trim();
+    return resolveComponentType(innerType, componentTypesMap);
+  }
+
+  // Check if it's a direct type reference
+  const result = resolveComponentType(
+    trimmedComponentString,
+    componentTypesMap,
+  );
+  if (result.length > 0) {
+    return result;
+  }
+
+  // Default to all components if we have them
+  if (allComponents.length > 0) {
+    return allComponents;
+  }
+
+  return ['[Unknown]'];
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Resolve a component type name to a list of component names
+ */
+function resolveComponentType(typeName, componentTypesMap) {
+  const trimmedTypeName = typeName.trim();
+
+  // Check if it's in our component types map
+  if (componentTypesMap[trimmedTypeName]) {
+    return componentTypesMap[trimmedTypeName];
+  }
+
+  // Handle special checkout types
+  if (
+    trimmedTypeName === 'AnyCheckoutComponent' ||
+    trimmedTypeName === 'AnyComponent' ||
+    trimmedTypeName === 'AnyThankYouComponent'
+  ) {
+    return parseCheckoutComponents();
+  }
+
+  // Check if it's a quoted string literal
+  const quotedMatch = trimmedTypeName.match(/^'([^']+)'$/);
+  if (quotedMatch) {
+    return [quotedMatch[1]];
+  }
+
+  return [];
+}
+
+function createCombinedMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for admin surface');
+  console.log(`📁 Base path: ${config.basePath}`);
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the combined JSON with reverse mappings
+  const combinedJson = createCombinedMapping(targetsJson);
+
+  // Write to output file
+  const outputDir = path.dirname(config.outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, {recursive: true});
+  }
+  fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
+
+  console.log('✅ Generated combined targets JSON at:', config.outputPath);
+
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(combinedJson).filter(
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api'),
+  ).length;
+  const componentEntries = Object.keys(combinedJson).filter(
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api'),
+  ).length;
+
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(combinedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -1,4 +1,5 @@
 /* eslint-disable no-undef, no-console */
+import childProcess from 'child_process';
 import fs from 'fs/promises';
 import {existsSync} from 'fs';
 import path from 'path';
@@ -410,25 +411,27 @@ const transformJson = async (filePath, isExtensions) => {
     }
   });
 
-  // Merge the App Bridge docs with the Shopify Dev docs
+  // Merge the App Bridge docs with the Shopify Dev docs (if that file exists)
   if (!isExtensions && shopifyDevExists) {
     const shopifyDevDocs = path.join(
       shopifyDevDBPath,
       'app_home/generated_docs_data.json',
     );
-    const shopifyDevDocsContent = await fs.readFile(shopifyDevDocs, 'utf8');
-    const shopifyDevDocsDocsParsed = JSON.parse(
-      shopifyDevDocsContent.toString(),
-    );
+    if (existsSync(shopifyDevDocs)) {
+      const shopifyDevDocsContent = await fs.readFile(shopifyDevDocs, 'utf8');
+      const shopifyDevDocsDocsParsed = JSON.parse(
+        shopifyDevDocsContent.toString(),
+      );
 
-    const filteredDocs = shopifyDevDocsDocsParsed.filter(
-      (entry) =>
-        entry.category !== 'Polaris web components' &&
-        entry.category !== 'Patterns', // Don't include old patterns
-    );
+      const filteredDocs = shopifyDevDocsDocsParsed.filter(
+        (entry) =>
+          entry.category !== 'Polaris web components' &&
+          entry.category !== 'Patterns', // Don't include old patterns
+      );
 
-    // Combine arrays with shopify dev docs first, followed by new data
-    jsonData = [...filteredDocs, ...jsonData];
+      // Combine arrays with shopify dev docs first, followed by new data
+      jsonData = [...filteredDocs, ...jsonData];
+    }
   }
 
   await fs.writeFile(filePath, JSON.stringify(jsonData, null, 2));
@@ -469,6 +472,13 @@ const generateExtensionsDocs = async () => {
     searchValue: '/docs/api/admin-extensions/unstable/',
     replaceValue: `/docs/api/admin-extensions/${EXTENSIONS_API_VERSION}`,
   });
+
+  // Generate targets.json (extension targets + APIs + components mapping)
+  const targetsScriptPath = path.join(__dirname, 'build-docs-targets-json.mjs');
+  childProcess.execSync(`node ${targetsScriptPath}`, {
+    stdio: 'inherit',
+    cwd: rootPath,
+  });
 };
 
 const generateAppBridgeDocs = async () => {
@@ -501,6 +511,24 @@ try {
   });
   await generateExtensionsDocs();
   await generateAppBridgeDocs();
+
+  const adminExtensionsOutput = path.join(
+    rootPath,
+    docsGeneratedRelativePath,
+    'admin_extensions',
+    EXTENSIONS_API_VERSION,
+  );
+  const appHomeOutput = path.join(
+    rootPath,
+    docsGeneratedRelativePath,
+    'app_home',
+  );
+  const targetsJsonPath = path.join(adminExtensionsOutput, 'targets.json');
+  console.log('\nGenerated docs at:');
+  console.log('  Admin extensions:', adminExtensionsOutput);
+  console.log('  targets.json:', targetsJsonPath);
+  console.log('  App Home:', appHomeOutput);
+
   await copyGeneratedToShopifyDev({
     generatedDocsPath,
     shopifyDevPath,

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
@@ -1,0 +1,529 @@
+/* eslint-disable no-console */
+/* eslint-env node */
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {
+  createTypeResolver,
+  splitByTopLevelComma,
+} from '../../shared/build-docs-type-resolver.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Find the generated_docs_data.json file to determine output location
+function findGeneratedDocsPath() {
+  const generatedDir = path.join(__dirname, 'generated');
+
+  // Look for generated_docs_data.json recursively
+  function findFile(dir) {
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+      const fullPath = path.join(dir, file);
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory()) {
+        const result = findFile(fullPath);
+        if (result) return result;
+      } else if (file === 'generated_docs_data.json') {
+        return path.dirname(fullPath);
+      }
+    }
+    return null;
+  }
+
+  const docsPath = findFile(generatedDir);
+  return docsPath || generatedDir; // Fallback to generated root if not found
+}
+
+// Configuration for checkout surface
+const config = {
+  basePath: path.join(__dirname, '../../../src/surfaces/checkout'),
+  outputPath: path.join(findGeneratedDocsPath(), 'targets.json'),
+  componentTypesPath: null,
+  hasComponentTypes: false,
+};
+
+// All components will be populated from SUPPORTED_COMPONENTS
+const allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+// Create type resolver for checkout surface
+const sharedTsPath = path.join(config.basePath, 'shared.ts');
+const typeResolver = createTypeResolver(sharedTsPath);
+
+// Expose resolver methods for use in this script
+const resolveType = typeResolver.resolveType;
+const resolveTypeUnfiltered = typeResolver.resolveTypeUnfiltered;
+const getTypeDefinitions = typeResolver.getTypeDefinitions;
+
+function parseComponentTypesFromFiles() {
+  // Checkout doesn't have separate component type files
+  return {};
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(config.basePath, 'extension-targets.ts');
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse component type definitions
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension or RunnableExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'RunnableExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'CustomerAccountExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match) {
+      // Parse RenderExtension targets (have components)
+      if (match[1].includes('RenderExtension<')) {
+        parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+      }
+      // Parse RunnableExtension targets (no components, like address-autocomplete)
+      if (match[1].includes('RunnableExtension<')) {
+        parseRunnableTargetsFromInterfaceBody(match[1], targets);
+      }
+    }
+  }
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(
+  interfaceBody,
+  targets,
+  componentTypesMap,
+) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    // Look backwards from the match to find a preceding JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      // Check if there's no other target between the JSDoc and this target
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      // If the text between JSDoc end and target is empty (or just whitespace), the JSDoc belongs to this target
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          // Skip this target if it's marked @private
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+/**
+ * Parse RunnableExtension targets from an interface body
+ * These targets don't have components (they return data, not UI)
+ */
+function parseRunnableTargetsFromInterfaceBody(interfaceBody, targets) {
+  // Parse each RunnableExtension target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RunnableExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
+    let runnableExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    runnableExtensionContent = runnableExtensionContent
+      .replace(/\/\/[^\n]*/g, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // Split by comma to separate API and Output type
+    const parts = splitByTopLevelComma(runnableExtensionContent);
+
+    if (parts.length >= 1) {
+      const apiString = parts[0].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // RunnableExtension targets don't have components - they return data
+      targets[targetName] = {
+        components: [],
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (Object.prototype.hasOwnProperty.call(apiDefinitionsCache, apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Try to find the API file in the surface's api directory
+  const apiDir = path.join(config.basePath, 'api');
+
+  if (!fs.existsSync(apiDir)) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Convert API name to potential file paths
+  // e.g., StandardApi -> standard-api, CartApi -> cart-api
+  const kebabName = apiName
+    .replace(/Api$/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+  // Try multiple possible locations
+  const possiblePaths = [
+    path.join(apiDir, `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}`, `${kebabName}.ts`),
+    path.join(apiDir, kebabName.replace(/-/g, ''), `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}-api`, `${kebabName}-api.ts`),
+    path.join(apiDir, `${kebabName}-api.ts`),
+    path.join(apiDir, `standard-api`, `standard-api.ts`),
+  ];
+
+  let content = null;
+  for (const apiFilePath of possiblePaths) {
+    try {
+      if (fs.existsSync(apiFilePath)) {
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      }
+    } catch (error) {
+      // Continue to next path
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    const startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  const trimmedApiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = trimmedApiString
+    .split('&')
+    .map((part) => part.trim())
+    .filter((part) => part);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const generalMatch = part.match(/(\w+Api)\b/);
+      if (generalMatch) {
+        apiName = generalMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+/**
+ * Parse a TypeScript component type expression
+ * Uses the generic resolveType() to handle any type expression dynamically
+ */
+function parseComponents(componentString) {
+  // Normalize whitespace
+  const trimmedComponentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle generic wrapper types like AnyCheckoutComponentExcept<'X' | 'Y'>
+  // These are defined as: type AnyCheckoutComponentExcept<Except> = Exclude<AnyCheckoutComponent, Except>
+  // We need to expand them to their actual Exclude form
+  const genericExceptMatch = trimmedComponentString.match(
+    /^(\w+Except)<([^>]+)>$/,
+  );
+  if (genericExceptMatch) {
+    const genericTypeName = genericExceptMatch[1];
+    const typeArg = genericExceptMatch[2];
+
+    // Look up the generic type definition to find the base type
+    const typeDefs = getTypeDefinitions();
+    const genericDef = typeDefs[genericTypeName];
+
+    if (genericDef) {
+      // Parse the generic definition to extract the base type from Exclude<BaseType, Except>
+      const baseTypeMatch = genericDef.match(/Exclude<(\w+),\s*Except>/);
+      if (baseTypeMatch) {
+        const baseTypeName = baseTypeMatch[1];
+        // Resolve as Exclude<BaseType, typeArg>
+        const baseComponents = resolveType(baseTypeName);
+        const excludedComponents = resolveType(typeArg);
+        return baseComponents.filter(
+          (component) => !excludedComponents.includes(component),
+        );
+      }
+    }
+  }
+
+  // Handle AllowedComponents<ComponentType> - it's just an identity wrapper
+  // BUT: AllowedComponents explicitly allows components, so don't filter private
+  // This is how targets like purchase.checkout.chat.render explicitly allow 'Chat'
+  const allowedMatch = trimmedComponentString.match(
+    /AllowedComponents<([^>]+)>/,
+  );
+  if (allowedMatch) {
+    const innerType = allowedMatch[1].trim();
+    // Use unfiltered resolution since AllowedComponents explicitly allows these
+    return resolveTypeUnfiltered(innerType);
+  }
+
+  // Use the generic resolver for everything else
+  // This handles: type references, Exclude<>, unions, string literals, etc.
+  const result = resolveType(componentString);
+  if (result.length > 0) {
+    return result;
+  }
+
+  // Default to all components if we have them
+  if (allComponents.length > 0) {
+    return allComponents;
+  }
+
+  return ['[Unknown]'];
+}
+
+function createCombinedMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for checkout surface');
+  console.log(`📁 Base path: ${config.basePath}`);
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the combined JSON with reverse mappings
+  const combinedJson = createCombinedMapping(targetsJson);
+
+  // Write to output file
+  const outputDir = path.dirname(config.outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, {recursive: true});
+  }
+  fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
+
+  console.log('✅ Generated combined targets JSON at:', config.outputPath);
+
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(combinedJson).filter(
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api'),
+  ).length;
+  const componentEntries = Object.keys(combinedJson).filter(
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api'),
+  ).length;
+
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(combinedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -95,6 +95,18 @@ if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
 fi
 
+# Generate targets.json (extension targets + APIs + components mapping)
+node ./$DOCS_PATH/build-docs-targets-json.mjs
+targets_exit=$?
+if [ $targets_exit -ne 0 ]; then
+  fail_and_exit $targets_exit
+fi
+
+echo ""
+echo "Generated docs at:"
+echo "  Checkout UI extensions: $PWD/$DOCS_PATH/generated"
+echo "  targets.json: $PWD/$DOCS_PATH/generated/targets.json"
+echo ""
 
 copy_generated_docs_to_shopify_dev() {
 # Copy the generated docs to shopify-dev

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
@@ -1,0 +1,660 @@
+/* eslint-disable no-console */
+/* eslint-env node */
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {
+  createTypeResolver,
+  splitByTopLevelComma,
+} from '../../shared/build-docs-type-resolver.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Find the generated_docs_data.json file to determine output location
+function findGeneratedDocsPath() {
+  const generatedDir = path.join(__dirname, 'generated');
+
+  // Look for generated_docs_data.json recursively
+  function findFile(dir) {
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+      const fullPath = path.join(dir, file);
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory()) {
+        const result = findFile(fullPath);
+        if (result) return result;
+      } else if (file === 'generated_docs_data.json') {
+        return path.dirname(fullPath);
+      }
+    }
+    return null;
+  }
+
+  const docsPath = findFile(generatedDir);
+  return docsPath || generatedDir; // Fallback to generated root if not found
+}
+
+// Configuration for customer-account surface
+const config = {
+  basePath: path.join(__dirname, '../../../src/surfaces/customer-account'),
+  outputPath: path.join(findGeneratedDocsPath(), 'targets.json'),
+  componentTypesPath: 'components',
+  hasComponentTypes: true,
+};
+
+// All components will be populated from StandardComponents
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+// Create type resolver for checkout's shared.ts (to resolve AnyComponent, etc.)
+const checkoutSharedPath = path.join(
+  __dirname,
+  '../../../src/surfaces/checkout/shared.ts',
+);
+const checkoutTypeResolver = createTypeResolver(checkoutSharedPath);
+
+// Cache for checkout components (resolved via type resolver, excluding @private)
+let checkoutComponentsCache = null;
+
+/**
+ * Parse components from checkout's shared.ts file
+ * Uses the shared type resolver to properly handle @private types
+ */
+function parseCheckoutComponents() {
+  // Return cached value if available
+  if (checkoutComponentsCache !== null) {
+    return checkoutComponentsCache;
+  }
+
+  try {
+    // Use the type resolver to get AnyComponent (which excludes @private)
+    // AnyComponent = SUPPORTED_COMPONENTS + PrivateComponent
+    // But resolveType automatically filters out PrivateComponent because it's @private
+    checkoutComponentsCache = checkoutTypeResolver.resolveType('AnyComponent');
+
+    if (checkoutComponentsCache.length === 0) {
+      // Fallback: try to get just SUPPORTED_COMPONENTS
+      const typeDefs = checkoutTypeResolver.getTypeDefinitions();
+      if (Array.isArray(typeDefs.SUPPORTED_COMPONENTS)) {
+        checkoutComponentsCache = [...typeDefs.SUPPORTED_COMPONENTS];
+      } else {
+        checkoutComponentsCache = ['[CheckoutComponentsNotFound]'];
+      }
+    }
+
+    return checkoutComponentsCache;
+  } catch (error) {
+    checkoutComponentsCache = ['[CheckoutComponentsError]'];
+    return checkoutComponentsCache;
+  }
+}
+
+/**
+ * Parse a string union type from a component file and resolve type references
+ * e.g., export type StandardComponents = AnyComponent | 'Avatar' | ... (with AnyComponent imported)
+ */
+function parseStringUnionType(filePath, componentTypesMap = {}) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    // Extract all quoted component names from the file (but not from import statements)
+    // Remove import lines first
+    const contentWithoutImports = content.replace(/^import.*?;$/gm, '');
+    const componentNames = contentWithoutImports.match(/'([^']+)'/g);
+    const quotedComponents = componentNames
+      ? componentNames.map((name) => name.replace(/'/g, ''))
+      : [];
+
+    // Check if the type references other types (like StandardComponents or AnyComponent)
+    // Look for patterns like: StandardComponents | 'OtherComponent'
+    const typeRefPattern = /export type \w+ =\s*([\s\S]*?);/;
+    const typeDefMatch = content.match(typeRefPattern);
+
+    if (typeDefMatch) {
+      const typeDef = typeDefMatch[1];
+      // Find references to other types (capitalized words that aren't in quotes)
+      const typeRefs = typeDef.match(/\b([A-Z]\w+(?:Components?)?)\b/g);
+
+      if (typeRefs) {
+        const components = [...quotedComponents];
+
+        for (const typeRef of typeRefs) {
+          // Check if this is AnyComponent (imported from checkout)
+          if (typeRef === 'AnyComponent') {
+            // Add all checkout components
+            const checkoutComponents = parseCheckoutComponents();
+            components.push(...checkoutComponents);
+          }
+          // If this type reference exists in our map, include its components
+          else if (componentTypesMap[typeRef]) {
+            components.push(...componentTypesMap[typeRef]);
+          }
+        }
+
+        // Remove duplicates
+        return [...new Set(components)];
+      }
+    }
+
+    return quotedComponents.length > 0 ? quotedComponents : null;
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from files in the components directory
+ * Uses a two-pass approach:
+ * 1. First pass: Parse all component types that only contain quoted strings
+ * 2. Second pass: Parse types that reference other types (like StandardComponents)
+ */
+function parseComponentTypesFromFiles() {
+  if (!config.hasComponentTypes || !config.componentTypesPath) {
+    return {};
+  }
+
+  const componentsPath = path.join(config.basePath, config.componentTypesPath);
+  const componentTypesMap = {};
+
+  try {
+    // Look for all TypeScript files in the components directory
+    const files = fs.readdirSync(componentsPath);
+    const tsFiles = files.filter(
+      (file) => file.endsWith('.ts') && !file.endsWith('.d.ts'),
+    );
+
+    // First pass: Parse files with only quoted strings
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, {});
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+
+        // If this is StandardComponents, use it as the base
+        if (componentTypeName === 'StandardComponents') {
+          allComponents = components.sort();
+        }
+      }
+    }
+
+    // Second pass: Re-parse files that might reference other types
+    for (const file of tsFiles) {
+      const filePath = path.join(componentsPath, file);
+      const componentTypeName = file.replace('.ts', '');
+
+      // Skip certain files
+      if (
+        componentTypeName === 'shared' ||
+        componentTypeName === 'components'
+      ) {
+        continue;
+      }
+
+      const components = parseStringUnionType(filePath, componentTypesMap);
+      if (components && components.length > 0) {
+        componentTypesMap[componentTypeName] = components;
+      }
+    }
+  } catch (error) {
+    console.error('Error parsing component types:', error.message);
+  }
+
+  return componentTypesMap;
+}
+
+function parseTargetsFile() {
+  const targetsFilePath = path.join(config.basePath, 'extension-targets.ts');
+
+  const content = fs.readFileSync(targetsFilePath, 'utf-8');
+
+  // Parse component type definitions
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  const targets = {};
+
+  // Look for all interfaces that might contain RenderExtension targets
+  const interfaceNames = [
+    'RenderExtensionTargets',
+    'OrderStatusExtensionTargets',
+    'CustomerAccountExtensionTargets',
+    'ExtensionTargets',
+  ];
+
+  for (const interfaceName of interfaceNames) {
+    // Try to find this interface
+    const regex = new RegExp(
+      `export interface ${interfaceName}[^{]*\\{([\\s\\S]+?)\\n\\}`,
+    );
+    const match = content.match(regex);
+
+    if (match && match[1].includes('RenderExtension<')) {
+      parseTargetsFromInterfaceBody(match[1], targets, componentTypesMap);
+    }
+  }
+
+  if (Object.keys(targets).length === 0) {
+    throw new Error('Could not find extension targets interface');
+  }
+
+  return targets;
+}
+
+function parseTargetsFromInterfaceBody(
+  interfaceBody,
+  targets,
+  componentTypesMap,
+) {
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    // Look backwards from the match to find a preceding JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      // Check if there's no other target between the JSDoc and this target
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      // If the text between JSDoc end and target is empty (or just whitespace), the JSDoc belongs to this target
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          // Skip this target if it's marked @private
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (Object.prototype.hasOwnProperty.call(apiDefinitionsCache, apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Try to find the API file in the surface's api directory
+  const apiDir = path.join(config.basePath, 'api');
+
+  if (!fs.existsSync(apiDir)) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Convert API name to potential file paths
+  // e.g., StandardApi -> standard-api, CartApi -> cart-api
+  const kebabName = apiName
+    .replace(/Api$/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+  // Try multiple possible locations
+  const possiblePaths = [
+    path.join(apiDir, `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}`, `${kebabName}.ts`),
+    path.join(apiDir, kebabName.replace(/-/g, ''), `${kebabName}.ts`),
+    path.join(apiDir, `${kebabName}-api`, `${kebabName}-api.ts`),
+    path.join(apiDir, `${kebabName}-api.ts`),
+    path.join(apiDir, `standard-api`, `standard-api.ts`),
+  ];
+
+  let content = null;
+  for (const apiFilePath of possiblePaths) {
+    try {
+      if (fs.existsSync(apiFilePath)) {
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      }
+    } catch (error) {
+      // Continue to next path
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    const startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  const trimmedApiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = trimmedApiString
+    .split('&')
+    .map((part) => part.trim())
+    .filter((part) => part);
+
+  for (const part of parts) {
+    // Match API names (e.g., StandardApi<'...'> or just ApiName)
+    let apiName = null;
+
+    // Extract just the type name before any generic parameters
+    const apiMatch = part.match(/^(\w+Api)/);
+    if (apiMatch) {
+      apiName = apiMatch[1];
+    } else {
+      // Try to match any capitalized type name ending in Api
+      const generalMatch = part.match(/(\w+Api)\b/);
+      if (generalMatch) {
+        apiName = generalMatch[1];
+      }
+    }
+
+    if (apiName) {
+      // Add the API itself
+      apisSet.add(apiName);
+
+      // Get nested APIs from this API (recursively)
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        apisSet.add(nestedApi);
+        // Recursively get nested APIs of nested APIs
+        const deepNestedApis = getNestedApis(nestedApi);
+        deepNestedApis.forEach((api) => apisSet.add(api));
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+/**
+ * Parse a TypeScript component type expression
+ * Handles various patterns: type refs, unions, Exclude, AllowedComponents, etc.
+ */
+function parseComponents(componentString, componentTypesMap) {
+  // Normalize whitespace
+  const trimmedComponentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Handle AnyCheckoutComponentExcept<'Component1' | 'Component2'>
+  const checkoutExceptMatch = trimmedComponentString.match(
+    /AnyCheckoutComponentExcept<([^>]+)>/,
+  );
+  if (checkoutExceptMatch) {
+    const excludedUnion = checkoutExceptMatch[1];
+    // Get all checkout components
+    const allCheckoutComponents = parseCheckoutComponents();
+    // Parse the union of excluded components
+    const excludedComponents = parseUnionOfStrings(excludedUnion);
+    // Filter out the excluded components
+    return allCheckoutComponents.filter(
+      (component) => !excludedComponents.includes(component),
+    );
+  }
+
+  // Handle Exclude<BaseType, ExcludedComponent>
+  const excludeMatch = trimmedComponentString.match(
+    /Exclude<(\w+),\s*'([^']+)'>/,
+  );
+  if (excludeMatch) {
+    const baseType = excludeMatch[1];
+    const excluded = excludeMatch[2];
+    const baseComponents = resolveComponentType(baseType, componentTypesMap);
+    return baseComponents.filter((component) => component !== excluded);
+  }
+
+  // Handle AllowedComponents<ComponentType>
+  const allowedMatch = trimmedComponentString.match(
+    /AllowedComponents<([^>]+)>/,
+  );
+  if (allowedMatch) {
+    const innerType = allowedMatch[1].trim();
+    return resolveComponentType(innerType, componentTypesMap);
+  }
+
+  // Check if it's a direct type reference
+  const result = resolveComponentType(
+    trimmedComponentString,
+    componentTypesMap,
+  );
+  if (result.length > 0) {
+    return result;
+  }
+
+  // Default to all components if we have them
+  if (allComponents.length > 0) {
+    return allComponents;
+  }
+
+  return ['[Unknown]'];
+}
+
+/**
+ * Parse a union of string literals (e.g., "'Image' | 'Banner'")
+ * Returns an array of the string values
+ */
+function parseUnionOfStrings(unionString) {
+  const components = [];
+  // Split by | and extract quoted strings
+  const parts = unionString.split('|');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const match = trimmed.match(/^'([^']+)'$/);
+    if (match) {
+      components.push(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Resolve a component type name to a list of component names
+ */
+function resolveComponentType(typeName, componentTypesMap) {
+  const trimmedTypeName = typeName.trim();
+
+  // Check if it's in our component types map
+  if (componentTypesMap[trimmedTypeName]) {
+    return componentTypesMap[trimmedTypeName];
+  }
+
+  // Handle special checkout types
+  if (
+    trimmedTypeName === 'AnyCheckoutComponent' ||
+    trimmedTypeName === 'AnyComponent' ||
+    trimmedTypeName === 'AnyThankYouComponent'
+  ) {
+    return parseCheckoutComponents();
+  }
+
+  // Check if it's a quoted string literal
+  const quotedMatch = trimmedTypeName.match(/^'([^']+)'$/);
+  if (quotedMatch) {
+    return [quotedMatch[1]];
+  }
+
+  return [];
+}
+
+function createCombinedMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Main execution
+try {
+  console.log('\n🔍 Generating targets JSON for customer-account surface');
+  console.log(`📁 Base path: ${config.basePath}`);
+
+  // Generate the JSON
+  const targetsJson = parseTargetsFile();
+
+  // Create the combined JSON with reverse mappings
+  const combinedJson = createCombinedMapping(targetsJson);
+
+  // Write to output file
+  const outputDir = path.dirname(config.outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, {recursive: true});
+  }
+  fs.writeFileSync(config.outputPath, JSON.stringify(combinedJson, null, 2));
+
+  console.log('✅ Generated combined targets JSON at:', config.outputPath);
+
+  // Count the different types of entries
+  const targetEntries = Object.keys(targetsJson).length;
+  const apiEntries = Object.keys(combinedJson).filter(
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && key.endsWith('Api'),
+  ).length;
+  const componentEntries = Object.keys(combinedJson).filter(
+    (key) =>
+      combinedJson[key].targets && !targetsJson[key] && !key.endsWith('Api'),
+  ).length;
+
+  console.log('\n📋 Summary:');
+  console.log(`  Extension targets: ${targetEntries}`);
+  console.log(`  API reverse mappings: ${apiEntries}`);
+  console.log(`  Component reverse mappings: ${componentEntries}`);
+  console.log(`  Total entries in JSON: ${Object.keys(combinedJson).length}`);
+} catch (error) {
+  console.error('❌ Error generating targets JSON:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.mjs
@@ -1,4 +1,5 @@
 /* eslint-disable no-undef, no-console */
+import childProcess from 'child_process';
 import fs from 'fs/promises';
 import {existsSync} from 'fs';
 import path from 'path';
@@ -90,6 +91,13 @@ const generateExtensionsDocs = async () => {
     ),
     {recursive: true},
   );
+
+  // Generate targets.json (extension targets + APIs + components mapping)
+  const targetsScriptPath = path.join(__dirname, 'build-docs-targets-json.mjs');
+  childProcess.execSync(`node ${targetsScriptPath}`, {
+    stdio: 'inherit',
+    cwd: rootPath,
+  });
 };
 
 try {
@@ -103,6 +111,18 @@ try {
     replaceValue: 'any',
   });
   await generateExtensionsDocs();
+
+  const customerAccountOutputDir = path.join(
+    rootPath,
+    docsGeneratedRelativePath,
+    'customer_account_ui_extensions',
+    EXTENSIONS_API_VERSION,
+  );
+  const targetsJsonPath = path.join(customerAccountOutputDir, 'targets.json');
+  console.log('\nGenerated docs at:');
+  console.log('  Customer Account UI extensions:', customerAccountOutputDir);
+  console.log('  targets.json:', targetsJsonPath);
+
   await copyGeneratedToShopifyDev({
     generatedDocsPath,
     shopifyDevPath,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs-targets-json.mjs
@@ -1,0 +1,534 @@
+/* eslint-disable no-console */
+/* eslint-env node */
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {splitByTopLevelComma} from '../../shared/build-docs-type-resolver.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// All POS components will be populated from StandardComponents.ts
+let allComponents = [];
+
+// Cache for parsed API files to avoid re-reading
+const apiDefinitionsCache = {};
+
+/**
+ * Parse a string union type from a component file
+ * e.g., export type SmartGridComponents = 'Tile';
+ * or multi-line: export type BlockExtensionComponents = 'Badge' | 'Box' | ...;
+ */
+function parseStringUnionType(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    // Extract all quoted component names from the file
+    const componentNames = content.match(/'([^']+)'/g);
+    if (componentNames) {
+      return componentNames.map((name) => name.replace(/'/g, ''));
+    }
+  } catch (error) {
+    console.error(`Error reading component file ${filePath}:`, error.message);
+  }
+  return null;
+}
+
+/**
+ * Parse component types from the separate files in ./components/targets/
+ */
+function parseComponentTypesFromFiles() {
+  const basePath = path.join(
+    __dirname,
+    '../../../src/surfaces/point-of-sale/components/targets',
+  );
+
+  const componentTypesMap = {};
+
+  // Parse SmartGridComponents
+  const smartGridComponents = parseStringUnionType(
+    path.join(basePath, 'SmartGridComponents.ts'),
+  );
+  if (smartGridComponents) {
+    componentTypesMap.SmartGridComponents = smartGridComponents;
+  }
+
+  // Parse ActionExtensionComponents
+  const actionComponents = parseStringUnionType(
+    path.join(basePath, 'ActionExtensionComponents.ts'),
+  );
+  if (actionComponents) {
+    componentTypesMap.ActionExtensionComponents = actionComponents;
+  }
+
+  // Parse BlockExtensionComponents
+  const blockComponents = parseStringUnionType(
+    path.join(basePath, 'BlockExtensionComponents.ts'),
+  );
+  if (blockComponents) {
+    componentTypesMap.BlockExtensionComponents = blockComponents;
+  }
+
+  // Parse ReceiptComponents
+  const receiptComponents = parseStringUnionType(
+    path.join(basePath, 'ReceiptComponents.ts'),
+  );
+  if (receiptComponents) {
+    componentTypesMap.ReceiptComponents = receiptComponents;
+  }
+
+  // Parse StandardComponents (for BasicComponents which excludes 'Tile')
+  const standardComponents = parseStringUnionType(
+    path.join(basePath, 'StandardComponents.ts'),
+  );
+  if (standardComponents) {
+    componentTypesMap.StandardComponents = standardComponents;
+    // BasicComponents = Exclude<StandardComponents, 'Tile'>
+    componentTypesMap.BasicComponents = standardComponents.filter(
+      (component) => component !== 'Tile',
+    );
+    // Update global allComponents
+    allComponents = standardComponents.sort();
+  }
+
+  return componentTypesMap;
+}
+
+const TARGETS_FILE_PATH = path.join(
+  __dirname,
+  '../../../src/surfaces/point-of-sale/extension-targets.ts',
+);
+
+function parseTargetsFile() {
+  const content = fs.readFileSync(TARGETS_FILE_PATH, 'utf-8');
+
+  // Parse component type definitions from the separate files
+  const componentTypesMap = parseComponentTypesFromFiles();
+
+  // Extract the RenderExtensionTargets interface
+  const interfaceMatch = content.match(
+    /export interface RenderExtensionTargets \{([\s\S]+?)\n\}/,
+  );
+  if (!interfaceMatch) {
+    throw new Error('Could not find RenderExtensionTargets interface');
+  }
+
+  const interfaceBody = interfaceMatch[1];
+
+  // Parse each target definition (handle multi-line)
+  const targetRegex = /'([^']+)':\s*RenderExtension<([\s\S]*?)>;/g;
+  const targets = {};
+
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    const matchStartPos = match.index;
+
+    // Check if this target has @private in its JSDoc comment
+    // Look backwards from the match to find a preceding JSDoc comment
+    const beforeMatch = interfaceBody.substring(0, matchStartPos);
+    const lastJsDocEnd = beforeMatch.lastIndexOf('*/');
+
+    if (lastJsDocEnd !== -1) {
+      // Check if there's no other target between the JSDoc and this target
+      const between = beforeMatch.substring(lastJsDocEnd + 2).trim();
+      // If the text between JSDoc end and target is empty (or just whitespace), the JSDoc belongs to this target
+      if (between === '') {
+        const jsDocStart = beforeMatch.lastIndexOf('/**');
+        if (jsDocStart !== -1) {
+          const jsDocContent = beforeMatch.substring(
+            jsDocStart,
+            lastJsDocEnd + 2,
+          );
+          // Skip this target if it's marked @private
+          if (jsDocContent.includes('@private')) {
+            continue;
+          }
+        }
+      }
+    }
+
+    let renderExtensionContent = match[2].trim();
+
+    // Remove comments before parsing (they can contain commas that break splitting)
+    renderExtensionContent = renderExtensionContent
+      .replace(/\/\/[^\n]*/g, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
+
+    // Split by comma to separate API and Components (but be careful with nested <> brackets)
+    const parts = splitByTopLevelComma(renderExtensionContent);
+
+    if (parts.length >= 2) {
+      const apiString = parts[0].trim();
+      const componentString = parts[1].trim();
+
+      // Parse APIs from the intersection type
+      const apis = parseApis(apiString);
+
+      // Parse components
+      const components = parseComponents(componentString, componentTypesMap);
+
+      targets[targetName] = {
+        components: components.sort(),
+        apis: apis.sort(),
+      };
+    }
+  }
+
+  return targets;
+}
+
+/**
+ * Parse EventExtensionTargets from extension-targets.ts and return
+ * a map of target name -> { components: [], apis: [] } so all extension
+ * targets (render + event) appear in the JSON.
+ */
+function parseEventTargetsFile(content) {
+  const eventMatch = content.match(
+    /export interface EventExtensionTargets \{([\s\S]+?)\n\}/,
+  );
+  if (!eventMatch) {
+    return {};
+  }
+  const interfaceBody = eventMatch[1];
+  const targetRegex = /'([^']+)':\s*\(/g;
+  const targets = {};
+  let match;
+  while ((match = targetRegex.exec(interfaceBody)) !== null) {
+    const targetName = match[1];
+    targets[targetName] = {
+      components: [],
+      apis: [],
+    };
+  }
+  return targets;
+}
+
+function getNestedApis(apiName) {
+  // Check if we've already parsed this API
+  if (Object.prototype.hasOwnProperty.call(apiDefinitionsCache, apiName)) {
+    return apiDefinitionsCache[apiName];
+  }
+
+  // Map API names to their file paths (try multiple possible locations)
+  const apiFilePaths = {
+    StandardApi: [
+      './api/standard/standard-api',
+      './render/api/standard/standard-api',
+    ],
+    SmartGridApi: ['./api/smartgrid-api/smartgrid-api'],
+    ActionApi: [
+      './api/action-api/action-api',
+      './render/api/action-api/action-api',
+    ],
+    NavigationApi: [
+      './api/navigation-api/navigation-api',
+      './render/api/navigation-api/navigation-api',
+    ],
+    ScannerApi: [
+      './api/scanner-api/scanner-api',
+      './render/api/scanner-api/scanner-api',
+    ],
+    CartApi: ['./api/cart-api/cart-api', './render/api/cart-api/cart-api'],
+    OrderApi: ['./api/order-api/order-api', './render/api/order-api/order-api'],
+    ConnectivityApi: [
+      './api/connectivity-api/connectivity-api',
+      './render/api/connectivity-api/connectivity-api',
+    ],
+    DeviceApi: [
+      './api/device-api/device-api',
+      './render/api/device-api/device-api',
+    ],
+    LocaleApi: [
+      './api/locale-api/locale-api',
+      './render/api/locale-api/locale-api',
+    ],
+    SessionApi: [
+      './api/session-api/session-api',
+      './render/api/session-api/session-api',
+    ],
+    ToastApi: ['./api/toast-api/toast-api', './render/api/toast-api/toast-api'],
+    ProductSearchApi: [
+      './api/product-search-api/product-search-api',
+      './render/api/product-search-api/product-search-api',
+    ],
+    ActionTargetApi: [
+      './api/action-target-api/action-target-api',
+      './render/api/action-target-api/action-target-api',
+    ],
+    ProductApi: [
+      './api/product-api/product-api',
+      './render/api/product-api/product-api',
+    ],
+    CustomerApi: [
+      './api/customer-api/customer-api',
+      './render/api/customer-api/customer-api',
+    ],
+    DraftOrderApi: [
+      './api/draft-order-api/draft-order-api',
+      './render/api/draft-order-api/draft-order-api',
+    ],
+    PrintApi: ['./api/print-api/print-api', './render/api/print-api/print-api'],
+    StorageApi: ['./api/storage-api/storage-api'],
+    CartLineItemApi: ['./api/cart-line-item-api/cart-line-item-api'],
+    CashDrawerApi: ['./api/cash-drawer-api/cash-drawer-api'],
+    PinPadApi: ['./api/pin-pad-api'],
+  };
+
+  const relativePaths = apiFilePaths[apiName];
+  if (!relativePaths) {
+    // Unknown API, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  // Try each possible path
+  let content = null;
+
+  for (const relativePath of relativePaths) {
+    const basePath = path.join(
+      __dirname,
+      '../../../src/surfaces/point-of-sale',
+      relativePath,
+    );
+
+    // Try both .ts and .tsx extensions
+    for (const ext of ['.ts', '.tsx']) {
+      try {
+        const apiFilePath = basePath + ext;
+        content = fs.readFileSync(apiFilePath, 'utf-8');
+        break;
+      } catch (error) {
+        // Try next extension
+      }
+    }
+
+    if (content) {
+      break;
+    }
+  }
+
+  if (!content) {
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+
+  try {
+    // Find the export type definition for this API
+    // We need to capture everything until we find a semicolon that's not inside braces
+    const typeDefStartRegex = new RegExp(`export type ${apiName}[^=]*=`, 's');
+    const startMatch = content.match(typeDefStartRegex);
+
+    if (!startMatch) {
+      apiDefinitionsCache[apiName] = [];
+      return [];
+    }
+
+    // Find the end position (semicolon at the correct nesting level)
+    const startPos = startMatch.index + startMatch[0].length;
+    let endPos = startPos;
+    let braceDepth = 0;
+    let angleDepth = 0;
+
+    for (let i = startPos; i < content.length; i++) {
+      const char = content[i];
+
+      if (char === '{') braceDepth++;
+      else if (char === '}') braceDepth--;
+      else if (char === '<') angleDepth++;
+      else if (char === '>') angleDepth--;
+      else if (char === ';' && braceDepth === 0 && angleDepth === 0) {
+        endPos = i;
+        break;
+      }
+    }
+
+    const typeDef = content.substring(startPos, endPos);
+
+    // Extract all API names from the type definition
+    const nestedApis = [];
+    const apiMatches = typeDef.matchAll(/(\w+Api)\b/g);
+
+    for (const apiMatch of apiMatches) {
+      const nestedApiName = apiMatch[1];
+      // Don't include the API itself
+      if (nestedApiName !== apiName && !nestedApis.includes(nestedApiName)) {
+        nestedApis.push(nestedApiName);
+      }
+    }
+
+    apiDefinitionsCache[apiName] = nestedApis;
+    return nestedApis;
+  } catch (error) {
+    // Error parsing, cache and return empty array
+    apiDefinitionsCache[apiName] = [];
+    return [];
+  }
+}
+
+// APIs that are composites of other documented APIs - we list their constituent APIs, not these wrapper types
+const COMPOSITE_APIS = new Set(['StandardApi', 'ActionTargetApi']);
+
+function parseApis(apiString) {
+  const apisSet = new Set();
+
+  // Remove any comments
+  const cleanedApiString = apiString
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Split by & and extract API names
+  const parts = cleanedApiString
+    .split('&')
+    .map((part) => part.trim())
+    .filter((part) => part);
+
+  for (const part of parts) {
+    // Match StandardApi<'...'> or just ApiName
+    let apiName = null;
+
+    if (part.includes('StandardApi')) {
+      apiName = 'StandardApi';
+    } else {
+      // Extract just the type name before any generic parameters
+      const apiMatch = part.match(/^(\w+Api)/);
+      if (apiMatch) {
+        apiName = apiMatch[1];
+      }
+    }
+
+    if (apiName) {
+      if (!COMPOSITE_APIS.has(apiName)) {
+        apisSet.add(apiName);
+      }
+
+      const nestedApis = getNestedApis(apiName);
+      for (const nestedApi of nestedApis) {
+        if (COMPOSITE_APIS.has(nestedApi)) {
+          const deepNestedApis = getNestedApis(nestedApi);
+          deepNestedApis.forEach((api) => {
+            if (!COMPOSITE_APIS.has(api)) apisSet.add(api);
+          });
+        } else {
+          apisSet.add(nestedApi);
+          const deepNestedApis = getNestedApis(nestedApi);
+          deepNestedApis.forEach((api) => {
+            if (!COMPOSITE_APIS.has(api)) apisSet.add(api);
+          });
+        }
+      }
+    }
+  }
+
+  return Array.from(apisSet);
+}
+
+function parseComponents(componentString, componentTypesMap) {
+  // Remove whitespace and newlines
+  const cleanedComponentString = componentString.replace(/\s+/g, ' ').trim();
+
+  // Check if it directly references one of our parsed component types
+  for (const [typeName, components] of Object.entries(componentTypesMap)) {
+    if (cleanedComponentString.includes(typeName)) {
+      return components;
+    }
+  }
+
+  // Default to all components if no match
+  return allComponents;
+}
+
+function createReverseMapping(targetsJson) {
+  const result = {...targetsJson};
+
+  // Create reverse mappings for APIs
+  const apiToTargets = {};
+  const componentToTargets = {};
+
+  // Iterate through all targets
+  for (const [targetName, targetData] of Object.entries(targetsJson)) {
+    // Map APIs to targets
+    for (const api of targetData.apis) {
+      if (!apiToTargets[api]) {
+        apiToTargets[api] = [];
+      }
+      apiToTargets[api].push(targetName);
+    }
+
+    // Map Components to targets
+    for (const component of targetData.components) {
+      if (!componentToTargets[component]) {
+        componentToTargets[component] = [];
+      }
+      componentToTargets[component].push(targetName);
+    }
+  }
+
+  // Add API reverse mappings to result
+  for (const [api, targets] of Object.entries(apiToTargets)) {
+    result[api] = {
+      targets: targets.sort(),
+    };
+  }
+
+  // Add Component reverse mappings to result
+  for (const [component, targets] of Object.entries(componentToTargets)) {
+    result[component] = {
+      targets: targets.sort(),
+    };
+  }
+
+  return result;
+}
+
+// Find the generated_docs_data.json file to determine output location
+function findGeneratedDocsPath() {
+  const generatedDir = path.join(__dirname, 'generated');
+
+  function findFile(dir) {
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+      const fullPath = path.join(dir, file);
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory()) {
+        const result = findFile(fullPath);
+        if (result) return result;
+      } else if (file === 'generated_docs_data.json') {
+        return path.dirname(fullPath);
+      }
+    }
+    return null;
+  }
+
+  const docsPath = findFile(generatedDir);
+  return docsPath ?? generatedDir;
+}
+
+// Generate the JSON (render targets + event targets)
+const renderTargets = parseTargetsFile();
+const fileContent = fs.readFileSync(TARGETS_FILE_PATH, 'utf-8');
+const eventTargets = parseEventTargetsFile(fileContent);
+const targetsJson = {...renderTargets, ...eventTargets};
+
+// Create the extended JSON with reverse mappings
+const extendedJson = createReverseMapping(targetsJson);
+
+// Write to output file
+const outputPath = path.join(findGeneratedDocsPath(), 'targets.json');
+const outputDir = path.dirname(outputPath);
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, {recursive: true});
+}
+fs.writeFileSync(outputPath, JSON.stringify(extendedJson, null, 2));
+
+console.log('✅ Generated extended targets JSON at:', outputPath);
+console.log('\n📋 Parsed component types:');
+console.log(
+  '  SmartGridComponents, ActionComponents, ReceiptComponents, BlockComponents, BasicComponents',
+);
+console.log('\n📋 Sample - First target:');
+const firstTarget = Object.keys(targetsJson)[0];
+console.log(JSON.stringify({[firstTarget]: targetsJson[firstTarget]}, null, 2));
+console.log('\n📋 Sample - API reverse mapping:');
+console.log(JSON.stringify({StandardApi: extendedJson.StandardApi}, null, 2));
+console.log('\n📋 Sample - Component reverse mapping:');
+console.log(JSON.stringify({Tile: extendedJson.Tile}, null, 2));

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
@@ -1,4 +1,5 @@
 /* eslint-disable no-undef, no-console */
+import childProcess from 'child_process';
 import fs from 'fs/promises';
 import {existsSync} from 'fs';
 import path from 'path';
@@ -150,6 +151,13 @@ const generateExtensionsDocs = async () => {
     ),
     {recursive: true},
   );
+
+  // Generate targets.json (extension targets + APIs + components mapping)
+  const targetsScriptPath = path.join(__dirname, 'build-docs-targets-json.mjs');
+  childProcess.execSync(`node ${targetsScriptPath}`, {
+    stdio: 'inherit',
+    cwd: rootPath,
+  });
 };
 
 try {
@@ -163,6 +171,18 @@ try {
     replaceValue: 'any',
   });
   await generateExtensionsDocs();
+
+  const posOutputDir = path.join(
+    rootPath,
+    docsGeneratedRelativePath,
+    'pos_ui_extensions',
+    EXTENSIONS_API_VERSION,
+  );
+  const targetsJsonPath = path.join(posOutputDir, 'targets.json');
+  console.log('\nGenerated docs at:');
+  console.log('  POS UI extensions:', posOutputDir);
+  console.log('  targets.json:', targetsJsonPath);
+
   await copyGeneratedToShopifyDev({
     generatedDocsPath,
     shopifyDevPath,


### PR DESCRIPTION

### Background

Part of: https://github.com/Shopify/temp-project-mover-Archetypically-20260312105649/issues/14

We want to parse target information for the dev docs for each surface.

### Solution

Added scripts for admin, checkout, customer-account, and point-of-sale to generate target information in the format shopify-dev needs.

**Note:** This is the 2026-04 API version branch.

The scripts handle:

- **@private JSDoc tags**: Targets marked with @private are excluded from the generated output.
- **Type resolution**: String union types, Exclude, AllowedComponents, AnyComponent (checkout), and Pick-style component lists are resolved to concrete component lists.
- **API parsing**: API types are extracted from RenderExtension definitions and nested APIs are expanded.
- **RunnableExtension targets**: Event/run targets (e.g. should-render) are included with empty component lists.
- **Reverse mappings**: Generates API to targets and Component to targets for docs navigation.

Surface-specific behavior:

- **Admin**: Reads extension-targets.ts and component types from the components folder; resolves StandardComponents, AnyComponent (from checkout), and AnyCheckoutComponentExcept.
- **Checkout**: Uses shared type resolver on shared.ts; supports resolveType/resolveTypeUnfiltered, AllowedComponents, and generic Except types.
- **Customer-account**: Same pattern as admin (component type files plus checkout AnyComponent); two-pass parse for type refs.
- **Point-of-sale**: Parses extension-targets.ts and component types (e.g. SmartGridComponents, BlockComponents); outputs under pos_ui_extensions version folder.

Shared logic lives in docs/shared/build-docs-type-resolver.mjs (type parsing, @private filtering, splitByTopLevelComma). Copy destinations use the areas/platforms/shopify-dev paths in shopify-dev.

### Top-hatting

Run the full docs generation (generates and copies docs, including targets.json, into shopify-dev when the repo is at ../../../shopify-dev):

# 1. Admin surface
yarn docs:admin 2026-04

# 2. Checkout surface
yarn docs:checkout 2026-04

# 3. Customer account surface
yarn docs:customer-account 2026-04

# 4. Point of sale surface
yarn docs:point-of-sale 2026-04

### To only regenerate targets.json locally (no copy to shopify-dev):

```
node docs/surfaces/admin/build-docs-targets-json.mjs
node docs/surfaces/checkout/build-docs-targets-json.mjs
node docs/surfaces/customer-account/build-docs-targets-json.mjs
node docs/surfaces/point-of-sale/build-docs-targets-json.mjs
```

## Checklist
- [x] I have top-hat'd these changes
