### PR TITLE
[POC] Add PrintOptions destination to Print API

### DIFF
--- a/.changeset/print-options-destination.md
+++ b/.changeset/print-options-destination.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add PrintOptions with destination parameter to Print API for receipt printer support

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/print-api.doc.ts
@@ -22,6 +22,17 @@ const data: ReferenceEntityTemplateSchema = {
         'The `PrintApi` object provides properties for triggering document printing. Access these properties through `shopify.print` to initiate print operations with various document types.',
       type: 'PrintApiContent',
     },
+    {
+      title: 'PrintOptions',
+      description:
+        'Options for configuring print behavior, such as selecting the print destination.',
+      type: 'PrintOptions',
+    },
+    {
+      title: 'PrintDestination',
+      description: 'The target destination for printing.',
+      type: 'PrintDestination',
+    },
   ],
   category: 'Target APIs',
   subCategory: 'Platform APIs',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -49,7 +49,12 @@ export type {
   DraftOrderApiContent,
 } from './api/draft-order-api/draft-order-api';
 
-export type {PrintApi, PrintApiContent} from './api/print-api/print-api';
+export type {
+  PrintApi,
+  PrintApiContent,
+  PrintOptions,
+  PrintDestination,
+} from './api/print-api/print-api';
 
 export type {
   PaginationParams,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/print-api/print-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/print-api/print-api.ts
@@ -1,3 +1,25 @@
+/** The target destination for printing. */
+export type PrintDestination = 'system' | 'receipt';
+
+/**
+ * Options for configuring print behavior.
+ * @example
+ * // Print to system dialog (default)
+ * shopify.print.print('https://example.com/invoice');
+ *
+ * // Print to receipt printer (POS only, requires API version 2026-04+)
+ * shopify.print.print('https://example.com/receipt', { destination: 'receipt' });
+ */
+export interface PrintOptions {
+  /**
+   * The print destination.
+   * - `'system'` opens the OS print dialog (default, works on all surfaces)
+   * - `'receipt'` sends HTML content to the connected receipt printer (POS only, requires API version 2026-04+)
+   * @defaultValue 'system'
+   */
+  destination?: PrintDestination;
+}
+
 /**
  * The `PrintApi` object provides methods for triggering document printing. Access these methods through `shopify.print` to initiate print operations with various document types.
  */
@@ -12,9 +34,10 @@ export interface PrintApiContent {
    * Returns a promise that resolves when content is ready and the native print dialog appears. Use for printing custom documents, receipts, labels, or reports.
    *
    * @param src the source URL of the content to print.
+   * @param options optional configuration for print behavior, such as selecting the print destination.
    * @returns Promise<void> that resolves when content is ready and native print dialog appears.
    */
-  print(src: string): Promise<void>;
+  print(src: string, options?: PrintOptions): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `PrintDestination` type (`'system' | 'receipt'`) and `PrintOptions` interface to the Print API
- Update `PrintApiContent.print()` method signature to accept an optional `PrintOptions` second parameter: `print(src: string, options?: PrintOptions): Promise<void>`
- Export new types from the POS surface barrel file (`api.ts`)
- Update `print-api.doc.ts` to include `PrintOptions` and `PrintDestination` in the generated documentation definitions

## Why
Extensions currently cannot print to the physical receipt printer connected to a POS device. This adds a `destination` option to the existing Print API so extensions can choose between the system print dialog (default) and the receipt printer.

The design follows the Web API alignment pattern (`Window.print()` extended with an options-bag, like `fetch(url, options)`), making the change backward-compatible — the second parameter is optional and defaults to `'system'` behavior.

## Type Changes

```typescript
/** The target destination for printing. */
export type PrintDestination = 'system' | 'receipt';

export interface PrintOptions {
  /** @defaultValue 'system' */
  destination?: PrintDestination;
}

export interface PrintApiContent {
  print(src: string, options?: PrintOptions): Promise<void>;
}
```

## Test plan
- [ ] TypeScript compiles cleanly (`tsc --project packages/ui-extensions/tsconfig.json` passes)
- [ ] Verify generated docs include PrintOptions and PrintDestination types
- [ ] Backward-compatible: existing `print(src)` calls without options continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)