### PR TITLE
[POS 2025-10]: Remove component name code syntax

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
@@ -34,11 +34,11 @@ export interface GlobalProps {
  */
 export interface ActionSlots {
   /**
-   * The primary action element to display, typically a `Button` or clickable link representing the most important action the user can take in the current context. This action should align with the user's primary goal or the main purpose of the interface. For example, "Save changes", "Checkout", "Add to cart", or "Submit order". The primary action typically receives visual emphasis through styling to draw user attention. Only one primary action should be provided to avoid confusion about the main call-to-action. If no primary action is needed, omit this property rather than providing an empty or placeholder action.
+   * The primary action element to display, typically a Button or clickable link representing the most important action the user can take in the current context. This action should align with the user's primary goal or the main purpose of the interface. For example, "Save changes", "Checkout", "Add to cart", or "Submit order". The primary action typically receives visual emphasis through styling to draw user attention. Only one primary action should be provided to avoid confusion about the main call-to-action. If no primary action is needed, omit this property rather than providing an empty or placeholder action.
    */
   primaryAction?: ComponentChildren;
   /**
-   * Secondary action elements to display, typically `Button` or clickable link elements representing alternative or supporting actions that are less important than the primary action. These might include "Cancel", "Save draft", "Skip", "Learn more", or other optional actions. Secondary actions receive less visual prominence than the primary action to maintain clear hierarchy. Multiple secondary actions can be provided and will typically be displayed together, often in a different visual style or position than the primary action. If no secondary actions are needed, omit this property. The order of actions in the array may affect their display order depending on the component.
+   * Secondary action elements to display, typically a Button or clickable link elements representing alternative or supporting actions that are less important than the primary action. These might include "Cancel", "Save draft", "Skip", "Learn more", or other optional actions. Secondary actions receive less visual prominence than the primary action to maintain clear hierarchy. Multiple secondary actions can be provided and will typically be displayed together, often in a different visual style or position than the primary action. If no secondary actions are needed, omit this property. The order of actions in the array may affect their display order depending on the component.
    */
   secondaryActions?: ComponentChildren;
 }
@@ -884,7 +884,7 @@ export type AccessibilityRole =
   | 'footer'
   /**
    * Used to indicate a generic section.
-   * Sections should always have a `Heading` or an accessible name provided in the `accessibilityLabel` property.
+   * Sections should always have a Heading or an accessible name provided in the `accessibilityLabel` property.
    *
    * In an HTML host `section` will render a `<section>` element.
    * Learn more about the [`<section>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) in the MDN web docs.
@@ -1437,7 +1437,7 @@ export interface MultipleInputProps extends BaseInputProps {
    */
   onInput?: (event: Event) => void;
   /**
-   * An array containing the values of currently selected options in a multi-select choice list. When provided, this creates a controlled component where this array must be updated in response to user selections using the `onChange` callback. The array should contain the `value` properties of selected child `Choice` components. For single-select lists (`multiple={false}`), this array should contain zero or one items. For multi-select lists, it can contain multiple items. This is a convenience property that automatically sets the `selected` state on matching child choices based on their `value` properties. When a choice's value appears in this array, it's automatically marked as selected. Update this array immutably in callbacks (create new arrays rather than mutating).
+   * An array containing the values of currently selected options in a multi-select choice list. When provided, this creates a controlled component where this array must be updated in response to user selections using the `onChange` callback. The array should contain the `value` properties of selected child Choice components. For single-select lists (`multiple={false}`), this array should contain zero or one items. For multi-select lists, it can contain multiple items. This is a convenience property that automatically sets the `selected` state on matching child choices based on their `value` properties. When a choice's value appears in this array, it's automatically marked as selected. Update this array immutably in callbacks (create new arrays rather than mutating).
    */
   values?: string[];
 }
@@ -1523,7 +1523,7 @@ export interface FieldDecorationProps {
    */
   icon?: IconType | AnyString;
   /**
-   * Additional interactive content displayed within the field, typically positioned at the end of the field after the input area. Only text-only `Button` and `Clickable` components are supported—no icons or complex content. Use the `slot="accessory"` attribute to place elements here. Common uses include action buttons (for example, "Copy" button, "Generate" button, "Clear" button), toggle visibility controls (for example, "Show password" button), or quick actions related to the field (for example, "Paste from clipboard"). The accessory must not interfere with the field's primary input functionality. Ensure sufficient contrast and touch target sizes for mobile usability.
+   * Additional interactive content displayed within the field, typically positioned at the end of the field after the input area. Only text-only Button and Clickable components are supported—no icons or complex content. Use the `slot="accessory"` attribute to place elements here. Common uses include action buttons (for example, "Copy" button, "Generate" button, "Clear" button), toggle visibility controls (for example, "Show password" button), or quick actions related to the field (for example, "Paste from clipboard"). The accessory must not interfere with the field's primary input functionality. Ensure sufficient contrast and touch target sizes for mobile usability.
    */
   accessory?: ComponentChildren;
 }
@@ -1592,7 +1592,7 @@ export interface BaseSelectableProps {
    */
   disabled?: boolean;
   /**
-   * The unique value associated with this selectable option. This value is what gets submitted with forms when the option is selected, and is used to identify which options are selected in the parent `ChoiceList`'s `values` array. The value should be unique among siblings within the same choice list to avoid selection ambiguity. When a choice is selected, this value appears in form data and in the parent's `values` array. Use meaningful, stable values that identify the choice semantically (for example, `"small"`, `"express-shipping"`, `"agree-to-terms"`) rather than display text which may change or be localized. The value isn't displayed to users—use the choice's `children` or label for visible text.
+   * The unique value associated with this selectable option. This value is what gets submitted with forms when the option is selected, and is used to identify which options are selected in the parent ChoiceList's `values` array. The value should be unique among siblings within the same choice list to avoid selection ambiguity. When a choice is selected, this value appears in form data and in the parent's `values` array. Use meaningful, stable values that identify the choice semantically (for example, `"small"`, `"express-shipping"`, `"agree-to-terms"`) rather than display text which may change or be localized. The value isn't displayed to users—use the choice's `children` or label for visible text.
    */
   value?: string;
 }
