### PR TITLE
Stop gitignoring generated docs JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ packages/**/*.js
 packages/**/bin
 !packages/**/.eslintrc.js
 *.log
-packages/ui-extensions/docs/**/generated
 
 # IntelliJ IDE ignore
 .idea

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 packages/*/build
 packages/web-pixels-extension/src/schemas/pixel-events.jtd.json
 packages/ui-extensions/src/surfaces/checkout/**/*.d.ts
+packages/ui-extensions/docs/**/generated/**/*.json


### PR DESCRIPTION
## Summary

Track generated documentation JSON files in version control instead of gitignoring them.

Follow-up to #3731 which was merged into `2025-07` but not yet applied to `2025-10`.

## Changes

- Remove `packages/ui-extensions/docs/**/generated` from `.gitignore`
- Add `packages/ui-extensions/docs/**/generated/**/*.json` to `.prettierignore`

## Why

Previously, generated docs were excluded from version control and had to be regenerated during the sync process. By tracking these files directly, downstream consumers can sync documentation without needing to run build commands in this repository.

This simplifies the documentation pipeline and makes the sync process more reliable.

## Test plan

- [x] Verified `.gitignore` entry is removed
- [x] Verified `.prettierignore` entry is added