### PR TITLE
[POS 2024-10]: Remove component name code syntax

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Badge.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Badge.doc.ts
@@ -7,14 +7,14 @@ const generateCodeBlockForBadge = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Badge',
   description:
-    'The `Badge` component uses color and text to communicate status information for orders, products, customers, and other business data. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes within your POS interface.\n\nThe component automatically adjusts its appearance based on the specified `tone` property, ensuring consistent visual communication across the POS interface. Badges support different sizes and can display text, numbers, or status indicators, making them versatile for representing everything from order counts to inventory alerts in a compact, scannable format.',
+    'The Badge component uses color and text to communicate status information for orders, products, customers, and other business data. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes within your POS interface.\n\nThe component automatically adjusts its appearance based on the specified `tone` property, ensuring consistent visual communication across the POS interface. Badges support different sizes and can display text, numbers, or status indicators, making them versatile for representing everything from order counts to inventory alerts in a compact, scannable format.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Badge` component.',
+        'Configure the following properties on the Badge component.',
       type: 'BadgeProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Badge.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Badge.doc.ts
@@ -13,8 +13,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the Badge component.',
+      description: 'Configure the following properties on the Badge component.',
       type: 'BadgeProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Banner.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Banner.doc.ts
@@ -7,14 +7,14 @@ const generateCodeBlockForBanner = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Banner',
   description:
-    'The `Banner` component highlights important information or required actions prominently within the POS interface. Use banners to communicate critical updates, warnings, informational messages, or success notifications that require merchant attention in a persistent but non-interruptive way.\n\nThe component provides persistent visibility for important messages while remaining non-intrusive to the main workflow, with support for dismissible and non-dismissible states. It includes automatic color coding based on message severity and integrates with the POS design system to maintain visual consistency across different alert types and use cases.',
+    'The Banner component highlights important information or required actions prominently within the POS interface. Use banners to communicate critical updates, warnings, informational messages, or success notifications that require merchant attention in a persistent but non-interruptive way.\n\nThe component provides persistent visibility for important messages while remaining non-intrusive to the main workflow, with support for dismissible and non-dismissible states. It includes automatic color coding based on message severity and integrates with the POS design system to maintain visual consistency across different alert types and use cases.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Banner` component.',
+        'Configure the following properties on the Banner component.',
       type: 'BannerProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Button.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Button.doc.ts
@@ -7,14 +7,14 @@ const generateCodeBlockForButton = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
-    'The `Button` component triggers actions or events, such as opening dialogs or navigating to other pages. Use `Button` to let merchants perform specific tasks or initiate interactions throughout the POS interface.\n\nButtons provide clear calls-to-action that guide merchants through workflows, enable form submissions, and trigger important operations. They support various visual styles, tones, and interaction patterns to communicate intent and hierarchy within the interface.',
+    'The Button component triggers actions or events, such as opening dialogs or navigating to other pages. Use Button to let merchants perform specific tasks or initiate interactions throughout the POS interface.\n\nButtons provide clear calls-to-action that guide merchants through workflows, enable form submissions, and trigger important operations. They support various visual styles, tones, and interaction patterns to communicate intent and hierarchy within the interface.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Button` component.',
+        'Configure the following properties on the Button component.',
       type: 'ButtonProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/CameraScanner.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/CameraScanner.doc.ts
@@ -7,14 +7,14 @@ const generateCodeBlockForCameraScanner = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'CameraScanner',
   description:
-    'The `CameraScanner` component provides camera-based scanning functionality with optional banner messaging. Use it to enable barcode scanning, QR code reading, or other camera-based input methods with contextual user feedback.\n\n`CameraScanner` works in conjunction with the Scanner API to capture scan data from device cameras, providing both the visual interface and the data handling capabilities for complete scanning workflows.\n\n`CameraScanner` components provide real-time feedback during scanning operations with visual guides for optimal positioning, helping merchants quickly capture barcodes even in challenging lighting conditions or with damaged labels. The component provides audio feedback during scanning operations, confirming successful scans without requiring visual confirmation.',
+    'The CameraScanner component provides camera-based scanning functionality with optional banner messaging. Use it to enable barcode scanning, QR code reading, or other camera-based input methods with contextual user feedback.\n\nCameraScanner works in conjunction with the Scanner API to capture scan data from device cameras, providing both the visual interface and the data handling capabilities for complete scanning workflows.\n\nCameraScanner components provide real-time feedback during scanning operations with visual guides for optimal positioning, helping merchants quickly capture barcodes even in challenging lighting conditions or with damaged labels. The component provides audio feedback during scanning operations, confirming successful scans without requiring visual confirmation.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `CameraScanner` component.',
+        'Configure the following properties on the CameraScanner component.',
       type: 'CameraScannerProps',
     },
   ],
@@ -49,7 +49,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`CameraScanner\` requires device camera access and appropriate permissions—functionality is limited on devices without cameras or when permissions are denied.
+- CameraScanner requires device camera access and appropriate permissions—functionality is limited on devices without cameras or when permissions are denied.
 - Banner messaging is the only built-in user feedback mechanism—complex scanning feedback or custom UI elements require additional components or external state management.
 - The component handles basic camera functionality—advanced camera controls, image processing, or custom scanning algorithms aren't supported within the component itself.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/DateField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/DateField.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'DateField',
   description:
-    'The `DateField` component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.\n\n`DateField` components support both manual text entry and picker selection, giving merchants flexibility to choose their preferred input method based on personal preference and specific date entry scenarios.\n\nFor visual calendar-based selection, consider `DatePicker`. The component validates dates in real-time and provides clear error messages for invalid entries, preventing form submission errors and reducing the need for merchants to correct date inputs multiple times.',
+    'The DateField component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.\n\nDateField components support both manual text entry and picker selection, giving merchants flexibility to choose their preferred input method based on personal preference and specific date entry scenarios.\n\nFor visual calendar-based selection, consider DatePicker. The component validates dates in real-time and provides clear error messages for invalid entries, preventing form submission errors and reducing the need for merchants to correct date inputs multiple times.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `DateField` component.',
+        'Configure the following properties on the DateField component.',
       type: 'DateFieldProps',
     },
   ],
@@ -48,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`DateField\` provides text-based date input—for calendar-style visual date selection, use the \`DatePicker\` component which offers an interactive calendar interface.
+- DateField provides text-based date input—for calendar-style visual date selection, use the DatePicker component which offers an interactive calendar interface.
 - The field defaults to the current date rather than being empty—if you need an empty initial state, explicitly set the \`value\` property to an empty string.
 - Action buttons are limited to simple press callbacks—complex action workflows require custom implementation or additional components.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/DatePicker.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/DatePicker.doc.ts
@@ -8,14 +8,14 @@ const generateCodeBlockForDatePicker = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'DatePicker',
   description:
-    'The `DatePicker` component allows merchants to select a specific date using a calendar-like picker interface. Use it to provide visual date selection with an intuitive calendar view for improved user experience.\n\n`DatePicker` offers a calendar-based alternative to direct text input. The calendar interface allows merchants to see dates in context of the full month, making it easier to select dates relative to specific days of the week or to visualize date ranges within a month view. For simple date entry when users know the exact date, use `DateField`.',
+    'The DatePicker component allows merchants to select a specific date using a calendar-like picker interface. Use it to provide visual date selection with an intuitive calendar view for improved user experience.\n\nDatePicker offers a calendar-based alternative to direct text input. The calendar interface allows merchants to see dates in context of the full month, making it easier to select dates relative to specific days of the week or to visualize date ranges within a month view. For simple date entry when users know the exact date, use DateField.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `DatePicker` component.',
+        'Configure the following properties on the DatePicker component.',
       type: 'DatePickerProps',
     },
   ],
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`DatePicker\` requires external visibility state management through the \`visibleState\` tuple—automatic show/hide behavior based on field focus isn't built-in.
+- DatePicker requires external visibility state management through the \`visibleState\` tuple—automatic show/hide behavior based on field focus isn't built-in.
 - The component provides date selection but doesn't include field labels, help text, or error messaging—combine with other UI elements or text components to provide complete form field experiences.
 - Input mode determines the interaction pattern but can't be changed dynamically while the picker is visible—you must set the mode before displaying the picker.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Dialog.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Dialog.doc.ts
@@ -7,14 +7,14 @@ const generateCodeBlockForDialog = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Dialog',
   description:
-    'The `Dialog` component displays a modal that requires user attention and interaction. Use dialogs to present important information, confirm actions, or collect input from merchants in a focused overlay that interrupts the current workflow until resolved.\n\nThe component creates a modal overlay that focuses user attention on important decisions or information, blocking interaction with underlying content until dismissed. It supports various configurations including alert dialogs, confirmation dialogs, and custom content dialogs, with built-in button layouts and keyboard shortcuts for efficient navigation and decision-making.\n\n`Dialog` components provide customizable button layouts and keyboard shortcuts that follow platform conventions, ensuring merchants can quickly approve or dismiss dialogs through familiar interaction patterns.',
+    'The Dialog component displays a modal that requires user attention and interaction. Use dialogs to present important information, confirm actions, or collect input from merchants in a focused overlay that interrupts the current workflow until resolved.\n\nThe component creates a modal overlay that focuses user attention on important decisions or information, blocking interaction with underlying content until dismissed. It supports various configurations including alert dialogs, confirmation dialogs, and custom content dialogs, with built-in button layouts and keyboard shortcuts for efficient navigation and decision-making.\n\nDialog components provide customizable button layouts and keyboard shortcuts that follow platform conventions, ensuring merchants can quickly approve or dismiss dialogs through familiar interaction patterns.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Dialog` component.',
+        'Configure the following properties on the Dialog component.',
       type: 'DialogProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/EmailField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/EmailField.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'EmailField',
   description:
-    'The `EmailField` component captures email address input from customers with built-in validation. Use it to collect email information in forms, customer profiles, or contact workflows.\n\nThe component includes built-in email format validation using standard email patterns to ensure data quality. It provides real-time feedback on invalid entries and supports features like autocomplete and keyboard optimization for email input, helping merchants quickly capture valid customer contact information during checkout or registration workflows.\n\n`EmailField` components integrate with browser autocomplete features to speed up email entry by suggesting previously used addresses, significantly reducing typing time during customer registration workflows.',
+    'The EmailField component captures email address input from customers with built-in validation. Use it to collect email information in forms, customer profiles, or contact workflows.\n\nThe component includes built-in email format validation using standard email patterns to ensure data quality. It provides real-time feedback on invalid entries and supports features like autocomplete and keyboard optimization for email input, helping merchants quickly capture valid customer contact information during checkout or registration workflows.\n\nEmailField components integrate with browser autocomplete features to speed up email entry by suggesting previously used addresses, significantly reducing typing time during customer registration workflows.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `EmailField` component.',
+        'Configure the following properties on the EmailField component.',
       type: 'EmailFieldProps',
     },
   ],
@@ -37,7 +37,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - **Provide helpful guidance with placeholder and helpText:** Use placeholder text for format examples like \`customer@example.com\` and the \`helpText\` property for additional context like "Required for digital receipts" or "We'll send order updates to this address."
 - **Implement proper email validation:** Use the \`error\` property to display validation messages when users enter invalid email formats. Provide clear, actionable error messages like "Please enter a valid email address" that help users correct their input.
-- **Use the email-optimized keyboard:** \`EmailField\` automatically display the email-optimized keyboard on mobile devices with easy access to \`@\` and domain symbols. This improves input speed and reduces errors on touch devices.
+- **Use the email-optimized keyboard:** EmailField automatically display the email-optimized keyboard on mobile devices with easy access to \`@\` and domain symbols. This improves input speed and reduces errors on touch devices.
 - **Use the required property appropriately:** Set \`required\` to \`true\` for fields that must have a value. While this adds semantic meaning, you must still implement validation logic and use the \`error\` property to display validation errors to users.
 - **Add action buttons for enhanced functionality:** Use the \`action\` property to provide helpful actions like "Validate Email," "Use Default Email," or "Clear Field." This enhances usability by providing quick access to common operations.
 - **Differentiate between input and change callbacks:** Use \`onInput\` for immediate feedback like clearing validation errors as soon as users start typing. Reserve \`onChange\` for updating the field value when editing is complete. Never use \`onInput\` to update the \`value\` property.
@@ -48,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`EmailField\` provides the input interface but doesn't perform automatic email validation—you must implement validation logic and use the \`error\` property to display validation results.
+- EmailField provides the input interface but doesn't perform automatic email validation—you must implement validation logic and use the \`error\` property to display validation results.
 - The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display or prevent form submission without additional validation logic.
 - Action buttons are limited to simple press callbacks—complex action workflows require custom implementation or additional components.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/FormattedTextField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/FormattedTextField.doc.ts
@@ -7,7 +7,7 @@ const generateCodeBlockForComponent = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'FormattedTextField',
   description:
-    'The `FormattedTextField` component captures text input with specific formatting, validation, and keyboard optimization. Use it to collect formatted text with appropriate input types and auto-capitalization rules.\n\nThe component applies real-time formatting as users type, supporting patterns like phone numbers, credit cards, postal codes, and custom formats through configurable masks. It maintains separate formatted display and raw value states, ensuring that validation and data submission use clean unformatted values while providing user-friendly formatted display during input.\n\n`FormattedTextField` components prevents invalid character entry at the input level rather than validation after entry, providing immediate feedback and reducing the frustration of correcting masked input patterns.',
+    'The FormattedTextField component captures text input with specific formatting, validation, and keyboard optimization. Use it to collect formatted text with appropriate input types and auto-capitalization rules.\n\nThe component applies real-time formatting as users type, supporting patterns like phone numbers, credit cards, postal codes, and custom formats through configurable masks. It maintains separate formatted display and raw value states, ensuring that validation and data submission use clean unformatted values while providing user-friendly formatted display during input.\n\nFormattedTextField components prevents invalid character entry at the input level rather than validation after entry, providing immediate feedback and reducing the frustration of correcting masked input patterns.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
@@ -58,7 +58,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`FormattedTextField\` provides keyboard optimization and basic validation UI but doesn't perform automatic formatting—you must implement formatting logic in your \`onChangeText\` callback for currency, phone numbers, or other formatted values.
+- FormattedTextField provides keyboard optimization and basic validation UI but doesn't perform automatic formatting—you must implement formatting logic in your \`onChangeText\` callback for currency, phone numbers, or other formatted values.
 - The \`isValid\` property controls visual styling only—it doesn't prevent form submission or enforce validation automatically, requiring custom validation logic.
 - Input types optimize the keyboard layout but don't enforce format restrictions—users can still enter any characters, so validation in \`onChangeText\` is essential.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Icon.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Icon.doc.ts
@@ -10,8 +10,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the Icon component.',
+      description: 'Configure the following properties on the Icon component.',
       type: 'IconProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Icon.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Icon.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
-    'The `Icon` component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories consistently. Use icons to enhance navigation or provide visual context alongside text in POS interfaces.\n\nIcons help merchants quickly understand interface elements and actions without relying solely on text labels. Icons are optimized for readability at standard sizes and automatically scale to maintain visual consistency across different screen densities and device types.',
+    'The Icon component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories consistently. Use icons to enhance navigation or provide visual context alongside text in POS interfaces.\n\nIcons help merchants quickly understand interface elements and actions without relying solely on text labels. Icons are optimized for readability at standard sizes and automatically scale to maintain visual consistency across different screen densities and device types.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Icon` component.',
+        'Configure the following properties on the Icon component.',
       type: 'IconProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Image.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Image.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
-    'The `Image` component adds visual content within the interface and allows you to customize the presentation of visuals. Use images to showcase products, illustrate concepts, provide visual context, or support user tasks and interactions in POS workflows.\n\nImages enhance the user experience by providing immediate visual recognition and reducing cognitive load.\n\n`Image` components handle loading errors gracefully with fallback options and provides placeholder states to maintain layout stability during image loading on slower network connections. The component implements lazy loading for images outside the viewport, improving initial page load performance while ensuring smooth scrolling as merchants navigate through product catalogs or image-heavy interfaces.',
+    'The Image component adds visual content within the interface and allows you to customize the presentation of visuals. Use images to showcase products, illustrate concepts, provide visual context, or support user tasks and interactions in POS workflows.\n\nImages enhance the user experience by providing immediate visual recognition and reducing cognitive load.\n\nImage components handle loading errors gracefully with fallback options and provides placeholder states to maintain layout stability during image loading on slower network connections. The component implements lazy loading for images outside the viewport, improving initial page load performance while ensuring smooth scrolling as merchants navigate through product catalogs or image-heavy interfaces.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Image` component.',
+        'Configure the following properties on the Image component.',
       type: 'ImageProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Image.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Image.doc.ts
@@ -10,8 +10,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the Image component.',
+      description: 'Configure the following properties on the Image component.',
       type: 'ImageProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/List.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/List.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'List',
   description:
-    'The `List` component displays structured data in rows with rich content including labels, subtitles, badges, images, and interactive elements. Use it to present organized information with consistent formatting and user interaction capabilities.\n\nList items no longer have dividers as of POS version 10.0.0.',
+    'The List component displays structured data in rows with rich content including labels, subtitles, badges, images, and interactive elements. Use it to present organized information with consistent formatting and user interaction capabilities.\n\nList items no longer have dividers as of POS version 10.0.0.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `List` component.',
+        'Configure the following properties on the List component.',
       type: 'ListProps',
     },
   ],
@@ -35,7 +35,7 @@ const data: ReferenceEntityTemplateSchema = {
 - **Implement efficient pagination with onEndReached:** Use the \`onEndReached\` callback to implement smooth pagination that doesn't disrupt the user experience. Set \`isLoadingMore\` appropriately to provide visual feedback during data fetching operations.
 - **Apply semantic colors for subtitle information:** Use \`ColorType\` values in subtitles to convey meaning effectively. Apply \`TextSuccess\` for positive states, \`TextCritical\` for errors, and \`TextSubdued\` for less important information.
 - **Design meaningful row interactions:** Use \`onPress\` callbacks for navigation or detail views, and \`showChevron\` to indicate navigation actions. Reserve toggle switches for immediate state changes that don't require navigation.
-- **Optimize for touch interfaces:** Ensure adequate spacing and touch target sizes by leveraging the \`List\` component's built-in touch optimization.
+- **Optimize for touch interfaces:** Ensure adequate spacing and touch target sizes by leveraging the List component's built-in touch optimization.
       `,
     },
     {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/List.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/List.doc.ts
@@ -10,8 +10,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the List component.',
+      description: 'Configure the following properties on the List component.',
       type: 'ListProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Navigator.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Navigator.doc.ts
@@ -7,14 +7,14 @@ const generateCodeBlockForComponent = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Navigator',
   description:
-    'The `Navigator` component manages navigation between multiple `Screen` components within a POS UI extension. Use it to create multi-screen workflows with proper navigation stack management and initial screen configuration.\n\n`Navigator` works with the Navigation API to provide complete navigation control for complex POS workflows that require multiple views and user interactions.\n\n`Navigator` components maintain navigation history across app lifecycle events and supports deep linking to specific screens, enabling merchants to return to their exact workflow state after interruptions The component supports gesture-based navigation like swipe-to-go-back on platforms where this is standard, providing familiar interaction patterns that feel native to each platform.',
+    'The Navigator component manages navigation between multiple Screen components within a POS UI extension. Use it to create multi-screen workflows with proper navigation stack management and initial screen configuration.\n\nNavigator works with the Navigation API to provide complete navigation control for complex POS workflows that require multiple views and user interactions.\n\nNavigator components maintain navigation history across app lifecycle events and supports deep linking to specific screens, enabling merchants to return to their exact workflow state after interruptions The component supports gesture-based navigation like swipe-to-go-back on platforms where this is standard, providing familiar interaction patterns that feel native to each platform.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Navigator` component.',
+        'Configure the following properties on the Navigator component.',
       type: 'NavigatorProps',
     },
   ],
@@ -71,7 +71,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`Navigator\` requires \`Screen\` components as children—it can't manage navigation for other component types or standalone content.
+- Navigator requires Screen components as children—it can't manage navigation for other component types or standalone content.
 - Navigation state is managed internally—external navigation state management or complex routing patterns require custom implementation using the Navigation API.
 - The component is designed for modal-style navigation within POS UI extensions—it's not suitable for main application navigation or replacing core POS navigation patterns.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/NumberField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/NumberField.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'NumberField',
   description:
-    'The `NumberField` component captures numeric input with built-in validation. Use it to collect quantity, price, or other numeric information with proper validation.\n\nThe component includes built-in number validation, optional min/max constraints, and step increments to ensure accurate numeric data entry. It supports various number formats including integers and decimals, with validation feedback to prevent entry errors during high-volume retail operations.',
+    'The NumberField component captures numeric input with built-in validation. Use it to collect quantity, price, or other numeric information with proper validation.\n\nThe component includes built-in number validation, optional min/max constraints, and step increments to ensure accurate numeric data entry. It supports various number formats including integers and decimals, with validation feedback to prevent entry errors during high-volume retail operations.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `NumberField` component.',
+        'Configure the following properties on the NumberField component.',
       type: 'NumberFieldProps',
     },
   ],
@@ -46,7 +46,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`NumberField\` provides numeric input but doesn't enforce \`min\`/\`max\` constraints for keyboard input—you must implement validation logic to enforce bounds and display appropriate errors.
+- NumberField provides numeric input but doesn't enforce \`min\`/\`max\` constraints for keyboard input—you must implement validation logic to enforce bounds and display appropriate errors.
 - The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display or prevent form submission without additional validation logic.
 - Action buttons are limited to simple press callbacks—complex action workflows require custom implementation or additional components.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSBlock.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSBlock.doc.ts
@@ -7,7 +7,7 @@ const generateCodeBlockForPOSBlock = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'POSBlock',
   description:
-    'The `POSBlock` component creates a container to place content with an action button. Use it to display structured content within POS block targets.\n\nThe component provides a standardized layout specifically designed for content blocks within POS detail views, with consistent padding, spacing, and optional action buttons. It integrates with the native POS design language, ensuring extension content feels cohesive with the core POS interface while maintaining clear content boundaries.\n\n`PosBlock` components provide consistent interaction patterns for action buttons across different block types, ensuring merchants can predict button behavior and location regardless of the specific POS context.',
+    'The POSBlock component creates a container to place content with an action button. Use it to display structured content within POS block targets.\n\nThe component provides a standardized layout specifically designed for content blocks within POS detail views, with consistent padding, spacing, and optional action buttons. It integrates with the native POS design language, ensuring extension content feels cohesive with the core POS interface while maintaining clear content boundaries.\n\nPOSBlock components provide consistent interaction patterns for action buttons across different block types, ensuring merchants can predict button behavior and location regardless of the specific POS context.',
   isVisualComponent: true,
   type: 'component',
   thumbnail: 'pos-block-thumbnail.png',
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `POSBlock` component.',
+        'Configure the following properties on the POSBlock component.',
       type: 'POSBlockProps',
     },
   ],
@@ -39,9 +39,9 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - **Design meaningful action buttons:** When providing an action, use clear and descriptive button titles that indicate exactly what will happen when pressed. Avoid generic terms like "Click here" in favor of specific actions like "View Details" or "Update Status."
 - **Handle action states appropriately:** Use the disabled property to prevent user interaction when actions are not available or appropriate. Provide clear feedback through your extension's description or other UI elements when actions are disabled.
-- **Design for the block context:** \`POSBlock\` appears within existing POS screens alongside other content.
+- **Design for the block context:** POSBlock appears within existing POS screens alongside other content.
 - **Implement responsive action callbacks:**  Consider showing loading states or confirmation messages when actions require network requests or significant processing time.
-- **Maintain consistent action patterns:** Use similar action patterns across different \`POSBlock\` instances in your extension to create predictable user experiences. Consistent button titles and behaviors help merchants understand and trust your extension.
+- **Maintain consistent action patterns:** Use similar action patterns across different POSBlock instances in your extension to create predictable user experiences. Consistent button titles and behaviors help merchants understand and trust your extension.
       `,
     },
     {
@@ -49,10 +49,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`POSBlock\` is designed specifically for block targets—it can't be used in modal or action (menu item) targets.
+- POSBlock is designed specifically for block targets—it can't be used in modal or action (menu item) targets.
 - The component's visual styling and layout are controlled by the POS design system—custom styling isn't supported.
 - Content display is determined by the extension's description rather than custom content properties—ensure your extension description is clear and informative.
-- Only one action button is supported for each \`POSBlock\` instance to maintain clean, focused interfaces that integrate well with existing POS workflows.
+- Only one action button is supported for each POSBlock instance to maintain clean, focused interfaces that integrate well with existing POS workflows.
       `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSBlockRow.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/POSBlockRow.doc.ts
@@ -7,7 +7,7 @@ const generateCodeBlockForPOSBlockRow = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'POSBlockRow',
   description:
-    "The `POSBlockRow` component renders individual rows within a `POSBlock` container. Use it to create structured content rows with optional tap interactions inside `POSBlock` components.\n\nThe component follows Shopify's design system specifications to ensure visual consistency across the POS interface. It includes built-in support for different device sizes and orientations, providing a reliable and familiar experience for merchants across various retail environments and use cases.\n\n`POSBlockRow` components handle edge cases and loading states gracefully, providing clear feedback during operations and maintaining interface responsiveness even when processing intensive tasks or handling large datasets.",
+    "The POSBlockRow component renders individual rows within a POSBlock container. Use it to create structured content rows with optional tap interactions inside POSBlock components.\n\nThe component follows Shopify's design system specifications to ensure visual consistency across the POS interface. It includes built-in support for different device sizes and orientations, providing a reliable and familiar experience for merchants across various retail environments and use cases.\n\nPOSBlockRow components handle edge cases and loading states gracefully, providing clear feedback during operations and maintaining interface responsiveness even when processing intensive tasks or handling large datasets.",
   isVisualComponent: true,
   type: 'component',
   thumbnail: 'pos-block-row-thumbnail.png',
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `POSBlockRow` component.',
+        'Configure the following properties on the POSBlockRow component.',
       type: 'POSBlockRowProps',
     },
   ],