@@ -1667,7 +1667,7 @@ export interface ChoiceListProps
    */
   multiple?: boolean;
   /**
-   * The child elements to render within this component. Within `ChoiceList`, use only `Choice` components as children. Other component types can't be used as options within the choice list.
+   * The child elements to render within this component. Within ChoiceList, use only Choice components as children. Other component types can't be used as options within the choice list.
    */
   children?: ComponentChildren;
   /**
@@ -2413,7 +2413,7 @@ export interface PageProps extends GlobalProps, ActionSlots {
    */
   subheading?: string;
   /**
-   * The additional content displayed in the header area. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content displayed in the header area. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChildren;
   /**
@@ -3964,7 +3964,7 @@ interface TextFieldJSXProps
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$h>) => void) | null;
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }
@@ -4046,7 +4046,7 @@ interface EmailFieldJSXProps
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$f>) => void) | null;
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }
@@ -4120,7 +4120,7 @@ interface TextAreaJSXProps
    */
   onFocus?: ((event: CallbackEvent<typeof tagName$d>) => void) | null;
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }
@@ -4188,7 +4188,7 @@ interface NumberFieldJSXProps
    */
   placeholder?: NumberFieldProps['placeholder'];
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
   /**
@@ -4635,7 +4635,7 @@ interface Badge {
 }
 
 /**
- * The `Banner` component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ * The Banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
  */
 interface BannerSlots {
   /**
@@ -4774,7 +4774,7 @@ interface Box {
 }
 
 /**
- * The `Button` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The Button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface ButtonEvents {
   /**
@@ -4864,7 +4864,7 @@ interface Choice {
 }
 
 /**
- * The `ChoiceList` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The ChoiceList component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface ChoiceListEvents {
   /**
@@ -4895,7 +4895,7 @@ interface ChoiceList {
 }
 
 /**
- * The `Clickable` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The Clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface ClickableEvents {
   /**
@@ -4916,7 +4916,7 @@ interface Clickable {
 }
 
 /**
- * The `DateField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The DateField component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface DateFieldEvents {
   /**
@@ -4967,7 +4967,7 @@ interface DateField {
 }
 
 /**
- * The `DatePicker` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The DatePicker component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface DatePickerEvents {
   /**
@@ -5002,7 +5002,7 @@ interface DatePicker {
 }
 
 /**
- * The `DateSpinner` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The DateSpinner component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface DateSpinnerEvents {
   /**
@@ -5052,7 +5052,7 @@ interface Divider {
 }
 
 /**
- * The `EmailField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The EmailField component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface EmailFieldEvents {
   /**
@@ -5074,11 +5074,11 @@ interface EmailFieldEvents {
 }
 
 /**
- * The `EmailField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ * The EmailField component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
  */
 interface EmailFieldSlots {
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: HTMLElement;
 }
@@ -5199,7 +5199,7 @@ interface Image {
 }
 
 /**
- * The `Modal` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The Modal component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface ModalEvents {
   /**
@@ -5213,7 +5213,7 @@ interface ModalEvents {
 }
 
 /**
- * The `Modal` component supports slots for additional content placement within the modal. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ * The Modal component supports slots for additional content placement within the modal. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
  */
 interface ModalSlots {
   /**
@@ -5238,7 +5238,7 @@ interface Modal {
 }
 
 /**
- * The `NumberField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The NumberField component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface NumberFieldEvents {
   /**
@@ -5260,11 +5260,11 @@ interface NumberFieldEvents {
 }
 
 /**
- * The `NumberField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ * The NumberField component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
  */
 interface NumberFieldSlots {
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: HTMLElement;
 }
@@ -5342,7 +5342,7 @@ interface NumberField {
 }
 
 /**
- * The `Page` component supports slots for additional content placement within the page. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ * The Page component supports slots for additional content placement within the page. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
  */
 interface PageSlots {
   /**
@@ -5373,7 +5373,7 @@ interface Page {
 }
 
 /**
- * The `PosBlock` component supports slots for additional content placement within the block. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ * The PosBlock component supports slots for additional content placement within the block. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
  */
 interface PosBlockSlots {
   /**
@@ -5503,7 +5503,7 @@ interface ScrollBox {
 }
 
 /**
- * The `SearchField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The SearchField component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface SearchFieldEvents {
   /**
@@ -5546,7 +5546,7 @@ interface SearchField {
 }
 
 /**
- * The `Section` component supports slots for additional content placement within the section. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ * The Section component supports slots for additional content placement within the section. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
  */
 interface SectionSlots {
   /**
@@ -5752,7 +5752,7 @@ interface Text {
 }
 
 /**
- * The `TextArea` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The TextArea component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface TextAreaEvents {
   /**
@@ -5774,11 +5774,11 @@ interface TextAreaEvents {
 }
 
 /**
- * The `TextArea` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ * The TextArea component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
  */
 interface TextAreaSlots {
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: HTMLElement;
 }
@@ -5835,7 +5835,7 @@ interface TextArea {
 }
 
 /**
- * The `TextField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The TextField component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface TextFieldEvents {
   /**
@@ -5857,11 +5857,11 @@ interface TextFieldEvents {
 }
 
 /**
- * The `TextField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+ * The TextField component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
  */
 interface TextFieldSlots {
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: HTMLElement;
 }
@@ -5954,7 +5954,7 @@ interface Tile {
 }
 
 /**
- * The `TimeField` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The TimeField component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface TimeFieldEvents {
   /**
@@ -6005,7 +6005,7 @@ interface TimeField {
 }
 
 /**
- * The `TimePicker` component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
+ * The TimePicker component provides event callbacks for handling user interactions and validation. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  */
 interface TimePickerEvents {
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Badge',
   description:
-    'The `Badge` component uses color and text to communicate status information for orders, products, customers, and other business data. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes.' +
+    'The Badge component uses color and text to communicate status information for orders, products, customers, and other business data. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes.' +
     "\n\nBadges aren't interactive elements. They display information but don't respond to user interactions like clicks or taps.",
   thumbnail: 'badge-thumbnail.png',
   isVisualComponent: true,
@@ -11,8 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the `Badge` component.',
+      description: 'Configure the following properties on the Badge component.',
       type: 'Badge',
     },
   ],
@@ -21,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'badge-default.png',
     description:
-      'Display status information using a `Badge` component with customizable tone and content. This example shows a basic badge with a tone property to indicate status through color.',
+      'Display status information using a Badge component with customizable tone and content. This example shows a basic badge with a tone property to indicate status through color.',
     codeblock: {
       title: 'Display status information with a badge',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Banner',
   description:
-    'The `Banner` component highlights important information or required actions. Use banners to communicate critical updates, warnings, informational messages, or success notifications that require merchant attention.' +
+    'The Banner component highlights important information or required actions. Use banners to communicate critical updates, warnings, informational messages, or success notifications that require merchant attention.' +
     '\n\nBanners provide persistent visibility with support for dismissible and non-dismissible states.',
   thumbnail: 'banner-thumbnail.png',
   isVisualComponent: true,
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Banner` component.',
+        'Configure the following properties on the Banner component.',
       type: 'Banner',
     },
     {
       title: 'Slots',
       description:
-        'The `Banner` component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The Banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'BannerSlots',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'banner-default.png',
     description:
-      'Display important messages using a `Banner` component with automatic color coding based on message severity. This example shows a basic banner with a heading and descriptive text.',
+      'Display important messages using a Banner component with automatic color coding based on message severity. This example shows a basic banner with a heading and descriptive text.',
     codeblock: {
       title: 'Display important messages with a banner',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -3,15 +3,15 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
-    'The `Box` component provides a container for layout and visual styling. Use it to apply padding, borders, and background colors, or to nest and group other components.' +
-    '\n\nFor user interaction, use `Box` in combination with interactive components like [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable). For scrollable content, use [`ScrollBox`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/layout-and-structure/scrollbox).',
+    'The Box component provides a container for layout and visual styling. Use it to apply padding, borders, and background colors, or to nest and group other components.' +
+    '\n\nFor user interaction, use Box in combination with interactive components like [Button](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [Clickable](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable). For scrollable content, use [ScrollBox](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/layout-and-structure/scrollbox).',
   thumbnail: 'box-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the `Box` component.',
+      description: 'Configure the following properties on the Box component.',
       type: 'Box',
     },
   ],
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'box-default.png',
     description:
-      'Create layouts using a `Box` component. This example demonstrates a basic box container with padding and styling.',
+      'Create layouts using a Box component. This example demonstrates a basic box container with padding and styling.',
     codeblock: {
       title: 'Create a container with a box',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
-    'The `Button` component triggers actions or events, such as opening dialogs or navigating to other pages. Use `Button` to let merchants perform specific tasks or to initiate interactions throughout the POS interface.' +
+    'The Button component triggers actions or events, such as opening dialogs or navigating to other pages. Use Button to let merchants perform specific tasks or to initiate interactions throughout the POS interface.' +
     '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy within the interface.',
   thumbnail: 'button-thumbnail.png',
   isVisualComponent: true,
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Button` component.',
+        'Configure the following properties on the Button component.',
       type: 'Button',
     },
     {
       title: 'Events',
       description:
-        'The `Button` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The Button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ButtonEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'button-default.png',
     description:
-      'Trigger actions using a `Button` component with customizable visual styles and tones. This example shows a basic button with text content.',
+      'Trigger actions using a Button component with customizable visual styles and tones. This example shows a basic button with text content.',
     codeblock: {
       title: 'Trigger actions with a button',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'ChoiceList',
   description:
-    'The `ChoiceList` component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
+    'The ChoiceList component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
     '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It offers multiple layout variants including list, inline, block, and grid formats to suit different space constraints and visual requirements.',
   thumbnail: 'choicelist-thumbnail.png',
   isVisualComponent: true,
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `ChoiceList` component.',
+        'Configure the following properties on the ChoiceList component.',
       type: 'ChoiceList',
     },
     {
       title: 'Events',
       description:
-        'The `ChoiceList` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The ChoiceList component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ChoiceListEvents',
     },
     {
       title: 'Choice',
       description:
-        'The `Choice` component creates options that let merchants select one or multiple items from a list of choices.',
+        'The Choice component creates options that let merchants select one or multiple items from a list of choices.',
       type: 'Choice',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'choicelist-default.png',
     description:
-      'Present options using a `ChoiceList` component. This example shows a basic choice list for single selection.',
+      'Present options using a ChoiceList component. This example shows a basic choice list for single selection.',
     codeblock: {
       title: 'Create a choice list for selections',
       tabs: [
@@ -59,7 +59,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-\`ChoiceList\` component types other than \`Choice\` can't be used as options within the choice list.`,
+ChoiceList component types other than Choice can't be used as options within the choice list.`,
     },
   ],
   related: [],
@@ -95,7 +95,7 @@ const data: ReferenceEntityTemplateSchema = {
       },
       {
         description:
-          'Compose rich choice content by nesting other components within `Choice` elements. This example demonstrates combining images, text, and layout components to create visually enhanced choice options with descriptions and supporting images.',
+          'Compose rich choice content by nesting other components within Choice elements. This example demonstrates combining images, text, and layout components to create visually enhanced choice options with descriptions and supporting images.',
         codeblock: {
           title: 'Compose rich choice content',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
-    'The `Clickable` component makes any content interactive. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.' +
-    "\n\nUnlike the [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) component, `Clickable` doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
+    'The Clickable component makes any content interactive. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.' +
+    "\n\nUnlike the [Button](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) component, Clickable doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
   thumbnail: 'clickable-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Clickable` component.',
+        'Configure the following properties on the Clickable component.',
       type: 'Clickable',
     },
     {
       title: 'Events',
       description:
-        'The `Clickable` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The Clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ClickableEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'clickable-default.png',
     description:
-      'Make any content interactive using a `Clickable` component wrapper without imposing visual styling. This example shows how to create custom interactive elements while maintaining full control over appearance.',
+      'Make any content interactive using a Clickable component wrapper without imposing visual styling. This example shows how to create custom interactive elements while maintaining full control over appearance.',
     codeblock: {
       title: 'Make content clickable',
       tabs: [
@@ -44,8 +44,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Implement visual feedback:** Since \`Clickable\` has no built-in styling, add focus indicators and active states to show interactivity.
-- **Wrap non-interactive elements:** Use \`Clickable\` for text, images, or icons. Avoid wrapping components with built-in interactions.
+- **Implement visual feedback:** Since Clickable has no built-in styling, add focus indicators and active states to show interactivity.
+- **Wrap non-interactive elements:** Use Clickable for text, images, or icons. Avoid wrapping components with built-in interactions.
 - **Handle disabled state carefully:** When \`disabled\`, child elements can still receive focus. Provide visual feedback for the non-interactive state.
 `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DateField',
   description:
-    'The `DateField` component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
-    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [`DatePicker`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) or [`DateSpinner`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) components.',
+    'The DateField component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
+    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [DatePicker](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) or [DateSpinner](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) components.',
   thumbnail: 'date-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `DateField` component.',
+        'Configure the following properties on the DateField component.',
       type: 'DateField',
     },
     {
       title: 'Events',
       description:
-        'The `DateField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The DateField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DateFieldEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'date-field-default.png',
     description:
-      'Capture date input using a `DateField` component with built-in validation and picker integration. This example shows a basic date field with label and placeholder text.',
+      'Capture date input using a DateField component with built-in validation and picker integration. This example shows a basic date field with label and placeholder text.',
     codeblock: {
       title: 'Capture date input with a date field',
       tabs: [
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for direct text input:** Use \`DateField\` when users know the exact date and can type it efficiently. Use [\`DatePicker\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) for calendar selection or [\`DateSpinner\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) for space-constrained layouts.
+- **Choose for direct text input:** Use DateField when users know the exact date and can type it efficiently. Use [DatePicker](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) for calendar selection or [DateSpinner](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) for space-constrained layouts.
 - **Explain date constraints:** Use \`details\` to clarify requirements like "Select a date within the next 30 days" or "Must be a future date."
 - **Write actionable error messages:** Provide clear validation messages for invalid dates that help users correct their input.
 `,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DatePicker',
   description:
-    'The `DatePicker` component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
-    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, consider using [`DateSpinner`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) instead. For text date entry, use [`DateField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield).',
+    'The DatePicker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, consider using [DateSpinner](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) instead. For text date entry, use [DateField](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield).',
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `DatePicker` component.',
+        'Configure the following properties on the DatePicker component.',
       type: 'DatePicker',
     },
     {
       title: 'Events',
       description:
-        'The `DatePicker` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The DatePicker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DatePickerEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'date-picker-default.png',
     description:
-      'Enable visual date selection using a `DatePicker` component with a calendar interface. This example shows a basic date picker with month view and date selection.',
+      'Enable visual date selection using a DatePicker component with a calendar interface. This example shows a basic date picker with month view and date selection.',
     codeblock: {
       title: 'Select dates with a calendar picker',
       tabs: [
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for calendar-based selection:** Use \`DatePicker\` when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use [\`DateSpinner\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) for tight spaces or [\`DateField\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield) when users know the exact date.
+- **Choose for calendar-based selection:** Use DatePicker when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use [DateSpinner](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datespinner) for tight spaces or [DateField](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield) when users know the exact date.
 - **Provide adequate space:** Ensure sufficient spacing around the picker to avoid interfering with on-screen keyboards or other interactive elements.
 `,
     },
@@ -56,7 +56,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Control `DatePicker` visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the calendar picker, enabling custom trigger patterns for date selection workflows.',
+          'Control DatePicker visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the calendar picker, enabling custom trigger patterns for date selection workflows.',
         codeblock: {
           title: 'Control picker visibility',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DateSpinner',
   description:
-    'The `DateSpinner` component enables merchants to select dates using a spinner interface with scrollable columns for month, day, and year. Use it for compact date selection in space-constrained layouts or when selecting dates close to the current date.' +
-    '\n\nFor visual calendar context, consider using [`DatePicker`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) instead. For text date entry, use [`DateField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield).',
+    'The DateSpinner component enables merchants to select dates using a spinner interface with scrollable columns for month, day, and year. Use it for compact date selection in space-constrained layouts or when selecting dates close to the current date.' +
+    '\n\nFor visual calendar context, consider using [DatePicker](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) instead. For text date entry, use [DateField](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datefield).',
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `DateSpinner` component.',
+        'Configure the following properties on the DateSpinner component.',
       type: 'DateSpinner',
     },
     {
       title: 'Events',
       description:
-        'The `DateSpinner` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The DateSpinner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DateSpinnerEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'date-spinner-default.png',
     description:
-      'Enable compact date selection using a `DateSpinner` component with scrollable columns for month, day, and year. This example shows a basic date spinner for space-constrained layouts.',
+      'Enable compact date selection using a DateSpinner component with scrollable columns for month, day, and year. This example shows a basic date spinner for space-constrained layouts.',
     codeblock: {
       title: 'Select dates with a spinner',
       tabs: [
@@ -44,8 +44,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Use for space-constrained layouts:** Choose \`DateSpinner\` for narrow layouts or split-screen interfaces where a calendar view would be impractical.
-- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, [\`DatePicker\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) provides faster navigation.
+- **Use for space-constrained layouts:** Choose DateSpinner for narrow layouts or split-screen interfaces where a calendar view would be impractical.
+- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, [DatePicker](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/datepicker) provides faster navigation.
 - **Provide interaction cues:** Consider labels or instructions to help first-time users understand the scrollable column interface.
 `,
     },
@@ -57,7 +57,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Control `DateSpinner` visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the spinner picker, enabling custom trigger patterns for date selection in constrained layouts.',
+          'Control DateSpinner visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the spinner picker, enabling custom trigger patterns for date selection in constrained layouts.',
         codeblock: {
           title: 'Control spinner visibility',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Divider',
   description:
-    'The `Divider` component creates visual separation between content sections by rendering a horizontal or vertical line. Use it to organize information and improve content hierarchy.',
+    'The Divider component creates visual separation between content sections by rendering a horizontal or vertical line. Use it to organize information and improve content hierarchy.',
   thumbnail: 'divider-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Divider` component.',
+        'Configure the following properties on the Divider component.',
       type: 'Divider',
     },
   ],
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'divider-default.png',
     description:
-      'Separate content sections using a `Divider` component. This example shows a basic horizontal divider.',
+      'Separate content sections using a Divider component. This example shows a basic horizontal divider.',
     codeblock: {
       title: 'Separate content sections with a divider',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField.d.ts
@@ -109,7 +109,7 @@ export interface EmailFieldJSXProps
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * Additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'EmailField',
   description:
-    'The `EmailField` component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
-    "\n\n`EmailField` doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results.",
+    'The EmailField component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
+    "\n\nEmailField doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results.",
   thumbnail: 'email-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `EmailField` component.',
+        'Configure the following properties on the EmailField component.',
       type: 'EmailField',
     },
     {
       title: 'Slots',
       description:
-        'The `EmailField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The EmailField component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'EmailFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'The `EmailField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The EmailField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'EmailFieldEvents',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'email-field-default.png',
     description:
-      'Capture email address input using an `EmailField` component. This example shows a basic email field with a label for collecting email information.',
+      'Capture email address input using an EmailField component. This example shows a basic email field with a label for collecting email information.',
     codeblock: {
       title: 'Capture email addresses with an email field',
       tabs: [
@@ -71,7 +71,7 @@ The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/20
     examples: [
       {
         description:
-          'Add action buttons to the email field using the accessory slot for quick actions like clearing input or verifying email addresses. This example shows how to use [`s-button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) and [`s-clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the email input context.',
+          'Add action buttons to the email field using the accessory slot for quick actions like clearing input or verifying email addresses. This example shows how to use [s-button](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the email input context.',
         codeblock: {
           title: 'Add accessory buttons',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
-    'The `Heading` component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces.' +
-    '\n\nHeading levels adjust automatically based on nesting within parent [`Section`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.',
+    'The Heading component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces.' +
+    '\n\nHeading levels adjust automatically based on nesting within parent [Section](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.',
   thumbnail: 'heading-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Heading` component.',
+        'Configure the following properties on the Heading component.',
       type: 'Heading',
     },
   ],
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'heading-default.png',
     description:
-      'Create hierarchical titles using a `Heading` component that adjusts levels automatically based on nesting. This example shows a basic heading with automatic level management.',
+      'Create hierarchical titles using a Heading component that adjusts levels automatically based on nesting. This example shows a basic heading with automatic level management.',
     codeblock: {
       title: 'Display hierarchical headings',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -3,16 +3,15 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
-    'The `Icon` component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories. Use icons to enhance navigation or provide visual context alongside text.' +
-    '\n\nFor interactive icons, wrap them in [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components.',
+    'The Icon component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories. Use icons to enhance navigation or provide visual context alongside text.' +
+    '\n\nFor interactive icons, wrap them in [Button](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [Clickable](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components.',
   thumbnail: 'icon-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the `Icon` component.',
+      description: 'Configure the following properties on the Icon component.',
       type: 'Icon',
     },
   ],
@@ -21,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'icon-default.png',
     description:
-      'Display standardized visual symbols using an `Icon` component from the POS icon catalog. This example shows a basic icon with proper sizing and accessibility.',
+      'Display standardized visual symbols using an Icon component from the POS icon catalog. This example shows a basic icon with proper sizing and accessibility.',
     codeblock: {
       title: 'Display icons from the POS catalog',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -3,16 +3,15 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
-    'The `Image` component displays visual content. Use images to showcase products, illustrate concepts, or provide visual context in POS workflows.' +
-    '\n\nImages are display-only components. For interactive functionality, wrap them in [`Button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [`Clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components.',
+    'The Image component displays visual content. Use images to showcase products, illustrate concepts, or provide visual context in POS workflows.' +
+    '\n\nImages are display-only components. For interactive functionality, wrap them in [Button](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) or [Clickable](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components.',
   thumbnail: 'image-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the `Image` component.',
+      description: 'Configure the following properties on the Image component.',
       type: 'Image',
     },
   ],
@@ -21,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'image-default.png',
     description:
-      'Display visual content using an `Image` component with automatic loading optimization and error handling. This example shows a basic image with source URL and alt text for accessibility.',
+      'Display visual content using an Image component with automatic loading optimization and error handling. This example shows a basic image with source URL and alt text for accessibility.',
     codeblock: {
       title: 'Display an image',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Modal',
   description:
-    'The `Modal` component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.' +
+    'The Modal component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.' +
     '\n\nModals block interaction with the underlying interface until the merchant resolves the modal content.' +
     "\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through [events](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/feedback-and-status-indicators/modal#events).",
   thumbnail: 'modal-thumbnail.png',
@@ -12,20 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the `Modal` component.',
+      description: 'Configure the following properties on the Modal component.',
       type: 'Modal',
     },
     {
       title: 'Slots',
       description:
-        'The `Modal` component supports slots for additional content placement within the modal. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The Modal component supports slots for additional content placement within the modal. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ModalSlots',
     },
     {
       title: 'Events',
       description:
-        'The `Modal` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The Modal component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ModalEvents',
     },
   ],
@@ -34,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'modal-default.png',
     description:
-      'Display focused content in an overlay using a `Modal` component that requires merchant attention. This example shows a basic modal with header, content area, and action buttons.',
+      'Display focused content in an overlay using a Modal component that requires merchant attention. This example shows a basic modal with header, content area, and action buttons.',
     codeblock: {
       title: 'Display content in a modal overlay',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'NumberField',
   description:
-    'The `NumberField` component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
+    'The NumberField component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
     '\n\nThe component supports optional stepper controls, min/max constraints, and step increments for guided numeric entry.',
   thumbnail: 'number-field-thumbnail.png',
   isVisualComponent: true,
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `NumberField` component.',
+        'Configure the following properties on the NumberField component.',
       type: 'NumberField',
     },
     {
       title: 'Slots',
       description:
-        'The `NumberField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The NumberField component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'NumberFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'The `NumberField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The NumberField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'NumberFieldEvents',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'number-field-default.png',
     description:
-      'Capture numeric input using a `NumberField` component. This example shows a basic number field with a label for collecting numeric values.',
+      'Capture numeric input using a NumberField component. This example shows a basic number field with a label for collecting numeric values.',
     codeblock: {
       title: 'Capture numeric input with a number field',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -3,22 +3,21 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Page',
   description:
-    'The `Page` component serves as the main container for app content with preset layouts and heading controls. Use it to structure full-screen views with consistent navigation and content organization.' +
-    "\n\n`Page` is designed for full-screen modal interfaces and isn't suitable for inline content or partial page layouts within existing POS screens.",
+    'The Page component serves as the main container for app content with preset layouts and heading controls. Use it to structure full-screen views with consistent navigation and content organization.' +
+    "\n\nPage is designed for full-screen modal interfaces and isn't suitable for inline content or partial page layouts within existing POS screens.",
   thumbnail: 'page-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the `Page` component.',
+      description: 'Configure the following properties on the Page component.',
       type: 'Page',
     },
     {
       title: 'Slots',
       description:
-        'The `Page` component supports slots for additional content placement within the page. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The Page component supports slots for additional content placement within the page. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'PageSlots',
     },
   ],
@@ -27,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'page-default.png',
     description:
-      'Structure full-screen views using a `Page` component with built-in header and content layouts. This example shows a basic page with title and main content area.',
+      'Structure full-screen views using a Page component with built-in header and content layouts. This example shows a basic page with title and main content area.',
     codeblock: {
       title: 'Structure a page layout',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'PosBlock',
   description:
-    'The `PosBlock` component creates a container to place content with an action button. Use it to display structured content within POS block targets.' +
+    'The PosBlock component creates a container to place content with an action button. Use it to display structured content within POS block targets.' +
     '\n\nThe component provides a standardized layout specifically designed for content blocks within POS detail views, with consistent padding, spacing, and optional action buttons.',
   thumbnail: 'pos-block-thumbnail.png',
   isVisualComponent: true,
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `PosBlock` component.',
+        'Configure the following properties on the PosBlock component.',
       type: 'PosBlock',
     },
     {
       title: 'QR Code',
       description:
-        'The `PosBlock` component renders a QR code when the block is used within a receipt target.',
+        'The PosBlock component renders a QR code when the block is used within a receipt target.',
       type: 'QrCode',
     },
     {
       title: 'Slots',
       description:
-        'The `PosBlock` component supports slots for additional content placement within the block. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The PosBlock component supports slots for additional content placement within the block. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'PosBlockSlots',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'pos-block-default.png',
     description:
-      'Create structured content blocks using a `PosBlock` component with optional action buttons. This example shows a basic block with content and an action button.',
+      'Create structured content blocks using a PosBlock component with optional action buttons. This example shows a basic block with content and an action button.',
     codeblock: {
       title: 'Create a content block with an action button',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'ScrollBox',
   description:
-    'The `ScrollBox` component creates a scrollable area for content that exceeds container bounds. Use it to display large amounts of content within constrained spaces while maintaining usability.' +
+    'The ScrollBox component creates a scrollable area for content that exceeds container bounds. Use it to display large amounts of content within constrained spaces while maintaining usability.' +
     '\n\nThe component creates a defined scrollable area with customizable dimensions and scroll behavior.',
   thumbnail: 'scrollbox-thumbnail.png',
   isVisualComponent: true,
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `ScrollBox` component.',
+        'Configure the following properties on the ScrollBox component.',
       type: 'ScrollBox',
     },
   ],
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'scrollbox-default.png',
     description:
-      'Create scrollable content areas using a `ScrollBox` component for content that exceeds container bounds. This example shows a basic scrollable area with customizable dimensions.',
+      'Create scrollable content areas using a ScrollBox component for content that exceeds container bounds. This example shows a basic scrollable area with customizable dimensions.',
     codeblock: {
       title: 'Create a scrollable content area',
       tabs: [
@@ -39,7 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent: `
 - **Set clear dimensions:** Use percentage values for responsive layouts or pixels for exact dimensions.
-- **Use for appropriate content:** Reserve \`ScrollBox\` for long lists or dynamic content that genuinely needs scrolling, not short content that fits within available space.
+- **Use for appropriate content:** Reserve ScrollBox for long lists or dynamic content that genuinely needs scrolling, not short content that fits within available space.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'SearchField',
   description:
-    'The `SearchField` component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers.',
+    'The SearchField component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers.',
   thumbnail: 'search-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -11,13 +11,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `SearchField` component.',
+        'Configure the following properties on the SearchField component.',
       type: 'SearchField',
     },
     {
       title: 'Events',
       description:
-        'The `SearchField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The SearchField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'SearchFieldEvents',
     },
   ],
@@ -26,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'search-field-default.png',
     description:
-      'Enable search functionality using a `SearchField` component. This example shows a basic search field with placeholder text.',
+      'Enable search functionality using a SearchField component. This example shows a basic search field with placeholder text.',
     codeblock: {
       title: 'Enable search with a search field',
       tabs: [
@@ -43,7 +43,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Use for inline search and filtering:** Choose \`SearchField\` for filtering within specific sections or lists, not for global navigation or complex multi-step searches.
+- **Use for inline search and filtering:** Choose SearchField for filtering within specific sections or lists, not for global navigation or complex multi-step searches.
 - **Follow placeholder pattern:** Use "Search {items}" format like "Search products" or "Search customers" to clarify scope.
 - **Choose the right event:** Use \`input\` for real-time filtering as users type. Use \`change\` for expensive operations that should wait until typing completes.
 - **Handle empty values:** When the field is cleared, reset filters or show all items appropriately.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Section',
   description:
-    'The `Section` component groups related content into clearly-defined thematic areas. Use it to organize content and provide clear navigation landmarks.' +
+    'The Section component groups related content into clearly-defined thematic areas. Use it to organize content and provide clear navigation landmarks.' +
     '\n\nThe component manages heading levels automatically, ensuring nested sections maintain proper semantic structure. Only one secondary action button is supported for each section.',
   thumbnail: 'section-thumbnail.png',
   isVisualComponent: true,
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Section` component.',
+        'Configure the following properties on the Section component.',
       type: 'Section',
     },
     {
       title: 'Slots',
       description:
-        'The `Section` component supports slots for additional content placement within the section. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The Section component supports slots for additional content placement within the section. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'SectionSlots',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'section-default.png',
     description:
-      'Group related content using a `Section` component. This example shows a basic section with a heading and content area.',
+      'Group related content using a Section component. This example shows a basic section with a heading and content area.',
     codeblock: {
       title: 'Group related content into sections',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack.d.ts
@@ -134,46 +134,46 @@ export interface StackJSXProps extends PickedProps {
    */
   paddingInlineEnd?: PaddingKeyword | '';
   /**
-   * The block size of the `Stack` component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The block size of the Stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * Learn more about [block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * The maximum block size constraint for the `Stack` component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum block size constraint for the Stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * Learn more about [max-block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * The maximum inline size constraint for the `Stack` component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum inline size constraint for the Stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * Learn more about [max-inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * The minimum block size constraint for the `Stack` component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum block size constraint for the Stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * Learn more about [min-block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * The minimum inline size constraint for the `Stack` component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum inline size constraint for the Stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * Learn more about [min-inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * The alignment of the `Stack` component's children along the cross axis.
+   * The alignment of the Stack component's children along the cross axis.
    */
   alignItems?: AlignItemsKeyword;
   /**
-   * The alignment of the `Stack` component along the cross axis.
+   * The alignment of the Stack component along the cross axis.
    */
   alignContent?: AlignContentKeyword;
   /**
@@ -189,20 +189,20 @@ export interface StackJSXProps extends PickedProps {
    */
   columnGap?: SpacingKeyword | '';
   /**
-   * The direction in which children are placed within the `Stack` component using logical properties. Use `'block'` for vertical arrangement where children are placed along the block axis (typically top to bottom) without wrapping. Use `'inline'` for horizontal arrangement where children are placed along the inline axis (typically left to right) with automatic wrapping when space is insufficient.
+   * The direction in which children are placed within the Stack component using logical properties. Use `'block'` for vertical arrangement where children are placed along the block axis (typically top to bottom) without wrapping. Use `'inline'` for horizontal arrangement where children are placed along the inline axis (typically left to right) with automatic wrapping when space is insufficient.
    *
    * @default 'block'
    */
   direction?: 'block' | 'inline';
   /**
-   * The inline size of the `Stack` component.
+   * The inline size of the Stack component.
    *
    * Learn more about [inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * The alignment of the `Stack` component along the main axis.
+   * The alignment of the Stack component along the main axis.
    *
    * Learn more about [justify-content on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
    * @default 'normal'

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -3,16 +3,15 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
-    'The `Stack` component organizes elements along the block (vertical) or inline (horizontal) axis. Use it to structure layouts and control spacing between elements.' +
-    '\n\nThe component automatically manages spacing through gap properties and supports flexible alignment and wrapping behavior. Complex grid-like layouts may require multiple nested `Stack` components or alternative layout approaches.',
+    'The Stack component organizes elements along the block (vertical) or inline (horizontal) axis. Use it to structure layouts and control spacing between elements.' +
+    '\n\nThe component automatically manages spacing through gap properties and supports flexible alignment and wrapping behavior. Complex grid-like layouts may require multiple nested Stack components or alternative layout approaches.',
   thumbnail: 'stack-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the `Stack` component.',
+      description: 'Configure the following properties on the Stack component.',
       type: 'Stack',
     },
   ],
@@ -21,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'stack-default.png',
     description:
-      'Organize elements using a `Stack` component. This example shows a basic stack with spacing between child elements.',
+      'Organize elements using a Stack component. This example shows a basic stack with spacing between child elements.',
     codeblock: {
       title: 'Organize elements with a stack',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Text',
   description:
-    'The `Text` component displays text with specific visual styles or tones. Use it to present content with appropriate emphasis, hierarchy, or tone while maintaining semantic meaning.' +
+    'The Text component displays text with specific visual styles or tones. Use it to present content with appropriate emphasis, hierarchy, or tone while maintaining semantic meaning.' +
     '\n\nText on mobile surfaces is blockish, rather than inline.',
   thumbnail: 'text-thumbnail.png',
   isVisualComponent: true,
@@ -11,8 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the `Text` component.',
+      description: 'Configure the following properties on the Text component.',
       type: 'Text',
     },
   ],
@@ -21,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'text-default.png',
     description:
-      'Display text content using a `Text` component with customizable visual styles and tones. This example shows basic text with appropriate emphasis and hierarchy.',
+      'Display text content using a Text component with customizable visual styles and tones. This example shows basic text with appropriate emphasis and hierarchy.',
     codeblock: {
       title: 'Display text with visual styles',
       tabs: [
@@ -41,7 +40,7 @@ const data: ReferenceEntityTemplateSchema = {
 - **Choose semantic types:** Use \`strong\` for emphasis, \`small\` for secondary info, \`generic\` for standard text.
 - **Apply appropriate tones:** Use \`success\` for positive outcomes, \`warning\` or \`critical\` for alerts, \`info\` for helpful context, \`auto\` for neutral content.
 - **Balance color intensity:** Use \`strong\` for emphasis, \`base\` for readability, \`subdued\` for secondary info.
-- **Nest for mixed formatting:** Nest \`Text\` components when you need multiple styles within one text block.
+- **Nest for mixed formatting:** Nest Text components when you need multiple styles within one text block.
 `,
     },
     {
@@ -49,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-Complex rich text formatting isn't supported—use multiple \`Text\` components or nested text elements for varied formatting needs.
+Complex rich text formatting isn't supported—use multiple Text components or nested text elements for varied formatting needs.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea.d.ts
@@ -110,7 +110,7 @@ export interface TextAreaJSXProps
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextArea',
   description:
-    'The `TextArea` component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
-    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [`TextField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/textfield).',
+    'The TextArea component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
+    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [TextField](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/textfield).',
   thumbnail: 'text-area-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `TextArea` component.',
+        'Configure the following properties on the TextArea component.',
       type: 'TextArea',
     },
     {
       title: 'Slots',
       description:
-        'The `TextArea` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The TextArea component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TextAreaSlots',
     },
     {
       title: 'Events',
       description:
-        'The `TextArea` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The TextArea component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TextAreaEvents',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'text-area-default.png',
     description:
-      'Capture multi-line text input using a `TextArea` component. This example shows a basic text area with a label for extended content.',
+      'Capture multi-line text input using a TextArea component. This example shows a basic text area with a label for extended content.',
     codeblock: {
       title: 'Capture multi-line text with a text area',
       tabs: [
@@ -60,7 +60,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components. Other component types can't be used for field accessories.
+The \`accessory\` slot supports only [Button](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) and [Clickable](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components. Other component types can't be used for field accessories.
 `,
     },
   ],
@@ -71,7 +71,7 @@ The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/20
     examples: [
       {
         description:
-          'Add action buttons to the text area using the accessory slot for quick actions like clearing text or formatting content. This example shows how to use [`s-button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) and [`s-clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the multi-line input context.',
+          'Add action buttons to the text area using the accessory slot for quick actions like clearing text or formatting content. This example shows how to use [s-button](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the multi-line input context.',
         codeblock: {
           title: 'Add accessory buttons',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField.d.ts
@@ -109,7 +109,7 @@ export interface TextFieldJSXProps
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only `Button` and `Clickable` components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextField',
   description:
-    'The `TextField` component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
-    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [`TextArea`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/textarea) component.',
+    'The TextField component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [TextArea](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/textarea) component.',
   thumbnail: 'text-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `TextField` component.',
+        'Configure the following properties on the TextField component.',
       type: 'TextField',
     },
     {
       title: 'Slots',
       description:
-        'The `TextField` component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The TextField component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TextFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'The `TextField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The TextField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TextFieldEvents',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'text-field-default.png',
     description:
-      'Capture single-line text input using a `TextField` component with validation support. This example shows a basic text field with label and placeholder text.',
+      'Capture single-line text input using a TextField component with validation support. This example shows a basic text field with label and placeholder text.',
     codeblock: {
       title: 'Capture text input with a text field',
       tabs: [
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Use for single-line text input:** Choose \`TextField\` for short values like names, titles, or identifiers. For multi-line content, use [\`TextArea\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/textarea).
+- **Use for single-line text input:** Choose TextField for short values like names, titles, or identifiers. For multi-line content, use [TextArea](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/textarea).
 - **Show character limit feedback:** When approaching \`maxLength\`, display remaining characters in the \`details\` text.
 - **Write descriptive labels:** Use specific labels like "Product Name" or "Reference Code" rather than generic terms.
 `,
@@ -60,7 +60,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) and [\`Clickable\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.
+The \`accessory\` slot supports only [Button](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) and [Clickable](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.
 `,
     },
   ],
@@ -71,7 +71,7 @@ The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/20
     examples: [
       {
         description:
-          'Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use [`s-button`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) and [`s-clickable`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components with text content in the accessory slot, enabling inline actions without leaving the input context.',
+          'Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use [s-button](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/actions/clickable) components with text content in the accessory slot, enabling inline actions without leaving the input context.',
         codeblock: {
           title: 'Add accessory buttons',
           tabs: [
@@ -84,7 +84,7 @@ The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/20
       },
       {
         description:
-          'Configure common `TextField` properties for validation, character limits, and user guidance. This example demonstrates using props like `maxlength`, `required`, `helperText`, and `error` to create a well-guided input experience with proper validation feedback.',
+          'Configure common TextField properties for validation, character limits, and user guidance. This example demonstrates using props like `maxlength`, `required`, `helperText`, and `error` to create a well-guided input experience with proper validation feedback.',
         codeblock: {
           title: 'Configure validation and guidance',
           tabs: [
@@ -97,7 +97,7 @@ The \`accessory\` slot supports only [\`Button\`](/docs/api/pos-ui-extensions/20
       },
       {
         description:
-          'Subscribe to `TextField` events including `onInput`, `onFocus`, `onBlur`, and `onChange` to respond to user interactions. This example shows how to handle different input events for real-time validation, autosave functionality, or dynamic form behavior.',
+          'Subscribe to TextField events including `onInput`, `onFocus`, `onBlur`, and `onChange` to respond to user interactions. This example shows how to handle different input events for real-time validation, autosave functionality, or dynamic form behavior.',
         codeblock: {
           title: 'Handle input events',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -3,23 +3,22 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Tile',
   description:
-    'The `Tile` component displays interactive buttons for the POS smart grid. Use tiles as customizable shortcuts that allow merchants to quickly access workflows, actions, and information from the smart grid.' +
+    'The Tile component displays interactive buttons for the POS smart grid. Use tiles as customizable shortcuts that allow merchants to quickly access workflows, actions, and information from the smart grid.' +
     '\n\nTiles can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They can display contextual information through titles, subtitles, and badge values.' +
-    '\n\nEach POS UI extension can only render one `Tile` component for each [home screen tile target](/docs/api/pos-ui-extensions/2025-10/targets/home-screen#home-screen-tile-).',
+    '\n\nEach POS UI extension can only render one Tile component for each [home screen tile target](/docs/api/pos-ui-extensions/2025-10/targets/home-screen#home-screen-tile-).',
   thumbnail: 'tile-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the `Tile` component.',
+      description: 'Configure the following properties on the Tile component.',
       type: 'Tile',
     },
     {
       title: 'Events',
       description:
-        'The `Tile` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The Tile component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TileEvents',
     },
   ],
@@ -28,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'tile-default.png',
     description:
-      'Create interactive smart grid shortcuts using a `Tile` component with customizable title, subtitle, and badge. This example shows a basic tile for the POS smart grid.',
+      'Create interactive smart grid shortcuts using a Tile component with customizable title, subtitle, and badge. This example shows a basic tile for the POS smart grid.',
     codeblock: {
       title: 'Create a smart grid tile',
       tabs: [
@@ -56,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-The \`Tile\` component supports click and long press interactions only. Swipe, drag, and other gestures aren't supported.
+The Tile component supports click and long press interactions only. Swipe, drag, and other gestures aren't supported.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimeField',
   description:
-    'The `TimeField` component captures time input through direct text entry. Use it when merchants know the exact time they want to enter or for quick time data entry.' +
-    '\n\nFor visual time selection with clock or spinner interfaces, use [`TimePicker`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/timepicker).',
+    'The TimeField component captures time input through direct text entry. Use it when merchants know the exact time they want to enter or for quick time data entry.' +
+    '\n\nFor visual time selection with clock or spinner interfaces, use [TimePicker](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/timepicker).',
   thumbnail: 'time-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `TimeField` component.',
+        'Configure the following properties on the TimeField component.',
       type: 'TimeField',
     },
     {
       title: 'Events',
       description:
-        'The `TimeField` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The TimeField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TimeFieldEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'time-field-default.png',
     description:
-      'Capture time input using a `TimeField` component. This example shows a basic time field with a label for time entry.',
+      'Capture time input using a TimeField component. This example shows a basic time field with a label for time entry.',
     codeblock: {
       title: 'Capture time input with a time field',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimePicker',
   description:
-    'The `TimePicker` component allows merchants to select times using an interactive picker interface. Use it when merchants benefit from visual time selection rather than typing exact times.' +
-    '\n\nFor direct text entry when merchants know the exact time, use [`TimeField`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/timefield).',
+    'The TimePicker component allows merchants to select times using an interactive picker interface. Use it when merchants benefit from visual time selection rather than typing exact times.' +
+    '\n\nFor direct text entry when merchants know the exact time, use [TimeField](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/timefield).',
   thumbnail: 'time-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `TimePicker` component.',
+        'Configure the following properties on the TimePicker component.',
       type: 'TimePicker',
     },
     {
       title: 'Events',
       description:
-        'The `TimePicker` component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The TimePicker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TimePickerEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'time-spinner-default.png',
     description:
-      'Select times using a `TimePicker` component. This example shows a basic time picker for selecting hours and minutes.',
+      'Select times using a TimePicker component. This example shows a basic time picker for selecting hours and minutes.',
     codeblock: {
       title: 'Select times with a time picker',
       tabs: [
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for visual time selection:** Use \`TimePicker\` when users benefit from a visual picker interface. Use [\`TimeField\`](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/timefield) when users know the exact time.
+- **Choose for visual time selection:** Use TimePicker when users benefit from a visual picker interface. Use [TimeField](/docs/api/pos-ui-extensions/2025-10/polaris-web-components/forms/timefield) when users know the exact time.
 - **Use correct format:** Always use \`HH:mm:ss\` format with leading zeros. The internal format is always 24-hour regardless of UI presentation.
 - **Validate before setting values:** Invalid values reset to empty string. Implement validation to show appropriate error messages.
 `,
@@ -57,7 +57,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Control `TimePicker` visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the time picker, enabling custom trigger patterns for time selection workflows.',
+          'Control TimePicker visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the time picker, enabling custom trigger patterns for time selection workflows.',
         codeblock: {
           title: 'Control picker visibility',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
@@ -32,11 +32,11 @@ export interface GlobalProps {
  */
 export interface ActionSlots {
   /**
-   * The primary action element to display, typically a `Button` or clickable link representing the most important action available in the current context. This action aligns with the user's primary goal or the main purpose of the interface (for example, "Save changes", "Checkout", "Add to cart", "Submit order"). The primary action receives visual emphasis through styling to draw user attention. Only one primary action is displayed to maintain clear focus on the main call-to-action.
+   * The primary action element to display, typically a Button or clickable link representing the most important action available in the current context. This action aligns with the user's primary goal or the main purpose of the interface (for example, "Save changes", "Checkout", "Add to cart", "Submit order"). The primary action receives visual emphasis through styling to draw user attention. Only one primary action is displayed to maintain clear focus on the main call-to-action.
    */
   primaryAction?: ComponentChildren;
   /**
-   * Secondary action elements to display, typically `Button` or clickable link elements representing alternative or supporting actions that are less important than the primary action (for example, "Cancel", "Save draft", "Skip", "Learn more"). Secondary actions receive less visual prominence than the primary action to maintain clear hierarchy. Multiple secondary actions can be provided and are displayed together, often in a different visual style or position than the primary action. The order of actions in the array may affect their display order depending on the component.
+   * Secondary action elements to display, typically Button or clickable link elements representing alternative or supporting actions that are less important than the primary action (for example, "Cancel", "Save draft", "Skip", "Learn more"). Secondary actions receive less visual prominence than the primary action to maintain clear hierarchy. Multiple secondary actions can be provided and are displayed together, often in a different visual style or position than the primary action. The order of actions in the array may affect their display order depending on the component.
    */
   secondaryActions?: ComponentChildren;
 }
@@ -879,7 +879,7 @@ export type AccessibilityRole =
   | 'footer'
   /**
    * Used to indicate a thematic grouping of content.
-   * Sections should always have a `Heading` or an accessible name provided in the `accessibilityLabel` property.
+   * Sections should always have a Heading or an accessible name provided in the `accessibilityLabel` property.
    *
    * In an HTML host `section` will render a `<section>` element.
    * Learn more about the [`<section>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) in the MDN web docs.
@@ -1193,7 +1193,7 @@ export interface OverflowProps {
    * Controls how the container handles content that exceeds its dimensions:
    * - `'visible'`: Content extends beyond the container's boundaries without clipping or scrolling. Overflow content is fully visible and may overlap other elements. This is the default behavior and works well for containers that should expand to fit their content naturally.
    * - `'hidden'`: Content that exceeds the container is clipped and hidden from view—users can't see or access the overflow content. No scrollbars appear. Typically applied to intentionally limit visible content, create masked effects, or prevent content from breaking layouts. Hidden content may include important information users can't access.
-   * - `'auto'`: Only available in some components like `ScrollBox`. Adds scrollbars automatically when content exceeds the container, allowing users to scroll to view overflow content. Scrollbars only appear when needed. Commonly applied to scrollable regions, content lists, or containers where users should access all content but space is limited.
+   * - `'auto'`: Only available in some components like ScrollBox. Adds scrollbars automatically when content exceeds the container, allowing users to scroll to view overflow content. Scrollbars only appear when needed. Commonly applied to scrollable regions, content lists, or containers where users should access all content but space is limited.
    *
    * The choice depends on layout needs: `'visible'` for flexible layouts, `'hidden'` for strict boundaries, `'auto'` for user-controlled scrolling. Setting overflow establishes a new block formatting context, which affects layout behaviors like margin collapsing and positioning.
    *
@@ -1423,7 +1423,7 @@ export interface MultipleInputProps extends BaseInputProps {
    */
   onInput?: (event: Event) => void;
   /**
-   * An array containing the values of currently selected options in a multi-select choice list. When provided, this creates a controlled component where this array must be updated in response to user selections using the `onChange` callback. The array contains the `value` properties of selected child `Choice` components. For single-select lists (`multiple={false}`), this array contains zero or one items. For multi-select lists, it can contain multiple items. This is a convenience property that automatically sets the `selected` state on matching child choices based on their `value` properties. When a choice's value appears in this array, it's automatically marked as selected. The array should be updated immutably in callbacks (creating new arrays rather than mutating existing ones).
+   * An array containing the values of currently selected options in a multi-select choice list. When provided, this creates a controlled component where this array must be updated in response to user selections using the `onChange` callback. The array contains the `value` properties of selected child Choice components. For single-select lists (`multiple={false}`), this array contains zero or one items. For multi-select lists, it can contain multiple items. This is a convenience property that automatically sets the `selected` state on matching child choices based on their `value` properties. When a choice's value appears in this array, it's automatically marked as selected. The array should be updated immutably in callbacks (creating new arrays rather than mutating existing ones).
    */
   values?: string[];
 }
@@ -1509,7 +1509,7 @@ export interface FieldDecorationProps {
    */
   icon?: IconType | AnyString;
   /**
-   * Additional interactive content displayed within the field, typically positioned at the end of the field after the input area. Only text-only `Button` and `Clickable` components are supported—no icons or complex content. Use the `slot="accessory"` attribute to place elements here. Common uses include action buttons (for example, "Copy" button, "Generate" button, "Clear" button), toggle visibility controls (for example, "Show password" button), or quick actions related to the field (for example, "Paste from clipboard"). The accessory must not interfere with the field's primary input functionality. Ensure sufficient contrast and touch target sizes for mobile usability.
+   * Additional interactive content displayed within the field, typically positioned at the end of the field after the input area. Only text-only Button and Clickable components are supported—no icons or complex content. Use the `slot="accessory"` attribute to place elements here. Common uses include action buttons (for example, "Copy" button, "Generate" button, "Clear" button), toggle visibility controls (for example, "Show password" button), or quick actions related to the field (for example, "Paste from clipboard"). The accessory must not interfere with the field's primary input functionality. Ensure sufficient contrast and touch target sizes for mobile usability.
    */
   accessory?: ComponentChildren;
 }
@@ -1578,7 +1578,7 @@ export interface BaseSelectableProps {
    */
   disabled?: boolean;
   /**
-   * The unique value associated with this selectable option. This value is what gets submitted with forms when the option is selected, and is used to identify which options are selected in the parent `ChoiceList`'s `values` array. The value should be unique among siblings within the same choice list to avoid selection ambiguity. When a choice is selected, this value appears in form data and in the parent's `values` array. Use meaningful, stable values that identify the choice semantically (for example, `"small"`, `"express-shipping"`, `"agree-to-terms"`) rather than display text which may change or be localized. The value isn't displayed to users—use the choice's `children` or label for visible text.
+   * The unique value associated with this selectable option. This value is what gets submitted with forms when the option is selected, and is used to identify which options are selected in the parent ChoiceList's `values` array. The value should be unique among siblings within the same choice list to avoid selection ambiguity. When a choice is selected, this value appears in form data and in the parent's `values` array. Use meaningful, stable values that identify the choice semantically (for example, `"small"`, `"express-shipping"`, `"agree-to-terms"`) rather than display text which may change or be localized. The value isn't displayed to users—use the choice's `children` or label for visible text.
    */
   value?: string;
 }
@@ -1653,7 +1653,7 @@ export interface ChoiceListProps
    */
   multiple?: boolean;
   /**
-   * The child elements to render within this component. Within `ChoiceList`, use only `Choice` components as children. Other component types can't be used as options within the choice list.
+   * The child elements to render within this component. Within ChoiceList, use only Choice components as children. Other component types can't be used as options within the choice list.
    */
   children?: ComponentChildren;
   /**
@@ -2390,7 +2390,7 @@ export interface PageProps extends GlobalProps, ActionSlots {
    */
   subheading?: string;
   /**
-   * Additional content displayed in the header area, typically action buttons or clickable text elements that complement the primary and secondary actions. Only `Button` and `Clickable` components with text content are supported in this slot. Elements must use the `slot="accessory"` attribute to be placed in this area. Commonly displays contextual actions like "View history", "Export data", or status indicators.
+   * Additional content displayed in the header area, typically action buttons or clickable text elements that complement the primary and secondary actions. Only Button and Clickable components with text content are supported in this slot. Elements must use the `slot="accessory"` attribute to be placed in this area. Commonly displays contextual actions like "View history", "Export data", or status indicators.
    */
   accessory?: ComponentChildren;
   /**


### PR DESCRIPTION
## Context

We've decided to remove the code syntax from component names in the docs. The code syntax on the business name (for example `Button`) makes it easy to think that `Button` is actual code.

## This PR: 
- Removes the code syntax syntax on all POS components for version 2025-10
