### PR TITLE
Improve examples for MoneyField, PasswordField, Select, Switch, URLField

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
@@ -43,7 +43,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Capture monetary values with automatic currency formatting. This example shows a labeled money field with placeholder text and helper details. Click to interact with the preview.',
+      'Capture monetary values with automatic currency formatting. This example shows a labeled money field with placeholder text and helper details.',
     codeblock: {
       title: 'Collect a currency value',
       tabs: [
@@ -63,7 +63,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Guide users with constraints and helpful context. This example shows a money field with min/max limits and helper text explaining the valid range. Click to interact with the preview.',
+              'Guide users with constraints and helpful context. This example shows a money field with min/max limits and helper text explaining the valid range.',
             codeblock: {
               title: 'Add a label and constraints',
               tabs: [
@@ -77,7 +77,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Communicate input problems clearly to users. This example shows an error message displayed when the entered value is invalid. Click to interact with the preview.',
+              'Communicate input problems clearly to users. This example shows an error message displayed when the entered value is invalid.',
             codeblock: {
               title: 'Handle validation errors',
               tabs: [
@@ -91,7 +91,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Collect multiple monetary values in a single form. This example shows money fields for price, compare-at price, and cost with individual constraints. Click to interact with the preview.',
+              'Collect multiple monetary values in a single form. This example shows money fields for price, compare-at price, and cost with individual constraints.',
             codeblock: {
               title: 'Combine multiple fields in a form',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
@@ -50,11 +50,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         {
           code: './examples/default.html',
           language: 'html',
-        },
-
-        {
-          code: './examples/default.jsx',
-          language: 'preview-jsx',
+          title: '',
         },
       ],
     },
@@ -74,11 +70,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/basic-usage.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/basic-usage.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -92,11 +84,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/basic-field.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/basic-field.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -110,30 +98,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/currency-formatting-with-form-integration.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/currency-formatting-with-form-integration.jsx',
-                  language: 'preview-jsx',
-                },
-              ],
-            },
-          },
-        ],
-      },
-      {
-        title: '',
-        examples: [
-          {
-            description:
-              'Provide immediate feedback as users type. This example shows real-time validation with dynamic error messages when values exceed min/max limits. Click to interact with the preview.',
-            codeblock: {
-              title: 'Validate input in real time',
-              tabs: [
-                {
-                  code: './examples/validation-example.jsx',
-                  language: 'preview-jsx',
-                  layout: 'formWrapper',
+                  title: '',
                 },
               ],
             },

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
@@ -42,9 +42,10 @@ const data: AdminReferenceEntityTemplateSchema = {
     },
   ],
   defaultExample: {
-    image: 'moneyfield-default.png',
+    description:
+      'Capture monetary values with automatic currency formatting. This example shows a labeled money field with placeholder text and helper details. Click to interact with the preview.',
     codeblock: {
-      title: 'Code',
+      title: 'Collect a currency value',
       tabs: [
         {
           code: './examples/default.html',
@@ -62,13 +63,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     description: 'Component examples',
     exampleGroups: [
       {
-        title: 'Basic usage',
+        title: '',
         examples: [
           {
             description:
-              'Demonstrates a simple money field with a label, initial value, and numeric constraints.',
+              'Guide users with constraints and helpful context. This example shows a money field with min/max limits and helper text explaining the valid range. Click to interact with the preview.',
             codeblock: {
-              title: 'Basic usage',
+              title: 'Add a label and constraints',
               tabs: [
                 {
                   code: './examples/basic-usage.html',
@@ -84,27 +85,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Showcases a money field with explicit minimum and maximum value limits, and a detailed description for user guidance.',
+              'Communicate input problems clearly to users. This example shows an error message displayed when the entered value is invalid. Click to interact with the preview.',
             codeblock: {
-              title: 'With validation limits',
-              tabs: [
-                {
-                  code: './examples/with-validation-limits.html',
-                  language: 'html',
-                },
-
-                {
-                  code: './examples/with-validation-limits.jsx',
-                  language: 'preview-jsx',
-                },
-              ],
-            },
-          },
-          {
-            description:
-              'Illustrates a money field demonstrating basic error handling and validation.',
-            codeblock: {
-              title: 'Basic field',
+              title: 'Handle validation errors',
               tabs: [
                 {
                   code: './examples/basic-field.html',
@@ -120,9 +103,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Displays multiple money fields in a vertical stack, showing how to integrate multiple currency inputs in a form with varied details and constraints.',
+              'Collect multiple monetary values in a single form. This example shows money fields for price, compare-at price, and cost with individual constraints. Click to interact with the preview.',
             codeblock: {
-              title: 'Currency formatting with form integration',
+              title: 'Combine multiple fields in a form',
               tabs: [
                 {
                   code: './examples/currency-formatting-with-form-integration.html',
@@ -139,13 +122,13 @@ const data: AdminReferenceEntityTemplateSchema = {
         ],
       },
       {
-        title: 'Form validation',
+        title: '',
         examples: [
           {
             description:
-              'Interactive example showing real-time validation with min/max limits and dynamic error messages.',
+              'Provide immediate feedback as users type. This example shows real-time validation with dynamic error messages when values exceed min/max limits. Click to interact with the preview.',
             codeblock: {
-              title: 'Money field validation',
+              title: 'Validate input in real time',
               tabs: [
                 {
                   code: './examples/validation-example.jsx',

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
@@ -43,13 +43,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Capture monetary values with automatic currency formatting. This example shows a labeled money field with placeholder text and helper details.',
+      'Capture monetary values with automatic currency formatting. This example pairs a label with placeholder text and helper details.',
     codeblock: {
       title: 'Collect a currency value',
       tabs: [
         {
           code: './examples/default.html',
-          language: 'html',
+          language: 'preview',
           title: '',
         },
       ],
@@ -63,13 +63,13 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Guide users with constraints and helpful context. This example shows a money field with min/max limits and helper text explaining the valid range.',
+              'Set input boundaries for valid amounts. This example configures min/max limits to constrain the accepted value range.',
             codeblock: {
               title: 'Add a label and constraints',
               tabs: [
                 {
                   code: './examples/basic-usage.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -77,13 +77,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Communicate input problems clearly to users. This example shows an error message displayed when the entered value is invalid.',
+              'Communicate input problems clearly to users. This example displays an error message when the entered value is invalid.',
             codeblock: {
               title: 'Handle validation errors',
               tabs: [
                 {
                   code: './examples/basic-field.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -91,13 +91,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Collect multiple monetary values in a single form. This example shows money fields for price, compare-at price, and cost with individual constraints.',
+              'Collect multiple monetary values in a single form. This example groups money fields for price, compare-at price, and cost with individual constraints.',
             codeblock: {
               title: 'Combine multiple fields in a form',
               tabs: [
                 {
                   code: './examples/currency-formatting-with-form-integration.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/examples/basic-field.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/examples/basic-field.html
@@ -1,6 +1,5 @@
 <s-money-field
   label="Product cost"
-  value="29.99"
   min="0.01"
   error="Product cost is required"
 ></s-money-field>

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -39,9 +39,10 @@ const data: AdminReferenceEntityTemplateSchema = {
     },
   ],
   defaultExample: {
-    image: 'password-field-default.png',
+    description:
+      'Securely collect sensitive credentials from users. This example shows a labeled password field with masked input. Click to interact with the preview.',
     codeblock: {
-      title: 'Code',
+      title: 'Collect a password',
       tabs: [
         {
           code: './examples/default.html',
@@ -59,13 +60,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     description: 'Component examples',
     exampleGroups: [
       {
-        title: 'Basic usage',
+        title: '',
         examples: [
           {
             description:
-              'Demonstrates a basic password field with a label, name, and required validation. Sets a minimum length of 8 characters and configures autocomplete for a new password.',
+              'Enforce password requirements before submission. This example shows a required field with minimum length validation and autocomplete for new passwords. Click to interact with the preview.',
             codeblock: {
-              title: 'Basic usage',
+              title: 'Set validation rules',
               tabs: [
                 {
                   code: './examples/basic-usage.html',
@@ -81,9 +82,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Shows a password field in an error state, displaying a custom error message when the password does not meet the minimum length requirement.',
+              'Communicate password problems clearly to users. This example shows an error message when the password doesn\'t meet length requirements. Click to interact with the preview.',
             codeblock: {
-              title: 'With error state',
+              title: 'Show validation errors',
               tabs: [
                 {
                   code: './examples/with-error-state.html',
@@ -99,9 +100,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Illustrates a password field with additional details providing guidance about password creation requirements.',
+              'Help users understand password requirements upfront. This example shows helper text beneath the field explaining what makes a valid password. Click to interact with the preview.',
             codeblock: {
-              title: 'With helper text',
+              title: 'Add helper text',
               tabs: [
                 {
                   code: './examples/with-helper-text.html',
@@ -117,9 +118,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Shows how the password field can be integrated into a form alongside other input fields, such as an email field, to create a complete login or registration form.',
+              'Create a complete authentication form. This example shows a password field combined with an email field for login or registration. Click to interact with the preview.',
             codeblock: {
-              title: 'In form layout',
+              title: 'Build a login form',
               tabs: [
                 {
                   code: './examples/in-form-layout.html',
@@ -135,9 +136,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Demonstrates a password field with dynamic password strength validation, showing real-time feedback on password complexity requirements.',
+              'Show users exactly what their password needs. This example shows a static checklist of requirements like character length and case requirements. Click to interact with the preview.',
             codeblock: {
-              title: 'With password strength requirements',
+              title: 'Display a requirement checklist',
               tabs: [
                 {
                   code: './examples/with-password-strength-requirements.html',
@@ -146,6 +147,24 @@ const data: AdminReferenceEntityTemplateSchema = {
 
                 {
                   code: './examples/with-password-strength-requirements.jsx',
+                  language: 'preview-jsx',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: '',
+        examples: [
+          {
+            description:
+              'Provide immediate feedback on password quality. This example shows real-time validation that checks requirements as the user types. Click to interact with the preview.',
+            codeblock: {
+              title: 'Validate password strength',
+              tabs: [
+                {
+                  code: './examples/password-strength-validation.jsx',
                   language: 'preview-jsx',
                 },
               ],

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -40,13 +40,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Securely collect sensitive credentials from users. This example shows a labeled password field with masked input.',
+      'Securely collect sensitive credentials from users. This example pairs a label with masked input.',
     codeblock: {
       title: 'Collect a password',
       tabs: [
         {
           code: './examples/default.html',
-          language: 'html',
+          language: 'preview',
           title: '',
         },
       ],
@@ -60,13 +60,13 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Enforce password requirements before submission. This example shows a required field with minimum length validation and autocomplete for new passwords.',
+              'Enforce password requirements before submission. This example configures a required field with minimum length validation and autocomplete for new passwords.',
             codeblock: {
               title: 'Set validation rules',
               tabs: [
                 {
                   code: './examples/basic-usage.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -74,13 +74,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              "Communicate password problems clearly to users. This example shows an error message when the password doesn't meet length requirements.",
+              "Communicate password problems clearly to users. This example displays an error message when the password doesn't meet length requirements.",
             codeblock: {
               title: 'Show validation errors',
               tabs: [
                 {
                   code: './examples/with-error-state.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -88,13 +88,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Help users understand password requirements upfront. This example shows helper text beneath the field explaining what makes a valid password.',
+              'Help users understand password requirements upfront. This example adds helper text beneath the field explaining what makes a valid password.',
             codeblock: {
               title: 'Add helper text',
               tabs: [
                 {
                   code: './examples/with-helper-text.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -102,13 +102,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Create a complete authentication form. This example shows a password field combined with an email field for login or registration.',
+              'Create a complete authentication form. This example combines a password field with an email field for login or registration.',
             codeblock: {
               title: 'Build a login form',
               tabs: [
                 {
                   code: './examples/in-form-layout.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -116,13 +116,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Show users exactly what their password needs. This example shows a static checklist of requirements like character length and case requirements.',
+              'Display a password requirements checklist alongside the field. This example lists requirements like character length and case requirements.',
             codeblock: {
               title: 'Display a requirement checklist',
               tabs: [
                 {
                   code: './examples/with-password-strength-requirements.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -82,7 +82,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Communicate password problems clearly to users. This example shows an error message when the password doesn\'t meet length requirements. Click to interact with the preview.',
+              "Communicate password problems clearly to users. This example shows an error message when the password doesn't meet length requirements. Click to interact with the preview.",
             codeblock: {
               title: 'Show validation errors',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -40,7 +40,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Securely collect sensitive credentials from users. This example shows a labeled password field with masked input. Click to interact with the preview.',
+      'Securely collect sensitive credentials from users. This example shows a labeled password field with masked input.',
     codeblock: {
       title: 'Collect a password',
       tabs: [
@@ -60,7 +60,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Enforce password requirements before submission. This example shows a required field with minimum length validation and autocomplete for new passwords. Click to interact with the preview.',
+              'Enforce password requirements before submission. This example shows a required field with minimum length validation and autocomplete for new passwords.',
             codeblock: {
               title: 'Set validation rules',
               tabs: [
@@ -74,7 +74,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              "Communicate password problems clearly to users. This example shows an error message when the password doesn't meet length requirements. Click to interact with the preview.",
+              "Communicate password problems clearly to users. This example shows an error message when the password doesn't meet length requirements.",
             codeblock: {
               title: 'Show validation errors',
               tabs: [
@@ -88,7 +88,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Help users understand password requirements upfront. This example shows helper text beneath the field explaining what makes a valid password. Click to interact with the preview.',
+              'Help users understand password requirements upfront. This example shows helper text beneath the field explaining what makes a valid password.',
             codeblock: {
               title: 'Add helper text',
               tabs: [
@@ -102,7 +102,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Create a complete authentication form. This example shows a password field combined with an email field for login or registration. Click to interact with the preview.',
+              'Create a complete authentication form. This example shows a password field combined with an email field for login or registration.',
             codeblock: {
               title: 'Build a login form',
               tabs: [
@@ -116,7 +116,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Show users exactly what their password needs. This example shows a static checklist of requirements like character length and case requirements. Click to interact with the preview.',
+              'Show users exactly what their password needs. This example shows a static checklist of requirements like character length and case requirements.',
             codeblock: {
               title: 'Display a requirement checklist',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -154,24 +154,6 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
         ],
       },
-      {
-        title: '',
-        examples: [
-          {
-            description:
-              'Provide immediate feedback on password quality. This example shows real-time validation that checks requirements as the user types. Click to interact with the preview.',
-            codeblock: {
-              title: 'Validate password strength',
-              tabs: [
-                {
-                  code: './examples/password-strength-validation.jsx',
-                  language: 'preview-jsx',
-                },
-              ],
-            },
-          },
-        ],
-      },
     ],
   },
 };

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -47,11 +47,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         {
           code: './examples/default.html',
           language: 'html',
-        },
-
-        {
-          code: './examples/default.jsx',
-          language: 'preview-jsx',
+          title: '',
         },
       ],
     },
@@ -71,11 +67,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/basic-usage.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/basic-usage.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -89,11 +81,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/with-error-state.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/with-error-state.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -107,11 +95,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/with-helper-text.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/with-helper-text.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -125,11 +109,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/in-form-layout.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/in-form-layout.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -143,11 +123,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/with-password-strength-requirements.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/with-password-strength-requirements.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -73,7 +73,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Let users pick one option from a predefined list. This example shows a labeled dropdown with selectable options. Click to interact with the preview.',
+      'Let users pick one option from a predefined list. This example shows a labeled dropdown with selectable options.',
     codeblock: {
       title: 'Create a dropdown menu',
       tabs: [
@@ -93,7 +93,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Provide sorting controls for lists or tables. This example shows a dropdown with sort options and a pre-selected default value. Click to interact with the preview.',
+              'Provide sorting controls for lists or tables. This example shows a dropdown with sort options and a pre-selected default value.',
             codeblock: {
               title: 'Add sorting options',
               tabs: [
@@ -107,7 +107,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Guide users before they make a selection. This example shows placeholder text that describes what the user should choose. Click to interact with the preview.',
+              'Guide users before they make a selection. This example shows placeholder text that describes what the user should choose.',
             codeblock: {
               title: 'Add placeholder text',
               tabs: [
@@ -121,7 +121,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Communicate selection problems clearly to users. This example shows an error message when a required selection is missing. Click to interact with the preview.',
+              'Communicate selection problems clearly to users. This example shows an error message when a required selection is missing.',
             codeblock: {
               title: 'Show validation errors',
               tabs: [
@@ -135,7 +135,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Make long option lists easier to scan. This example shows options organized into logical groups like geographical regions. Click to interact with the preview.',
+              'Make long option lists easier to scan. This example shows options organized into logical groups like geographical regions.',
             codeblock: {
               title: 'Group options by category',
               tabs: [
@@ -149,7 +149,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Visually indicate the purpose of a select field. This example shows a sort icon that signals filtering functionality. Click to interact with the preview.',
+              'Visually indicate the purpose of a select field. This example shows a sort icon that signals filtering functionality.',
             codeblock: {
               title: 'Add an icon',
               tabs: [
@@ -163,7 +163,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              "Lock a selection when changes aren't allowed. This example shows a disabled dropdown that preserves its selected value but prevents interaction. Click to interact with the preview.",
+              "Lock a selection when changes aren't allowed. This example shows a disabled dropdown that preserves its selected value but prevents interaction.",
             codeblock: {
               title: 'Disable the select',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -205,24 +205,6 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
         ],
       },
-      {
-        title: '',
-        examples: [
-          {
-            description:
-              'Respond to user selections with custom logic. This example shows the onChange event triggering an action when the user picks an option. Click to interact with the preview.',
-            codeblock: {
-              title: 'Handle selection changes',
-              tabs: [
-                {
-                  code: './examples/handle-selection-change.jsx',
-                  language: 'preview-jsx',
-                },
-              ],
-            },
-          },
-        ],
-      },
     ],
   },
 };

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -187,7 +187,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Lock a selection when changes aren\'t allowed. This example shows a disabled dropdown that preserves its selected value but prevents interaction. Click to interact with the preview.',
+              "Lock a selection when changes aren't allowed. This example shows a disabled dropdown that preserves its selected value but prevents interaction. Click to interact with the preview.",
             codeblock: {
               title: 'Disable the select',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -72,9 +72,10 @@ const data: AdminReferenceEntityTemplateSchema = {
     },
   ],
   defaultExample: {
-    image: 'select-default.png',
+    description:
+      'Let users pick one option from a predefined list. This example shows a labeled dropdown with selectable options. Click to interact with the preview.',
     codeblock: {
-      title: 'Code',
+      title: 'Create a dropdown menu',
       tabs: [
         {
           code: './examples/default.html',
@@ -92,13 +93,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     description: 'Component examples',
     exampleGroups: [
       {
-        title: 'Basic usage',
+        title: '',
         examples: [
           {
             description:
-              'A simple select dropdown with pre-selected value for product sorting options.',
+              'Provide sorting controls for lists or tables. This example shows a dropdown with sort options and a pre-selected default value. Click to interact with the preview.',
             codeblock: {
-              title: 'Basic usage',
+              title: 'Add sorting options',
               tabs: [
                 {
                   code: './examples/basic-usage.html',
@@ -114,9 +115,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Select dropdown with helpful placeholder text guiding category selection.',
+              'Guide users before they make a selection. This example shows placeholder text that describes what the user should choose. Click to interact with the preview.',
             codeblock: {
-              title: 'With placeholder',
+              title: 'Add placeholder text',
               tabs: [
                 {
                   code: './examples/with-placeholder.html',
@@ -132,9 +133,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Select in error state showing specific business context and actionable error message.',
+              'Communicate selection problems clearly to users. This example shows an error message when a required selection is missing. Click to interact with the preview.',
             codeblock: {
-              title: 'With error state',
+              title: 'Show validation errors',
               tabs: [
                 {
                   code: './examples/with-error-state.html',
@@ -150,9 +151,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Grouped select options organized by geographical regions for international shipping.',
+              'Make long option lists easier to scan. This example shows options organized into logical groups like geographical regions. Click to interact with the preview.',
             codeblock: {
-              title: 'With option groups',
+              title: 'Group options by category',
               tabs: [
                 {
                   code: './examples/with-option-groups.html',
@@ -168,9 +169,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Select dropdown with sort icon for filtering order management views.',
+              'Visually indicate the purpose of a select field. This example shows a sort icon that signals filtering functionality. Click to interact with the preview.',
             codeblock: {
-              title: 'With icon',
+              title: 'Add an icon',
               tabs: [
                 {
                   code: './examples/with-icon.html',
@@ -186,9 +187,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Select in disabled state preventing user interaction with pre-selected value.',
+              'Lock a selection when changes aren\'t allowed. This example shows a disabled dropdown that preserves its selected value but prevents interaction. Click to interact with the preview.',
             codeblock: {
-              title: 'Disabled state',
+              title: 'Disable the select',
               tabs: [
                 {
                   code: './examples/disabled-state.html',
@@ -197,6 +198,24 @@ const data: AdminReferenceEntityTemplateSchema = {
 
                 {
                   code: './examples/disabled-state.jsx',
+                  language: 'preview-jsx',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: '',
+        examples: [
+          {
+            description:
+              'Respond to user selections with custom logic. This example shows the onChange event triggering an action when the user picks an option. Click to interact with the preview.',
+            codeblock: {
+              title: 'Handle selection changes',
+              tabs: [
+                {
+                  code: './examples/handle-selection-change.jsx',
                   language: 'preview-jsx',
                 },
               ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -73,13 +73,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Let users pick one option from a predefined list. This example shows a labeled dropdown with selectable options.',
+      'Let users pick one option from a predefined list. This example pairs a label with selectable options.',
     codeblock: {
       title: 'Create a dropdown menu',
       tabs: [
         {
           code: './examples/default.html',
-          language: 'html',
+          language: 'preview',
           title: '',
         },
       ],
@@ -93,13 +93,13 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Provide sorting controls for lists or tables. This example shows a dropdown with sort options and a pre-selected default value.',
+              'Provide sorting controls for lists or tables. This example configures sort options with a pre-selected default value.',
             codeblock: {
               title: 'Add sorting options',
               tabs: [
                 {
                   code: './examples/basic-usage.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -107,13 +107,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Guide users before they make a selection. This example shows placeholder text that describes what the user should choose.',
+              'Show instructional text before a selection is made. This example uses placeholder text to describe what the user should choose.',
             codeblock: {
               title: 'Add placeholder text',
               tabs: [
                 {
                   code: './examples/with-placeholder.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -121,13 +121,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Communicate selection problems clearly to users. This example shows an error message when a required selection is missing.',
+              'Communicate selection problems clearly to users. This example displays an error message when a required selection is missing.',
             codeblock: {
               title: 'Show validation errors',
               tabs: [
                 {
                   code: './examples/with-error-state.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -135,13 +135,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Make long option lists easier to scan. This example shows options organized into logical groups like geographical regions.',
+              'Make long option lists easier to scan. This example organizes options into logical groups like geographical regions.',
             codeblock: {
               title: 'Group options by category',
               tabs: [
                 {
                   code: './examples/with-option-groups.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -149,13 +149,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Visually indicate the purpose of a select field. This example shows a sort icon that signals filtering functionality.',
+              'Visually indicate the purpose of a select field. This example adds a sort icon that signals filtering functionality.',
             codeblock: {
               title: 'Add an icon',
               tabs: [
                 {
                   code: './examples/with-icon.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -163,13 +163,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              "Lock a selection when changes aren't allowed. This example shows a disabled dropdown that preserves its selected value but prevents interaction.",
+              "Lock a selection when changes aren't allowed. This example disables a dropdown while preserving its selected value.",
             codeblock: {
               title: 'Disable the select',
               tabs: [
                 {
                   code: './examples/disabled-state.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -80,11 +80,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         {
           code: './examples/default.html',
           language: 'html',
-        },
-
-        {
-          code: './examples/default.jsx',
-          language: 'preview-jsx',
+          title: '',
         },
       ],
     },
@@ -104,11 +100,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/basic-usage.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/basic-usage.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -122,11 +114,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/with-placeholder.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/with-placeholder.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -140,11 +128,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/with-error-state.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/with-error-state.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -158,11 +142,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/with-option-groups.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/with-option-groups.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -176,11 +156,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/with-icon.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/with-icon.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -194,11 +170,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/disabled-state.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/disabled-state.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/examples/with-error-state.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/examples/with-error-state.html
@@ -4,7 +4,7 @@
   required
 >
   <s-option value="ca">Canada</s-option>
-  <s-option value="us">United states</s-option>
+  <s-option value="us">United States</s-option>
   <s-option value="mx">Mexico</s-option>
-  <s-option value="uk">United kingdom</s-option>
+  <s-option value="uk">United Kingdom</s-option>
 </s-select>

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/examples/with-option-groups.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/examples/with-option-groups.html
@@ -1,16 +1,16 @@
 <s-select label="Shipping destination">
-  <s-option-group label="North america">
+  <s-option-group label="North America">
     <s-option value="ca">Canada</s-option>
-    <s-option value="us">United states</s-option>
+    <s-option value="us">United States</s-option>
     <s-option value="mx">Mexico</s-option>
   </s-option-group>
   <s-option-group label="Europe">
-    <s-option value="uk">United kingdom</s-option>
+    <s-option value="uk">United Kingdom</s-option>
     <s-option value="fr">France</s-option>
     <s-option value="de">Germany</s-option>
     <s-option value="it">Italy</s-option>
   </s-option-group>
-  <s-option-group label="Asia pacific">
+  <s-option-group label="Asia Pacific">
     <s-option value="au">Australia</s-option>
     <s-option value="jp">Japan</s-option>
     <s-option value="sg">Singapore</s-option>

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
@@ -165,24 +165,6 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
         ],
       },
-      {
-        title: '',
-        examples: [
-          {
-            description:
-              'Respond to toggle changes with custom logic. This example shows state tracking that displays the current value when the switch is toggled.',
-            codeblock: {
-              title: 'Track toggle state',
-              tabs: [
-                {
-                  code: './examples/toggle-with-feedback.jsx',
-                  language: 'preview-jsx',
-                },
-              ],
-            },
-          },
-        ],
-      },
     ],
   },
 };

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
@@ -32,8 +32,10 @@ const data: AdminReferenceEntityTemplateSchema = {
     },
   ],
   defaultExample: {
+    description:
+      'Give users a clear way to turn a feature on or off. This example shows a labeled toggle switch for enabling a preference.',
     codeblock: {
-      title: 'Code',
+      title: 'Toggle a setting',
       tabs: [
         {
           code: './examples/default.html',
@@ -51,31 +53,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     description: 'Component examples',
     exampleGroups: [
       {
-        title: 'Basic usage',
+        title: '',
         examples: [
           {
             description:
-              'Standard toggle switch for enabling or disabling merchant preferences. This example demonstrates a simple switch with a label, allowing merchants to toggle a single setting on or off.',
+              "Indicate when a feature isn't available. This example shows a locked switch that prevents interaction while showing its current state.",
             codeblock: {
-              title: 'Basic switch',
-              tabs: [
-                {
-                  code: './examples/basic-switch.html',
-                  language: 'html',
-                },
-
-                {
-                  code: './examples/basic-switch.jsx',
-                  language: 'preview-jsx',
-                },
-              ],
-            },
-          },
-          {
-            description:
-              'Locked switch with explanatory text for unavailable premium features. This example shows a switch that is visually disabled and cannot be interacted with, typically used to indicate a feature is not currently available.',
-            codeblock: {
-              title: 'Disabled switch',
+              title: 'Show a disabled switch',
               tabs: [
                 {
                   code: './examples/disabled-switch.html',
@@ -91,9 +75,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Multiple switches within a form for notification preferences submission. This example illustrates how switches can be used together in a form to allow merchants to configure multiple related settings simultaneously.',
+              'Collect multiple settings that save together. This example shows switches grouped in a form for batch submission.',
             codeblock: {
-              title: 'Form integration',
+              title: 'Submit multiple settings in a form',
               tabs: [
                 {
                   code: './examples/form-integration.html',
@@ -109,9 +93,27 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Switch with visually hidden label that remains accessible to screen readers. This example demonstrates how to create a switch with a label that is only perceivable by assistive technologies, maintaining accessibility while minimizing visual clutter.',
+              'Apply changes instantly without a save button. This example shows switches arranged in a panel where each toggle takes effect immediately.',
             codeblock: {
-              title: 'Hidden label for accessibility',
+              title: 'Apply multiple settings immediately',
+              tabs: [
+                {
+                  code: './examples/settings-panel-with-stack.html',
+                  language: 'html',
+                },
+
+                {
+                  code: './examples/settings-panel-with-stack.jsx',
+                  language: 'preview-jsx',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              "Keep switches accessible when labels aren't visually needed. This example shows a visually hidden label that screen readers can still announce.",
+            codeblock: {
+              title: 'Hide the label visually',
               tabs: [
                 {
                   code: './examples/hidden-label-for-accessibility.html',
@@ -127,9 +129,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Required switch with validation error and contextual details for user guidance. This example shows a switch that requires user interaction, provides additional context through details, and displays an error message when validation fails.',
+              "Communicate switch-related problems clearly. This example shows helper text with an error message when a required switch isn't enabled.",
             codeblock: {
-              title: 'With details and error',
+              title: 'Show validation errors',
               tabs: [
                 {
                   code: './examples/with-details-and-error.html',
@@ -145,9 +147,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Switch with enhanced accessibility description for screen reader users. This example illustrates how to provide a more descriptive accessibility label that provides additional context beyond the visible label.',
+              'Provide extra context for screen reader users. This example shows an accessibility label that gives more detail than the visible label alone.',
             codeblock: {
-              title: 'Switch with accessibility label',
+              title: 'Add an accessibility label',
               tabs: [
                 {
                   code: './examples/switch-with-accessibility-label.html',
@@ -161,19 +163,19 @@ const data: AdminReferenceEntityTemplateSchema = {
               ],
             },
           },
+        ],
+      },
+      {
+        title: '',
+        examples: [
           {
             description:
-              'Group of related switches arranged in a vertical stack for settings configuration. This example demonstrates how to use the stack component to create a clean, organized layout for multiple related switch settings.',
+              'Respond to toggle changes with custom logic. This example shows state tracking that displays the current value when the switch is toggled.',
             codeblock: {
-              title: 'Settings panel with Stack',
+              title: 'Track toggle state',
               tabs: [
                 {
-                  code: './examples/settings-panel-with-stack.html',
-                  language: 'html',
-                },
-
-                {
-                  code: './examples/settings-panel-with-stack.jsx',
+                  code: './examples/toggle-with-feedback.jsx',
                   language: 'preview-jsx',
                 },
               ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
@@ -40,11 +40,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         {
           code: './examples/default.html',
           language: 'html',
-        },
-
-        {
-          code: './examples/default.jsx',
-          language: 'preview-jsx',
+          title: '',
         },
       ],
     },
@@ -64,11 +60,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/disabled-switch.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/disabled-switch.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -82,11 +74,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/form-integration.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/form-integration.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -100,11 +88,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/settings-panel-with-stack.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/settings-panel-with-stack.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -118,11 +102,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/hidden-label-for-accessibility.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/hidden-label-for-accessibility.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -136,11 +116,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/with-details-and-error.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/with-details-and-error.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -154,11 +130,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/switch-with-accessibility-label.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/switch-with-accessibility-label.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
@@ -33,13 +33,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Give users a clear way to turn a feature on or off. This example shows a labeled toggle switch for enabling a preference.',
+      'Give users a clear way to turn a feature on or off. This example pairs a label with a toggle switch.',
     codeblock: {
       title: 'Toggle a setting',
       tabs: [
         {
           code: './examples/default.html',
-          language: 'html',
+          language: 'preview',
           title: '',
         },
       ],
@@ -53,13 +53,13 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              "Indicate when a feature isn't available. This example shows a locked switch that prevents interaction while showing its current state.",
+              "Indicate when a feature isn't available. This example locks a switch to prevent interaction while displaying its current state.",
             codeblock: {
               title: 'Show a disabled switch',
               tabs: [
                 {
                   code: './examples/disabled-switch.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -67,13 +67,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Collect multiple settings that save together. This example shows switches grouped in a form for batch submission.',
+              'Collect multiple settings that save together. This example groups switches in a form for batch submission.',
             codeblock: {
               title: 'Submit multiple settings in a form',
               tabs: [
                 {
                   code: './examples/form-integration.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -81,13 +81,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Apply changes instantly without a save button. This example shows switches arranged in a panel where each toggle takes effect immediately.',
+              'Organize settings in a panel layout. This example arranges switches in a stack to display related preferences together.',
             codeblock: {
               title: 'Apply multiple settings immediately',
               tabs: [
                 {
                   code: './examples/settings-panel-with-stack.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -95,13 +95,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              "Keep switches accessible when labels aren't visually needed. This example shows a visually hidden label that screen readers can still announce.",
+              "Keep switches accessible when labels aren't visually needed. This example uses a visually hidden label that screen readers can still announce.",
             codeblock: {
               title: 'Hide the label visually',
               tabs: [
                 {
                   code: './examples/hidden-label-for-accessibility.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -109,13 +109,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              "Communicate switch-related problems clearly. This example shows helper text with an error message when a required switch isn't enabled.",
+              "Communicate switch-related problems clearly. This example displays helper text with an error message when a required switch isn't enabled.",
             codeblock: {
               title: 'Show validation errors',
               tabs: [
                 {
                   code: './examples/with-details-and-error.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -123,13 +123,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Provide extra context for screen reader users. This example shows an accessibility label that gives more detail than the visible label alone.',
+              'Provide extra context for screen reader users. This example adds an accessibility label that gives more detail than the visible label alone.',
             codeblock: {
               title: 'Add an accessibility label',
               tabs: [
                 {
                   code: './examples/switch-with-accessibility-label.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/disabled-switch.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/disabled-switch.html
@@ -1,6 +1,6 @@
 <s-switch
   id="disabled-switch"
   label="Feature locked (Premium plan required)"
-  checked="true"
-  disabled="true"
+  checked
+  disabled
 ></s-switch>

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/form-integration.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/form-integration.html
@@ -1,14 +1,17 @@
 <form>
-  <s-switch
-    id="email-notifications"
-    label="Email notifications"
-    name="emailNotifications"
-    value="enabled"
-  ></s-switch>
-  <s-switch
-    id="sms-notifications"
-    label="SMS notifications"
-    name="smsNotifications"
-    value="enabled"
-  ></s-switch>
+  <s-stack gap="base">
+    <s-switch
+      id="email-notifications"
+      label="Email notifications"
+      name="emailNotifications"
+      value="enabled"
+    ></s-switch>
+    <s-switch
+      id="sms-notifications"
+      label="SMS notifications"
+      name="smsNotifications"
+      value="enabled"
+    ></s-switch>
+    <s-button type="submit">Save preferences</s-button>
+  </s-stack>
 </form>

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/hidden-label-for-accessibility.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/hidden-label-for-accessibility.html
@@ -2,5 +2,5 @@
   id="hidden-label-switch"
   labelAccessibilityVisibility="exclusive"
   label="Toggle feature"
-  checked="true"
+  checked
 ></s-switch>

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/settings-panel-with-stack.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/settings-panel-with-stack.html
@@ -4,6 +4,6 @@
   <s-switch
     id="analytics-setting"
     label="Usage analytics"
-    checked="true"
+    checked
   ></s-switch>
 </s-stack>

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/with-details-and-error.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/examples/with-details-and-error.html
@@ -4,6 +4,6 @@
   details="You must agree to continue with the purchase"
   error="Agreement is required"
   name="termsAgreement"
-  required="true"
+  required
   value="agreed"
 ></s-switch>

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -29,7 +29,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   ],
   definitions: [
     {
-      title: 'URLField',
+      title: 'Properties',
       description:
         'Configure the following properties on the URL field component.',
       type: 'URLField',
@@ -42,12 +42,12 @@ const data: AdminReferenceEntityTemplateSchema = {
     },
   ],
   defaultExample: {
-    image: 'urlfield-default.png',
+    description:
+      'Capture web addresses from users with URL-specific input. This example shows a labeled field with placeholder text guiding the expected format.',
     codeblock: {
-      title: 'Code',
+      title: 'Collect a URL',
       tabs: [
         {
-          title: 'HTML',
           code: './examples/default.html',
           language: 'html',
         },
@@ -62,31 +62,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     description: 'Component examples',
     exampleGroups: [
       {
-        title: 'Basic usage',
+        title: '',
         examples: [
           {
             description:
-              'Demonstrates a simple URL input field with a label and placeholder, showing the minimal configuration needed for collecting a URL.',
+              'Enforce URL requirements before form submission. This example shows required validation with length constraints and custom error messages.',
             codeblock: {
-              title: 'Basic usage',
-              tabs: [
-                {
-                  code: './examples/basic-usage.html',
-                  language: 'html',
-                },
-
-                {
-                  code: './examples/basic-usage.jsx',
-                  language: 'preview-jsx',
-                },
-              ],
-            },
-          },
-          {
-            description:
-              'Shows a URL input field with built-in validation, including required status, minimum and maximum length constraints, and a custom error message for invalid inputs.',
-            codeblock: {
-              title: 'With validation',
+              title: 'Set validation constraints',
               tabs: [
                 {
                   code: './examples/with-validation.html',
@@ -102,9 +84,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Illustrates a URL field pre-populated with a default value, set to read-only mode to prevent user modifications.',
+              'Display a URL for reference without allowing changes. This example shows a read-only field pre-populated with a store URL.',
             codeblock: {
-              title: 'With default value',
+              title: 'Pre-fill a URL',
               tabs: [
                 {
                   code: './examples/with-default-value.html',
@@ -120,9 +102,9 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Shows a URL field in a disabled state, displaying a pre-filled URL that cannot be edited by the user.',
+              'Display a URL that users can view but not change. This example shows a disabled field with a pre-filled value that prevents editing.',
             codeblock: {
-              title: 'Disabled state',
+              title: 'Show a disabled field',
               tabs: [
                 {
                   code: './examples/disabled-state.html',
@@ -131,6 +113,24 @@ const data: AdminReferenceEntityTemplateSchema = {
 
                 {
                   code: './examples/disabled-state.jsx',
+                  language: 'preview-jsx',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: '',
+        examples: [
+          {
+            description:
+              'Provide immediate feedback on URL validity. This example shows real-time validation that checks the URL format as the user types.',
+            codeblock: {
+              title: 'Validate URL in real time',
+              tabs: [
+                {
+                  code: './examples/validate-url-input.jsx',
                   language: 'preview-jsx',
                 },
               ],

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -91,7 +91,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Display a URL that users can view but not change. This example shows a disabled field with a pre-filled value that prevents editing.',
+              'Display a URL that users can view but not change. This example shows a pre-filled, disabled field that prevents editing.',
             codeblock: {
               title: 'Show a disabled field',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -120,24 +120,6 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
         ],
       },
-      {
-        title: '',
-        examples: [
-          {
-            description:
-              'Provide immediate feedback on URL validity. This example shows real-time validation that checks the URL format as the user types.',
-            codeblock: {
-              title: 'Validate URL in real time',
-              tabs: [
-                {
-                  code: './examples/validate-url-input.jsx',
-                  language: 'preview-jsx',
-                },
-              ],
-            },
-          },
-        ],
-      },
     ],
   },
 };

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -43,13 +43,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   ],
   defaultExample: {
     description:
-      'Capture web addresses from users with URL-specific input. This example shows a labeled field with placeholder text guiding the expected format.',
+      'Capture web addresses from users with URL-specific input. This example pairs a label with placeholder text guiding the expected format.',
     codeblock: {
       title: 'Collect a URL',
       tabs: [
         {
           code: './examples/default.html',
-          language: 'html',
+          language: 'preview',
           title: '',
         },
       ],
@@ -63,13 +63,13 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Enforce URL requirements before form submission. This example shows required validation with length constraints and custom error messages.',
+              'Enforce URL requirements before form submission. This example configures required validation with length constraints and custom error messages.',
             codeblock: {
               title: 'Set validation constraints',
               tabs: [
                 {
                   code: './examples/with-validation.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -77,13 +77,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Display a URL for reference without allowing changes. This example shows a read-only field pre-populated with a store URL.',
+              'Display a URL that users can copy but not edit. This example uses readOnly to prevent changes while keeping the value selectable and included in form submissions.',
             codeblock: {
               title: 'Pre-fill a URL',
               tabs: [
                 {
                   code: './examples/with-default-value.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],
@@ -91,13 +91,13 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Display a URL that users can view but not change. This example shows a pre-filled, disabled field that prevents editing.',
+              'Show a URL in a non-interactive state. This example uses disabled to gray out the field and exclude it from form submission.',
             codeblock: {
               title: 'Show a disabled field',
               tabs: [
                 {
                   code: './examples/disabled-state.html',
-                  language: 'html',
+                  language: 'preview',
                   title: '',
                 },
               ],

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -50,10 +50,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         {
           code: './examples/default.html',
           language: 'html',
-        },
-        {
-          code: './examples/default.jsx',
-          language: 'preview-jsx',
+          title: '',
         },
       ],
     },
@@ -73,11 +70,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/with-validation.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/with-validation.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -91,11 +84,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/with-default-value.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/with-default-value.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },
@@ -109,11 +98,7 @@ const data: AdminReferenceEntityTemplateSchema = {
                 {
                   code: './examples/disabled-state.html',
                   language: 'html',
-                },
-
-                {
-                  code: './examples/disabled-state.jsx',
-                  language: 'preview-jsx',
+                  title: '',
                 },
               ],
             },

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/default.html
@@ -1,5 +1,5 @@
 <s-url-field
   label="Your website"
-  details="Join the partner ecosystem"
-  placeholder="https://shopify.com/partner"
+  details="Enter your business website"
+  placeholder="https://example.com"
 ></s-url-field>

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/with-default-value.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/with-default-value.html
@@ -1,7 +1,5 @@
-<s-stack gap="base">
-  <s-url-field
-    label="Profile URL"
-    value="https://shop.myshopify.com"
-    readOnly
-  ></s-url-field>
-</s-stack>
+<s-url-field
+  label="Profile URL"
+  value="https://shop.myshopify.com"
+  readOnly
+></s-url-field>


### PR DESCRIPTION
Updating examples only for App Home polaris components: MoneyField, PasswordField, Select, Switch URLField.

Updates:
- Improves examples descriptions to 3-sentence structure: What this pattern helps merchants accomplish + What this specific example demonstrates beginning with "This example shows..."
- Update to action-oriented titles
- Removes any redundant examples

Relates to:
https://github.com/Shopify/shopify-dev/issues/67273
https://github.com/Shopify/shopify-dev/issues/67423
https://github.com/Shopify/temp-project-mover-Archetypically-20260313091522/issues/297
https://github.com/Shopify/shopify-dev/issues/67421
https://github.com/Shopify/temp-project-mover-Archetypically-20260313091522/issues/298

## Test plan
- [ ] Verify descriptions render correctly on docs pages