@@ -37,10 +37,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Organize content logically within rows:** Structure your \`POSBlockRow\` content to be scannable and focused. Each row should represent a discrete piece of information or functionality that users can easily understand and interact with.
+- **Organize content logically within rows:** Structure your POSBlockRow content to be scannable and focused. Each row should represent a discrete piece of information or functionality that users can easily understand and interact with.
 - **Provide visual feedback for interactive rows:** When rows are interactive (have \`onPress\` callbacks), ensure users understand they can be tapped.
-- **Keep row content concise and focused:** Design row content to be easily readable and actionable within the constrained space of a \`POSBlock\`. Focus on the most important information and avoid cluttering rows with excessive detail.
-- **Maintain consistent interaction patterns:** Use similar \`onPress\` behaviors across different \`POSBlockRow\` instances in your extension to create predictable user experiences. Consistent interaction patterns help merchants understand and trust your extension.
+- **Keep row content concise and focused:** Design row content to be easily readable and actionable within the constrained space of a POSBlock. Focus on the most important information and avoid cluttering rows with excessive detail.
+- **Maintain consistent interaction patterns:** Use similar \`onPress\` behaviors across different POSBlockRow instances in your extension to create predictable user experiences. Consistent interaction patterns help merchants understand and trust your extension.
       `,
     },
     {
@@ -48,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`POSBlockRow\` can only be used as children of \`POSBlock\` components—it can't be used independently or within other container types.
+- POSBlockRow can only be used as children of POSBlock components—it can't be used independently or within other container types.
 - The component's visual styling and layout are controlled by the POS design system—custom row styling beyond content organization isn't supported.
 - Row content is provided through child components rather than direct content properties—organize your row content through component composition.
 - Interactive behavior is limited to the \`onPress\` callback—complex interactions or multiple actions for each row require custom implementation within the row content.

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/PinPad.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/PinPad.doc.ts
@@ -3,14 +3,14 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'PinPad',
   description:
-    'The `PinPad` component provides a secure numeric keypad interface for PIN entry and validation. Use it to collect PIN codes, passcodes, or other sensitive numeric input with proper masking and validation.\n\nThe component provides a secure numeric input interface specifically designed for PIN entry, with visual feedback that masks entered digits for security. It includes built-in validation for PIN length requirements, supports error states for invalid PINs, and provides haptic feedback on touch-enabled devices to confirm key presses during secure authentication workflows.\n\n`PinPad` components meets security standards for PIN entry by preventing screenshot capture and display recording, protecting sensitive authentication data during payment authorization and staff access workflows.',
+    'The PinPad component provides a secure numeric keypad interface for PIN entry and validation. Use it to collect PIN codes, passcodes, or other sensitive numeric input with proper masking and validation.\n\nThe component provides a secure numeric input interface specifically designed for PIN entry, with visual feedback that masks entered digits for security. It includes built-in validation for PIN length requirements, supports error states for invalid PINs, and provides haptic feedback on touch-enabled devices to confirm key presses during secure authentication workflows.\n\nPinPad components meets security standards for PIN entry by preventing screenshot capture and display recording, protecting sensitive authentication data during payment authorization and staff access workflows.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `PinPad` component.',
+        'Configure the following properties on the PinPad component.',
       type: 'PinPadProps',
     },
   ],
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`PinPad\` is designed for numeric PIN entry only—alphanumeric passcodes or complex passwords require different input components.
+- PinPad is designed for numeric PIN entry only—alphanumeric passcodes or complex passwords require different input components.
 - PIN length is constrained to 4-10 digits—requirements outside this range need alternative authentication methods.
 - The component provides the keypad interface and basic validation—additional security measures like rate limiting, attempt tracking, or lockout mechanisms must be implemented in your \`onSubmit\` callback.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/RadioButtonList.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/RadioButtonList.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'RadioButtonList',
   description:
-    'The `RadioButtonList` component presents radio button options for single selection from a list of string values. Use it when merchants need to choose exactly one option from a defined set of choices.\n\nThe component ensures single-selection behavior with clear visual indication of the selected option and disabled states for unavailable choices, making it suitable for settings, preferences, and any scenario requiring exclusive choice from multiple options.',
+    'The RadioButtonList component presents radio button options for single selection from a list of string values. Use it when merchants need to choose exactly one option from a defined set of choices.\n\nThe component ensures single-selection behavior with clear visual indication of the selected option and disabled states for unavailable choices, making it suitable for settings, preferences, and any scenario requiring exclusive choice from multiple options.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `RadioButtonList` component.',
+        'Configure the following properties on the RadioButtonList component.',
       type: 'RadioButtonListProps',
     },
   ],
@@ -46,9 +46,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`RadioButtonList\` accepts only string arrays for options—complex option objects with additional metadata or custom rendering require alternative components or additional state management.
+- RadioButtonList accepts only string arrays for options—complex option objects with additional metadata or custom rendering require alternative components or additional state management.
 - The component is designed for single selection only—multiple selection scenarios require alternative approaches or custom implementation.
-- \`RadioButtonList\` requires you to manage the selected value in your app must update \`initialSelectedItem\` in response to \`onItemSelected\` events to reflect the new selection in the UI.
+- RadioButtonList requires you to manage the selected value in your app must update \`initialSelectedItem\` in response to \`onItemSelected\` events to reflect the new selection in the UI.
       `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Screen.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Screen.doc.ts
@@ -7,14 +7,14 @@ const generateCodeBlockForComponent = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Screen',
   description:
-    'The `Screen` component represents a screen in the navigation stack with full control over presentation, actions, and navigation lifecycle. Use it to create navigable screens with titles, loading states, and custom navigation behavior.\n\nThe component manages full-screen presentations with proper navigation stack integration, allowing extensions to push and pop screens as part of the POS navigation flow. It handles transitions, back button behavior, and safe area padding automatically, ensuring extensions provide native-feeling navigation experiences on both iOS and Android devices.\n\n`Screen` components maintain scroll position across navigation operations where appropriate, allowing merchants to return to their previous location after viewing details or completing sub-tasks.',
+    'The Screen component represents a screen in the navigation stack with full control over presentation, actions, and navigation lifecycle. Use it to create navigable screens with titles, loading states, and custom navigation behavior.\n\nThe component manages full-screen presentations with proper navigation stack integration, allowing extensions to push and pop screens as part of the POS navigation flow. It handles transitions, back button behavior, and safe area padding automatically, ensuring extensions provide native-feeling navigation experiences on both iOS and Android devices.\n\nScreen components maintain scroll position across navigation operations where appropriate, allowing merchants to return to their previous location after viewing details or completing sub-tasks.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Screen` component.',
+        'Configure the following properties on the Screen component.',
       type: 'ScreenProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/ScrollView.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/ScrollView.doc.ts
@@ -7,7 +7,7 @@ const generateCodeBlockForComponent = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'ScrollView',
   description:
-    "The `ScrollView` component creates a scrollable container for content that exceeds the available display area. Use it to enable scrolling behavior for long content lists or detailed information that doesn't fit within screen constraints.\n\nThe component creates scrollable containers that automatically adjust to content size with optimized rendering for long lists and large content areas. It supports pull-to-refresh gestures, scroll position tracking, and lazy loading integration, providing smooth scrolling performance even with extensive content on resource-constrained POS hardware.\n\n`ScrollView` components provide scroll position tracking through callbacks, enabling features like back-to-top buttons, infinite scroll, and scroll-based animations that enhance the browsing experience.",
+    "The ScrollView component creates a scrollable container for content that exceeds the available display area. Use it to enable scrolling behavior for long content lists or detailed information that doesn't fit within screen constraints.\n\nThe component creates scrollable containers that automatically adjust to content size with optimized rendering for long lists and large content areas. It supports pull-to-refresh gestures, scroll position tracking, and lazy loading integration, providing smooth scrolling performance even with extensive content on resource-constrained POS hardware.\n\nScrollView components provide scroll position tracking through callbacks, enabling features like back-to-top buttons, infinite scroll, and scroll-based animations that enhance the browsing experience.",
   isVisualComponent: true,
   type: 'component',
   definitions: [],
@@ -31,9 +31,9 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent: `
 - **Organize content for efficient scrolling:** Structure your scrollable content logically with clear visual hierarchy, consistent spacing, and logical grouping. This helps users navigate efficiently through longer content areas.
-- **Consider touch interface optimization:** \`ScrollView\` is optimized for touch-based POS devices, providing smooth scrolling with appropriate momentum and bounce effects. Design your content layout to take advantage of these touch-optimized behaviors.
-- **Combine with other layout components strategically:** Use \`ScrollView\` in combination with other layout components like \`Stack\` or \`Section\` to create well-organized scrollable content areas. \`ScrollView\` handles the scrolling behavior while other components manage content arrangement.
-- **Design for various content types:** \`ScrollView\` supports any valid POS UI extension components as children, allowing for flexible content organization. Use this flexibility to create rich, interactive scrollable experiences.
+- **Consider touch interface optimization:** ScrollView is optimized for touch-based POS devices, providing smooth scrolling with appropriate momentum and bounce effects. Design your content layout to take advantage of these touch-optimized behaviors.
+- **Combine with other layout components strategically:** Use ScrollView in combination with other layout components like Stack or Section to create well-organized scrollable content areas. ScrollView handles the scrolling behavior while other components manage content arrangement.
+- **Design for various content types:** ScrollView supports any valid POS UI extension components as children, allowing for flexible content organization. Use this flexibility to create rich, interactive scrollable experiences.
       `,
     },
     {
@@ -41,7 +41,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`ScrollView\` automatically manage scroll behavior—manual scroll control or custom scroll physics are not available.
+- ScrollView automatically manage scroll behavior—manual scroll control or custom scroll physics are not available.
 - Scroll styling and behavior are controlled by the POS design system—custom scroll bar appearance or scroll interactions beyond the default behavior aren't supported.
 - The component provides basic scrolling functionality without advanced features like pull-to-refresh, infinite scrolling, or scroll position management that would require custom implementation.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/SearchBar.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/SearchBar.doc.ts
@@ -5,14 +5,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'SearchBar',
   description:
-    'The `SearchBar` component provides a specialized input field for search functionality with built-in search button and text change handling. Use it to enable product searches, customer lookups, or other search-driven workflows in POS interfaces.\n\nThe component includes a dedicated search input with built-in search icon, clear button, and cancel functionality following platform-specific search patterns. It provides visual feedback for search states, supports voice input where available, and integrates with platform search behaviors to deliver familiar search experiences on both iOS and Android POS devices.\n\n`SearchBar` components maintain search focus during typing and automatically dismisses the keyboard when search is submitted, streamlining the search workflow and reducing unnecessary interaction steps.',
+    'The SearchBar component provides a specialized input field for search functionality with built-in search button and text change handling. Use it to enable product searches, customer lookups, or other search-driven workflows in POS interfaces.\n\nThe component includes a dedicated search input with built-in search icon, clear button, and cancel functionality following platform-specific search patterns. It provides visual feedback for search states, supports voice input where available, and integrates with platform search behaviors to deliver familiar search experiences on both iOS and Android POS devices.\n\nSearchBar components maintain search focus during typing and automatically dismisses the keyboard when search is submitted, streamlining the search workflow and reducing unnecessary interaction steps.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `SearchBar` component.',
+        'Configure the following properties on the SearchBar component.',
       type: 'SearchBarProps',
     },
   ],
@@ -49,9 +49,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`SearchBar\` provides the input interface but requires integration with the Product Search API or custom search logic for actual search functionality.
+- SearchBar provides the input interface but requires integration with the Product Search API or custom search logic for actual search functionality.
 - The component handles basic text input and search button interactions—advanced search features like filters, sorting controls, or search history require additional components or custom implementation.
-- Search result display and management are not included in the \`SearchBar\` component—use other components like List or custom layouts to present search results to users.
+- Search result display and management are not included in the SearchBar component—use other components like List or custom layouts to present search results to users.
       `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Section.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Section.doc.ts
@@ -7,14 +7,14 @@ const generateCodeBlockForComponent = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Section',
   description:
-    'The `Section` component groups related content into clearly-defined thematic areas. Sections provide visual boundaries and optional actions to organize content within POS interfaces.\n\nUse sections to create structured layouts with clear titles and actionable elements that help users navigate and interact with grouped content.\n\nThe component supports customizable section dividers and spacing between sections, allowing you to create visual rhythm and hierarchy that guides merchants through complex forms and settings interfaces. Sections can be nested to create hierarchical content organization, with each level automatically adjusting its visual styling and semantic meaning to maintain clear structure and relationships throughout complex interfaces.\n\nThe `Section` component no longer has a border as of POS version 10.0.0.',
+    'The Section component groups related content into clearly-defined thematic areas. Sections provide visual boundaries and optional actions to organize content within POS interfaces.\n\nUse sections to create structured layouts with clear titles and actionable elements that help users navigate and interact with grouped content.\n\nThe component supports customizable section dividers and spacing between sections, allowing you to create visual rhythm and hierarchy that guides merchants through complex forms and settings interfaces. Sections can be nested to create hierarchical content organization, with each level automatically adjusting its visual styling and semantic meaning to maintain clear structure and relationships throughout complex interfaces.\n\nThe Section component no longer has a border as of POS version 10.0.0.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Section` component.',
+        'Configure the following properties on the Section component.',
       type: 'SectionProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/SectionHeader.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/SectionHeader.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'SectionHeader',
   description:
-    'The `SectionHeader` component displays a title with an optional action button and divider line. Use it to create consistent section headings with interactive elements that organize content and provide contextual actions.\n\nThe component provides a consistent header layout for section groupings with support for titles, actions, and dividers following POS design specifications. It ensures proper visual hierarchy and spacing within forms and settings interfaces, helping merchants understand content organization and providing quick access to section-level actions.\n\n`SectionHeader` components ensure consistent header styling and spacing across all sections while allowing action button customization, maintaining visual unity while supporting context-specific functionality.',
+    'The SectionHeader component displays a title with an optional action button and divider line. Use it to create consistent section headings with interactive elements that organize content and provide contextual actions.\n\nThe component provides a consistent header layout for section groupings with support for titles, actions, and dividers following POS design specifications. It ensures proper visual hierarchy and spacing within forms and settings interfaces, helping merchants understand content organization and providing quick access to section-level actions.\n\nSectionHeader components ensure consistent header styling and spacing across all sections while allowing action button customization, maintaining visual unity while supporting context-specific functionality.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `SectionHeader` component.',
+        'Configure the following properties on the SectionHeader component.',
       type: 'SectionHeaderProps',
     },
   ],
