### PR TITLE
[2026-04-rc]: Transition POS component names from Pascal case to sentence case

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/pin-pad-api.ts
@@ -4,7 +4,7 @@ export interface PinPadApiContent {
   /**
    * Shows a PIN pad to the user in a modal dialog. The `onSubmit` function is called when the PIN is submitted and should validate the PIN, returning `'accept'` or `'reject'`.
    *
-   * • **When accepted**: Modal dismisses and triggers the `onDismissed` callback—perform any post-validation navigation in this callback rather than in `onSubmit`.
+   * • **When accepted**: The modal dismisses and triggers the `onDismissed` callback—perform any post-validation navigation in this callback rather than in `onSubmit`.
    *
    * • **When rejected**: Displays the optional `errorMessage` and keeps the modal open.
    *

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
@@ -725,11 +725,11 @@ export type AnyString = string & {};
 export type optionalSpace = '' | ' ';
 export interface BadgeProps extends GlobalProps {
   /**
-   * The content of the Badge.
+   * The content of the badge.
    */
   children?: ComponentChildren;
   /**
-   * Sets the tone of the Badge, based on the intention of the information being conveyed.
+   * Sets the tone of the badge, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
@@ -765,11 +765,11 @@ export interface BannerProps extends GlobalProps, ActionSlots {
    */
   heading?: string;
   /**
-   * The content of the Banner.
+   * The content of the banner.
    */
   children?: ComponentChildren;
   /**
-   * Sets the tone of the Banner, based on the intention of the information being conveyed.
+   * Sets the tone of the banner, based on the intention of the information being conveyed.
    *
    * The banner is a live region and the type of status will be dictated by the Tone selected.
    *
@@ -881,7 +881,7 @@ export type AccessibilityRole =
   | 'footer'
   /**
    * Used to indicate a generic section.
-   * Sections should always have a Heading or an accessible name provided in the `accessibilityLabel` property.
+   * Sections should always have a heading or an accessible name provided in the `accessibilityLabel` property.
    *
    * In an HTML host `section` will render a `<section>` element.
    * Learn more about the [`<section>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) in the MDN web docs.
@@ -1252,7 +1252,7 @@ export interface BaseBoxProps
     BorderProps,
     OverflowProps {
   /**
-   * The content of the Box.
+   * The content of the box.
    */
   children?: ComponentChildren;
   /**
@@ -1268,7 +1268,7 @@ export interface BaseBoxPropsWithRole
     AccessibilityRoleProps {}
 export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
   /**
-   * The behavior of the Button.
+   * The behavior of the button.
    *
    * - `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.
    * - `button`: Used to indicate the component acts as a button, meaning it has no default action.
@@ -1280,14 +1280,14 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
    */
   type?: 'submit' | 'button' | 'reset';
   /**
-   * Callback when the Button is activated.
+   * Callback when the button is activated.
    * This will be called before the action indicated by `type`.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event
    */
   onClick?: (event: Event) => void;
   /**
-   * Disables the Button meaning it cannot be clicked or receive focus.
+   * Disables the button meaning it cannot be clicked or receive focus.
    *
    * @default false
    */
@@ -1295,7 +1295,7 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
   /**
    * Replaces content with a loading indicator while a background action is being performed.
    *
-   * This also disables the Button.
+   * This also disables the button.
    *
    * @default false
    */
@@ -1372,24 +1372,24 @@ export interface BaseClickableProps
     LinkBehaviorProps {}
 export interface ButtonProps extends GlobalProps, BaseClickableProps {
   /**
-   * A label that describes the purpose or contents of the Button. It will be read to users using assistive technologies such as screen readers.
+   * A label that describes the purpose or contents of the button. It will be read to users using assistive technologies such as screen readers.
    *
-   * Use this when using only an icon or the Button text is not enough context
+   * Use this when using only an icon or the button text is not enough context
    * for users using assistive technologies.
    */
   accessibilityLabel?: string;
   /**
-   * The content of the Button.
+   * The content of the button.
    */
   children?: ComponentChildren;
   /**
-   * The type of icon to be displayed in the Button.
+   * The type of icon to be displayed in the button.
    *
    * @default ''
    */
   icon?: IconType | AnyString;
   /**
-   * The displayed inline width of the Button.
+   * The displayed inline width of the button.
    *
    * - `auto`: the size of the button depends on the surface and context.
    * - `fill`: the button will takes up 100% of the available inline size.
@@ -1399,13 +1399,13 @@ export interface ButtonProps extends GlobalProps, BaseClickableProps {
    */
   inlineSize?: 'auto' | 'fill' | 'fit-content';
   /**
-   * Changes the visual appearance of the Button.
+   * Changes the visual appearance of the button.
    *
-   * @default 'auto' - the variant is automatically determined by the Button's context
+   * @default 'auto' - the variant is automatically determined by the button's context
    */
   variant?: 'auto' | 'primary' | 'secondary' | 'tertiary';
   /**
-   * Sets the tone of the Button based on the intention of the information being conveyed.
+   * Sets the tone of the button based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
@@ -1745,7 +1745,7 @@ export interface ChoiceListProps
   /**
    * The choices a user can select from.
    *
-   * Accepts Choice components.
+   * Accepts choice components.
    */
   children?: ComponentChildren;
   /**
@@ -2251,7 +2251,7 @@ export interface EmbedProps extends GlobalProps, SizingProps {
    */
   src?: string;
   /**
-   * A label that describes the purpose or contents of the Embed. It will be read to users
+   * A label that describes the purpose or contents of the embed. It will be read to users
    * using assistive technologies such as screen readers.
    *
    * @implementation for web-based implementations, this should map to the [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/title) attribute
@@ -2260,15 +2260,15 @@ export interface EmbedProps extends GlobalProps, SizingProps {
 }
 export interface EmptyStateProps extends GlobalProps, ActionSlots {
   /**
-   * The heading of the EmptyState.
+   * The heading of the empty state.
    */
   heading?: string;
   /**
-   * The subheading of the EmptyState.
+   * The subheading of the empty state.
    */
   subheading?: ComponentChildren | StringChildren;
   /**
-   * The graphic to display in the EmptyState. The only supported components are Image and Icon.
+   * The graphic to display in the empty state. The only supported components are Image and Icon.
    */
   graphic?: ComponentChildren;
 }
@@ -2402,7 +2402,7 @@ export interface HeadingProps
     AccessibilityVisibilityProps,
     BlockTypographyProps {
   /**
-   * The content of the Heading.
+   * The content of the heading.
    */
   children?: ComponentChildren;
   /**
@@ -2571,17 +2571,17 @@ export interface ImageProps extends GlobalProps, BaseImageProps, BorderProps {
 }
 export interface LinkProps extends GlobalProps, LinkBehaviorProps {
   /**
-   * The content of the Link.
+   * The content of the link.
    */
   children?: ComponentChildren;
   /**
-   * Sets the tone of the Link, based on the intention of the information being conveyed.
+   * Sets the tone of the link, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * A label that describes the purpose or contents of the Link. It will be read to users using assistive technologies such as screen readers.
+   * A label that describes the purpose or contents of the link. It will be read to users using assistive technologies such as screen readers.
    *
    * Use this when using only an icon or the content of the link is not enough context
    * for users using assistive technologies.
@@ -2608,32 +2608,32 @@ export interface ModalProps
    */
   accessibilityLabel?: string;
   /**
-   * A title that describes the content of the Modal.
+   * A title that describes the content of the modal.
    *
    */
   heading?: string;
   /**
-   * Adjust the padding around the Modal content.
+   * Adjust the padding around the modal content.
    *
    * `base`: applies padding that is appropriate for the element.
    *
-   * `none`: removes all padding from the element. This can be useful when elements inside the Modal need to span
-   * to the edge of the Modal. For example, a full-width image. In this case, rely on Box with a padding of 'base'
+   * `none`: removes all padding from the element. This can be useful when elements inside the modal need to span
+   * to the edge of the modal. For example, a full-width image. In this case, rely on Box with a padding of 'base'
    * to bring back the desired padding for the rest of the content.
    *
    * @default 'base'
    */
   padding?: 'base' | 'none';
   /**
-   * Adjust the size of the Modal.
+   * Adjust the size of the modal.
    *
-   * `max`: expands the Modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
+   * `max`: expands the modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
    *
    * @default 'base'
    */
   size?: SizeKeyword | 'max';
   /**
-   * The content of the Modal.
+   * The content of the modal.
    */
   children?: ComponentChildren;
 }
@@ -2672,7 +2672,7 @@ export type NumberAutocompleteField = ExtractStrict<
 >;
 export interface PageProps extends GlobalProps, ActionSlots {
   /**
-   * The content of the Page.
+   * The content of the page.
    */
   children?: ComponentChildren;
   /**
@@ -2838,14 +2838,14 @@ export interface SearchFieldProps
 export type SearchAutocompleteField = TextAutocompleteField;
 export interface SectionProps extends GlobalProps, ActionSlots {
   /**
-   * The content of the Section.
+   * The content of the section.
    */
   children?: ComponentChildren;
   /**
    * A label used to describe the section that will be announced by assistive technologies.
    *
-   * When no `heading` property is provided or included as a children of the Section, you **must** provide an
-   * `accessibilityLabel` to describe the Section. This is important as it allows assistive technologies to provide
+   * When no `heading` property is provided or included as a children of the section, you **must** provide an
+   * `accessibilityLabel` to describe the section. This is important as it allows assistive technologies to provide
    * the right context to users.
    */
   accessibilityLabel?: string;
@@ -2858,8 +2858,8 @@ export interface SectionProps extends GlobalProps, ActionSlots {
    *
    * - `base`: applies padding that is appropriate for the element. Note that it may result in no padding if
    * this is the right design decision in a particular context.
-   * - `none`: removes all padding from the element. This can be useful when elements inside the Section need to span
-   * to the edge of the Section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base'
+   * - `none`: removes all padding from the element. This can be useful when elements inside the section need to span
+   * to the edge of the section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base'
    * to bring back the desired padding for the rest of the content.
    *
    * @default 'base'
@@ -2887,11 +2887,11 @@ export interface StackProps
     BaseBoxPropsWithRole,
     GapProps {
   /**
-   * The content of the Stack.
+   * The content of the stack.
    */
   children?: ComponentChildren;
   /**
-   * Sets how the children are placed within the Stack. This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
+   * Sets how the children are placed within the stack. This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
    *
    * @default 'block'
    *
@@ -2899,21 +2899,21 @@ export interface StackProps
    */
   direction?: MaybeResponsive<'block' | 'inline'>;
   /**
-   * Aligns the Stack along the main axis.
+   * Aligns the stack along the main axis.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
    * @default 'normal'
    */
   justifyContent?: MaybeResponsive<JustifyContentKeyword>;
   /**
-   * Aligns the Stack's children along the cross axis.
+   * Aligns the stack's children along the cross axis.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
    * @default 'normal'
    */
   alignItems?: MaybeResponsive<AlignItemsKeyword>;
   /**
-   * Aligns the Stack along the cross axis.
+   * Aligns the stack along the cross axis.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
    * @default 'normal'
@@ -2928,7 +2928,7 @@ export interface SwitchProps
     FieldErrorProps {}
 export interface TabProps extends GlobalProps {
   /**
-   * Corresponds to the `id` property of the TabPanel component that will be displayed when selected
+   * Corresponds to the `id` property of the tab panel component that will be displayed when selected
    */
   controls?: string;
   /**
@@ -2952,18 +2952,18 @@ export interface TabProps extends GlobalProps {
 }
 export interface TabListProps extends GlobalProps {
   /**
-   * Accepts only Tabs components.
+   * Accepts only tabs components.
    */
   children?: ComponentChildren;
 }
 export interface TabPanelProps extends GlobalProps {
   /**
-   * The id of the TabPanel used for identification in the Tabs component.
-   * Must match the `controls` prop of the corresponding Tab component.
+   * The id of the tab panel used for identification in the tabs component.
+   * Must match the `controls` prop of the corresponding tab component.
    */
   id?: string;
   /**
-   * The content of the TabPanel.
+   * The content of the tab panel.
    */
   children?: ComponentChildren;
 }
@@ -2976,20 +2976,20 @@ export interface TabsProps
    */
   accessibilityLabel?: string;
   /**
-   * Accepts only TabList and TabPanel components.
+   * Accepts only tab list and tab panel components.
    */
   children?: ComponentChildren;
   /**
    * The value of the selected tab.
    *
-   * This should match the `id` prop of one of the TabPanel components.
+   * This should match the `id` prop of one of the tab panel components.
    * If not provided, the first tab will be selected by default.
    */
   value?: string;
   /**
    * The default value of the selected tab.
    *
-   * This should match the `id` prop of one of the TabPanel components.
+   * This should match the `id` prop of one of the tab panel components.
    * If not provided, the first tab will be selected by default.
    *
    * Reflects to the `value` attribute
@@ -3129,7 +3129,7 @@ export interface TileProps
   extends GlobalProps,
     Pick<BaseClickableProps, 'onClick' | 'disabled'> {
   /**
-   * A title that describes the content of the Tile.
+   * A title that describes the content of the tile.
    *
    * @default ''
    */
@@ -3141,7 +3141,7 @@ export interface TileProps
    */
   subheading?: string;
   /**
-   * A numeric indicator rendered within the Tile (for example, a count or a step number).
+   * A numeric indicator rendered within the tile (for example, a count or a step number).
    *
    * - When provided, the indicator is displayed inside the tile.
    * - Intended for small integers. It may clamp, truncate, or abbreviate larger values.
@@ -3149,7 +3149,7 @@ export interface TileProps
    */
   itemCount?: number;
   /**
-   * Sets the tone of the Tile, based on the intention of the information being conveyed.
+   * Sets the tone of the tile, based on the intention of the information being conveyed.
    * @default 'auto'
    */
   tone?: ExtractStrict<ToneKeyword, 'auto' | 'neutral' | 'accent'>;
@@ -3490,7 +3490,7 @@ interface CallbackEvent<T extends keyof HTMLElementTagNameMap> {
 declare const tagName$E = 's-badge';
 interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
   /**
-   * Sets the tone of the Badge, based on the intention of the information being conveyed.
+   * Sets the tone of the badge, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
@@ -3499,7 +3499,7 @@ interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
     'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'critical' | 'caution'
   >;
   /**
-   * The content of the Badge.
+   * The content of the badge.
    */
   children?: ComponentChildren;
 }
@@ -3525,7 +3525,7 @@ interface BannerJSXProps extends Pick<BannerProps, 'heading' | 'id'> {
    */
   hidden?: BannerProps['hidden'];
   /**
-   * Sets the tone of the Banner, based on the intention of the information being conveyed.
+   * Sets the tone of the banner, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
@@ -3534,11 +3534,11 @@ interface BannerJSXProps extends Pick<BannerProps, 'heading' | 'id'> {
     'auto' | 'success' | 'info' | 'warning' | 'critical'
   >;
   /**
-   * The action taken when the Banner is pressed.
+   * The action taken when the banner is pressed.
    */
   primaryAction?: ComponentChild;
   /**
-   * The content of the Banner.
+   * The content of the banner.
    */
   children?: ComponentChildren;
 }
@@ -3673,7 +3673,7 @@ interface BoxJSXProps {
    */
   paddingInlineEnd?: PaddingKeyword$2 | '';
   /**
-   * The content of the Box.
+   * The content of the box.
    */
   children?: ComponentChildren;
 }
@@ -3715,7 +3715,7 @@ interface ButtonJSXProps
     '--auto' | '--show' | '--hide' | '--toggle'
   >;
   /**
-   * Sets the tone of the Button, based on the intention of the information being conveyed.
+   * Sets the tone of the button, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
@@ -3724,9 +3724,9 @@ interface ButtonJSXProps
     'auto' | 'critical' | 'neutral' | 'warning' | 'caution'
   >;
   /**
-   * Changes the visual appearance of the Button.
+   * Changes the visual appearance of the button.
    *
-   * @default 'auto' - the variant is automatically determined by the Button's context
+   * @default 'auto' - the variant is automatically determined by the button's context
    */
   variant?: Extract<ButtonProps['variant'], 'primary' | 'secondary'>;
   /**
@@ -3734,7 +3734,7 @@ interface ButtonJSXProps
    */
   onClick?: (event: CallbackEvent<typeof tagName$B>) => void;
   /**
-   * The content of the Button.
+   * The content of the button.
    */
   children?: ComponentChildren;
 }
@@ -3781,7 +3781,7 @@ interface ChoiceListJSXProps
    */
   onChange?: ((event: CallbackEvent<typeof tagName$z>) => void) | null;
   /**
-   * The content of the ChoiceList. Should be one or more Choice elements.
+   * The content of the choice list. Should be one or more choice elements.
    */
   children?: ComponentChildren;
 }
@@ -3805,7 +3805,7 @@ interface ClickableJSXProps extends Pick<ClickableProps, 'id' | 'disabled'> {
    */
   onClick?: (event: CallbackEvent<typeof tagName$y>) => void;
   /**
-   * The content of the Clickable.
+   * The content of the clickable.
    */
   children?: ComponentChildren;
 }
@@ -3990,7 +3990,7 @@ declare module 'preact' {
 declare const tagName$s = 's-heading';
 interface HeadingJSXProps extends Pick<HeadingProps, 'id'> {
   /**
-   * The content of the Heading.
+   * The content of the heading.
    */
   children?: ComponentChildren;
 }
@@ -4220,7 +4220,7 @@ interface ModalJSXProps extends Pick<ModalProps, 'id' | 'heading'> {
    */
   secondaryActions?: ComponentChild;
   /**
-   * The content of the Modal.
+   * The content of the modal.
    */
   children?: ComponentChildren;
 }
@@ -4372,7 +4372,7 @@ interface PageJSXProps extends Pick<PageProps, 'id'> {
    */
   aside?: ComponentChild;
   /**
-   * The content of the Page.
+   * The content of the page.
    */
   children?: ComponentChildren;
 }
@@ -4543,7 +4543,7 @@ interface ScrollBoxJSXProps extends Pick<ScrollBoxProps, 'id'> {
    */
   paddingInlineEnd?: PaddingKeyword$1 | '';
   /**
-   * The content of the ScrollBox.
+   * The content of the scroll box.
    */
   children?: ComponentChildren;
 }
@@ -4606,7 +4606,7 @@ interface SectionJSXProps extends Pick<SectionProps, 'id'> {
    */
   secondaryActions?: ComponentChild;
   /**
-   * The content of the Section.
+   * The content of the section.
    */
   children?: ComponentChildren;
 }
@@ -4763,11 +4763,11 @@ interface StackJSXProps extends PickedProps {
    */
   minInlineSize?: SizeUnits;
   /**
-   * Aligns the Stack's children along the cross axis.
+   * Aligns the stack's children along the cross axis.
    */
   alignItems?: AlignItemsKeyword;
   /**
-   * Aligns the Stack along the cross axis.
+   * Aligns the stack along the cross axis.
    */
   alignContent?: AlignContentKeyword;
   /**
@@ -4784,7 +4784,7 @@ interface StackJSXProps extends PickedProps {
    */
   columnGap?: SpacingKeyword | '';
   /**
-   * Sets how the children are placed within the Stack. This uses logical properties.
+   * Sets how the children are placed within the stack. This uses logical properties.
    *
    * @default 'block'
    * @implementation - the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'
@@ -4798,7 +4798,7 @@ interface StackJSXProps extends PickedProps {
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Aligns the Stack along the main axis.
+   * Aligns the stack along the main axis.
    * @see — https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
    *
    * @default 'normal'
@@ -4811,7 +4811,7 @@ interface StackJSXProps extends PickedProps {
    */
   rowGap?: SpacingKeyword | '';
   /**
-   * The content of the Stack.
+   * The content of the stack.
    */
   children?: ComponentChildren;
 }
@@ -4977,13 +4977,13 @@ interface TileJSXProps
     'heading' | 'id' | 'itemCount' | 'tone' | 'subheading'
   > {
   /**
-   * Disables the Tile meaning it cannot be clicked or receive focus.
+   * Disables the tile meaning it cannot be clicked or receive focus.
    *
    * @default false
    */
   disabled?: TileProps['disabled'];
   /**
-   * Callback when the Tile is activated.
+   * Callback when the tile is activated.
    */
   onClick?: (event: CallbackEvent<typeof tagName$d>) => void;
 }
@@ -5079,7 +5079,7 @@ interface LinkJSXProps
    */
   onClick?: (event: CallbackEvent<typeof tagName$a>) => void;
   /**
-   * The Link content.
+   * The link content.
    */
   children?: ComponentChildren;
 }
@@ -5099,7 +5099,7 @@ declare module 'preact' {
 declare const tagName$9 = 's-empty-state';
 interface EmptyStateJSXProps extends Pick<EmptyStateProps, 'heading'> {
   /**
-   * The subheading of the EmptyState.
+   * The subheading of the empty state.
    */
   subheading?: string;
   /**
@@ -5111,7 +5111,7 @@ interface EmptyStateJSXProps extends Pick<EmptyStateProps, 'heading'> {
    */
   secondaryActions?: ComponentChild;
   /**
-   * The graphic to display in the EmptyState. The only supported components is Icon, with a type of `alert-circle`, `search`, `info`, or `circle-info`.
+   * The graphic to display in the empty state. The only supported components is Icon, with a type of `alert-circle`, `search`, `info`, or `circle-info`.
    */
   graphic?: ComponentChild;
 }
@@ -5475,7 +5475,7 @@ interface Link {
    */
   command?: '--auto' | '--show' | '--hide' | '--toggle' | '--copy';
   /**
-   * A label that describes the purpose or contents of the Link. It will be read to users using assistive technologies such as screen readers.
+   * A label that describes the purpose or contents of the link. It will be read to users using assistive technologies such as screen readers.
    *
    * Use this when using only an icon or the content of the link is not enough context
    * for users using assistive technologies.
@@ -5488,14 +5488,14 @@ interface EmptyStateSlots {
   'primary-action'?: HTMLElement;
   /** The secondary actions to perform, provided as button or link type elements. */
   'secondary-actions'?: HTMLElement;
-  /** The graphic to display in the EmptyState. The only supported components is Icon, with a type of `alert-circle`, `search`, `info`, or `circle-info`. */
+  /** The graphic to display in the empty state. The only supported components is Icon, with a type of `alert-circle`, `search`, `info`, or `circle-info`. */
   graphic?: HTMLElement;
 }
 
 interface EmptyState {
-  /** The subheading of the EmptyState. */
+  /** The subheading of the empty state. */
   subheading?: string;
-  /** The heading of the EmptyState. */
+  /** The heading of the empty state. */
   heading?: string;
 }
 
@@ -5550,7 +5550,7 @@ interface Embed {
    */
   src?: string;
   /**
-   * A label that describes the purpose or contents of the Embed. It will be read to users
+   * A label that describes the purpose or contents of the embed. It will be read to users
    * using assistive technologies such as screen readers.
    * @implementation for web-based implementations, this should map to the [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/title) attribute
    */
@@ -5635,14 +5635,14 @@ interface Tabs {
   /**
    * The value of the selected tab.
    *
-   * This should match the `id` prop of one of the TabPanel components.
+   * This should match the `id` prop of one of the tab panel components.
    * If not provided, the first tab will be selected by default.
    */
   value?: string;
   /**
    * The default value of the selected tab.
    *
-   * This should match the `id` prop of one of the TabPanel components.
+   * This should match the `id` prop of one of the tab panel components.
    * If not provided, the first tab will be selected by default.
    *
    * Reflects to the `value` attribute
@@ -5653,7 +5653,7 @@ interface Tabs {
 }
 
 interface Tab {
-  /** Corresponds to the `id` property of the TabPanel component that will be displayed when selected */
+  /** Corresponds to the `id` property of the tab panel component that will be displayed when selected */
   controls?: string;
   /**
    * Disables the control, disallowing any interaction.
@@ -5664,8 +5664,8 @@ interface Tab {
 
 interface TabPanel {
   /**
-   * The id of the TabPanel used for identification in the Tabs component.
-   * Must match the `controls` prop of the corresponding Tab component.
+   * The id of the tab panel used for identification in the tabs component.
+   * Must match the `controls` prop of the corresponding tab component.
    */
   id?: string;
 }
@@ -5801,19 +5801,19 @@ interface Button {
    */
   command?: '--auto' | '--show' | '--hide' | '--toggle';
   /**
-   * Sets the tone of the Button, based on the intention of the information being conveyed.
+   * Sets the tone of the button, based on the intention of the information being conveyed.
    * @default 'auto'
    */
   tone?: 'auto' | 'neutral' | 'caution' | 'warning' | 'critical';
   /**
-   * Changes the visual appearance of the Button.
-   * @default 'auto' - the variant is automatically determined by the Button's context
+   * Changes the visual appearance of the button.
+   * @default 'auto' - the variant is automatically determined by the button's context
    */
   variant?: 'primary' | 'secondary';
   /** A unique identifier for the element. */
   id?: string;
   /**
-   * Disables the Button meaning it cannot be clicked or receive focus.
+   * Disables the button meaning it cannot be clicked or receive focus.
    * @default false
    */
   disabled?: boolean;
@@ -5827,7 +5827,7 @@ interface Button {
   /**
    * Replaces content with a loading indicator while a background action is being performed.
    *
-   * This also disables the Button.
+   * This also disables the button.
    * @default false
    */
   loading?: boolean;
@@ -5964,32 +5964,32 @@ interface ScrollBox {
 }
 
 interface TileEvents {
-  /** Callback when the Tile is activated. */
+  /** Callback when the tile is activated. */
   click?: (event: CallbackEvent<typeof tagName$d>) => void;
 }
 
 interface Tile {
   /**
-   * Disables the Tile meaning it cannot be clicked or receive focus.
+   * Disables the tile meaning it cannot be clicked or receive focus.
    * @default false
    */
   disabled?: boolean;
   /**
-   * A title that describes the content of the Tile.
+   * A title that describes the content of the tile.
    * @default ''
    */
   heading?: string;
   /** A unique identifier for the element. */
   id?: string;
   /**
-   * A numeric indicator rendered within the Tile (for example, a count or a step number).
+   * A numeric indicator rendered within the tile (for example, a count or a step number).
    *
    * - When provided, the indicator is displayed inside the tile.
    * - Intended for small integers. It may clamp, truncate, or abbreviate larger values.
    */
   itemCount?: number;
   /**
-   * Sets the tone of the Tile, based on the intention of the information being conveyed.
+   * Sets the tone of the tile, based on the intention of the information being conveyed.
    * @default 'auto'
    */
   tone?: ExtractStrict<ToneKeyword, 'auto' | 'neutral' | 'accent'>;
@@ -6001,7 +6001,7 @@ interface Tile {
 }
 
 interface BannerSlots {
-  /** The action taken when the Banner is pressed. */
+  /** The action taken when the banner is pressed. */
   'primary-action'?: HTMLElement;
 }
 
@@ -6012,7 +6012,7 @@ interface Banner {
    */
   hidden?: boolean;
   /**
-   * Sets the tone of the Banner, based on the intention of the information being conveyed.
+   * Sets the tone of the banner, based on the intention of the information being conveyed.
    * @default 'auto'
    */
   tone?: 'auto' | 'info' | 'success' | 'warning' | 'critical';
@@ -6253,9 +6253,9 @@ interface Stack {
    * @default '0'
    */
   minInlineSize?: SizeUnits;
-  /** Aligns the Stack's children along the cross axis. */
+  /** Aligns the stack's children along the cross axis. */
   alignItems?: AlignItemsKeyword;
-  /** Aligns the Stack along the cross axis. */
+  /** Aligns the stack along the cross axis. */
   alignContent?: AlignContentKeyword;
   /**
    * Adjust spacing between elements.
@@ -6269,7 +6269,7 @@ interface Stack {
    */
   columnGap?: '' | SpacingKeyword;
   /**
-   * Sets how the children are placed within the Stack. This uses logical properties.
+   * Sets how the children are placed within the stack. This uses logical properties.
    * @default 'block'
    * @implementation - the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'
    */
@@ -6281,7 +6281,7 @@ interface Stack {
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * Aligns the Stack along the main axis.
+   * Aligns the stack along the main axis.
    * @see — https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
    * @default 'normal'
    */
@@ -6297,7 +6297,7 @@ interface Stack {
 
 interface Badge {
   /**
-   * Sets the tone of the Badge, based on the intention of the information being conveyed.
+   * Sets the tone of the badge, based on the intention of the information being conveyed.
    * @default 'auto'
    */
   tone?:
@@ -6421,7 +6421,7 @@ interface ModalSlots {
 interface Modal {
   /** A unique identifier for the element. */
   id?: string;
-  /** A title that describes the content of the Modal. */
+  /** A title that describes the content of the modal. */
   heading?: string;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Badge',
   description:
-    'The Badge component uses color and text to communicate status information for orders, products, customers, and other business data. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes.' +
+    'The badge component uses color and text to communicate status information for orders, products, customers, and other business data. Use badges to create visual hierarchy and help merchants quickly identify important information or status changes.' +
     "\n\nBadges aren't interactive elements. They display information but don't respond to user interactions like clicks or taps.",
   thumbnail: 'badge-thumbnail.png',
   isVisualComponent: true,
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Badge component.',
+      description: 'Configure the following properties on the badge component.',
       type: 'Badge',
     },
   ],
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'badge-default.png',
     description:
-      'Display status information using a Badge component with customizable tone and content. This example shows a basic badge with a tone property to indicate status through color.',
+      'Display status information using a badge component with customizable tone and content. This example shows a basic badge with a tone property to indicate status through color.',
     codeblock: {
       title: 'Display status information with a badge',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Banner',
   description:
-    'The Banner component highlights important information or required actions. Use banners to communicate critical updates, warnings, informational messages, or success notifications that require merchant attention.' +
+    'The banner component highlights important information or required actions. Use banners to communicate critical updates, warnings, informational messages, or success notifications that require merchant attention.' +
     '\n\nBanners provide persistent visibility with support for dismissible and non-dismissible states.',
   thumbnail: 'banner-thumbnail.png',
   isVisualComponent: true,
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Banner component.',
+        'Configure the following properties on the banner component.',
       type: 'Banner',
     },
     {
       title: 'Slots',
       description:
-        'The Banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'BannerSlots',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'banner-default.png',
     description:
-      'Display important messages using a Banner component with automatic color coding based on message severity. This example shows a basic banner with a heading and descriptive text.',
+      'Display important messages using a banner component with automatic color coding based on message severity. This example shows a basic banner with a heading and descriptive text.',
     codeblock: {
       title: 'Display important messages with a banner',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -3,15 +3,15 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
-    'The Box component provides a container for layout and visual styling. Use it to apply padding, borders, and background colors, or to nest and group other components.' +
-    '\n\nFor user interaction, use Box in combination with interactive components like [Button](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [Clickable](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable). For scrollable content, use [ScrollBox](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/scrollbox).',
+    'The box component provides a container for layout and visual styling. Use it to apply padding, borders, and background colors, or to nest and group other components.' +
+    '\n\nFor user interaction, use box in combination with interactive components like [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable). For scrollable content, use [scroll box](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/scroll-box).',
   thumbnail: 'box-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Box component.',
+      description: 'Configure the following properties on the box component.',
       type: 'Box',
     },
   ],
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'box-default.png',
     description:
-      'Create layouts using a Box component. This example demonstrates a basic box container with padding and styling.',
+      'Create layouts using a box component. This example demonstrates a basic box container with padding and styling.',
     codeblock: {
       title: 'Create a container with a box',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button.d.ts
@@ -113,7 +113,7 @@ export interface ButtonJSXProps
    * - `primary`: Creates a prominent call-to-action button with high visual emphasis for the most important action on a screen.
    * - `secondary`: Provides a less prominent button appearance for supporting actions and secondary interactions.
    *
-   * @default 'auto' - the variant is automatically determined by the Button's context
+   * @default 'auto' - the variant is automatically determined by the button's context
    */
   variant?: Extract<ButtonProps['variant'], 'primary' | 'secondary'>;
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
-    'The Button component triggers actions or events, such as opening dialogs or navigating to other pages. Use Button to let merchants perform specific tasks or to initiate interactions throughout the POS interface.' +
+    'The button component triggers actions or events, such as opening dialogs or navigating to other pages. Use button to let merchants perform specific tasks or to initiate interactions throughout the POS interface.' +
     '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy within the interface.',
   thumbnail: 'button-thumbnail.png',
   isVisualComponent: true,
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Button component.',
+        'Configure the following properties on the button component.',
       type: 'Button',
     },
     {
       title: 'Events',
       description:
-        'The Button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ButtonEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'button-default.png',
     description:
-      'Trigger actions using a Button component with customizable visual styles and tones. This example shows a basic button with text content.',
+      'Trigger actions using a button component with customizable visual styles and tones. This example shows a basic button with text content.',
     codeblock: {
       title: 'Trigger actions with a button',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList.d.ts
@@ -85,7 +85,7 @@ export interface ChoiceListJSXProps
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * The child elements to render within this component. Should be one or more Choice elements.
+   * The child elements to render within this component. Should be one or more choice elements.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -1,9 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'ChoiceList',
+  name: 'Choice list',
   description:
-    'The ChoiceList component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
+    'The choice list component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
     '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It offers multiple layout variants including list, inline, block, and grid formats to suit different space constraints and visual requirements.',
   thumbnail: 'choicelist-thumbnail.png',
   isVisualComponent: true,
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the ChoiceList component.',
+        'Configure the following properties on the choice list component.',
       type: 'ChoiceList',
     },
     {
       title: 'Events',
       description:
-        'The ChoiceList component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ChoiceListEvents',
     },
     {
       title: 'Choice',
       description:
-        'The Choice component creates options that let merchants select one or multiple items from a list of choices.',
+        'The choice component creates options that let merchants select one or multiple items from a list of choices.',
       type: 'Choice',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'choicelist-default.png',
     description:
-      'Present options using a ChoiceList component. This example shows a basic choice list for single selection.',
+      'Present options using a choice list component. This example shows a basic choice list for single selection.',
     codeblock: {
       title: 'Create a choice list for selections',
       tabs: [
@@ -59,7 +59,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-ChoiceList component types other than Choice can't be used as options within the choice list.`,
+Choice list component types other than choice can't be used as options within the choice list.`,
     },
   ],
   related: [],
@@ -95,7 +95,7 @@ ChoiceList component types other than Choice can't be used as options within the
       },
       {
         description:
-          'Compose rich choice content by nesting other components within Choice elements. This example demonstrates combining images, text, and layout components to create visually enhanced choice options with descriptions and supporting images.',
+          'Compose rich choice content by nesting other components within choice elements. This example demonstrates combining images, text, and layout components to create visually enhanced choice options with descriptions and supporting images.',
         codeblock: {
           title: 'Compose rich choice content',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
-    'The Clickable component makes any content interactive. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.' +
-    "\n\nUnlike the [Button](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) component, Clickable doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
+    'The clickable component makes any content interactive. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.' +
+    "\n\nUnlike the [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) component, clickable doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
   thumbnail: 'clickable-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Clickable component.',
+        'Configure the following properties on the clickable component.',
       type: 'Clickable',
     },
     {
       title: 'Events',
       description:
-        'The Clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ClickableEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'clickable-default.png',
     description:
-      'Make any content interactive using a Clickable component wrapper without imposing visual styling. This example shows how to create custom interactive elements while maintaining full control over appearance.',
+      'Make any content interactive using a clickable component wrapper without imposing visual styling. This example shows how to create custom interactive elements while maintaining full control over appearance.',
     codeblock: {
       title: 'Make content clickable',
       tabs: [
@@ -44,8 +44,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Implement visual feedback:** Since Clickable has no built-in styling, add focus indicators and active states to show interactivity.
-- **Wrap non-interactive elements:** Use Clickable for text, images, or icons. Avoid wrapping components with built-in interactions.
+- **Implement visual feedback:** Since clickable has no built-in styling, add focus indicators and active states to show interactivity.
+- **Wrap non-interactive elements:** Use clickable for text, images, or icons. Avoid wrapping components with built-in interactions.
 - **Handle disabled state carefully:** When \`disabled\`, child elements can still receive focus. Provide visual feedback for the non-interactive state.
 `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -1,10 +1,10 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'DateField',
+  name: 'Date field',
   description:
-    'The DateField component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
-    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [DatePicker](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) or [DateSpinner](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) components.',
+    'The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
+    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) or [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) components.',
   thumbnail: 'date-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the DateField component.',
+        'Configure the following properties on the date field component.',
       type: 'DateField',
     },
     {
       title: 'Events',
       description:
-        'The DateField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DateFieldEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'date-field-default.png',
     description:
-      'Capture date input using a DateField component with built-in validation and picker integration. This example shows a basic date field with label and placeholder text.',
+      'Capture date input using a date field component with built-in validation and picker integration. This example shows a basic date field with label and placeholder text.',
     codeblock: {
       title: 'Capture date input with a date field',
       tabs: [
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for direct text input:** Use DateField when users know the exact date and can type it efficiently. Use [DatePicker](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) for calendar selection or [DateSpinner](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) for space-constrained layouts.
+- **Choose for direct text input:** Use date field when users know the exact date and can type it efficiently. Use [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) for calendar selection or [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) for space-constrained layouts.
 - **Explain date constraints:** Use \`details\` to clarify requirements like "Select a date within the next 30 days" or "Must be a future date."
 - **Write actionable error messages:** Provide clear validation messages for invalid dates that help users correct their input.
 `,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -1,10 +1,10 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'DatePicker',
+  name: 'Date picker',
   description:
-    'The DatePicker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
-    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, consider using [DateSpinner](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) instead. For text date entry, use [DateField](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datefield).',
+    'The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, consider using [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) instead. For text date entry, use [date field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-field).',
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the DatePicker component.',
+        'Configure the following properties on the date picker component.',
       type: 'DatePicker',
     },
     {
       title: 'Events',
       description:
-        'The DatePicker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DatePickerEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'date-picker-default.png',
     description:
-      'Enable visual date selection using a DatePicker component with a calendar interface. This example shows a basic date picker with month view and date selection.',
+      'Enable visual date selection using a date picker component with a calendar interface. This example shows a basic date picker with month view and date selection.',
     codeblock: {
       title: 'Select dates with a calendar picker',
       tabs: [
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for calendar-based selection:** Use DatePicker when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use [DateSpinner](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datespinner) for tight spaces or [DateField](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datefield) when users know the exact date.
+- **Choose for calendar-based selection:** Use date picker when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) for tight spaces or [date field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-field) when users know the exact date.
 - **Provide adequate space:** Ensure sufficient spacing around the picker to avoid interfering with on-screen keyboards or other interactive elements.
 `,
     },
@@ -56,7 +56,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Control DatePicker visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the calendar picker, enabling custom trigger patterns for date selection workflows.',
+          'Control date picker visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the calendar picker, enabling custom trigger patterns for date selection workflows.',
         codeblock: {
           title: 'Control picker visibility',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -1,10 +1,10 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'DateSpinner',
+  name: 'Date spinner',
   description:
-    'The DateSpinner component enables merchants to select dates using a spinner interface with scrollable columns for month, day, and year. Use it for compact date selection in space-constrained layouts or when selecting dates close to the current date.' +
-    '\n\nFor visual calendar context, consider using [DatePicker](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) instead. For text date entry, use [DateField](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datefield).',
+    'The date spinner component enables merchants to select dates using a spinner interface with scrollable columns for month, day, and year. Use it for compact date selection in space-constrained layouts or when selecting dates close to the current date.' +
+    '\n\nFor visual calendar context, consider using [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) instead. For text date entry, use [date field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-field).',
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the DateSpinner component.',
+        'Configure the following properties on the date spinner component.',
       type: 'DateSpinner',
     },
     {
       title: 'Events',
       description:
-        'The DateSpinner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The date spinner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DateSpinnerEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'date-spinner-default.png',
     description:
-      'Enable compact date selection using a DateSpinner component with scrollable columns for month, day, and year. This example shows a basic date spinner for space-constrained layouts.',
+      'Enable compact date selection using a date spinner component with scrollable columns for month, day, and year. This example shows a basic date spinner for space-constrained layouts.',
     codeblock: {
       title: 'Select dates with a spinner',
       tabs: [
@@ -44,8 +44,8 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Use for space-constrained layouts:** Choose DateSpinner for narrow layouts or split-screen interfaces where a calendar view would be impractical.
-- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, [DatePicker](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/datepicker) provides faster navigation.
+- **Use for space-constrained layouts:** Choose date spinner for narrow layouts or split-screen interfaces where a calendar view would be impractical.
+- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) provides faster navigation.
 - **Provide interaction cues:** Consider labels or instructions to help first-time users understand the scrollable column interface.
 `,
     },
@@ -57,7 +57,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Control DateSpinner visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the spinner picker, enabling custom trigger patterns for date selection in constrained layouts.',
+          'Control date spinner visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the spinner picker, enabling custom trigger patterns for date selection in constrained layouts.',
         codeblock: {
           title: 'Control spinner visibility',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Divider',
   description:
-    'The Divider component creates visual separation between content sections by rendering a horizontal or vertical line. Use it to organize information and improve content hierarchy.',
+    'The divider component creates visual separation between content sections by rendering a horizontal or vertical line. Use it to organize information and improve content hierarchy.',
   thumbnail: 'divider-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Divider component.',
+        'Configure the following properties on the divider component.',
       type: 'Divider',
     },
   ],
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'divider-default.png',
     description:
-      'Separate content sections using a Divider component. This example shows a basic horizontal divider.',
+      'Separate content sections using a divider component. This example shows a basic horizontal divider.',
     codeblock: {
       title: 'Separate content sections with a divider',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -1,10 +1,10 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'EmailField',
+  name: 'Email field',
   description:
-    'The EmailField component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
-    "\n\nEmailField doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results.",
+    'The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
+    "\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results.",
   thumbnail: 'email-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the EmailField component.',
+        'Configure the following properties on the email field component.',
       type: 'EmailField',
     },
     {
       title: 'Events',
       description:
-        'The EmailField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'EmailFieldEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'email-field-default.png',
     description:
-      'Capture email address input using an EmailField component. This example shows a basic email field with a label for collecting email information.',
+      'Capture email address input using an email field component. This example shows a basic email field with a label for collecting email information.',
     codeblock: {
       title: 'Capture email addresses with an email field',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Embed/Embed.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Embed/Embed.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Embed',
   description:
-    'The Embed component displays a preview of printable content from a specified source URL. Use it to show users what will be printed before triggering the actual print operation.\n\nEmbed works in conjunction with the Print API to provide complete print functionality from preview to execution.\n\nSupported document types:\n\n- **HTML documents** (`.html`, `.htm`) - Best printing experience with full CSS styling, embedded images, and complex layouts. Use for receipts, invoices, and formatted reports.\n\n- **Text files** (`.txt`, `.csv`) - Plain text with basic content and tabular data support. Use for simple receipts and data exports.\n\n- **PDF files** (`.pdf`) - Behavior varies by platform: prints directly on iOS/desktop, but downloads to external viewer on Android. Use for complex documents and compliance requirements.\n\n[Learn how to build a print extension in POS](/docs/apps/build/pos/build-print-extension).',
+    'The embed component displays a preview of printable content from a specified source URL. Use it to show users what will be printed before triggering the actual print operation.\n\nEmbed works in conjunction with the Print API to provide complete print functionality from preview to execution.\n\nSupported document types:\n\n- **HTML documents** (`.html`, `.htm`) - Best printing experience with full CSS styling, embedded images, and complex layouts. Use for receipts, invoices, and formatted reports.\n\n- **Text files** (`.txt`, `.csv`) - Plain text with basic content and tabular data support. Use for simple receipts and data exports.\n\n- **PDF files** (`.pdf`) - Behavior varies by platform: prints directly on iOS/desktop, but downloads to external viewer on Android. Use for complex documents and compliance requirements.\n\n[Learn how to build a print extension in POS](/docs/apps/build/pos/build-print-extension).',
   isVisualComponent: true,
   type: 'component',
   thumbnail: 'embed-thumbnail.png',
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Embed component. This component must be a direct child of the Screen component.',
+        'Configure the following properties on the embed component. This component must be a direct child of the screen component.',
       type: 'EmbedProps',
     },
   ],
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'embed-default.png',
     description:
-      'Display a preview of printable content before triggering the print operation. This example shows how to use Embed with HTML documents, PDFs, or text files, supporting various document formats with proper rendering for receipts, invoices, and formatted reports.',
+      'Display a preview of printable content before triggering the print operation. This example shows how to use embed with HTML documents, PDFs, or text files, supporting various document formats with proper rendering for receipts, invoices, and formatted reports.',
     codeblock: {
       title: 'Preview printable content',
       tabs: [{code: './examples/embed.html', language: 'html'}],
@@ -39,7 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Generic',
       anchorLink: 'limitations',
       title: 'Limitations',
-      sectionContent: `\n- Embed must be a direct child of the Screen component and can't be nested inside any other component—this structural requirement ensures proper preview rendering and print functionality.\n- The component requires network access to fetch content from the specified source URL—offline functionality isn't supported for remote content.\n- Content is displayed as-is from the source—real-time content modification or editing within the preview isn't supported.\n- PDF printing on Android devices requires external applications—the component can't handle PDF printing natively on all platforms, which may affect user experience consistency across different POS devices.\n`,
+      sectionContent: `\n- Embed must be a direct child of the screen component and can't be nested inside any other component—this structural requirement ensures proper preview rendering and print functionality.\n- The component requires network access to fetch content from the specified source URL—offline functionality isn't supported for remote content.\n- Content is displayed as-is from the source—real-time content modification or editing within the preview isn't supported.\n- PDF printing on Android devices requires external applications—the component can't handle PDF printing natively on all platforms, which may affect user experience consistency across different POS devices.\n`,
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmptyState.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmptyState.d.ts
@@ -38,7 +38,7 @@ export type HtmlElementTagNameProps<T> = T & HTMLElement;
 declare const tagName = 's-empty-state';
 export interface EmptyStateJSXProps extends Pick<EmptyStateProps, 'heading'> {
   /**
-   * The subheading of the EmptyState.
+   * The subheading of the empty state.
    */
   subheading?: string;
   /**
@@ -50,7 +50,7 @@ export interface EmptyStateJSXProps extends Pick<EmptyStateProps, 'heading'> {
    */
   secondaryActions?: ComponentChild;
   /**
-   * The graphic to display in the EmptyState. The only supported components is Icon, with a type of `alert-circle`, `search`, `info`, or `circle-info`.
+   * The graphic to display in the empty state. The only supported components is icon, with a type of `alert-circle`, `search`, `info`, or `circle-info`.
    */
   graphic?: ComponentChild;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmptyState/EmptyState.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmptyState/EmptyState.doc.ts
@@ -1,9 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'EmptyState',
+  name: 'Empty state',
   description:
-    'The EmptyState component displays a placeholder view when there is no content to show. Use it to guide users on what to do next, such as adding new items or performing actions to populate the view.',
+    'The empty state component displays a placeholder view when there is no content to show. Use it to guide users on what to do next, such as adding new items or performing actions to populate the view.',
   thumbnail: 'emptystate-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -11,13 +11,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the EmptyState component.',
+        'Configure the following properties on the empty state component.',
       type: 'EmptyState',
     },
     {
       title: 'Slots',
       description:
-        'The EmptyState component supports slots for adding graphics and actions. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The empty state component supports slots for adding graphics and actions. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'EmptyStateSlots',
     },
   ],
@@ -26,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'emptystate-default.png',
     description:
-      'Create layouts using an EmptyState component. This example demonstrates a basic empty state container.',
+      'Create layouts using an empty state component. This example demonstrates a basic empty state container.',
     codeblock: {
       title: 'Create a generic empty state',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
-    'The Heading component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces.' +
-    '\n\nHeading levels adjust automatically based on nesting within parent [Section](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.',
+    'The heading component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces.' +
+    '\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.',
   thumbnail: 'heading-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Heading component.',
+        'Configure the following properties on the heading component.',
       type: 'Heading',
     },
   ],
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'heading-default.png',
     description:
-      'Create hierarchical titles using a Heading component that adjusts levels automatically based on nesting. This example shows a basic heading with automatic level management.',
+      'Create hierarchical titles using a heading component that adjusts levels automatically based on nesting. This example shows a basic heading with automatic level management.',
     codeblock: {
       title: 'Display hierarchical headings',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -3,15 +3,15 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
-    'The Icon component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories. Use icons to enhance navigation or provide visual context alongside text.' +
-    '\n\nFor interactive icons, wrap them in [Button](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [Clickable](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components.',
+    'The icon component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories. Use icons to enhance navigation or provide visual context alongside text.' +
+    '\n\nFor interactive icons, wrap them in [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components.',
   thumbnail: 'icon-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Icon component.',
+      description: 'Configure the following properties on the icon component.',
       type: 'Icon',
     },
   ],
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'icon-default.png',
     description:
-      'Display standardized visual symbols using an Icon component from the POS icon catalog. This example shows a basic icon with proper sizing and accessibility.',
+      'Display standardized visual symbols using an icon component from the POS icon catalog. This example shows a basic icon with proper sizing and accessibility.',
     codeblock: {
       title: 'Display icons from the POS catalog',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -3,15 +3,15 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
-    'The Image component displays visual content. Use images to showcase products, illustrate concepts, or provide visual context in POS workflows.' +
-    '\n\nImages are display-only components. For interactive functionality, wrap them in [Button](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) or [Clickable](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components.',
+    'The image component displays visual content. Use images to showcase products, illustrate concepts, or provide visual context in POS workflows.' +
+    '\n\nImages are display-only components. For interactive functionality, wrap them in [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components.',
   thumbnail: 'image-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Image component.',
+      description: 'Configure the following properties on the image component.',
       type: 'Image',
     },
   ],
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'image-default.png',
     description:
-      'Display visual content using an Image component with automatic loading optimization and error handling. This example shows a basic image with source URL and alt text for accessibility.',
+      'Display visual content using an image component with automatic loading optimization and error handling. This example shows a basic image with source URL and alt text for accessibility.',
     codeblock: {
       title: 'Display an image',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Link.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Link.d.ts
@@ -44,7 +44,7 @@ export interface LinkJSXProps extends Pick<LinkProps, 'id' | 'commandFor' | 'com
      */
     onClick?: (event: CallbackEvent<typeof tagName>) => void;
     /**
-     * The Link content.
+     * The link content.
      */
     children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Link/Link.doc.ts
@@ -3,21 +3,21 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Link',
   description:
-    'The Link component makes text interactive, allowing users to trigger actions through tappable text. Use it for lightweight interactions, navigation triggers, or actions embedded within text content.' +
-    '\n\nLinks support the command system for controlling other components declaratively. Use `command` and `commandFor` to show, hide, or toggle modals and other targetable elements. For primary actions like submitting forms or triggering operations, use [Button](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) instead.',
+    'The link component makes text interactive, allowing users to trigger actions through tappable text. Use it for lightweight interactions, navigation triggers, or actions embedded within text content.' +
+    '\n\nLinks support the command system for controlling other components declaratively. Use `command` and `commandFor` to show, hide, or toggle modals and other targetable elements. For primary actions like submitting forms or triggering operations, use [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) instead.',
   thumbnail: 'link-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Link component.',
+      description: 'Configure the following properties on the link component.',
       type: 'Link',
     },
     {
       title: 'Events',
       description:
-        'The Link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'LinkEvents',
     },
   ],
@@ -26,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'link-default.png',
     description:
-      'Create interactive links using the Link component. This example demonstrates basic link usage with onClick handlers for custom actions.',
+      'Create interactive links using the link component. This example demonstrates basic link usage with onClick handlers for custom actions.',
     codeblock: {
       title: 'Create an interactive link',
       tabs: [
@@ -43,12 +43,12 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Write clear, descriptive text:** Link text should clearly indicate the action or destination, helping users understand what will happen when they tap.
+- **Write clear, descriptive text:** link text should clearly indicate the action or destination, helping users understand what will happen when they tap.
 - **Keep text concise:** Use brief, actionable language that doesn't clutter the interface. Links work well embedded within text content.
 - **Provide accessibility labels when needed:** Use \`accessibilityLabel\` when the visible text doesn't fully describe the action, especially for short labels like "Edit" or "View".
 - **Use the command system for component control:** Use \`command\` (\`--show\`, \`--hide\`, \`--toggle\`, \`--copy\`) with \`commandFor\` to control modals and other components declaratively.
 - **Handle onClick for custom logic:** Implement \`onClick\` handlers for actions like showing toasts, updating state, or triggering side effects.
-- **Reserve buttons for primary actions:** Use Button for prominent actions like "Save" or "Submit". Use Link for secondary, embedded, or text-based interactions.
+- **Reserve buttons for primary actions:** Use button for prominent actions like "Save" or "Submit". Use link for secondary, embedded, or text-based interactions.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -3,28 +3,28 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Modal',
   description:
-    'The Modal component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.' +
+    'The modal component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.' +
     '\n\nModals block interaction with the underlying interface until the merchant resolves the modal content.' +
-    "\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through [events](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/feedback-and-status-indicators/modal#events).",
+    "\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through [events](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/modal#events).",
   thumbnail: 'modal-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Modal component.',
+      description: 'Configure the following properties on the modal component.',
       type: 'Modal',
     },
     {
       title: 'Slots',
       description:
-        'The Modal component supports slots for additional content placement within the modal. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The modal component supports slots for additional content placement within the modal. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ModalSlots',
     },
     {
       title: 'Events',
       description:
-        'The Modal component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The modal component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ModalEvents',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'modal-default.png',
     description:
-      'Display focused content in an overlay using a Modal component that requires merchant attention. This example shows a basic modal with header, content area, and action buttons.',
+      'Display focused content in an overlay using a modal component that requires merchant attention. This example shows a basic modal with header, content area, and action buttons.',
     codeblock: {
       title: 'Display content in a modal overlay',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -1,9 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'NumberField',
+  name: 'Number field',
   description:
-    'The NumberField component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
+    'The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
     '\n\nThe component supports optional stepper controls, min/max constraints, and step increments for guided numeric entry.',
   thumbnail: 'number-field-thumbnail.png',
   isVisualComponent: true,
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the NumberField component.',
+        'Configure the following properties on the number field component.',
       type: 'NumberField',
     },
     {
       title: 'Slots',
       description:
-        'The NumberField component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The number field component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'NumberFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'The NumberField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'NumberFieldEvents',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'number-field-default.png',
     description:
-      'Capture numeric input using a NumberField component. This example shows a basic number field with a label for collecting numeric values.',
+      'Capture numeric input using a number field component. This example shows a basic number field with a label for collecting numeric values.',
     codeblock: {
       title: 'Capture numeric input with a number field',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Page',
   description:
-    'The Page component serves as the main container for app content with preset layouts and heading controls. Use it to structure full-screen views with consistent navigation and content organization.' +
+    'The page component serves as the main container for app content with preset layouts and heading controls. Use it to structure full-screen views with consistent navigation and content organization.' +
     "\n\nPage is designed for full-screen modal interfaces and isn't suitable for inline content or partial page layouts within existing POS screens.",
   thumbnail: 'page-thumbnail.png',
   isVisualComponent: true,
@@ -11,13 +11,13 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Page component.',
+      description: 'Configure the following properties on the page component.',
       type: 'Page',
     },
     {
       title: 'Slots',
       description:
-        'The Page component supports slots for additional content placement within the page. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The page component supports slots for additional content placement within the page. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'PageSlots',
     },
   ],
@@ -26,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'page-default.png',
     description:
-      'Structure full-screen views using a Page component with built-in header and content layouts. This example shows a basic page with title and main content area.',
+      'Structure full-screen views using a page component with built-in header and content layouts. This example shows a basic page with title and main content area.',
     codeblock: {
       title: 'Structure a page layout',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -1,9 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'PosBlock',
+  name: 'POS block',
   description:
-    'The PosBlock component creates a container to place content with an action button. Use it to display structured content within POS block targets.' +
+    'The POS block component creates a container to place content with an action button. Use it to display structured content within POS block targets.' +
     '\n\nThe component provides a standardized layout specifically designed for content blocks within POS detail views, with consistent padding, spacing, and optional action buttons.',
   thumbnail: 'pos-block-thumbnail.png',
   isVisualComponent: true,
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the PosBlock component.',
+        'Configure the following properties on the POS block component.',
       type: 'PosBlock',
     },
     {
       title: 'QR Code',
       description:
-        'The PosBlock component renders a QR code when the block is used within a receipt target.',
+        'The POS block component renders a QR code when the block is used within a receipt target.',
       type: 'QrCode',
     },
     {
       title: 'Slots',
       description:
-        'The PosBlock component supports slots for additional content placement within the block. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The POS block component supports slots for additional content placement within the block. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'PosBlockSlots',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'pos-block-default.png',
     description:
-      'Create structured content blocks using a PosBlock component with optional action buttons. This example shows a basic block with content and an action button.',
+      'Create structured content blocks using a POS block component with optional action buttons. This example shows a basic block with content and an action button.',
     codeblock: {
       title: 'Create a content block with an action button',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -1,9 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'ScrollBox',
+  name: 'Scroll box',
   description:
-    'The ScrollBox component creates a scrollable area for content that exceeds container bounds. Use it to display large amounts of content within constrained spaces while maintaining usability.' +
+    'The scroll box component creates a scrollable area for content that exceeds container bounds. Use it to display large amounts of content within constrained spaces while maintaining usability.' +
     '\n\nThe component creates a defined scrollable area with customizable dimensions and scroll behavior.',
   thumbnail: 'scrollbox-thumbnail.png',
   isVisualComponent: true,
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the ScrollBox component.',
+        'Configure the following properties on the scroll box component.',
       type: 'ScrollBox',
     },
   ],
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'scrollbox-default.png',
     description:
-      'Create scrollable content areas using a ScrollBox component for content that exceeds container bounds. This example shows a basic scrollable area with customizable dimensions.',
+      'Create scrollable content areas using a scroll box component for content that exceeds container bounds. This example shows a basic scrollable area with customizable dimensions.',
     codeblock: {
       title: 'Create a scrollable content area',
       tabs: [
@@ -39,7 +39,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent: `
 - **Set clear dimensions:** Use percentage values for responsive layouts or pixels for exact dimensions.
-- **Use for appropriate content:** Reserve ScrollBox for long lists or dynamic content that genuinely needs scrolling, not short content that fits within available space.
+- **Use for appropriate content:** Reserve scroll box for long lists or dynamic content that genuinely needs scrolling, not short content that fits within available space.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -1,9 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'SearchField',
+  name: 'Search field',
   description:
-    'The SearchField component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers.',
+    'The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers.',
   thumbnail: 'search-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -11,13 +11,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the SearchField component.',
+        'Configure the following properties on the search field component.',
       type: 'SearchField',
     },
     {
       title: 'Events',
       description:
-        'The SearchField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'SearchFieldEvents',
     },
   ],
@@ -26,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'search-field-default.png',
     description:
-      'Enable search functionality using a SearchField component. This example shows a basic search field with placeholder text.',
+      'Enable search functionality using a search field component. This example shows a basic search field with placeholder text.',
     codeblock: {
       title: 'Enable search with a search field',
       tabs: [
@@ -43,7 +43,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Use for inline search and filtering:** Choose SearchField for filtering within specific sections or lists, not for global navigation or complex multi-step searches.
+- **Use for inline search and filtering:** Choose search field for filtering within specific sections or lists, not for global navigation or complex multi-step searches.
 - **Follow placeholder pattern:** Use "Search {items}" format like "Search products" or "Search customers" to clarify scope.
 - **Choose the right event:** Use \`input\` for real-time filtering as users type. Use \`change\` for expensive operations that should wait until typing completes.
 - **Handle empty values:** When the field is cleared, reset filters or show all items appropriately.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Section',
   description:
-    'The Section component groups related content into clearly-defined thematic areas. Use it to organize content and provide clear navigation landmarks.' +
+    'The section component groups related content into clearly-defined thematic areas. Use it to organize content and provide clear navigation landmarks.' +
     '\n\nThe component manages heading levels automatically, ensuring nested sections maintain proper semantic structure. Only one secondary action button is supported for each section.',
   thumbnail: 'section-thumbnail.png',
   isVisualComponent: true,
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Section component.',
+        'Configure the following properties on the section component.',
       type: 'Section',
     },
     {
       title: 'Slots',
       description:
-        'The Section component supports slots for additional content placement within the section. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The section component supports slots for additional content placement within the section. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'SectionSlots',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'section-default.png',
     description:
-      'Group related content using a Section component. This example shows a basic section with a heading and content area.',
+      'Group related content using a section component. This example shows a basic section with a heading and content area.',
     codeblock: {
       title: 'Group related content into sections',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Spinner/Spinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Spinner/Spinner.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Spinner',
   description:
-    'The Spinner component indicates ongoing processes or loading states. Use it to provide visual feedback when content is loading or an operation is in progress, helping users understand that the system is working.',
+    'The spinner component indicates ongoing processes or loading states. Use it to provide visual feedback when content is loading or an operation is in progress, helping users understand that the system is working.',
   thumbnail: 'spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Spinner component.',
+        'Configure the following properties on the spinner component.',
       type: 'Spinner',
     },
   ],
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'spinner-default.png',
     description:
-      'Display loading states using a Spinner component. This example shows a basic spinner that indicates an ongoing process.',
+      'Display loading states using a spinner component. This example shows a basic spinner that indicates an ongoing process.',
     codeblock: {
       title: 'Show loading state with a spinner',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack.d.ts
@@ -134,46 +134,46 @@ export interface StackJSXProps extends PickedProps {
    */
   paddingInlineEnd?: PaddingKeyword | '';
   /**
-   * The block size of the Stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The block size of the stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * Learn more about [block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
    * @default 'auto'
    */
   blockSize?: SizeUnitsOrAuto;
   /**
-   * The maximum block size constraint for the Stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum block size constraint for the stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * Learn more about [max-block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    * @default 'none'
    */
   maxBlockSize?: SizeUnitsOrNone;
   /**
-   * The maximum inline size constraint for the Stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The maximum inline size constraint for the stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * Learn more about [max-inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    * @default 'none'
    */
   maxInlineSize?: SizeUnitsOrNone;
   /**
-   * The minimum block size constraint for the Stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum block size constraint for the stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * Learn more about [min-block-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    * @default '0'
    */
   minBlockSize?: SizeUnits;
   /**
-   * The minimum inline size constraint for the Stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
+   * The minimum inline size constraint for the stack component. On mobile surfaces, avoid using percentage-based sizes as they don't behave as expected when placed within a scrollable container.
    *
    * Learn more about [min-inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    * @default '0'
    */
   minInlineSize?: SizeUnits;
   /**
-   * The alignment of the Stack component's children along the cross axis.
+   * The alignment of the stack component's children along the cross axis.
    */
   alignItems?: AlignItemsKeyword;
   /**
-   * The alignment of the Stack component along the cross axis.
+   * The alignment of the stack component along the cross axis.
    */
   alignContent?: AlignContentKeyword;
   /**
@@ -189,20 +189,20 @@ export interface StackJSXProps extends PickedProps {
    */
   columnGap?: SpacingKeyword | '';
   /**
-   * The direction in which children are placed within the Stack component using logical properties. Use `'block'` for vertical arrangement where children are placed along the block axis (typically top to bottom) without wrapping. Use `'inline'` for horizontal arrangement where children are placed along the inline axis (typically left to right) with automatic wrapping when space is insufficient.
+   * The direction in which children are placed within the stack component using logical properties. Use `'block'` for vertical arrangement where children are placed along the block axis (typically top to bottom) without wrapping. Use `'inline'` for horizontal arrangement where children are placed along the inline axis (typically left to right) with automatic wrapping when space is insufficient.
    *
    * @default 'block'
    */
   direction?: 'block' | 'inline';
   /**
-   * The inline size of the Stack component.
+   * The inline size of the stack component.
    *
    * Learn more about [inline-size on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    * @default 'auto'
    */
   inlineSize?: SizeUnitsOrAuto;
   /**
-   * The alignment of the Stack component along the main axis.
+   * The alignment of the stack component along the main axis.
    *
    * Learn more about [justify-content on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
    * @default 'normal'

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -3,15 +3,15 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
-    'The Stack component organizes elements along the block (vertical) or inline (horizontal) axis. Use it to structure layouts and control spacing between elements.' +
-    '\n\nThe component automatically manages spacing through gap properties and supports flexible alignment and wrapping behavior. Complex grid-like layouts may require multiple nested Stack components or alternative layout approaches.',
+    'The stack component organizes elements along the block (vertical) or inline (horizontal) axis. Use it to structure layouts and control spacing between elements.' +
+    '\n\nThe component automatically manages spacing through gap properties and supports flexible alignment and wrapping behavior. Complex grid-like layouts may require multiple nested stack components or alternative layout approaches.',
   thumbnail: 'stack-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Stack component.',
+      description: 'Configure the following properties on the stack component.',
       type: 'Stack',
     },
   ],
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'stack-default.png',
     description:
-      'Organize elements using a Stack component. This example shows a basic stack with spacing between child elements.',
+      'Organize elements using a stack component. This example shows a basic stack with spacing between child elements.',
     codeblock: {
       title: 'Organize elements with a stack',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Switch/Switch.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Switch',
   description:
-    'The Switch component creates a toggle control that allows merchants to turn an option on or off. Use switches for settings that take effect immediately, such as enabling notifications or toggling features.' +
+    'The switch component creates a toggle control that allows merchants to turn an option on or off. Use switches for settings that take effect immediately, such as enabling notifications or toggling features.' +
     "\n\nSwitches provide clear visual feedback about the current state and are ideal for binary choices that don't require confirmation.",
   thumbnail: 'switch-thumbnail.png',
   isVisualComponent: true,
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Switch component.',
+        'Configure the following properties on the switch component.',
       type: 'Switch',
     },
     {
       title: 'Events',
       description:
-        'The Switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'SwitchEvents',
     },
   ],
@@ -26,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Forms',
   defaultExample: {
     image: 'switch-default.png',
-    description: 'Toggle settings on or off using a Switch component.',
+    description: 'Toggle settings on or off using a switch component.',
     codeblock: {
       title: 'Create a toggle switch',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tabs/Tabs.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tabs/Tabs.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Tabs',
   description:
-    'The Tabs component organizes content into separate views, allowing merchants to switch between related information without leaving the current page. Use tabs when you need to present multiple categories of content in a space-efficient manner.' +
+    'The tabs component organizes content into separate views, allowing merchants to switch between related information without leaving the current page. Use tabs when you need to present multiple categories of content in a space-efficient manner.' +
     '\n\nTabs consist of a tab list containing clickable tab buttons and corresponding tab panels that display the content. Only one panel is visible at a time, reducing cognitive load and keeping the interface clean.',
   thumbnail: 'tab-thumbnail.png',
   isVisualComponent: true,
@@ -11,31 +11,31 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Tabs Properties',
-      description: 'Configure the following properties on the Tabs component.',
+      description: 'Configure the following properties on the tabs component.',
       type: 'Tabs',
     },
     {
       title: 'Tabs Events',
       description:
-        'The Tabs component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The tabs component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TabsEvents',
     },
     {
       title: 'TabList',
       description:
-        'The TabList component contains the tab buttons. It must be a direct child of the Tabs component.',
+        'The tab list component contains the tab buttons. It must be a direct child of the tabs component.',
       type: 'TabListJSXProps',
     },
     {
       title: 'Tab',
       description:
-        'The Tab component represents an individual tab button. It must be placed within a TabList and should use the `controls` property to associate it with a corresponding TabPanel.',
+        'The tab component represents an individual tab button. It must be placed within a tab list and should use the `controls` property to associate it with a corresponding tab panel.',
       type: 'Tab',
     },
     {
       title: 'TabPanel',
       description:
-        'The TabPanel component contains the content for each tab. It must have an `id` that matches the `controls` property of the corresponding Tab.',
+        'The tab panel component contains the content for each tab. It must have an `id` that matches the `controls` property of the corresponding tab.',
       type: 'TabPanel',
     },
   ],
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'tab-default.png',
     description:
-      'Organize content into tabs using the Tabs component with TabList, Tab, and TabPanel components. This example shows a basic tabbed interface with two tabs.',
+      'Organize content into tabs using the tabs component with tab list, tab, and tab panel components. This example shows a basic tabbed interface with two tabs.',
     codeblock: {
       title: 'Create a tabbed interface',
       tabs: [
@@ -61,9 +61,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'accessibility',
       title: 'Accessibility',
       sectionContent: `
-- **Provide accessibility labels:** Use the \`accessibilityLabel\` prop on the Tabs component to describe the purpose of the tab group.
+- **Provide accessibility labels:** Use the \`accessibilityLabel\` prop on the tabs component to describe the purpose of the tab group.
 - **Ensure keyboard navigation:** The component supports arrow key navigation between tabs and Enter/Space to activate tabs.
-- **Connect tabs and panels:** Always use matching \`controls\` (on Tab) and \`id\` (on TabPanel) properties to maintain proper semantic relationships.
+- **Connect tabs and panels:** Always use matching \`controls\` (on tab) and \`id\` (on tab panel) properties to maintain proper semantic relationships.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text.d.ts
@@ -76,7 +76,7 @@ export interface TextJSXProps extends Pick<TextProps, 'id'> {
     'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'critical' | 'caution'
   >;
   /**
-   * The Text content. Supports nested text elements.
+   * The text content. Supports nested text elements.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Text',
   description:
-    'The Text component displays text with specific visual styles or tones. Use it to present content with appropriate emphasis, hierarchy, or tone while maintaining semantic meaning.' +
+    'The text component displays text with specific visual styles or tones. Use it to present content with appropriate emphasis, hierarchy, or tone while maintaining semantic meaning.' +
     '\n\nText on mobile surfaces is blockish, rather than inline.',
   thumbnail: 'text-thumbnail.png',
   isVisualComponent: true,
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Text component.',
+      description: 'Configure the following properties on the text component.',
       type: 'Text',
     },
   ],
@@ -20,7 +20,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'text-default.png',
     description:
-      'Display text content using a Text component with customizable visual styles and tones. This example shows basic text with appropriate emphasis and hierarchy.',
+      'Display text content using a text component with customizable visual styles and tones. This example shows basic text with appropriate emphasis and hierarchy.',
     codeblock: {
       title: 'Display text with visual styles',
       tabs: [
@@ -40,8 +40,8 @@ const data: ReferenceEntityTemplateSchema = {
 - **Choose semantic types:** Use \`strong\` for emphasis, \`small\` for secondary info, \`generic\` for standard text.
 - **Apply appropriate tones:** Use \`success\` for positive outcomes, \`warning\` or \`critical\` for alerts, \`info\` for helpful context, \`auto\` for neutral content.
 - **Balance color intensity:** Use \`strong\` for emphasis, \`base\` for readability, \`subdued\` for secondary info.
-- **Nest for mixed formatting:** Nest Text components when you need multiple styles within one text block.
-- **Use Stack for icons and badges:** When combining text with icons or badges, use Stack with direction="inline" instead of nesting components inside Text.
+- **Nest for mixed formatting:** Nest text components when you need multiple styles within one text block.
+- **Use stack for icons and badges:** When combining text with icons or badges, use stack with direction="inline" instead of nesting components inside text.
 `,
     },
     {
@@ -49,9 +49,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-Complex rich text formatting isn't supported—use multiple Text components or nested text elements for varied formatting needs.
+Complex rich text formatting isn't supported—use multiple text components or nested text elements for varied formatting needs.
 
-Nesting Icon or Badge components inside Text isn't supported due to React Native alignment limitations—use Stack with direction="inline" and alignItems="center" instead to properly align icons and badges with text.
+Nesting icon or badge components inside text isn't supported due to React Native alignment limitations—use stack with direction="inline" and alignItems="center" instead to properly align icons and badges with text.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -1,10 +1,10 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'TextArea',
+  name: 'Text area',
   description:
-    'The TextArea component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
-    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [TextField](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textfield).',
+    'The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
+    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/text-field).',
   thumbnail: 'text-area-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the TextArea component.',
+        'Configure the following properties on the text area component.',
       type: 'TextArea',
     },
     {
       title: 'Events',
       description:
-        'The TextArea component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TextAreaEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'text-area-default.png',
     description:
-      'Capture multi-line text input using a TextArea component. This example shows a basic text area with a label for extended content.',
+      'Capture multi-line text input using a text area component. This example shows a basic text area with a label for extended content.',
     codeblock: {
       title: 'Capture multi-line text with a text area',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField.d.ts
@@ -109,7 +109,7 @@ export interface TextFieldJSXProps
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only Button and Clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
+   * The additional content to be displayed in the field. Commonly used to display clickable text or action elements. Only button and clickable components with text content only are supported in this slot. Use the `slot="accessory"` attribute to place elements in this area.
    */
   accessory?: ComponentChild;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -1,10 +1,10 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'TextField',
+  name: 'Text field',
   description:
-    'The TextField component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
-    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [TextArea](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textarea) component.',
+    'The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [text area](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/text-area) component.',
   thumbnail: 'text-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,19 +12,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the TextField component.',
+        'Configure the following properties on the text field component.',
       type: 'TextField',
     },
     {
       title: 'Slots',
       description:
-        'The TextField component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The text field component supports slots for additional content placement within the field. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TextFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'The TextField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TextFieldEvents',
     },
   ],
@@ -33,7 +33,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'text-field-default.png',
     description:
-      'Capture single-line text input using a TextField component with validation support. This example shows a basic text field with label and placeholder text.',
+      'Capture single-line text input using a text field component with validation support. This example shows a basic text field with label and placeholder text.',
     codeblock: {
       title: 'Capture text input with a text field',
       tabs: [
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Use for single-line text input:** Choose TextField for short values like names, titles, or identifiers. For multi-line content, use [TextArea](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/textarea).
+- **Use for single-line text input:** Choose text field for short values like names, titles, or identifiers. For multi-line content, use [text area](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/text-area).
 - **Show character limit feedback:** When approaching \`maxLength\`, display remaining characters in the \`details\` text.
 - **Write descriptive labels:** Use specific labels like "Product Name" or "Reference Code" rather than generic terms.
 `,
@@ -60,7 +60,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-The \`accessory\` slot supports only [Button](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [Clickable](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.
+The \`accessory\` slot supports only [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.
 `,
     },
   ],
@@ -71,7 +71,7 @@ The \`accessory\` slot supports only [Button](/docs/api/pos-ui-extensions/2026-0
     examples: [
       {
         description:
-          'Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use [`s-button`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/button) and [`s-clickable`](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/actions/clickable) components with text content in the accessory slot, enabling inline actions without leaving the input context.',
+          'Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use [`s-button`](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [`s-clickable`](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components with text content in the accessory slot, enabling inline actions without leaving the input context.',
         codeblock: {
           title: 'Add accessory buttons',
           tabs: [
@@ -84,7 +84,7 @@ The \`accessory\` slot supports only [Button](/docs/api/pos-ui-extensions/2026-0
       },
       {
         description:
-          'Configure common TextField properties for validation, character limits, and user guidance. This example demonstrates using props like `maxlength`, `required`, `helperText`, and `error` to create a well-guided input experience with proper validation feedback.',
+          'Configure common text field properties for validation, character limits, and user guidance. This example demonstrates using props like `maxlength`, `required`, `helperText`, and `error` to create a well-guided input experience with proper validation feedback.',
         codeblock: {
           title: 'Configure validation and guidance',
           tabs: [
@@ -97,7 +97,7 @@ The \`accessory\` slot supports only [Button](/docs/api/pos-ui-extensions/2026-0
       },
       {
         description:
-          'Subscribe to TextField events including `onInput`, `onFocus`, `onBlur`, and `onChange` to respond to user interactions. This example shows how to handle different input events for real-time validation, autosave functionality, or dynamic form behavior.',
+          'Subscribe to text field events including `onInput`, `onFocus`, `onBlur`, and `onChange` to respond to user interactions. This example shows how to handle different input events for real-time validation, autosave functionality, or dynamic form behavior.',
         codeblock: {
           title: 'Handle input events',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -3,22 +3,22 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Tile',
   description:
-    'The Tile component displays interactive buttons for the POS smart grid. Use tiles as customizable shortcuts that allow merchants to quickly access workflows, actions, and information from the smart grid.' +
+    'The tile component displays interactive buttons for the POS smart grid. Use tiles as customizable shortcuts that allow merchants to quickly access workflows, actions, and information from the smart grid.' +
     '\n\nTiles can change their appearance, content, and enabled state based on surrounding context such as cart contents, device conditions, or runtime state. They can display contextual information through titles, subtitles, and badge values.' +
-    '\n\nEach POS UI extension can only render one Tile component for each [home screen tile target](/docs/api/pos-ui-extensions/2026-01-rc/targets/home-screen#home-screen-tile-).',
+    '\n\nEach POS UI extension can only render one tile component for each [home screen tile target](/docs/api/pos-ui-extensions/{API_VERSION}/targets/home-screen#home-screen-tile-).',
   thumbnail: 'tile-thumbnail.png',
   isVisualComponent: true,
   type: '',
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Tile component.',
+      description: 'Configure the following properties on the tile component.',
       type: 'Tile',
     },
     {
       title: 'Events',
       description:
-        'The Tile component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The tile component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TileEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'tile-default.png',
     description:
-      'Create interactive smart grid shortcuts using a Tile component with customizable title, subtitle, and badge. This example shows a basic tile for the POS smart grid.',
+      'Create interactive smart grid shortcuts using a tile component with customizable title, subtitle, and badge. This example shows a basic tile for the POS smart grid.',
     codeblock: {
       title: 'Create a smart grid tile',
       tabs: [
@@ -55,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-The Tile component supports click and long press interactions only. Swipe, drag, and other gestures aren't supported.
+The tile component supports click and long press interactions only. Swipe, drag, and other gestures aren't supported.
 `,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -1,10 +1,10 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'TimeField',
+  name: 'Time field',
   description:
-    'The TimeField component captures time input through direct text entry. Use it when merchants know the exact time they want to enter or for quick time data entry.' +
-    '\n\nFor visual time selection with clock or spinner interfaces, use [TimePicker](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timepicker).',
+    'The time field component captures time input through direct text entry. Use it when merchants know the exact time they want to enter or for quick time data entry.' +
+    '\n\nFor visual time selection with clock or spinner interfaces, use [time picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/time-picker).',
   thumbnail: 'time-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the TimeField component.',
+        'Configure the following properties on the time field component.',
       type: 'TimeField',
     },
     {
       title: 'Events',
       description:
-        'The TimeField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The time field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TimeFieldEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'time-field-default.png',
     description:
-      'Capture time input using a TimeField component. This example shows a basic time field with a label for time entry.',
+      'Capture time input using a time field component. This example shows a basic time field with a label for time entry.',
     codeblock: {
       title: 'Capture time input with a time field',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -1,10 +1,10 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'TimePicker',
+  name: 'Time picker',
   description:
-    'The TimePicker component allows merchants to select times using an interactive picker interface. Use it when merchants benefit from visual time selection rather than typing exact times.' +
-    '\n\nFor direct text entry when merchants know the exact time, use [TimeField](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timefield).',
+    'The time picker component allows merchants to select times using an interactive picker interface. Use it when merchants benefit from visual time selection rather than typing exact times.' +
+    '\n\nFor direct text entry when merchants know the exact time, use [time field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/time-field).',
   thumbnail: 'time-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -12,13 +12,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the TimePicker component.',
+        'Configure the following properties on the time picker component.',
       type: 'TimePicker',
     },
     {
       title: 'Events',
       description:
-        'The TimePicker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The time picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TimePickerEvents',
     },
   ],
@@ -27,7 +27,7 @@ const data: ReferenceEntityTemplateSchema = {
   defaultExample: {
     image: 'time-spinner-default.png',
     description:
-      'Select times using a TimePicker component. This example shows a basic time picker for selecting hours and minutes.',
+      'Select times using a time picker component. This example shows a basic time picker for selecting hours and minutes.',
     codeblock: {
       title: 'Select times with a time picker',
       tabs: [
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for visual time selection:** Use TimePicker when users benefit from a visual picker interface. Use [TimeField](/docs/api/pos-ui-extensions/2026-01-rc/polaris-web-components/forms/timefield) when users know the exact time.
+- **Choose for visual time selection:** Use time picker when users benefit from a visual picker interface. Use [time field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/time-field) when users know the exact time.
 - **Use correct format:** Always use \`HH:mm:ss\` format with leading zeros. The internal format is always 24-hour regardless of UI presentation.
 - **Validate before setting values:** Invalid values reset to empty string. Implement validation to show appropriate error messages.
 `,
@@ -57,7 +57,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Control TimePicker visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the time picker, enabling custom trigger patterns for time selection workflows.',
+          'Control time picker visibility programmatically using the command system with `show` and `hide` methods. This example demonstrates using button commands to display or dismiss the time picker, enabling custom trigger patterns for time selection workflows.',
         codeblock: {
           title: 'Control picker visibility',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
@@ -723,11 +723,11 @@ export type AnyString = string & {};
 export type optionalSpace = '' | ' ';
 export interface BadgeProps extends GlobalProps {
   /**
-   * The content of the Badge.
+   * The content of the badge.
    */
   children?: ComponentChildren;
   /**
-   * Sets the tone of the Badge, based on the intention of the information being conveyed.
+   * Sets the tone of the badge, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
@@ -763,11 +763,11 @@ export interface BannerProps extends GlobalProps, ActionSlots {
    */
   heading?: string;
   /**
-   * The content of the Banner.
+   * The content of the banner.
    */
   children?: ComponentChildren;
   /**
-   * Sets the tone of the Banner, based on the intention of the information being conveyed.
+   * Sets the tone of the banner, based on the intention of the information being conveyed.
    *
    * The banner is a live region and the type of status will be dictated by the Tone selected.
    *
@@ -879,7 +879,7 @@ export type AccessibilityRole =
   | 'footer'
   /**
    * Used to indicate a generic section.
-   * Sections should always have a Heading or an accessible name provided in the `accessibilityLabel` property.
+   * Sections should always have a heading or an accessible name provided in the `accessibilityLabel` property.
    *
    * In an HTML host `section` will render a `<section>` element.
    * Learn more about the [`<section>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) in the MDN web docs.
@@ -1250,7 +1250,7 @@ export interface BaseBoxProps
     BorderProps,
     OverflowProps {
   /**
-   * The content of the Box.
+   * The content of the box.
    */
   children?: ComponentChildren;
   /**
@@ -1266,7 +1266,7 @@ export interface BaseBoxPropsWithRole
     AccessibilityRoleProps {}
 export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
   /**
-   * The behavior of the Button.
+   * The behavior of the button.
    *
    * - `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.
    * - `button`: Used to indicate the component acts as a button, meaning it has no default action.
@@ -1278,14 +1278,14 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
    */
   type?: 'submit' | 'button' | 'reset';
   /**
-   * Callback when the Button is activated.
+   * Callback when the button is activated.
    * This will be called before the action indicated by `type`.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event
    */
   onClick?: (event: Event) => void;
   /**
-   * Disables the Button meaning it cannot be clicked or receive focus.
+   * Disables the button meaning it cannot be clicked or receive focus.
    *
    * @default false
    */
@@ -1293,7 +1293,7 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
   /**
    * Replaces content with a loading indicator while a background action is being performed.
    *
-   * This also disables the Button.
+   * This also disables the button.
    *
    * @default false
    */
@@ -1370,24 +1370,24 @@ export interface BaseClickableProps
     LinkBehaviorProps {}
 export interface ButtonProps extends GlobalProps, BaseClickableProps {
   /**
-   * A label that describes the purpose or contents of the Button. It will be read to users using assistive technologies such as screen readers.
+   * A label that describes the purpose or contents of the button. It will be read to users using assistive technologies such as screen readers.
    *
-   * Use this when using only an icon or the Button text is not enough context
+   * Use this when using only an icon or the button text is not enough context
    * for users using assistive technologies.
    */
   accessibilityLabel?: string;
   /**
-   * The content of the Button.
+   * The content of the button.
    */
   children?: ComponentChildren;
   /**
-   * The type of icon to be displayed in the Button.
+   * The type of icon to be displayed in the button.
    *
    * @default ''
    */
   icon?: IconType | AnyString;
   /**
-   * The displayed inline width of the Button.
+   * The displayed inline width of the button.
    *
    * - `auto`: the size of the button depends on the surface and context.
    * - `fill`: the button will takes up 100% of the available inline size.
@@ -1397,13 +1397,13 @@ export interface ButtonProps extends GlobalProps, BaseClickableProps {
    */
   inlineSize?: 'auto' | 'fill' | 'fit-content';
   /**
-   * Changes the visual appearance of the Button.
+   * Changes the visual appearance of the button.
    *
-   * @default 'auto' - the variant is automatically determined by the Button's context
+   * @default 'auto' - the variant is automatically determined by the button's context
    */
   variant?: 'auto' | 'primary' | 'secondary' | 'tertiary';
   /**
-   * Sets the tone of the Button based on the intention of the information being conveyed.
+   * Sets the tone of the button based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
@@ -1743,7 +1743,7 @@ export interface ChoiceListProps
   /**
    * The choices a user can select from.
    *
-   * Accepts Choice components.
+   * Accepts choice components.
    */
   children?: ComponentChildren;
   /**
@@ -2249,7 +2249,7 @@ export interface EmbedProps extends GlobalProps, SizingProps {
    */
   src?: string;
   /**
-   * A label that describes the purpose or contents of the Embed. It will be read to users
+   * A label that describes the purpose or contents of the embed. It will be read to users
    * using assistive technologies such as screen readers.
    *
    * @implementation for web-based implementations, this should map to the [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/title) attribute
@@ -2258,15 +2258,15 @@ export interface EmbedProps extends GlobalProps, SizingProps {
 }
 export interface EmptyStateProps extends GlobalProps, ActionSlots {
   /**
-   * The heading of the EmptyState.
+   * The heading of the empty state.
    */
   heading?: string;
   /**
-   * The subheading of the EmptyState.
+   * The subheading of the empty state.
    */
   subheading?: ComponentChildren | StringChildren;
   /**
-   * The graphic to display in the EmptyState. The only supported components are Image and Icon.
+   * The graphic to display in the empty state. The only supported components are image and icon.
    */
   graphic?: ComponentChildren;
 }
@@ -2400,7 +2400,7 @@ export interface HeadingProps
     AccessibilityVisibilityProps,
     BlockTypographyProps {
   /**
-   * The content of the Heading.
+   * The content of the heading.
    */
   children?: ComponentChildren;
   /**
@@ -2569,17 +2569,17 @@ export interface ImageProps extends GlobalProps, BaseImageProps, BorderProps {
 }
 export interface LinkProps extends GlobalProps, LinkBehaviorProps {
   /**
-   * The content of the Link.
+   * The content of the link.
    */
   children?: ComponentChildren;
   /**
-   * Sets the tone of the Link, based on the intention of the information being conveyed.
+   * Sets the tone of the link, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * A label that describes the purpose or contents of the Link. It will be read to users using assistive technologies such as screen readers.
+   * A label that describes the purpose or contents of the link. It will be read to users using assistive technologies such as screen readers.
    *
    * Use this when using only an icon or the content of the link is not enough context
    * for users using assistive technologies.
@@ -2606,32 +2606,32 @@ export interface ModalProps
    */
   accessibilityLabel?: string;
   /**
-   * A title that describes the content of the Modal.
+   * A title that describes the content of the modal.
    *
    */
   heading?: string;
   /**
-   * Adjust the padding around the Modal content.
+   * Adjust the padding around the modal content.
    *
    * `base`: applies padding that is appropriate for the element.
    *
-   * `none`: removes all padding from the element. This can be useful when elements inside the Modal need to span
-   * to the edge of the Modal. For example, a full-width image. In this case, rely on Box with a padding of 'base'
+   * `none`: removes all padding from the element. This can be useful when elements inside the modal need to span
+   * to the edge of the modal. For example, a full-width image. In this case, rely on Box with a padding of 'base'
    * to bring back the desired padding for the rest of the content.
    *
    * @default 'base'
    */
   padding?: 'base' | 'none';
   /**
-   * Adjust the size of the Modal.
+   * Adjust the size of the modal.
    *
-   * `max`: expands the Modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
+   * `max`: expands the modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
    *
    * @default 'base'
    */
   size?: SizeKeyword | 'max';
   /**
-   * The content of the Modal.
+   * The content of the modal.
    */
   children?: ComponentChildren;
 }
@@ -2670,7 +2670,7 @@ export type NumberAutocompleteField = ExtractStrict<
 >;
 export interface PageProps extends GlobalProps, ActionSlots {
   /**
-   * The content of the Page.
+   * The content of the page.
    */
   children?: ComponentChildren;
   /**
@@ -2836,14 +2836,14 @@ export interface SearchFieldProps
 export type SearchAutocompleteField = TextAutocompleteField;
 export interface SectionProps extends GlobalProps, ActionSlots {
   /**
-   * The content of the Section.
+   * The content of the section.
    */
   children?: ComponentChildren;
   /**
    * A label used to describe the section that will be announced by assistive technologies.
    *
-   * When no `heading` property is provided or included as a children of the Section, you **must** provide an
-   * `accessibilityLabel` to describe the Section. This is important as it allows assistive technologies to provide
+   * When no `heading` property is provided or included as a children of the section, you **must** provide an
+   * `accessibilityLabel` to describe the section. This is important as it allows assistive technologies to provide
    * the right context to users.
    */
   accessibilityLabel?: string;
@@ -2856,8 +2856,8 @@ export interface SectionProps extends GlobalProps, ActionSlots {
    *
    * - `base`: applies padding that is appropriate for the element. Note that it may result in no padding if
    * this is the right design decision in a particular context.
-   * - `none`: removes all padding from the element. This can be useful when elements inside the Section need to span
-   * to the edge of the Section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base'
+   * - `none`: removes all padding from the element. This can be useful when elements inside the section need to span
+   * to the edge of the section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base'
    * to bring back the desired padding for the rest of the content.
    *
    * @default 'base'
@@ -2885,11 +2885,11 @@ export interface StackProps
     BaseBoxPropsWithRole,
     GapProps {
   /**
-   * The content of the Stack.
+   * The content of the stack.
    */
   children?: ComponentChildren;
   /**
-   * Sets how the children are placed within the Stack. This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
+   * Sets how the children are placed within the stack. This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
    *
    * @default 'block'
    *
@@ -2897,21 +2897,21 @@ export interface StackProps
    */
   direction?: MaybeResponsive<'block' | 'inline'>;
   /**
-   * Aligns the Stack along the main axis.
+   * Aligns the stack along the main axis.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
    * @default 'normal'
    */
   justifyContent?: MaybeResponsive<JustifyContentKeyword>;
   /**
-   * Aligns the Stack's children along the cross axis.
+   * Aligns the stack's children along the cross axis.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
    * @default 'normal'
    */
   alignItems?: MaybeResponsive<AlignItemsKeyword>;
   /**
-   * Aligns the Stack along the cross axis.
+   * Aligns the stack along the cross axis.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
    * @default 'normal'
@@ -2926,7 +2926,7 @@ export interface SwitchProps
     FieldErrorProps {}
 export interface TabProps extends GlobalProps {
   /**
-   * Corresponds to the `id` property of the TabPanel component that will be displayed when selected
+   * Corresponds to the `id` property of the tab panel component that will be displayed when selected
    */
   controls?: string;
   /**
@@ -2950,18 +2950,18 @@ export interface TabProps extends GlobalProps {
 }
 export interface TabListProps extends GlobalProps {
   /**
-   * Accepts only Tabs components.
+   * Accepts only tabs components.
    */
   children?: ComponentChildren;
 }
 export interface TabPanelProps extends GlobalProps {
   /**
-   * The id of the TabPanel used for identification in the Tabs component.
-   * Must match the `controls` prop of the corresponding Tab component.
+   * The id of the tab panel used for identification in the tabs component.
+   * Must match the `controls` prop of the corresponding tab component.
    */
   id?: string;
   /**
-   * The content of the TabPanel.
+   * The content of the tab panel.
    */
   children?: ComponentChildren;
 }
@@ -2974,20 +2974,20 @@ export interface TabsProps
    */
   accessibilityLabel?: string;
   /**
-   * Accepts only TabList and TabPanel components.
+   * Accepts only tab list and tab panel components.
    */
   children?: ComponentChildren;
   /**
    * The value of the selected tab.
    *
-   * This should match the `id` prop of one of the TabPanel components.
+   * This should match the `id` prop of one of the tab panel components.
    * If not provided, the first tab will be selected by default.
    */
   value?: string;
   /**
    * The default value of the selected tab.
    *
-   * This should match the `id` prop of one of the TabPanel components.
+   * This should match the `id` prop of one of the tab panel components.
    * If not provided, the first tab will be selected by default.
    *
    * Reflects to the `value` attribute
@@ -3127,7 +3127,7 @@ export interface TileProps
   extends GlobalProps,
     Pick<BaseClickableProps, 'onClick' | 'disabled'> {
   /**
-   * A title that describes the content of the Tile.
+   * A title that describes the content of the tile.
    *
    * @default ''
    */
@@ -3139,7 +3139,7 @@ export interface TileProps
    */
   subheading?: string;
   /**
-   * A numeric indicator rendered within the Tile (for example, a count or a step number).
+   * A numeric indicator rendered within the tile (for example, a count or a step number).
    *
    * - When provided, the indicator is displayed inside the tile.
    * - Intended for small integers. It may clamp, truncate, or abbreviate larger values.
@@ -3147,7 +3147,7 @@ export interface TileProps
    */
   itemCount?: number;
   /**
-   * Sets the tone of the Tile, based on the intention of the information being conveyed.
+   * Sets the tone of the tile, based on the intention of the information being conveyed.
    * @default 'auto'
    */
   tone?: ExtractStrict<ToneKeyword, 'auto' | 'neutral' | 'accent'>;


### PR DESCRIPTION
## Context

In older versions (2025-07 and earlier), components use React/JSX syntax, so PascalCase names like `ButtonGroup` make sense — that's what devs write in their code. But in versions 2025-10+, the syntax shifted to web components (`<s-button-group>`), so PascalCase no longer maps to anything developers actually write in code. We're switching to sentence case for component names in versions 2025-10+.

## This PR:
- Updates all POS component names to use sentence case versus Pascal case in the 2026-04-rc version
- Uses the `{API_VERSION}` variable in links for ease of maintenance going forward