### PR TITLE
Update subcategory for Page component to Layout and structure

### DIFF
--- a/packages/ui-extensions/src/docs/shared/components/Page.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Page.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     ' Use `s-page` as the main container for placing content in your app. Page comes with preset layouts and automatically adds spacing between elements.',
   category: 'Polaris web components',
-  subCategory: 'Structure',
+  subCategory: 'Layout and structure',
   related: [],
 };
 


### PR DESCRIPTION
### Background

The current Polaris docs for App Home has two categories 'Layout and structure' and 'Structure'. The 'Structure' section contains only the Page component.

### Solution

Updating the subcategory for Page to move it into the Layout and structure section along with Box, Divider, Grid, etc.

### 🎩

See PR [#67951](https://github.com/Shopify/shopify-dev/pull/67951) for details on top-hatting the docs page where this change is reflected.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