@@ -44,10 +44,10 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Action buttons require a title to function properly—\`SectionHeader\` can't display actions without an accompanying title.
-- Only one action button is supported per \`SectionHeader\` to maintain clean, focused interfaces that don't overwhelm users.
+- Action buttons require a title to function properly—SectionHeader can't display actions without an accompanying title.
+- Only one action button is supported per SectionHeader to maintain clean, focused interfaces that don't overwhelm users.
 - The component's visual styling and layout are controlled by the POS design system—custom header styling beyond the provided properties is not supported.
-- \`SectionHeader\` is a standalone component separate from \`Section\`—it doesn't automatically integrate with \`Section\` component functionality or provide the same semantic benefits.
+- SectionHeader is a standalone component separate from Section—it doesn't automatically integrate with Section component functionality or provide the same semantic benefits.
       `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/SegmentedControl.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/SegmentedControl.doc.ts
@@ -5,14 +5,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'SegmentedControl',
   description:
-    'The `SegmentedControl` component displays a horizontal row of segments that allow users to switch between different views or filter content. Use it to provide mutually exclusive options with clear visual selection states.\n\nThe component provides mutually exclusive selection within a compact horizontal layout, with visual highlighting of the active segment and smooth transition animations, making it ideal for view switching, filter controls, or any interface requiring clear, space-efficient option selection.\n\n`SegmentedControl` components provide animated transitions between segments that clearly indicate state changes without being distracting, helping merchants confirm their selection while maintaining focus on content.',
+    'The SegmentedControl component displays a horizontal row of segments that allow users to switch between different views or filter content. Use it to provide mutually exclusive options with clear visual selection states.\n\nThe component provides mutually exclusive selection within a compact horizontal layout, with visual highlighting of the active segment and smooth transition animations, making it ideal for view switching, filter controls, or any interface requiring clear, space-efficient option selection.\n\nSegmentedControl components provide animated transitions between segments that clearly indicate state changes without being distracting, helping merchants confirm their selection while maintaining focus on content.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `SegmentedControl` component.',
+        'Configure the following properties on the SegmentedControl component.',
       type: 'SegmentedControlProps',
     },
   ],
@@ -48,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`SegmentedControl\` is designed for mutually exclusive selections—multiple selection scenarios require different components like checkbox lists or choice lists.
+- SegmentedControl is designed for mutually exclusive selections—multiple selection scenarios require different components like checkbox lists or choice lists.
 - The component provides the selection interface but doesn't manage content switching—you must implement the logic to show/hide or update content based on the selected segment.
 - Visual styling and layout are controlled by the POS design system—custom segment styling or layout modifications beyond the provided properties are not supported.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Selectable.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Selectable.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Selectable',
   description:
-    "The `Selectable` component allows you to wrap any non-interactive UI component to make it selectable. Use `Selectable` to add tap interactions to components that don't normally respond to user input while maintaining their original styling.\n\nWrap non-interactive components like `Text`, `Image`, `Icon`, or custom layouts that need tap functionality. Don't wrap components that already have built-in interactions like `Button` or `TextField`. `Selectable` components maintain consistent selection state across re-renders and navigation, ensuring merchants don't lose their choices when moving between screens or interacting with other interface elements.",
+    "The Selectable component allows you to wrap any non-interactive UI component to make it selectable. Use Selectable to add tap interactions to components that don't normally respond to user input while maintaining their original styling.\n\nWrap non-interactive components like Text, Image, Icon, or custom layouts that need tap functionality. Don't wrap components that already have built-in interactions like Button or TextField. Selectable components maintain consistent selection state across re-renders and navigation, ensuring merchants don't lose their choices when moving between screens or interacting with other interface elements.",
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Selectable` component.',
+        'Configure the following properties on the Selectable component.',
       type: 'SelectableProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Spacing.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Spacing.doc.ts
@@ -4,7 +4,7 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Spacing',
   description:
-    "The `Spacing` component provides a set of spacing constants to be used in the POS UI extensions components library. Use these predefined values to maintain consistent spacing and layout patterns across POS interfaces.\n\nThe component provides access to design system spacing tokens through a set of predefined constants, ensuring consistent spacing throughout extensions. It eliminates the need for hardcoded pixel values by offering semantic spacing values that automatically adapt to design system changes, maintaining visual consistency across different screen sizes and orientations.\n\n`Spacing` components provide semantic spacing names like 'tight', 'loose', and 'extraLoose' that map to specific design system values, making spacing choices more intuitive and maintainable.",
+    "The Spacing component provides a set of spacing constants to be used in the POS UI extensions components library. Use these predefined values to maintain consistent spacing and layout patterns across POS interfaces.\n\nThe component provides access to design system spacing tokens through a set of predefined constants, ensuring consistent spacing throughout extensions. It eliminates the need for hardcoded pixel values by offering semantic spacing values that automatically adapt to design system changes, maintaining visual consistency across different screen sizes and orientations.\n\nSpacing components provide semantic spacing names like 'tight', 'loose', and 'extraLoose' that map to specific design system values, making spacing choices more intuitive and maintainable.",
   isVisualComponent: true,
   type: 'component',
   definitions: [
@@ -41,7 +41,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Apply numeric spacing for precise control:** Use the numeric spacing values when you need precise control over spacing amounts, particularly in \`Stack\` components where exact spacing relationships are important for visual hierarchy.
+- **Apply numeric spacing for precise control:** Use the numeric spacing values when you need precise control over spacing amounts, particularly in Stack components where exact spacing relationships are important for visual hierarchy.
 - **Maintain consistent spacing patterns:** Establish consistent patterns for how you use spacing values across your extension. Similar types of content should use similar spacing values, helping users develop familiarity with your interface organization.
 - **Consider touch interface requirements:** Ensure adequate spacing for touch-based interactions by using appropriate spacing values that provide comfortable touch targets. POS interfaces require generous spacing for reliable touch interaction.
 - **Balance spacing with content density:** Choose spacing values that balance content density with readability. Use smaller spacing values for information-dense interfaces and larger values when content needs breathing room.
@@ -54,7 +54,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Limitations',
       sectionContent: `
 - Spacing values are predefined constants—custom spacing values outside the provided scales aren't supported to maintain design system consistency.
-- The \`Spacing\` component is primarily designed for layout components like \`Stack\`—not all components support all spacing types.
+- The Spacing component is primarily designed for layout components like Stack—not all components support all spacing types.
 - Spacing behavior may vary between different POS device screen sizes and resolutions, though the relative relationships between spacing values remain consistent.
       `,
     },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Stack.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Stack.doc.ts
@@ -16,14 +16,14 @@ const generateCodeBlockForStack = (title: string, fileName: string) => {
 const data: ReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
-    'The `Stack` component organizes elements horizontally or vertically along the block or inline axis. Use it to structure layouts, group related components, or control spacing between elements with flexible alignment options.\n\nThe component simplifies layout creation by automatically managing spacing between child elements through gap properties, eliminating the need for manual margin management. It supports both horizontal and vertical arrangements, flexible alignment options, and wrapping behavior, making it the foundation for building consistent, responsive layouts throughout POS extensions.\n\n`Stack` components support responsive gap values that automatically adjust spacing based on screen size, ensuring layouts remain visually balanced and maintain proper element separation across different devices.',
+    'The Stack component organizes elements horizontally or vertically along the block or inline axis. Use it to structure layouts, group related components, or control spacing between elements with flexible alignment options.\n\nThe component simplifies layout creation by automatically managing spacing between child elements through gap properties, eliminating the need for manual margin management. It supports both horizontal and vertical arrangements, flexible alignment options, and wrapping behavior, making it the foundation for building consistent, responsive layouts throughout POS extensions.\n\nStack components support responsive gap values that automatically adjust spacing based on screen size, ensuring layouts remain visually balanced and maintain proper element separation across different devices.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Stack` component.',
+        'Configure the following properties on the Stack component.',
       type: 'StackProps',
     },
   ],
@@ -109,7 +109,7 @@ const data: ReferenceEntityTemplateSchema = {
 - **Apply consistent spacing using numeric values:** Use the predefined numeric spacing values (0.5 through 16) to maintain consistency across your interface. Start with 3 or 4 for standard spacing and adjust up or down based on your content hierarchy needs.
 - **Use semantic padding for consistent layouts:** Apply \`paddingVertical\` and \`paddingHorizontal\` using the semantic spacing values (\`HalfPoint\` through \`ExtraLarge\`) to create consistent padding patterns that align with the POS design system.
 - **Use alignment properties for professional layouts:** Use the \`alignment\` property to control cross-axis positioning. Choose \`'flex-start'\` for natural alignment, \`'center'\` for centered layouts, or distribution values like \`'space-between'\` for evenly distributed content.
-- **Control flex behavior strategically:** Use the \`flex\` property to make \`Stack\` components grow or shrink within their containers, and \`flexChildren\` to stretch child elements to fill available cross-axis space when needed.
+- **Control flex behavior strategically:** Use the \`flex\` property to make Stack components grow or shrink within their containers, and \`flexChildren\` to stretch child elements to fill available cross-axis space when needed.
 - **Manage wrapping behavior appropriately:** Use \`flexWrap\` to control how children behave when they exceed container space. Choose \`'wrap'\` for responsive layouts, \`'nowrap'\` for fixed layouts, or \`'wrap-reverse'\` for specialized arrangements.
       `,
     },
@@ -118,9 +118,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Direction is limited to vertical and horizontal orientations—diagonal or complex arrangements require multiple nested \`Stack\` components or alternative layout approaches.
+- Direction is limited to vertical and horizontal orientations—diagonal or complex arrangements require multiple nested Stack components or alternative layout approaches.
 - Spacing values are predefined numeric constants—custom spacing values outside the provided scale aren't supported to maintain design consistency.
-- Flex behavior follows standard CSS flexbox rules—complex layout requirements may need multiple \`Stack\` components with different configurations for optimal results.
+- Flex behavior follows standard CSS flexbox rules—complex layout requirements may need multiple Stack components with different configurations for optimal results.
       `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Stack.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Stack.doc.ts
@@ -22,8 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the Stack component.',
+      description: 'Configure the following properties on the Stack component.',
       type: 'StackProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Stepper.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Stepper.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Stepper',
   description:
-    'The `Stepper` component provides increment and decrement controls for numeric values with visual feedback. Use it to adjust quantities, counts, or other numeric values with clear visual buttons.\n\nThe component provides visual increment and decrement controls with customizable step values and min/max constraints to control numeric adjustments. It supports both button clicks and keyboard input for flexibility, with visual feedback for boundary conditions and disabled states to prevent invalid value entries during quantity adjustments or numeric configurations.\n\n`Stepper` components provide continuous increment behavior when buttons are held down, enabling rapid value changes while still supporting single-step precision adjustments for fine-tuned control.',
+    'The Stepper component provides increment and decrement controls for numeric values with visual feedback. Use it to adjust quantities, counts, or other numeric values with clear visual buttons.\n\nThe component provides visual increment and decrement controls with customizable step values and min/max constraints to control numeric adjustments. It supports both button clicks and keyboard input for flexibility, with visual feedback for boundary conditions and disabled states to prevent invalid value entries during quantity adjustments or numeric configurations.\n\nStepper components provide continuous increment behavior when buttons are held down, enabling rapid value changes while still supporting single-step precision adjustments for fine-tuned control.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Stepper` component.',
+        'Configure the following properties on the Stepper component.',
       type: 'StepperProps',
     },
   ],
@@ -36,10 +36,10 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent: `
 - **Use initialValue for default starting points:** Set \`initialValue\` to a sensible default that makes sense for your use case, such as 1 for quantities or a typical value for settings.
-- **Let the component manage its own state:** By default, \`Stepper\` manages its own internal state—you only need to respond to \`onValueChanged\` to capture the new value. Avoid using the \`value\` property unless you specifically need to override the internal state for external synchronization.
+- **Let the component manage its own state:** By default, Stepper manages its own internal state—you only need to respond to \`onValueChanged\` to capture the new value. Avoid using the \`value\` property unless you specifically need to override the internal state for external synchronization.
 - **Handle value changes appropriately:** Implement the \`onValueChanged\` callback to capture value changes and update your application state, trigger calculations, or perform related actions based on the new numeric value.
-- **Provide visual context for stepper values:** While \`Stepper\` handles the increment/decrement controls, consider displaying the current value prominently alongside the \`Stepper\` buttons so users can see the exact numeric value, not just the controls.
-- **Design for touch interaction:** \`Stepper\` buttons are optimized for touch interaction on POS devices. Ensure adequate spacing around the \`Stepper\` buttons and consider the overall layout to prevent accidental taps on adjacent controls.
+- **Provide visual context for stepper values:** While Stepper handles the increment/decrement controls, consider displaying the current value prominently alongside the Stepper buttons so users can see the exact numeric value, not just the controls.
+- **Design for touch interaction:** Stepper buttons are optimized for touch interaction on POS devices. Ensure adequate spacing around the Stepper buttons and consider the overall layout to prevent accidental taps on adjacent controls.
       `,
     },
     {
@@ -47,9 +47,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`Stepper\` provides increment/decrement controls only—if users need to enter specific values directly by keyboard, combine \`Stepper\` with a \`NumberField\` component.
+- Stepper provides increment/decrement controls only—if users need to enter specific values directly by keyboard, combine Stepper with a NumberField component.
 - The component manages integer values by default—fractional or decimal increments require using the optional \`value\` property with external state management.
-- \`Stepper\` doesn't include labels or field descriptions—combine with \`Text\` components or other UI elements to provide context about what value is being adjusted.
+- Stepper doesn't include labels or field descriptions—combine with Text components or other UI elements to provide context about what value is being adjusted.
       `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Text.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Text.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Text',
   description:
-    'The `Text` component displays text with specific visual styles and colors. Use it to present content with appropriate typography hierarchy and semantic coloring for different types of information.\n\nText provides a comprehensive typography system that ensures consistent styling and proper visual hierarchy across POS interfaces.\n\n`Text` components ensure proper text rendering across different device types and screen sizes while maintaining readability through appropriate line heights, letter spacing, and color contrast ratios. The component automatically adjusts line length for optimal readability based on container width, preventing overly long lines that reduce reading speed and comprehension in wider layouts.',
+    'The Text component displays text with specific visual styles and colors. Use it to present content with appropriate typography hierarchy and semantic coloring for different types of information.\n\nText provides a comprehensive typography system that ensures consistent styling and proper visual hierarchy across POS interfaces.\n\nText components ensure proper text rendering across different device types and screen sizes while maintaining readability through appropriate line heights, letter spacing, and color contrast ratios. The component automatically adjusts line length for optimal readability based on container width, preventing overly long lines that reduce reading speed and comprehension in wider layouts.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Text` component.',
+        'Configure the following properties on the Text component.',
       type: 'TextProps',
     },
   ],
@@ -48,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - Text content is provided through child components rather than direct text properties—organize your text content through component composition.
 - Typography and color options are limited to the predefined design system variants—custom fonts, sizes, or colors beyond the available options aren't supported.
-- Complex rich text formatting requires multiple \`Text\` components with different variants and colors rather than inline formatting options.
+- Complex rich text formatting requires multiple Text components with different variants and colors rather than inline formatting options.
       `,
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Text.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Text.doc.ts
@@ -10,8 +10,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the Text component.',
+      description: 'Configure the following properties on the Text component.',
       type: 'TextProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/TextArea.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/TextArea.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextArea',
   description:
-    'The `TextArea` component captures longer text content with a multi-line, resizable text input area. Use it to collect descriptions, notes, comments, or other extended text input in forms and data entry workflows.\n\nThe component provides a multi-line text input area that accommodates longer content. It supports validation and multi-line formatting, making it ideal for capturing detailed information such as order notes, product descriptions, or customer feedback that requires more than single-line input.',
+    'The TextArea component captures longer text content with a multi-line, resizable text input area. Use it to collect descriptions, notes, comments, or other extended text input in forms and data entry workflows.\n\nThe component provides a multi-line text input area that accommodates longer content. It supports validation and multi-line formatting, making it ideal for capturing detailed information such as order notes, product descriptions, or customer feedback that requires more than single-line input.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `TextArea` component.',
+        'Configure the following properties on the TextArea component.',
       type: 'TextAreaProps',
     },
   ],
@@ -48,7 +48,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`TextArea\` has a maximum of 8 visible rows—content requiring more vertical space should use scrolling within the text area or alternative layouts with \`ScrollView\` components.
+- TextArea has a maximum of 8 visible rows—content requiring more vertical space should use scrolling within the text area or alternative layouts with ScrollView components.
 - The component provides multi-line text input but doesn't include rich text formatting capabilities—complex formatting like bold, italic, or lists requires alternative solutions or plain text representations.
 - The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display or validation, so you must implement validation logic manually.
 - Action buttons are limited to simple press callbacks—complex action workflows require custom implementation or additional components.

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/TextField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/TextField.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TextField',
   description:
-    'The `TextField` component captures single-line text input. Use it to collect short, free-form information in forms and data entry workflows.\n\nThe component supports various input configurations including placeholders, character limits, and validation. It includes built-in support for labels, helper text, and error states to guide merchants through data entry, ensuring accurate and efficient information capture across different retail scenarios.',
+    'The TextField component captures single-line text input. Use it to collect short, free-form information in forms and data entry workflows.\n\nThe component supports various input configurations including placeholders, character limits, and validation. It includes built-in support for labels, helper text, and error states to guide merchants through data entry, ensuring accurate and efficient information capture across different retail scenarios.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `TextField` component.',
+        'Configure the following properties on the TextField component.',
       type: 'NewTextFieldProps',
     },
   ],
@@ -49,7 +49,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`TextField\` provides single-line text input only—multi-line text entry requires the \`TextArea\` component.
+- TextField provides single-line text input only—multi-line text entry requires the TextArea component.
 - The \`required\` property adds semantic meaning only—it doesn't trigger automatic error display or validation, so you must implement validation logic manually.
 - Action buttons are limited to simple press callbacks—complex action workflows require custom implementation or additional components.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Tile.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Tile.doc.ts
@@ -7,14 +7,14 @@ const generateCodeBlockForTile = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'Tile',
   description:
-    'The `Tile` component displays interactive buttons for the POS smart grid that allow merchants to complete actions quickly. Tiles serve as customizable shortcuts that provide contextual information and enable merchants to quickly access workflows, actions, and information from the smart grid.\n\nTiles are dynamic components that can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They support tap interactions, visual feedback, and can display contextual information through titles, subtitles, and badge values.',
+    'The Tile component displays interactive buttons for the POS smart grid that allow merchants to complete actions quickly. Tiles serve as customizable shortcuts that provide contextual information and enable merchants to quickly access workflows, actions, and information from the smart grid.\n\nTiles are dynamic components that can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They support tap interactions, visual feedback, and can display contextual information through titles, subtitles, and badge values.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `Tile` component.',
+        'Configure the following properties on the Tile component.',
       type: 'TileProps',
     },
   ],
@@ -48,11 +48,11 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- Each POS UI extension can only render one \`Tile\` component.
+- Each POS UI extension can only render one Tile component.
 - Badge values must be numeric-string or text badges aren't supported.
 - Custom icons, images, or visual styling beyond built-in properties aren't supported.
 - Tile size and layout is determined by the smart grid and can't be customized.
-- The \`Tile\` component is limited to tap interactions only. There's no support for long press, swipe, or other gestures.
+- The Tile component is limited to tap interactions only. There's no support for long press, swipe, or other gestures.
 - Title and subtitle text must be plain strings-no HTML, markdown, or rich text formatting.
       `,
     },

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Tile.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/Tile.doc.ts
@@ -13,8 +13,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description:
-        'Configure the following properties on the Tile component.',
+      description: 'Configure the following properties on the Tile component.',
       type: 'TileProps',
     },
   ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/TimeField.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/TimeField.doc.ts
@@ -4,14 +4,14 @@ import {generateCodeBlock} from '../helpers/generateCodeBlock';
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimeField',
   description:
-    'The `TimeField` component captures time input from merchants with a consistent interface for time selection and proper validation. Use it to collect time information in scheduling, booking, or data entry workflows.\n\nThe component supports both 12-hour and 24-hour time formats based on locale settings, with built-in validation to ensure valid time entries. It includes features like time picker integration, keyboard shortcuts, and formatted display to streamline time entry for scheduling, appointment booking, and time-sensitive operations in retail environments.\n\n`TimeField` components respects merchant locale settings for default time format preferences while allowing manual override for specific use cases that require alternative formats.',
+    'The TimeField component captures time input from merchants with a consistent interface for time selection and proper validation. Use it to collect time information in scheduling, booking, or data entry workflows.\n\nThe component supports both 12-hour and 24-hour time formats based on locale settings, with built-in validation to ensure valid time entries. It includes features like time picker integration, keyboard shortcuts, and formatted display to streamline time entry for scheduling, appointment booking, and time-sensitive operations in retail environments.\n\nTimeField components respects merchant locale settings for default time format preferences while allowing manual override for specific use cases that require alternative formats.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `TimeField` component.',
+        'Configure the following properties on the TimeField component.',
       type: 'TimeFieldProps',
     },
   ],
@@ -39,7 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
 - **Offer helpful guidance with helpText:** Use the \`helpText\` property to explain time constraints, business hours, or format expectations. For example, "Business hours only (9 AM - 5 PM)" or "Must be a future time."
 - **Implement proper time validation:** Use the \`error\` property to display validation messages when users enter invalid times or times outside acceptable ranges. Provide clear, actionable error messages that help users correct their input.
 - **Add action buttons for time operations:** Use the \`action\` property to provide helpful actions like "Set to Now," "Clear Time," or "Use Business Hours." This enhances usability by providing quick access to common time operations.
-- **Handle focus events for time picker coordination:** Use \`onFocus\` and \`onBlur\` callbacks to coordinate with \`TimePicker\` components or other time selection interfaces. This is useful for showing/hiding time pickers or managing related form fields.
+- **Handle focus events for time picker coordination:** Use \`onFocus\` and \`onBlur\` callbacks to coordinate with TimePicker components or other time selection interfaces. This is useful for showing/hiding time pickers or managing related form fields.
       `,
     },
     {
@@ -47,7 +47,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`TimeField\` provides text-based time input—for visual time selection with clock or spinner interfaces, use the \`TimePicker\` component which offers interactive time selection.
+- TimeField provides text-based time input—for visual time selection with clock or spinner interfaces, use the TimePicker component which offers interactive time selection.
 - The \`is24Hour\` property only affects Android devices—other platforms may use their system-level time format preferences regardless of this setting.
 - Action buttons are limited to simple press callbacks—complex action workflows require custom implementation or additional components.
       `,

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/TimePicker.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/TimePicker.doc.ts
@@ -8,14 +8,14 @@ const generateCodeBlockForTimePicker = (title: string, fileName: string) =>
 const data: ReferenceEntityTemplateSchema = {
   name: 'TimePicker',
   description:
-    'The `TimePicker` component allows merchants to select a specific time using an interactive picker interface. Use it to provide visual time selection for improved user experience and reduced input errors.\n\n`TimePicker` offers a more visual and touch-friendly alternative to text-based time input, making time selection faster and more accurate. The picker interface provides an intuitive way to select hours and minutes through an interactive interface.',
+    'The TimePicker component allows merchants to select a specific time using an interactive picker interface. Use it to provide visual time selection for improved user experience and reduced input errors.\n\nTimePicker offers a more visual and touch-friendly alternative to text-based time input, making time selection faster and more accurate. The picker interface provides an intuitive way to select hours and minutes through an interactive interface.',
   isVisualComponent: true,
   type: 'component',
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the `TimePicker` component.',
+        'Configure the following properties on the TimePicker component.',
       type: 'TimePickerProps',
     },
   ],
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-- \`TimePicker\` requires external visibility state management through the \`visibleState\` tuple—automatic show/hide behavior based on field focus is not built-in.
+- TimePicker requires external visibility state management through the \`visibleState\` tuple—automatic show/hide behavior based on field focus is not built-in.
 - The \`inputMode\` property has platform limitations—iOS only supports spinner mode regardless of the \`inputMode\` setting, which may affect cross-platform consistency.
 - The \`is24Hour\` property only affects Android devices—iOS and other platforms use their system-level time format preferences regardless of this setting.
 - The component provides time selection but doesn't include field labels, help text, or error messaging—combine with other UI elements or text components to provide complete form field experiences.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/List/List.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/List/List.ts
@@ -86,7 +86,7 @@ export interface ListRowRightSide {
 }
 
 /**
- * Defines the structure and content options for individual rows within the `List` component.
+ * Defines the structure and content options for individual rows within the List component.
  */
 export interface ListRow {
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Navigator/Navigator.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Navigator/Navigator.ts
@@ -2,7 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export interface NavigatorProps {
   /**
-   * The name of the initial `Screen` component to display when the Navigator is first rendered. Must match the `name` property of a child `Screen` component.
+   * The name of the initial Screen component to display when the Navigator is first rendered. Must match the `name` property of a child Screen component.
    */
   initialScreenName?: string;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlock.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlock.ts
@@ -2,7 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export interface POSBlockProps {
   /**
-   * An optional action button configuration to be displayed on the `POSBlock`.
+   * An optional action button configuration to be displayed on the POSBlock.
    */
   action?: {
     /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
@@ -6,7 +6,7 @@ export interface SectionHeaderProps {
    */
   title: string;
   /**
-   * An optional action button configuration to be displayed alongside the title. The `SectionHeader` must have a title for the action to work properly.
+   * An optional action button configuration to be displayed alongside the title. The SectionHeader must have a title for the action to work properly.
    */
   action?: {
     /**
@@ -23,7 +23,7 @@ export interface SectionHeaderProps {
     disabled?: boolean;
   };
   /**
-   * Whether the divider line under the `SectionHeader` should be hidden.
+   * Whether the divider line under the SectionHeader should be hidden.
    */
   hideDivider?: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SegmentedControl/SegmentedControl.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SegmentedControl/SegmentedControl.ts
@@ -1,6 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 /**
- * Defines the structure and configuration options for individual segments within the `SegmentedControl` component.
+ * Defines the structure and configuration options for individual segments within the SegmentedControl component.
  */
 export interface Segment {
   /**


### PR DESCRIPTION
## Context

We've decided to remove the code syntax from component names in the docs. The code syntax on the business name (for example `Button`) makes it easy to think that `Button` is actual code.

## This PR: 
- Removes the code syntax syntax on all POS components for version 2024-10
