### PR TITLE
[2026-01]: Transition Admin UI component names from Pascal case to sentence case

### DIFF
--- a/packages/ui-extensions/src/docs/shared/components/Avatar.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Avatar.ts
@@ -3,8 +3,8 @@ import {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Avatar',
   description:
-    "The Avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use Avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available." +
-    '\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [Thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For full-size images, use [Image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image).',
+    "The avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available." +
+    '\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image).',
   category: 'Polaris web components',
   subCategory: 'Media and visuals',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Badge.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Badge.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Badge',
   description:
-    'The Badge component displays status information or indicates completed actions through compact visual indicators. Use Badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.' +
-    '\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [Chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) instead.',
+    'The badge component displays status information or indicates completed actions through compact visual indicators. Use badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.' +
+    '\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) instead.',
   category: 'Polaris web components',
   subCategory: 'Feedback and status indicators',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Banner.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Banner.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Banner',
   description:
-    'The Banner component highlights important information or required actions prominently within the interface. Use Banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.' +
-    '\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [Badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge).',
+    'The banner component highlights important information or required actions prominently within the interface. Use banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.' +
+    '\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge).',
   category: 'Polaris web components',
   subCategory: 'Feedback and status indicators',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Box.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Box.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
-    "The Box component provides a generic, flexible container for custom designs and layouts. Use Box to apply styling like backgrounds, padding, borders, or border radius when existing components don't meet your needs, or to nest and group other components." +
-    '\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [Stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [Grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).',
+    "The box component provides a generic, flexible container for custom designs and layouts. Use box to apply styling like backgrounds, padding, borders, or border radius when existing components don't meet your needs, or to nest and group other components." +
+    '\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Button.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Button.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
     'The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface.' +
-    '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/buttongroup).',
+    '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button-group).',
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Button.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Button.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
-    'The Button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use Button to let users perform specific tasks or initiate interactions throughout the interface.' +
-    '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [Link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [ButtonGroup](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/buttongroup).',
+    'The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface.' +
+    '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/buttongroup).',
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ButtonGroup.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ButtonGroup.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'ButtonGroup',
+  name: 'Button group',
   description:
-    'The ButtonGroup component displays multiple related buttons in a structured layout. Use ButtonGroup to organize action buttons together, creating clear visual hierarchies and helping users understand available options.' +
-    '\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [Button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button).',
+    'The button group component displays multiple related buttons in a structured layout. Use button group to organize action buttons together, creating clear visual hierarchies and helping users understand available options.' +
+    '\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button).',
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Checkbox.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Checkbox.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Checkbox',
   description:
-    'The Checkbox component provides a clear way for users to make selections, such as agreeing to terms, enabling settings, or choosing multiple items from a list. Use Checkbox to create binary on/off controls or multi-select interfaces where users can select any combination of options.' +
-    '\n\nCheckboxes support labels, help text, error states, and an indeterminate state for "select all" functionality when working with grouped selections. For settings that take effect immediately, use [Switch](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/switch) instead.',
+    'The checkbox component provides a clear way for users to make selections, such as agreeing to terms, enabling settings, or choosing multiple items from a list. Use checkbox to create binary on/off controls or multi-select interfaces where users can select any combination of options.' +
+    '\n\nCheckboxes support labels, help text, error states, and an indeterminate state for "select all" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/switch) instead.',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Chip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Chip.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Chip',
   description:
-    'The Chip component displays static labels, categories, or attributes that help classify and organize content. Use Chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.' +
-    '\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [Badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [ClickableChip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickablechip).',
+    'The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.' +
+    '\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickablechip).',
   category: 'Polaris web components',
   subCategory: 'Typography and content',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Chip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Chip.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Chip',
   description:
     'The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.' +
-    '\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickablechip).',
+    '\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip).',
   category: 'Polaris web components',
   subCategory: 'Typography and content',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Choice.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Choice.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Choice',
   description:
-    'The Choice component creates individual selectable options within a ChoiceList. Use Choice to define each option that merchants can select, supporting both single selection (radio buttons) and multiple selection (checkboxes) modes.' +
+    'The choice component creates individual selectable options within a choice list. Use choice to define each option that merchants can select, supporting both single selection (radio buttons) and multiple selection (checkboxes) modes.' +
     '\n\nChoice components support labels, help text, and custom content through slots, providing flexible option presentation within choice lists.',
   category: 'Polaris web components',
   subCategory: 'Forms',

--- a/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'ChoiceList',
+  name: 'Choice list',
   description:
-    'The ChoiceList component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
-    '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [Select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select).',
+    'The choice list component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
+    '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Clickable.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Clickable.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
-    'The Clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [Button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [Link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.' +
+    'The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.' +
     '\n\nClickable supports button, link, and submit modes with built-in accessibility properties for keyboard navigation and screen reader support.',
   category: 'Polaris web components',
   subCategory: 'Actions',

--- a/packages/ui-extensions/src/docs/shared/components/ClickableChip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ClickableChip.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'ClickableChip',
+  name: 'Clickable chip',
   description:
-    'The ClickableChip component displays interactive labels or categories that users can click or remove. Use ClickableChip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.' +
-    '\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [Chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip).',
+    'The clickable chip component displays interactive labels or categories that users can click or remove. Use clickable chip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.' +
+    '\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip).',
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ColorField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ColorField.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Color field',
   description:
     'The color field component allows users to select colors through an integrated color picker or direct text input. Use color field for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.' +
-    '\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/colorpicker).',
+    '\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-picker).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ColorField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ColorField.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'ColorField',
+  name: 'Color field',
   description:
-    'The ColorField component allows users to select colors through an integrated color picker or direct text input. Use ColorField for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.' +
-    '\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [ColorPicker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/colorpicker).',
+    'The color field component allows users to select colors through an integrated color picker or direct text input. Use color field for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.' +
+    '\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/colorpicker).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ColorPicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ColorPicker.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'ColorPicker',
+  name: 'Color picker',
   description:
-    'The ColorPicker component allows users to select colors from a visual color palette interface. Use ColorPicker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.' +
-    '\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [ColorField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/colorfield).',
+    'The color picker component allows users to select colors from a visual color palette interface. Use color picker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.' +
+    '\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/colorfield).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ColorPicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ColorPicker.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Color picker',
   description:
     'The color picker component allows users to select colors from a visual color palette interface. Use color picker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.' +
-    '\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/colorfield).',
+    '\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/DateField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DateField.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Date field',
   description:
     'The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
-    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/datepicker).',
+    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-picker).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/DateField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DateField.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'DateField',
+  name: 'Date field',
   description:
-    'The DateField component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
-    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [DatePicker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/datepicker).',
+    'The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
+    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/datepicker).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Date picker',
   description:
     'The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
-    '\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/datefield).',
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-field).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'DatePicker',
+  name: 'Date picker',
   description:
-    'The DatePicker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
-    '\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [DateField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/datefield).',
+    'The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/datefield).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Divider.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Divider.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Divider',
   description:
     'The divider component creates clear visual separation between elements in the interface. Use divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.' +
-    '\n\ndividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section).',
+    '\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section).',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Divider.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Divider.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Divider',
   description:
-    'The Divider component creates clear visual separation between elements in the interface. Use Divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.' +
-    '\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [Section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section).',
+    'The divider component creates clear visual separation between elements in the interface. Use divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.' +
+    '\n\ndividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section).',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/EmailField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/EmailField.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'EmailField',
+  name: 'Email field',
   description:
-    'The EmailField component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
-    "\n\nEmailField doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [TextField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).",
+    'The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
+    "\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).",
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/EmailField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/EmailField.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Email field',
   description:
     'The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
-    "\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).",
+    "\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Form.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Form.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Form',
   description:
     'The form component wraps form controls and enables implicit submission, allowing users to submit from any input by pressing **Enter**. Use form to group related input fields and handle form submission through JavaScript event handlers.' +
-    "\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/functionsettings).",
+    "\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/function-settings).",
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Form.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Form.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Form',
   description:
-    'The Form component wraps form controls and enables implicit submission, allowing users to submit from any input by pressing **Enter**. Use Form to group related input fields and handle form submission through JavaScript event handlers.' +
-    "\n\nUnlike HTML forms, Form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [FunctionSettings](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/functionsettings).",
+    'The form component wraps form controls and enables implicit submission, allowing users to submit from any input by pressing **Enter**. Use form to group related input fields and handle form submission through JavaScript event handlers.' +
+    "\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/functionsettings).",
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/FunctionSettings.ts
+++ b/packages/ui-extensions/src/docs/shared/components/FunctionSettings.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'FunctionSettings',
+  name: 'Function settings',
   description:
-    'The FunctionSettings component configures metafield settings for [Shopify Functions](/docs/api/functions). Use FunctionSettings to create configuration interfaces that allow merchants to customize function behavior through structured input fields and controls.' +
-    '\n\nThis component provides a standardized layout for settings forms and integrates with the native save bar to handle form submission and reset actions automatically. For general form submission, use [Form](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/form).',
+    'The function settings component configures metafield settings for [Shopify Functions](/docs/api/functions). Use function settings to create configuration interfaces that allow merchants to customize function behavior through structured input fields and controls.' +
+    '\n\nThis component provides a standardized layout for settings forms and integrates with the native save bar to handle form submission and reset actions automatically. For general form submission, use [form](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/form).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Grid.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Grid.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Grid',
   description:
     'The grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.' +
-    '\n\ngrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack).',
+    '\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack).',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Grid.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Grid.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Grid',
   description:
-    'The Grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use Grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.' +
-    '\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [Stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack).',
+    'The grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.' +
+    '\n\ngrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack).',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/GridItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/GridItem.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'GridItem',
+  name: 'Grid item',
   description:
-    'The GridItem component represents a single cell within a Grid layout, allowing you to control how content is positioned and sized within the grid. Use GridItem as a child of Grid to specify column span, row span, and positioning for individual content areas.' +
-    '\n\nGridItem supports precise placement control through column and row properties, enabling you to create complex layouts where different items occupy varying amounts of space or appear in specific grid positions.',
+    'The grid item component represents a single cell within a grid layout, allowing you to control how content is positioned and sized within the grid. Use grid item as a child of grid to specify column span, row span, and positioning for individual content areas.' +
+    '\n\ngrid item supports precise placement control through column and row properties, enabling you to create complex layouts where different items occupy varying amounts of space or appear in specific grid positions.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/GridItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/GridItem.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Grid item',
   description:
     'The grid item component represents a single cell within a grid layout, allowing you to control how content is positioned and sized within the grid. Use grid item as a child of grid to specify column span, row span, and positioning for individual content areas.' +
-    '\n\ngrid item supports precise placement control through column and row properties, enabling you to create complex layouts where different items occupy varying amounts of space or appear in specific grid positions.',
+    '\n\nGrid item supports precise placement control through column and row properties, enabling you to create complex layouts where different items occupy varying amounts of space or appear in specific grid positions.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Heading.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Heading.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
     'The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.' +
-    '\n\nheading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.',
+    '\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.',
   category: 'Polaris web components',
   subCategory: 'Typography and content',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Heading.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Heading.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
-    'The Heading component renders hierarchical titles to communicate the structure and organization of page content. Use Heading to create section titles and content headers that help users understand information hierarchy and navigate content.' +
-    '\n\nHeading levels adjust automatically based on nesting within parent [Section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.',
+    'The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.' +
+    '\n\nheading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.',
   category: 'Polaris web components',
   subCategory: 'Typography and content',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Icon.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Icon.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
     'The icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.' +
-    '\n\nicons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) to enhance visual communication.',
+    '\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) to enhance visual communication.',
   category: 'Polaris web components',
   subCategory: 'Media and visuals',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Icon.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Icon.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
-    'The Icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use Icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.' +
-    '\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [Button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button), [Badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), and [Chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) to enhance visual communication.',
+    'The icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.' +
+    '\n\nicons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) to enhance visual communication.',
   category: 'Polaris web components',
   subCategory: 'Media and visuals',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Image.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Image.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
     'The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.' +
-    '\n\nimages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).',
+    '\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).',
   category: 'Polaris web components',
   subCategory: 'Media and visuals',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Image.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Image.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
-    'The Image component embeds images within the interface with control over presentation and loading behavior. Use Image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.' +
-    '\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [Thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For profile images, use [Avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).',
+    'The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.' +
+    '\n\nimages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).',
   category: 'Polaris web components',
   subCategory: 'Media and visuals',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Link.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Link.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Link',
   description:
-    'The Link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use Link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.' +
-    '\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [Button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) instead.',
+    'The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.' +
+    '\n\nlinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) instead.',
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Link.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Link.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Link',
   description:
     'The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.' +
-    '\n\nlinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) instead.',
+    '\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) instead.',
   category: 'Polaris web components',
   subCategory: 'Actions',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ListItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ListItem.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'ListItem',
+  name: 'List item',
   description:
-    'The ListItem component represents a single entry within an OrderedList or UnorderedList. Use ListItem to structure individual points, steps, or items within a list, with each item automatically receiving appropriate list markers (bullets or numbers) from its parent list.' +
-    '\n\nListItem must be used as a direct child of OrderedList or UnorderedList components. Each ListItem can contain text, inline formatting, or other components to create rich list content.',
+    'The list item component represents a single entry within an ordered list or unordered list. Use list item to structure individual points, steps, or items within a list, with each item automatically receiving appropriate list markers (bullets or numbers) from its parent list.' +
+    '\n\nlist item must be used as a direct child of ordered list or unordered list components. Each list item can contain text, inline formatting, or other components to create rich list content.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/ListItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ListItem.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'List item',
   description:
     'The list item component represents a single entry within an ordered list or unordered list. Use list item to structure individual points, steps, or items within a list, with each item automatically receiving appropriate list markers (bullets or numbers) from its parent list.' +
-    '\n\nlist item must be used as a direct child of ordered list or unordered list components. Each list item can contain text, inline formatting, or other components to create rich list content.',
+    '\n\nList item must be used as a direct child of ordered list or unordered list components. Each list item can contain text, inline formatting, or other components to create rich list content.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Menu.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Menu.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Menu',
   description:
-    'The Menu component displays a list of actions that can be performed on a resource or within a specific context. Use Menu to present multiple related actions in a compact dropdown format, reducing visual clutter while maintaining discoverability.' +
+    'The menu component displays a list of actions that can be performed on a resource or within a specific context. Use menu to present multiple related actions in a compact dropdown format, reducing visual clutter while maintaining discoverability.' +
     '\n\nMenus support action grouping, icons for visual clarity, and keyboard navigation for efficient interaction.',
   category: 'Polaris web components',
   subCategory: 'Actions',

--- a/packages/ui-extensions/src/docs/shared/components/MoneyField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/MoneyField.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Money field',
   description:
     'The money field component collects monetary values from users with built-in currency formatting and validation. Use money field for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.' +
-    '\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/numberfield).',
+    '\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/number-field).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/MoneyField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/MoneyField.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'MoneyField',
+  name: 'Money field',
   description:
-    'The MoneyField component collects monetary values from users with built-in currency formatting and validation. Use MoneyField for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.' +
-    '\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [NumberField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/numberfield).',
+    'The money field component collects monetary values from users with built-in currency formatting and validation. Use money field for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.' +
+    '\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/numberfield).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/NumberField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/NumberField.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'NumberField',
+  name: 'Number field',
   description:
-    'The NumberField component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
-    '\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [MoneyField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/moneyfield).',
+    'The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
+    '\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/moneyfield).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/NumberField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/NumberField.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Number field',
   description:
     'The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
-    '\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/moneyfield).',
+    '\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/money-field).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/OrderedList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/OrderedList.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'OrderedList',
+  name: 'Ordered list',
   description:
-    'The OrderedList component displays a numbered list of related items in a specific sequence. Use OrderedList to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.' +
-    "\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [UnorderedList](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unorderedlist).",
+    'The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.' +
+    "\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unorderedlist).",
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/OrderedList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/OrderedList.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Ordered list',
   description:
     'The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.' +
-    "\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unorderedlist).",
+    "\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list).",
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Paragraph',
   description:
-    'The Paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use Paragraph to present standalone blocks of readable content, descriptions, or explanatory text.' +
-    '\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [Text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text).',
+    'The paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use paragraph to present standalone blocks of readable content, descriptions, or explanatory text.' +
+    '\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text).',
   category: 'Polaris web components',
   subCategory: 'Typography and content',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/PasswordField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PasswordField.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Password field',
   description:
     'The password field component securely collects sensitive information from users. Use password field for password entry, where input characters are automatically masked for privacy.' +
-    '\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
+    '\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/PasswordField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PasswordField.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'PasswordField',
+  name: 'Password field',
   description:
-    'The PasswordField component securely collects sensitive information from users. Use PasswordField for password entry, where input characters are automatically masked for privacy.' +
-    '\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [TextField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
+    'The password field component securely collects sensitive information from users. Use password field for password entry, where input characters are automatically masked for privacy.' +
+    '\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/QueryContainer.ts
+++ b/packages/ui-extensions/src/docs/shared/components/QueryContainer.ts
@@ -1,9 +1,9 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'QueryContainer',
+  name: 'Query container',
   description:
-    "The QueryContainer component establishes a container query context for responsive design. Use QueryContainer to define an element as a containment context, enabling child components or styles to adapt based on the container's size rather than viewport width." +
+    "The query container component establishes a container query context for responsive design. Use query container to define an element as a containment context, enabling child components or styles to adapt based on the container's size rather than viewport width." +
     '\n\nQuery containers support modern responsive patterns where components respond to their container dimensions, creating more flexible and reusable layouts.',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',

--- a/packages/ui-extensions/src/docs/shared/components/SearchField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/SearchField.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Search field',
   description:
-    'The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
+    'The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/SearchField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/SearchField.ts
@@ -1,9 +1,9 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'SearchField',
+  name: 'Search field',
   description:
-    'The SearchField component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [TextField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
+    'The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Section.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Section.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Section',
   description:
-    'The Section component groups related content into clearly-defined thematic areas with consistent styling and structure. Use Section to organize page content into logical blocks, each with its own heading and visual container.' +
-    '\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [Divider](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/divider).',
+    'The section component groups related content into clearly-defined thematic areas with consistent styling and structure. Use section to organize page content into logical blocks, each with its own heading and visual container.' +
+    '\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/divider).',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Select.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Select.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Select',
   description:
     'The select component allows users to choose one option from a dropdown menu. Use select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.' +
-    '\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choicelist).',
+    '\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Select.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Select.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Select',
   description:
-    'The Select component allows users to choose one option from a dropdown menu. Use Select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.' +
-    '\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [ChoiceList](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choicelist).',
+    'The select component allows users to choose one option from a dropdown menu. Use select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.' +
+    '\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choicelist).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Spinner.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Spinner.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Spinner',
   description:
-    'The Spinner component displays an animated indicator showing users that content or actions are loading. Use Spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.' +
-    '\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [Button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) component instead.',
+    'The spinner component displays an animated indicator showing users that content or actions are loading. Use spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.' +
+    '\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) component instead.',
   category: 'Polaris web components',
   subCategory: 'Feedback and status indicators',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Stack.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Stack.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
-    'The Stack component organizes elements horizontally or vertically along the block or inline axis. Use Stack to structure layouts, group related components, control spacing between elements, or create flexible arrangements that adapt to content.' +
-    '\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [Grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).',
+    'The stack component organizes elements horizontally or vertically along the block or inline axis. Use stack to structure layouts, group related components, control spacing between elements, or create flexible arrangements that adapt to content.' +
+    '\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Switch.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Switch.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Switch',
   description:
-    'The Switch component provides a clear way for users to toggle options or settings on and off. Use Switch for binary controls that take effect immediately, like enabling features, activating settings, or controlling visibility.' +
-    "\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [Checkbox](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/checkbox) instead.",
+    'The switch component provides a clear way for users to toggle options or settings on and off. Use switch for binary controls that take effect immediately, like enabling features, activating settings, or controlling visibility.' +
+    "\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/checkbox) instead.",
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Table.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Table.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Table',
   description:
-    'The Table component displays data clearly in rows and columns, helping users view, analyze, and compare structured information. Use Table to present datasets, product lists, order details, or any tabular content that benefits from organized rows and columns.' +
+    'The table component displays data clearly in rows and columns, helping users view, analyze, and compare structured information. Use table to present datasets, product lists, order details, or any tabular content that benefits from organized rows and columns.' +
     '\n\nTables automatically adapt to screen size, rendering as lists on small screens and tables on larger ones for optimal readability across devices.',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',

--- a/packages/ui-extensions/src/docs/shared/components/TableBody.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableBody.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'TableBody',
+  name: 'Table body',
   description:
-    'The TableBody component represents the main content area of a table, containing the data rows. Use TableBody as a child of Table to structure your table data, with each TableRow within the body representing a single record or entry.' +
-    '\n\nTableBody must contain TableRow components, which in turn contain TableCell components for the actual data values.',
+    'The table body component represents the main content area of a table, containing the data rows. Use table body as a child of table to structure your table data, with each table row within the body representing a single record or entry.' +
+    '\n\nTable body must contain table row components, which in turn contain table cell components for the actual data values.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/TableCell.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableCell.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'TableCell',
+  name: 'Table cell',
   description:
-    'The TableCell component represents a single data cell within a table row. Use TableCell as a child of TableRow to display individual data values, with each cell corresponding to a column in the table.' +
-    '\n\nTableCell automatically inherits styling and alignment from its parent table structure and supports text content or other inline components.',
+    'The table cell component represents a single data cell within a table row. Use table cell as a child of table row to display individual data values, with each cell corresponding to a column in the table.' +
+    '\n\nTable cell automatically inherits styling and alignment from its parent table structure and supports text content or other inline components.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/TableHeader.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableHeader.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'TableHeader',
+  name: 'Table header',
   description:
-    'The TableHeader component represents a single column header within a table header row. Use TableHeader as a child of TableHeaderRow to define column headings and optionally enable column sorting.' +
-    '\n\nTableHeader provides semantic meaning for screen readers and can include sorting controls when configured. Each header corresponds to a column in the table body.',
+    'The table header component represents a single column header within a table header row. Use table header as a child of table header row to define column headings and optionally enable column sorting.' +
+    '\n\nTable header provides semantic meaning for screen readers and can include sorting controls when configured. Each header corresponds to a column in the table body.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/TableHeaderRow.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableHeaderRow.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'TableHeaderRow',
+  name: 'Table header row',
   description:
-    'The TableHeaderRow component represents the header row of a table, containing column headings. Use TableHeaderRow as the first child of Table (before TableBody) to define the table structure and provide column labels.' +
-    '\n\nTableHeaderRow must contain TableHeader components for each column. These headers provide context for the data columns and can support sorting functionality.',
+    'The table header row component represents the header row of a table, containing column headings. Use table header row as the first child of table (before table body) to define the table structure and provide column labels.' +
+    '\n\nTable header row must contain table header components for each column. These headers provide context for the data columns and can support sorting functionality.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/TableRow.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableRow.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'TableRow',
+  name: 'Table row',
   description:
-    'The TableRow component represents a single row of data within a table body. Use TableRow as a child of TableBody to structure individual records or entries in the table.' +
-    '\n\nTableRow must contain TableCell components, with each cell representing a data value for the corresponding column. The number of cells should match the number of headers in the table.',
+    'The table row component represents a single row of data within a table body. Use table row as a child of table body to structure individual records or entries in the table.' +
+    '\n\nTable row must contain table cell components, with each cell representing a data value for the corresponding column. The number of cells should match the number of headers in the table.',
   category: 'Polaris web components',
   subCategory: 'Structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Text.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Text.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Text',
   description:
-    'The Text component displays inline text with specific visual styles or tones. Use Text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.' +
-    '\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [Paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph).',
+    'The text component displays inline text with specific visual styles or tones. Use text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.' +
+    '\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph).',
   category: 'Polaris web components',
   subCategory: 'Typography and content',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/TextArea.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextArea.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Text area',
   description:
     'The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
-    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
+    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/TextArea.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextArea.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'TextArea',
+  name: 'Text area',
   description:
-    'The TextArea component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
-    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [TextField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
+    'The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
+    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/TextField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextField.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Text field',
   description:
     'The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
-    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textarea). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/emailfield), [URL field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/urlfield), [password field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/passwordfield), or [search field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/searchfield).',
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/search-field).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/TextField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextField.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'TextField',
+  name: 'Text field',
   description:
-    'The TextField component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
-    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [TextArea](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textarea). For specialized input types, use [EmailField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/emailfield), [URLField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/urlfield), [PasswordField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/passwordfield), or [SearchField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/searchfield).',
+    'The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textarea). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/emailfield), [URL field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/urlfield), [password field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/passwordfield), or [search field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/searchfield).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Thumbnail.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Thumbnail.ts
@@ -3,8 +3,8 @@ import {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Thumbnail',
   description:
-    'The Thumbnail component displays small preview images representing content, products, or media items. Use Thumbnail to provide visual identification in lists, tables, or cards where space is constrained and quick recognition is important.' +
-    '\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [Image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image). For user profile images, use [Avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).',
+    'The thumbnail component displays small preview images representing content, products, or media items. Use thumbnail to provide visual identification in lists, tables, or cards where space is constrained and quick recognition is important.' +
+    '\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).',
   category: 'Polaris web components',
   subCategory: 'Media and visuals',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/Tooltip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Tooltip.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Tooltip',
   description:
-    'The Tooltip component displays helpful information in a small overlay when users hover over or focus on an element. Use Tooltip to provide additional context, explain functionality, or clarify terms without cluttering the interface with permanent text.' +
+    'The tooltip component displays helpful information in a small overlay when users hover over or focus on an element. Use tooltip to provide additional context, explain functionality, or clarify terms without cluttering the interface with permanent text.' +
     '\n\nTooltips support keyboard accessibility, positioning options, and activation on both hover and focus for inclusive interaction patterns.',
   category: 'Polaris web components',
   subCategory: 'Typography and content',

--- a/packages/ui-extensions/src/docs/shared/components/URLField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/URLField.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'URLField',
+  name: 'URL field',
   description:
-    'The URLField component collects URLs from users with built-in formatting and validation. Use URLField for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.' +
-    '\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [TextField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
+    'The URL field component collects URLs from users with built-in formatting and validation. Use URL field for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.' +
+    '\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/URLField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/URLField.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'URL field',
   description:
     'The URL field component collects URLs from users with built-in formatting and validation. Use URL field for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.' +
-    '\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield).',
+    '\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
   category: 'Polaris web components',
   subCategory: 'Forms',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/UnorderedList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/UnorderedList.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Unordered list',
   description:
     "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning." +
-    '\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/orderedlist).',
+    '\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list).',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/docs/shared/components/UnorderedList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/UnorderedList.ts
@@ -1,10 +1,10 @@
 import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 
 const data: SharedReferenceEntityTemplateSchema = {
-  name: 'UnorderedList',
+  name: 'Unordered list',
   description:
-    "The UnorderedList component displays a bulleted list of related items where sequence isn't critical. Use UnorderedList to present collections of features, options, requirements, or any group of items where order doesn't affect meaning." +
-    '\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [OrderedList](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/orderedlist).',
+    "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning." +
+    '\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/orderedlist).',
   category: 'Polaris web components',
   subCategory: 'Layout and structure',
   related: [],

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminaction) component.',
+    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-action) component.',
   defaultExample: {
     description:
       'Send selected product IDs to your backend for bulk processing. This example shows how to map selected items, make an authenticated API call, and close the modal when the operation completes.',

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [AdminAction](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminaction) component.',
+    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminaction) component.',
   defaultExample: {
     description:
       'Send selected product IDs to your backend for bulk processing. This example shows how to map selected items, make an authenticated API call, and close the modal when the operation completes.',
@@ -74,7 +74,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.\n' +
-        "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [Button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
+        "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.',
   defaultExample: {
     description:
       "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [spinner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/spinner) component while fetching.",

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [AdminBlock](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
   defaultExample: {
     description:
-      "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [Spinner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/spinner) component while fetching.",
+      "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [spinner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/spinner) component while fetching.",
     codeblock: {
       title: 'Display product information',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.',
   defaultExample: {
     description:
-      'Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/numberfield) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.',
+      'Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.',
     codeblock: {
       title: 'Set minimum quantity',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [FunctionSettings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
   defaultExample: {
     description:
       'Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/numberfield) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.',

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.',
   defaultExample: {
     description:
-      'Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/textfield) for input, calls `applyMetafieldChange`, and displays success or error feedback.',
+      'Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) for input, calls `applyMetafieldChange`, and displays success or error feedback.',
     codeblock: {
       title: 'Configure discount threshold',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [FunctionSettings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
   defaultExample: {
     description:
       'Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/textfield) for input, calls `applyMetafieldChange`, and displays success or error feedback.',

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.',
   defaultExample: {
     description:
-      'Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/textfield) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.',
+      'Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.',
     codeblock: {
       title: 'Configure location priority',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [FunctionSettings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/functionsettings) component.',
   defaultExample: {
     description:
       'Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/textfield) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.',

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [AdminPrintAction](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminprintaction) component.',
+    'the [admin print action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminprintaction) component.',
   defaultExample: {
     description:
       "Generate a packing slip PDF for selected orders by calling your app's backend service. This example shows extracting order IDs from the selected resources, making an API call to your backend to generate the PDF, and returning the printable URL to display the document.",

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin print action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminprintaction) component.',
+    'the [admin print action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-print-action) component.',
   defaultExample: {
     description:
       "Generate a packing slip PDF for selected orders by calling your app's backend service. This example shows extracting order IDs from the selected resources, making an API call to your backend to generate the PDF, and returning the printable URL to display the document.",

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [AdminBlock](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
   defaultExample: {
     description:
       'Open the product [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select up to five components for a [bundle](/docs/apps/build/product-merchandising/bundles). This example filters out draft and archived products, saves the bundle configuration to your backend, and tracks the selection count.',

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.',
   defaultExample: {
     description:
       'Open the product [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select up to five components for a [bundle](/docs/apps/build/product-merchandising/bundles). This example filters out draft and archived products, saves the bundle configuration to your backend, and tracks the selection count.',

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [AdminBlock](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
   defaultExample: {
     description:
       'Use the product variant [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select component variants for a [bundle](/docs/apps/build/product-merchandising/bundles). This example picks product variants, tracks selections, and posts the product variant IDs to configure the bundle.',

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminblock) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.',
   defaultExample: {
     description:
       'Use the product variant [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select component variants for a [bundle](/docs/apps/build/product-merchandising/bundles). This example picks product variants, tracks selections, and posts the product variant IDs to configure the bundle.',

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [AdminAction](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminaction) component.',
+    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminaction) component.',
   defaultExample: {
     description:
       'Update a subscription by sending product and selling plan IDs to your backend. This example checks for selling plan presence, posts the update request, and shows a success banner before auto-closing the modal.',

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/adminaction) component.',
+    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-action) component.',
   defaultExample: {
     description:
       'Update a subscription by sending product and selling plan IDs to your backend. This example checks for selling plan presence, posts the update request, and shows a success banner before auto-closing the modal.',

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -288,7 +288,7 @@ export interface BackgroundProps {
  * Defines the semantic color treatment of a component to convey specific intent or status.
  *
  * Tones apply coordinated color schemes (text, background, icons) across the component.
- * Some components, like Banner, also use tone to determine accessibility attributes and screen reader announcements.
+ * Some components, like banner, also use tone to determine accessibility attributes and screen reader announcements.
  *
  * - `auto`: Automatically determined based on context.
  * - `neutral`: General-purpose information without specific sentiment.
@@ -972,7 +972,7 @@ interface BadgeProps$1 extends GlobalProps {
    */
   iconPosition?: 'start' | 'end';
   /**
-   * The size of the Badge component. Available sizes range from `small-500` (smallest) to `large-500` (largest), with `base` providing the default medium size.
+   * The size of the badge component. Available sizes range from `small-500` (smallest) to `large-500` (largest), with `base` providing the default medium size.
    *
    * @default 'base'
    */
@@ -1127,7 +1127,7 @@ export type AccessibilityRole =
   /**
    * An accessibility role used to indicate a generic section.
    *
-   * Sections should always have a Heading or an accessible name provided in the `accessibilityLabel` property.
+   * sections should always have a heading or an accessible name provided in the `accessibilityLabel` property.
    *
    * In an HTML host `section` will render a `<section>` element.
    * Learn more about the [`<section>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) in the MDN web docs.
@@ -1557,7 +1557,7 @@ export interface BaseBoxProps
     BorderProps,
     OverflowProps {
   /**
-   * The content displayed within the Box component, which serves as a flexible container for organizing and styling other components.
+   * The content displayed within the box component, which serves as a flexible container for organizing and styling other components.
    */
   children?: ComponentChildren;
   /**
@@ -1571,7 +1571,7 @@ export interface BaseBoxPropsWithRole
 interface BoxProps$1 extends BaseBoxPropsWithRole, GlobalProps {}
 export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
   /**
-   * The behavior of the Button component.
+   * The behavior of the button component.
    *
    * - `button`: Used to indicate the component acts as a button, meaning it has no default action.
    * - `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).
@@ -1583,7 +1583,7 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
    */
   type?: 'submit' | 'button' | 'reset';
   /**
-   * A callback fired when the Button is activated, before performing the action indicated by `type`. Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
+   * A callback fired when the button is activated, before performing the action indicated by `type`. Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
    */
   onClick?: (event: Event) => void;
   /**
@@ -1595,7 +1595,7 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
   /**
    * Whether to replace the button content with a loading indicator while a background action is being performed.
    *
-   * This also disables the Button component.
+   * This also disables the button component.
    *
    * @default false
    */
@@ -1672,7 +1672,7 @@ interface ButtonProps$1 extends GlobalProps, BaseClickableProps {
    */
   accessibilityLabel?: string;
   /**
-   * The label text or elements displayed inside the Button component, describing the action that will be performed when clicked.
+   * The label text or elements displayed inside the button component, describing the action that will be performed when clicked.
    */
   children?: ComponentChildren;
   /**
@@ -1684,7 +1684,7 @@ interface ButtonProps$1 extends GlobalProps, BaseClickableProps {
    */
   icon?: IconType | AnyString;
   /**
-   * The displayed inline width of the Button.
+   * The displayed inline width of the button.
    *
    * - `auto`: the size of the button depends on the surface and context.
    * - `fill`: the button will takes up 100% of the available inline size.
@@ -1694,9 +1694,9 @@ interface ButtonProps$1 extends GlobalProps, BaseClickableProps {
    */
   inlineSize?: 'auto' | 'fill' | 'fit-content';
   /**
-   * The visual appearance of the Button component.
+   * The visual appearance of the button component.
    *
-   * - `auto`: The variant is automatically determined by the Button component's context.
+   * - `auto`: The variant is automatically determined by the button component's context.
    * - `primary`: High emphasis button for the primary action on the page. Should be used sparingly.
    * - `secondary`: Medium emphasis button for secondary actions.
    * - `tertiary`: Low emphasis button for less important actions.
@@ -1721,7 +1721,7 @@ interface ButtonProps$1 extends GlobalProps, BaseClickableProps {
 }
 interface ButtonGroupProps$1 extends GlobalProps, ActionSlots {
   /**
-   * The buttons displayed within the ButtonGroup component, which are arranged together as a cohesive set of related actions.
+   * The buttons displayed within the button group component, which are arranged together as a cohesive set of related actions.
    */
   children?: ComponentChildren;
   /**
@@ -1779,7 +1779,7 @@ export interface MultipleInputProps extends BaseInputProps {
    */
   onInput?: (event: Event) => void;
   /**
-   * An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child Option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected.
+   * An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected.
    */
   values?: string[];
 }
@@ -2057,7 +2057,7 @@ interface CheckboxProps$1
 }
 export interface ChipProps$1 extends GlobalProps {
   /**
-   * The text label displayed within the Chip component, typically representing a selected filter, tag, or removable item.
+   * The text label displayed within the chip component, typically representing a selected filter, tag, or removable item.
    */
   children?: ComponentChildren;
   /**
@@ -2101,7 +2101,7 @@ interface ChoiceProps$1 extends GlobalProps, BaseOptionProps {
    */
   details?: ComponentChildren;
   /**
-   * Whether to associate this choice with the error passed to ChoiceList.
+   * Whether to associate this choice with the error passed to choice list.
    *
    * @default false
    */
@@ -2131,7 +2131,7 @@ interface ChoiceListProps$1
   /**
    * The selectable options displayed to the user, each representing a choice they can make.
    *
-   * Only accepts Choice components as children. Each Choice represents an individual selectable option with its own label and value.
+   * Only accepts choice components as children. Each choice represents an individual selectable option with its own label and value.
    */
   children?: ComponentChildren;
   /**
@@ -2728,7 +2728,7 @@ export type EmailAutocompleteField = ExtractStrict<
 >;
 interface FormProps$1 extends GlobalProps {
   /**
-   * The form fields and controls displayed within the Form component, typically including input fields, buttons, and other form elements.
+   * The form fields and controls displayed within the form component, typically including input fields, buttons, and other form elements.
    */
   children?: ComponentChildren;
   /**
@@ -3092,7 +3092,7 @@ interface HeadingProps$1
     AccessibilityVisibilityProps,
     BlockTypographyProps {
   /**
-   * The heading text displayed within the Heading component, which provides a title or section header for content.
+   * The heading text displayed within the heading component, which provides a title or section header for content.
    */
   children?: ComponentChildren;
   /**
@@ -3276,7 +3276,7 @@ interface ImageProps$1 extends GlobalProps, BaseImageProps, BorderProps {
 }
 interface LinkProps$1 extends GlobalProps, LinkBehaviorProps {
   /**
-   * The text or elements displayed within the Link component, which navigates users to a different location when activated.
+   * The text or elements displayed within the link component, which navigates users to a different location when activated.
    */
   children?: ComponentChildren;
   /**
@@ -3310,7 +3310,7 @@ interface MenuProps$1 extends GlobalProps {
    */
   accessibilityLabel?: string;
   /**
-   * The children define the actions to render inside the Menu. Only Button components are allowed as children of a Menu, and these Buttons can perform actions (using `onClick`) or link to other parts of the application (using `to`/ `href`). Any other component placed here will be ignored.
+   * The children define the actions to render inside the menu. Only button components are allowed as children of a menu, and these buttons can perform actions (using `onClick`) or link to other parts of the application (using `to`/ `href`). Any other component placed here will be ignored.
    */
   children?: ComponentChildren;
 }
@@ -3328,32 +3328,32 @@ interface ModalProps$1
    */
   accessibilityLabel?: string;
   /**
-   * A title that describes the content of the Modal.
+   * A title that describes the content of the modal.
    *
    */
   heading?: string;
   /**
-   * Adjust the padding around the Modal content.
+   * Adjust the padding around the modal content.
    *
    * `base`: applies padding that is appropriate for the element.
    *
-   * `none`: removes all padding from the element. This can be useful when elements inside the Modal need to span
-   * to the edge of the Modal. For example, a full-width image. In this case, rely on Box with a padding of 'base'
+   * `none`: removes all padding from the element. This can be useful when elements inside the modal need to span
+   * to the edge of the modal. For example, a full-width image. In this case, rely on box with a padding of 'base'
    * to bring back the desired padding for the rest of the content.
    *
    * @default 'base'
    */
   padding?: 'base' | 'none';
   /**
-   * Adjust the size of the Modal.
+   * Adjust the size of the modal.
    *
-   * `max`: expands the Modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
+   * `max`: expands the modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
    *
    * @default 'base'
    */
   size?: SizeKeyword | 'max';
   /**
-   * The content of the Modal.
+   * The content of the modal.
    */
   children?: ComponentChildren;
 }
@@ -3427,14 +3427,14 @@ interface OptionGroupProps$1 extends GlobalProps {
    */
   label?: string;
   /**
-   * The selectable options displayed in the dropdown list. Only accepts Option components as children. Each Option represents an individual selectable item with its own label and value.
+   * The selectable options displayed in the dropdown list. Only accepts option components as children. Each option represents an individual selectable item with its own label and value.
    */
   children?: ComponentChildren;
 }
 interface OrderedListProps$1 extends GlobalProps {}
 interface PageProps$1 extends GlobalProps, ActionSlots {
   /**
-   * The content of the Page.
+   * The content of the page.
    */
   children?: ComponentChildren;
   /**
@@ -3474,7 +3474,7 @@ interface ParagraphProps$1
     BlockTypographyProps,
     AccessibilityVisibilityProps {
   /**
-   * The paragraph text content displayed within the Paragraph component, which presents a block of related text with appropriate styling.
+   * The paragraph text content displayed within the paragraph component, which presents a block of related text with appropriate styling.
    */
   children?: ComponentChildren;
   /**
@@ -3533,13 +3533,13 @@ interface PopoverProps$1
 }
 interface QueryContainerProps$1 extends GlobalProps {
   /**
-   * The content displayed within the QueryContainer component, which enables container queries for responsive styling based on the container's size rather than the viewport.
+   * The content displayed within the query container component, which enables container queries for responsive styling based on the container's size rather than the viewport.
    */
   children?: ComponentChildren;
   /**
    * An identifier for this container that you can reference in CSS container queries to apply styles based on this specific container's size.
    *
-   * All QueryContainer components automatically receive a container name of `s-default`. You can omit the container name in your queries, so `@container (inline-size <= 300px)` is equivalent to `@container s-default (inline-size <= 300px)`.
+   * All query container components automatically receive a container name of `s-default`. You can omit the container name in your queries, so `@container (inline-size <= 300px)` is equivalent to `@container s-default (inline-size <= 300px)`.
    *
    * When you provide a custom `containerName`, it's added alongside `s-default`. For example, `containerName="product-card"` results in `s-default product-card` being set on the `container-name` CSS property, allowing you to target this container with `@container product-card (inline-size <= 300px)`.
    *
@@ -3553,7 +3553,7 @@ interface QueryContainerProps$1 extends GlobalProps {
 }
 interface SectionProps$1 extends GlobalProps, ActionSlots {
   /**
-   * The content displayed within the Section component, which groups related elements together in a logical unit with an optional heading.
+   * The content displayed within the section component, which groups related elements together in a logical unit with an optional heading.
    */
   children?: ComponentChildren;
   /**
@@ -3569,8 +3569,8 @@ interface SectionProps$1 extends GlobalProps, ActionSlots {
    *
    * - `base`: applies padding that is appropriate for the element. Note that it might result in no padding if
    * this is the right design decision in a particular context.
-   * - `none`: removes all padding from the element. This can be useful when elements inside the Section need to span
-   * to the edge of the Section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base'
+   * - `none`: removes all padding from the element. This can be useful when elements inside the section need to span
+   * to the edge of the section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base'
    * to bring back the desired padding for the rest of the content.
    *
    * @default 'base'
@@ -3584,7 +3584,7 @@ interface SelectProps$1
     Omit<FieldProps, 'defaultValue'>,
     FocusEventProps {
   /**
-   * The selectable options displayed in the dropdown list. Accepts Option components for individual selectable items, and OptionGroup components to organize related options into logical groups with labels.
+   * The selectable options displayed in the dropdown list. Accepts option components for individual selectable items, and option group components to organize related options into logical groups with labels.
    */
   children?: ComponentChildren;
 }
@@ -3602,11 +3602,11 @@ interface SpinnerProps$1 extends GlobalProps {
 }
 interface StackProps$1 extends GlobalProps, BaseBoxPropsWithRole, GapProps {
   /**
-   * The child elements displayed within the Stack component, which are arranged vertically or horizontally with consistent spacing.
+   * The child elements displayed within the stack component, which are arranged vertically or horizontally with consistent spacing.
    */
   children?: ComponentChildren;
   /**
-   * The direction in which children are arranged within the Stack.
+   * The direction in which children are arranged within the stack.
    *
    * - `block`: Arranges children vertically in a column (in horizontal writing modes). Children will not wrap.
    * - `inline`: Arranges children horizontally in a row (in horizontal writing modes). Children will wrap to the next line if needed.
@@ -3617,7 +3617,7 @@ interface StackProps$1 extends GlobalProps, BaseBoxPropsWithRole, GapProps {
    */
   direction?: MaybeResponsive<'block' | 'inline'>;
   /**
-   * The distribution of children along the Stack component's main axis (the direction of stacking).
+   * The distribution of children along the stack component's main axis (the direction of stacking).
    *
    * For example, in a vertical stack (block direction), this controls vertical distribution.
    * Use this to space out children or align them to the start, center, or end.
@@ -3628,7 +3628,7 @@ interface StackProps$1 extends GlobalProps, BaseBoxPropsWithRole, GapProps {
    */
   justifyContent?: MaybeResponsive<JustifyContentKeyword>;
   /**
-   * The alignment of individual children along the Stack component's cross axis (perpendicular to the stacking direction).
+   * The alignment of individual children along the stack component's cross axis (perpendicular to the stacking direction).
    *
    * For example, in a vertical stack (block direction), this controls horizontal alignment of each child.
    *
@@ -3638,7 +3638,7 @@ interface StackProps$1 extends GlobalProps, BaseBoxPropsWithRole, GapProps {
    */
   alignItems?: MaybeResponsive<AlignItemsKeyword>;
   /**
-   * The alignment of multiple lines of content along the Stack component's cross axis.
+   * The alignment of multiple lines of content along the stack component's cross axis.
    *
    * This only applies when content wraps to multiple lines (typically in inline direction).
    *
@@ -3691,15 +3691,15 @@ export interface PaginationProps {
 }
 interface TableProps$1 extends GlobalProps, PaginationProps {
   /**
-   * The table structure displayed within the Table component, including table headers, rows, and cells that organize data in a grid format.
+   * The table structure displayed within the table component, including table headers, rows, and cells that organize data in a grid format.
    */
   children?: ComponentChildren;
   /**
-   * The filter controls displayed above the table, such as SearchField or other input components for searching and filtering table data.
+   * The filter controls displayed above the table, such as search field or other input components for searching and filtering table data.
    */
   filters?: ComponentChildren;
   /**
-   * The layout variant of the Table component.
+   * The layout variant of the table component.
    *
    * - `list`: Always displays as a list layout.
    * - `table`: Always displays as a traditional table layout.
@@ -3767,14 +3767,14 @@ interface TableHeaderProps$1 extends GlobalProps {
 interface TableHeaderRowProps$1 extends GlobalProps {
   /**
    * The header cells that define the columns of the table.
-   * Only accepts TableHeader components as children, with each header representing a column and providing its label.
+   * Only accepts table header components as children, with each header representing a column and providing its label.
    */
   children?: ComponentChildren;
 }
 interface TableRowProps$1 extends GlobalProps {
   /**
    * The data cells displayed within this table row, with each cell containing content for its corresponding column.
-   * Only accepts TableCell components as children.
+   * Only accepts table cell components as children.
    */
   children?: ComponentChildren;
   /**
@@ -3796,13 +3796,13 @@ interface TextProps$1
     DisplayProps,
     Pick<InteractionProps, 'interestFor'> {
   /**
-   * The text content displayed within the Text component, which applies semantic meaning and styling appropriate to the specified text type.
+   * The text content displayed within the text component, which applies semantic meaning and styling appropriate to the specified text type.
    */
   children?: ComponentChildren;
   /**
    * The semantic type and styling treatment for the text content.
    *
-   * Other presentation properties on Text override the default styling.
+   * Other presentation properties on text override the default styling.
    *
    * @default 'generic'
    */
@@ -3923,7 +3923,7 @@ interface ThumbnailProps$1 extends GlobalProps, BaseImageProps {
 }
 interface TooltipProps$1 extends GlobalProps {
   /**
-   * The informational text or elements displayed within the Tooltip overlay, providing helpful context or explanations when users interact with the associated element.
+   * The informational text or elements displayed within the tooltip overlay, providing helpful context or explanations when users interact with the associated element.
    */
   children?: ComponentChildren;
 }
@@ -5049,13 +5049,13 @@ export interface BadgeJSXProps
   extends Partial<BadgeProps>,
     Pick<BadgeProps$1, 'id' | 'children'> {
   /**
-   * The text label displayed within the Badge component, typically a short status indicator or category label.
+   * The text label displayed within the badge component, typically a short status indicator or category label.
    */
   children?: ComponentChildren;
 }
 
 /**
- * Represents the Banner component props with all properties marked as required.
+ * Represents the banner component props with all properties marked as required.
  */
 export type RequiredBannerProps = Required<BannerProps$1>;
 export interface BannerProps
@@ -5095,12 +5095,12 @@ export interface BannerJSXProps
   extends Partial<BannerProps>,
     Pick<BannerProps$1, 'id' | 'children'> {
   /**
-   * The main message content displayed within the Banner component, providing important information or guidance to users.
+   * The main message content displayed within the banner component, providing important information or guidance to users.
    */
   children?: ComponentChildren;
   /**
    * Action buttons displayed at the bottom of the banner that let users respond to the message.
-   * Accepts up to two Button components with `variant="secondary"` or `variant="auto"`.
+   * Accepts up to two button components with `variant="secondary"` or `variant="auto"`.
    */
   secondaryActions?: ComponentChildren;
   /**
@@ -5141,7 +5141,7 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * Represents the Box component props with all properties marked as required.
+ * Represents the box component props with all properties marked as required.
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
@@ -5168,7 +5168,7 @@ export type BoxBorderRadii = Extract<
   | 'large-200'
 >;
 /**
- * Represents the subset of border style values supported by the Box component.
+ * Represents the subset of border style values supported by the box component.
  *
  * - `auto`: Default border style determined by the system.
  * - `none`: No border style (removes the border).
@@ -5180,7 +5180,7 @@ export type BoxBorderStyles = Extract<
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * Represents Box props with responsive capabilities for layout properties.
+ * Represents box props with responsive capabilities for layout properties.
  *
  * This enables conditional styling based on container queries.
  */
@@ -5472,13 +5472,13 @@ export interface BoxJSXProps
   extends Partial<BoxProps>,
     Pick<BoxProps$1, 'id' | 'children'> {
   /**
-   * The content displayed within the Box component, which serves as a flexible container for organizing and styling other components.
+   * The content displayed within the box component, which serves as a flexible container for organizing and styling other components.
    */
   children?: ComponentChildren;
 }
 
 /**
- * Represents Button props that are specific to button-type elements only.
+ * Represents button props that are specific to button-type elements only.
  * Extracts the subset of `ButtonProps` that includes the `type` property.
  */
 export type ButtonOnlyProps = Extract<
@@ -5488,7 +5488,7 @@ export type ButtonOnlyProps = Extract<
   }
 >;
 /**
- * Represents the base Button props with all properties marked as required.
+ * Represents the base button props with all properties marked as required.
  */
 export type ButtonBaseProps = Required<
   Pick<
@@ -5575,7 +5575,7 @@ export interface ButtonJSXProps
   extends Partial<ButtonProps>,
     Pick<ButtonProps$1, 'id' | 'children'> {
   /**
-   * The label text or elements displayed inside the Button component, describing the action that will be performed when clicked.
+   * The label text or elements displayed inside the button component, describing the action that will be performed when clicked.
    */
   children?: ComponentChildren;
   /**
@@ -5625,19 +5625,19 @@ export interface ButtonGroupJSXProps
   extends Partial<ButtonGroupProps>,
     Pick<ButtonGroupProps$1, 'id' | 'children'> {
   /**
-   * The buttons displayed within the ButtonGroup component, which are arranged together as a cohesive set of related actions.
+   * The buttons displayed within the button group component, which are arranged together as a cohesive set of related actions.
    */
   children?: ComponentChildren;
   /**
    * The main action for this group, displayed with high visual emphasis.
-   * Accepts a single Button with `variant="primary"`.
+   * Accepts a single button with `variant="primary"`.
    *
    * Use this for the primary action you want users to take. This can't be used when `gap="none"`.
    */
   primaryAction?: ComponentChildren;
   /**
    * Supporting actions displayed with less emphasis than the primary action.
-   * Accepts one or more Button components with `variant="secondary"` or `variant="auto"`.
+   * Accepts one or more button components with `variant="secondary"` or `variant="auto"`.
    *
    * Use these for alternative or less critical actions.
    */
@@ -5793,11 +5793,11 @@ export interface ChipJSXProps
   extends Partial<ChipProps>,
     Pick<ChipProps$2, 'id' | 'children'> {
   /**
-   * The text label displayed within the Chip component, typically representing a selected filter, tag, or removable item.
+   * The text label displayed within the chip component, typically representing a selected filter, tag, or removable item.
    */
   children?: ComponentChildren;
   /**
-   * An optional icon to display at the start of the chip. Accepts only Icon components.
+   * An optional icon to display at the start of the chip. Accepts only icon components.
    */
   graphic?: ComponentChildren;
 }
@@ -5925,7 +5925,7 @@ export interface ChoiceListJSXProps
   /**
    * The choices a user can select from.
    *
-   * Accepts Choice components.
+   * Accepts choice components.
    */
   children?: ComponentChildren;
   /**
@@ -5939,7 +5939,7 @@ export interface ChoiceListJSXProps
 }
 
 /**
- * Represents the base Clickable props with all properties marked as required.
+ * Represents the base clickable props with all properties marked as required.
  */
 export type ClickableBaseProps = Required<
   Pick<
@@ -5993,7 +5993,7 @@ export interface ClickableJSXProps
   extends Partial<ClickableProps>,
     Pick<ClickableProps$1, 'id' | 'children'> {
   /**
-   * The content displayed within the Clickable component, which makes any content interactive and clickable without the semantic meaning of a button or link.
+   * The content displayed within the clickable component, which makes any content interactive and clickable without the semantic meaning of a button or link.
    */
   children?: ComponentChildren;
   /**
@@ -6065,7 +6065,7 @@ export interface ClickableChipJSXProps
    */
   children?: ComponentChildren;
   /**
-   * An optional icon to display at the start of the chip. Accepts only Icon components.
+   * An optional icon to display at the start of the chip. Accepts only icon components.
    */
   graphic?: ComponentChildren;
   /**
@@ -6537,7 +6537,7 @@ export interface DropZoneJSXProps
   extends Partial<DropZoneProps>,
     Pick<DropZoneProps$1, 'id'> {
   /**
-   * The content to include inside the DropZone container
+   * The content to include inside the drop zone container
    */
   children?: ComponentChildren;
   /**
@@ -6597,11 +6597,11 @@ export interface EmailFieldJSXProps
     FieldReactProps<typeof tagName$H> {}
 
 /**
- * Represents the Grid component props with all properties marked as required.
+ * Represents the grid component props with all properties marked as required.
  */
 export type RequiredAlignedProps = Required<GridProps$1>;
 /**
- * Represents Grid props with responsive capabilities for layout properties.
+ * Represents grid props with responsive capabilities for layout properties.
  *
  * This enables conditional styling based on container queries.
  */
@@ -6745,13 +6745,13 @@ export interface GridJSXProps
   extends Partial<GridProps>,
     Pick<GridProps$1, 'id' | 'children'> {
   /**
-   * The child elements displayed within the Grid component, which are arranged in a flexible grid layout with configurable columns, rows, and spacing.
+   * The child elements displayed within the grid component, which are arranged in a flexible grid layout with configurable columns, rows, and spacing.
    */
   children?: ComponentChildren;
 }
 
 /**
- * Represents the GridItem component props with all properties marked as required.
+ * Represents the grid item component props with all properties marked as required.
  */
 export type RequiredGridItemProps = Required<GridItemProps$1>;
 export interface GridItemProps
@@ -6785,7 +6785,7 @@ export interface GridItemJSXProps
   extends Partial<GridItemProps>,
     Pick<GridItemProps$1, 'id' | 'children'> {
   /**
-   * The content displayed within the GridItem component, which represents a single cell in the grid layout and can span multiple columns or rows.
+   * The content displayed within the grid item component, which represents a single cell in the grid layout and can span multiple columns or rows.
    */
   children?: ComponentChildren;
 }
@@ -6823,7 +6823,7 @@ export interface HeadingJSXProps
   extends Partial<HeadingProps>,
     Pick<HeadingProps$1, 'id' | 'children'> {
   /**
-   * The heading text displayed within the Heading component, which provides a title or section header for content.
+   * The heading text displayed within the heading component, which provides a title or section header for content.
    */
   children?: ComponentChildren;
 }
@@ -6940,11 +6940,11 @@ export interface ImageJSXProps
 }
 
 /**
- * Represents the Link component props with all properties marked as required.
+ * Represents the link component props with all properties marked as required.
  */
 export type RequiredLinkProps = Required<LinkProps$1>;
 /**
- * Represents the base Link props with all core properties marked as required.
+ * Represents the base link props with all core properties marked as required.
  */
 export type LinkBaseProps = Required<
   Pick<
@@ -6995,7 +6995,7 @@ export interface LinkJSXProps
   extends Partial<LinkProps>,
     Pick<LinkProps$1, 'id' | 'lang' | 'children'> {
   /**
-   * The text or elements displayed within the Link component, which navigates users to a different location when activated.
+   * The text or elements displayed within the link component, which navigates users to a different location when activated.
    */
   children?: ComponentChildren;
   /**
@@ -7039,7 +7039,7 @@ export interface MenuProps
 /**
  * Shared symbols for overlay control functionality.
  * These symbols are used by components that implement overlay behavior
- * (like Popover, Tooltip, or Modal) to communicate with the overlay control system.
+ * (like popover, tooltip, or modal) to communicate with the overlay control system.
  */
 /**
  * Symbol used to track the open or closed state of the overlay.
@@ -7110,13 +7110,13 @@ export interface MenuJSXProps
   extends Partial<MenuProps>,
     Pick<MenuProps$1, 'id' | 'children'> {
   /**
-   * The items displayed within the menu. Only accepts Button and Section components. Use Button for individual menu actions and Section to group related items.
+   * The items displayed within the menu. Only accepts button and section components. Use button for individual menu actions and section to group related items.
    */
   children?: ComponentChildren;
 }
 
 /**
- * Represents the Modal component props with all properties marked as required.
+ * Represents the modal component props with all properties marked as required.
  */
 export type RequiredAlignedModalProps = Required<ModalProps$1>;
 export interface ModalProps
@@ -7131,7 +7131,7 @@ export interface ModalProps
     | 'toggleOverlay'
   > {
   /**
-   * The size of the Modal component, controlling its width and height. Larger sizes provide more space for content while smaller sizes are more compact.
+   * The size of the modal component, controlling its width and height. Larger sizes provide more space for content while smaller sizes are more compact.
    */
   size: Extract<
     ModalProps$1['size'],
@@ -7259,19 +7259,19 @@ export interface ModalJSXProps
   extends Partial<ModalProps>,
     Pick<ModalProps$1, 'id' | 'children'> {
   /**
-   * The content displayed within the Modal component, typically including form fields, information, or interactive elements.
+   * The content displayed within the modal component, typically including form fields, information, or interactive elements.
    */
   children?: ComponentChildren;
   /**
    * The main action button displayed in the modal footer, representing the primary action users should take.
    *
-   * Only accepts a single Button component with a `variant` of `primary`. This action should align with the modal's main purpose.
+   * Only accepts a single button component with a `variant` of `primary`. This action should align with the modal's main purpose.
    */
   primaryAction?: ComponentChildren;
   /**
    * Additional action buttons displayed in the modal footer, providing alternative or supporting actions.
    *
-   * Only accepts Button components with a `variant` of `secondary` or `auto`. These are visually de-emphasized to establish clear hierarchy.
+   * Only accepts button components with a `variant` of `secondary` or `auto`. These are visually de-emphasized to establish clear hierarchy.
    */
   secondaryActions?: ComponentChildren;
   /**
@@ -7293,7 +7293,7 @@ export interface ModalJSXProps
 }
 
 /**
- * Represents the MoneyField component props with all properties marked as required.
+ * Represents the money field component props with all properties marked as required.
  */
 export type RequiredMoneyFieldProps = Required<MoneyFieldProps$1>;
 export interface MoneyFieldProps
@@ -7449,7 +7449,7 @@ export interface OptionGroupJSXProps
   extends Partial<OptionGroupProps>,
     Pick<OptionGroupProps$1, 'id' | 'children'> {
   /**
-   * The selectable options displayed in the dropdown list. Accepts Option components for individual selectable items within this group.
+   * The selectable options displayed in the dropdown list. Accepts option components for individual selectable items within this group.
    */
   children?: ComponentChildren;
 }
@@ -7481,7 +7481,7 @@ export interface OrderedListJSXProps
   extends Partial<OrderedListProps>,
     Pick<OrderedListProps$1, 'id'> {
   /**
-   * The list entries displayed within the ordered list, where each item is numbered sequentially. Only accepts ListItem components as children. Each ListItem represents a single numbered entry in the sequence.
+   * The list entries displayed within the ordered list, where each item is numbered sequentially. Only accepts list item components as children. Each list item represents a single numbered entry in the sequence.
    */
   children?: ComponentChildren;
 }
@@ -7522,7 +7522,7 @@ export interface PageJSXProps
   extends Partial<PageProps>,
     Pick<PageProps$1, 'id' | 'children'> {
   /**
-   * The main page content displayed within the Page component, which serves as the primary container for the page's information and interface elements.
+   * The main page content displayed within the page component, which serves as the primary container for the page's information and interface elements.
    */
   children?: ComponentChildren;
   /**
@@ -7534,20 +7534,20 @@ export interface PageJSXProps
   /**
    * The primary action for the page.
    *
-   * Only accepts a single Button component with a `variant` of `primary`.
+   * Only accepts a single button component with a `variant` of `primary`.
    *
    */
   primaryAction?: ComponentChildren;
   /**
    * The secondary actions for the page.
    *
-   * Only accepts ButtonGroup and Button components with a `variant` of `secondary` or `auto`.
+   * Only accepts button group and button components with a `variant` of `secondary` or `auto`.
    */
   secondaryActions?: ComponentChildren;
   /**
    * The navigation back actions for the page.
    *
-   * Only accepts Link components.
+   * Only accepts link components.
    */
   breadcrumbActions?: ComponentChildren;
 }
@@ -7618,7 +7618,7 @@ export interface ParagraphJSXProps
   extends Partial<ParagraphProps>,
     Pick<ParagraphProps$1, 'id' | 'children'> {
   /**
-   * The paragraph text content displayed within the Paragraph component, which presents a block of related text with appropriate styling.
+   * The paragraph text content displayed within the paragraph component, which presents a block of related text with appropriate styling.
    */
   children?: ComponentChildren;
 }
@@ -7733,7 +7733,7 @@ export interface PopoverJSXProps
   extends Partial<PopoverProps>,
     Pick<PopoverProps$1, 'id' | 'children'> {
   /**
-   * The content displayed within the Popover component, which appears in an overlay positioned relative to its trigger element.
+   * The content displayed within the popover component, which appears in an overlay positioned relative to its trigger element.
    */
   children?: ComponentChildren;
   /**
@@ -7793,7 +7793,7 @@ export interface QueryContainerJSXProps
   extends Partial<QueryContainerProps$1>,
     Pick<QueryContainerProps$1, 'id' | 'children'> {
   /**
-   * The content displayed within the QueryContainer component, which enables container queries for responsive styling based on the container's size rather than the viewport.
+   * The content displayed within the query container component, which enables container queries for responsive styling based on the container's size rather than the viewport.
    */
   children?: ComponentChildren;
 }
@@ -7860,7 +7860,7 @@ export interface SearchFieldJSXProps
     FieldReactProps<typeof tagName$n> {}
 
 /**
- * Represents the Section component props with all properties marked as required.
+ * Represents the section component props with all properties marked as required.
  */
 export type RequiredSectionProps = Required<SectionProps$1>;
 export interface SectionProps
@@ -7900,7 +7900,7 @@ export interface SectionJSXProps
   extends Partial<SectionProps>,
     Pick<SectionProps$1, 'id' | 'children'> {
   /**
-   * The content displayed within the Section component, which groups related elements together in a logical unit with an optional heading.
+   * The content displayed within the section component, which groups related elements together in a logical unit with an optional heading.
    */
   children?: ComponentChildren;
 }
@@ -7956,7 +7956,7 @@ declare class Select extends PreactInputElement implements SelectProps {
    */
   [hasInitialValueSymbol]: boolean;
   /**
-   * The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected Option component.
+   * The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected option component.
    */
   get value(): string;
   set value(value: string);
@@ -7981,7 +7981,7 @@ export interface SelectJSXProps
   extends Partial<SelectProps>,
     Pick<SelectProps$1, 'id' | 'children'> {
   /**
-   * The selectable options displayed in the dropdown list. Accepts Option components for individual selectable items, and OptionGroup components to organize related options into logical groups with labels.
+   * The selectable options displayed in the dropdown list. Accepts option components for individual selectable items, and option group components to organize related options into logical groups with labels.
    */
   children?: ComponentChildren;
   onChange?: (event: CallbackEvent<typeof tagName$l>) => void;
@@ -8026,11 +8026,11 @@ export interface SpinnerJSXProps
     Pick<SpinnerProps$1, 'id'> {}
 
 /**
- * Represents the Stack component props with all properties marked as required.
+ * Represents the stack component props with all properties marked as required.
  */
 export type AlignedStackProps = Required<StackProps$1>;
 /**
- * Represents Stack props with responsive capabilities for layout properties.
+ * Represents stack props with responsive capabilities for layout properties.
  *
  * This enables conditional styling based on container queries.
  */
@@ -8100,7 +8100,7 @@ export interface StackProps
    */
   columnGap: ResponsiveStackProps['columnGap'];
   /**
-   * The direction in which the Stack's children are placed within the Stack.
+   * The direction in which the stack's children are placed within the stack.
    *
    * Accepts:
    * - A single value, either `inline` or `block`
@@ -8141,7 +8141,7 @@ export interface StackJSXProps
   extends Partial<StackProps>,
     Pick<StackProps$1, 'id' | 'children'> {
   /**
-   * The child elements displayed within the Stack component, which are arranged vertically or horizontally with consistent spacing.
+   * The child elements displayed within the stack component, which are arranged vertically or horizontally with consistent spacing.
    */
   children?: ComponentChildren;
 }
@@ -8215,7 +8215,7 @@ export interface TableHeaderProps
 declare const actualTableVariantSymbol: unique symbol;
 declare const tableHeadersSharedDataSymbol: unique symbol;
 /**
- * Represents the actual rendered variant of a Table component.
+ * Represents the actual rendered variant of a table component.
  * - `table`: Displays as a traditional table layout.
  * - `list`: Displays as a list layout.
  */
@@ -8262,7 +8262,7 @@ export interface TableJSXProps
   extends Partial<TableProps>,
     Pick<TableProps$1, 'id' | 'children' | 'onNextPage' | 'onPreviousPage'> {
   /**
-   * The table structure displayed within the Table component, including table headers, rows, and cells that organize data in a grid format.
+   * The table structure displayed within the table component, including table headers, rows, and cells that organize data in a grid format.
    */
   children?: ComponentChildren;
   /**
@@ -8400,7 +8400,7 @@ export interface TableHeaderRowJSXProps
     Pick<TableHeaderRowProps$1, 'id' | 'children'> {
   /**
    * The header cells that define the columns of the table.
-   * Only accepts TableHeader components as children, with each header representing a column and providing its label.
+   * Only accepts table header components as children, with each header representing a column and providing its label.
    */
   children?: ComponentChildren;
 }
@@ -8432,7 +8432,7 @@ export interface TableRowJSXProps
     Pick<TableRowProps$1, 'id' | 'children'> {
   /**
    * The data cells displayed within this table row, with each cell containing content for its corresponding column.
-   * Only accepts TableCell components as children.
+   * Only accepts table cell components as children.
    */
   children?: ComponentChildren;
 }
@@ -8454,7 +8454,7 @@ export interface TextProps
   /**
    * The semantic type and styling treatment for the text content.
    *
-   * Other presentation properties on Text override the default styling.
+   * Other presentation properties on text override the default styling.
    *
    * - `strong`: Emphasizes the text with strong importance, typically displayed in bold.
    * - `generic`: Standard text with no special semantic meaning or styling.
@@ -8537,7 +8537,7 @@ export interface TextJSXProps
   extends Partial<TextProps>,
     Pick<TextProps$1, 'id' | 'children'> {
   /**
-   * The text content displayed within the Text component, which applies semantic meaning and styling appropriate to the specified text type.
+   * The text content displayed within the text component, which applies semantic meaning and styling appropriate to the specified text type.
    */
   children?: ComponentChildren;
 }
@@ -8715,9 +8715,9 @@ export interface TooltipJSXProps
   extends Partial<TooltipProps>,
     Pick<TooltipProps$1, 'id' | 'children'> {
   /**
-   * The informational text or elements displayed within the Tooltip overlay, providing helpful context or explanations when users interact with the associated element.
+   * The informational text or elements displayed within the tooltip overlay, providing helpful context or explanations when users interact with the associated element.
    *
-   * Only accepts Text, Paragraph components, and raw `textContent`.
+   * Only accepts text, paragraph components, and raw `textContent`.
    */
   children?: ComponentChildren;
 }
@@ -8791,7 +8791,7 @@ export interface UnorderedListJSXProps
   extends Partial<UnorderedListProps>,
     Pick<UnorderedListProps$1, 'id'> {
   /**
-   * The list entries displayed within the unordered list, where each item is marked with a bullet point. Only accepts ListItem components as children. Each ListItem represents a single bulleted entry in the list.
+   * The list entries displayed within the unordered list, where each item is marked with a bullet point. Only accepts list item components as children. Each list item represents a single bulleted entry in the list.
    */
   children?: ComponentChildren;
 }
@@ -9151,7 +9151,7 @@ export interface AvatarEvents {
 
 export interface BadgeSlots {
   /**
-   * The text label displayed within the Badge component, typically a short status indicator or category label.
+   * The text label displayed within the badge component, typically a short status indicator or category label.
    */
   children?: HTMLElement;
 }
@@ -9169,19 +9169,19 @@ export interface BannerEvents {
 
 export interface BannerSlots {
   /**
-   * The main message content displayed within the Banner component, providing important information or guidance to users.
+   * The main message content displayed within the banner component, providing important information or guidance to users.
    */
   children?: HTMLElement;
   /**
    * Action buttons displayed at the bottom of the banner that let users respond to the message.
-   * Accepts up to two Button components with `variant="secondary"` or `variant="auto"`.
+   * Accepts up to two button components with `variant="secondary"` or `variant="auto"`.
    */
   'secondary-actions'?: HTMLElement;
 }
 
 export interface BoxSlots {
   /**
-   * The content displayed within the Box component, which serves as a flexible container for organizing and styling other components.
+   * The content displayed within the box component, which serves as a flexible container for organizing and styling other components.
    */
   children?: HTMLElement;
 }
@@ -9209,26 +9209,26 @@ export interface ButtonEvents {
 
 export interface ButtonSlots {
   /**
-   * The label text or elements displayed inside the Button component, describing the action that will be performed when clicked.
+   * The label text or elements displayed inside the button component, describing the action that will be performed when clicked.
    */
   children?: HTMLElement;
 }
 
 export interface ButtonGroupSlots {
   /**
-   * The buttons displayed within the ButtonGroup component, which are arranged together as a cohesive set of related actions.
+   * The buttons displayed within the button group component, which are arranged together as a cohesive set of related actions.
    */
   children?: HTMLElement;
   /**
    * The main action for this group, displayed with high visual emphasis.
-   * Accepts a single Button with `variant="primary"`.
+   * Accepts a single button with `variant="primary"`.
    *
    * Use this for the primary action you want users to take. This can't be used when `gap="none"`.
    */
   'primary-action'?: HTMLElement;
   /**
    * Supporting actions displayed with less emphasis than the primary action.
-   * Accepts one or more Button components with `variant="secondary"` or `variant="auto"`.
+   * Accepts one or more button components with `variant="secondary"` or `variant="auto"`.
    *
    * Use these for alternative or less critical actions.
    */
@@ -9252,11 +9252,11 @@ export interface CheckboxEvents {
 
 export interface ChipSlots {
   /**
-   * The text label displayed within the Chip component, typically representing a selected filter, tag, or removable item.
+   * The text label displayed within the chip component, typically representing a selected filter, tag, or removable item.
    */
   children?: HTMLElement;
   /**
-   * An optional icon to display at the start of the chip. Accepts only Icon components.
+   * An optional icon to display at the start of the chip. Accepts only icon components.
    */
   graphic?: HTMLElement;
 }
@@ -9300,7 +9300,7 @@ export interface ChoiceListSlots {
   /**
    * The choices a user can select from.
    *
-   * Accepts Choice components.
+   * Accepts choice components.
    */
   children?: HTMLElement;
 }
@@ -9328,7 +9328,7 @@ export interface ClickableEvents {
 
 export interface ClickableSlots {
   /**
-   * The content displayed within the Clickable component, which makes any content interactive and clickable without the semantic meaning of a button or link.
+   * The content displayed within the clickable component, which makes any content interactive and clickable without the semantic meaning of a button or link.
    */
   children?: HTMLElement;
 }
@@ -9356,7 +9356,7 @@ export interface ClickableChipSlots {
    */
   children?: HTMLElement;
   /**
-   * An optional icon to display at the start of the chip. Accepts only Icon components.
+   * An optional icon to display at the start of the chip. Accepts only icon components.
    */
   graphic?: HTMLElement;
 }
@@ -9492,7 +9492,7 @@ export interface DropZoneEvents {
 
 export interface DropZoneSlots {
   /**
-   * The content to include inside the DropZone container
+   * The content to include inside the drop zone container
    */
   children?: HTMLElement;
 }
@@ -9526,21 +9526,21 @@ export interface EmailFieldEvents {
 
 export interface GridSlots {
   /**
-   * The child elements displayed within the Grid component, which are arranged in a flexible grid layout with configurable columns, rows, and spacing.
+   * The child elements displayed within the grid component, which are arranged in a flexible grid layout with configurable columns, rows, and spacing.
    */
   children?: HTMLElement;
 }
 
 export interface GridItemSlots {
   /**
-   * The content displayed within the GridItem component, which represents a single cell in the grid layout and can span multiple columns or rows.
+   * The content displayed within the grid item component, which represents a single cell in the grid layout and can span multiple columns or rows.
    */
   children?: HTMLElement;
 }
 
 export interface HeadingSlots {
   /**
-   * The heading text displayed within the Heading component, which provides a title or section header for content.
+   * The heading text displayed within the heading component, which provides a title or section header for content.
    */
   children?: HTMLElement;
 }
@@ -9571,7 +9571,7 @@ export interface LinkEvents {
 
 export interface LinkSlots {
   /**
-   * The text or elements displayed within the Link component, which navigates users to a different location when activated.
+   * The text or elements displayed within the link component, which navigates users to a different location when activated.
    */
   children?: HTMLElement;
 }
@@ -9585,7 +9585,7 @@ export interface ListItemSlots {
 
 export interface MenuSlots {
   /**
-   * The items displayed within the menu. Only accepts Button and Section components. Use Button for individual menu actions and Section to group related items.
+   * The items displayed within the menu. Only accepts button and section components. Use button for individual menu actions and section to group related items.
    */
   children?: HTMLElement;
 }
@@ -9611,19 +9611,19 @@ export interface ModalEvents {
 
 export interface ModalSlots {
   /**
-   * The content displayed within the Modal component, typically including form fields, information, or interactive elements.
+   * The content displayed within the modal component, typically including form fields, information, or interactive elements.
    */
   children?: HTMLElement;
   /**
    * The main action button displayed in the modal footer, representing the primary action users should take.
    *
-   * Only accepts a single Button component with a `variant` of `primary`. This action should align with the modal's main purpose.
+   * Only accepts a single button component with a `variant` of `primary`. This action should align with the modal's main purpose.
    */
   'primary-action'?: HTMLElement;
   /**
    * Additional action buttons displayed in the modal footer, providing alternative or supporting actions.
    *
-   * Only accepts Button components with a `variant` of `secondary` or `auto`. These are visually de-emphasized to establish clear hierarchy.
+   * Only accepts button components with a `variant` of `secondary` or `auto`. These are visually de-emphasized to establish clear hierarchy.
    */
   'secondary-actions'?: HTMLElement;
 }
@@ -9691,21 +9691,21 @@ export interface OptionSlots {
 
 export interface OptionGroupSlots {
   /**
-   * The selectable options displayed in the dropdown list. Accepts Option components for individual selectable items within this group.
+   * The selectable options displayed in the dropdown list. Accepts option components for individual selectable items within this group.
    */
   children?: HTMLElement;
 }
 
 export interface OrderedListSlots {
   /**
-   * The list entries displayed within the ordered list, where each item is numbered sequentially. Only accepts ListItem components as children. Each ListItem represents a single numbered entry in the sequence.
+   * The list entries displayed within the ordered list, where each item is numbered sequentially. Only accepts list item components as children. Each list item represents a single numbered entry in the sequence.
    */
   children?: HTMLElement;
 }
 
 export interface PageSlots {
   /**
-   * The main page content displayed within the Page component, which serves as the primary container for the page's information and interface elements.
+   * The main page content displayed within the page component, which serves as the primary container for the page's information and interface elements.
    */
   children?: HTMLElement;
   /**
@@ -9717,27 +9717,27 @@ export interface PageSlots {
   /**
    * The primary action for the page.
    *
-   * Only accepts a single Button component with a `variant` of `primary`.
+   * Only accepts a single button component with a `variant` of `primary`.
    *
    */
   'primary-action'?: HTMLElement;
   /**
    * The secondary actions for the page.
    *
-   * Only accepts ButtonGroup and Button components with a `variant` of `secondary` or `auto`.
+   * Only accepts button group and button components with a `variant` of `secondary` or `auto`.
    */
   'secondary-actions'?: HTMLElement;
   /**
    * The navigation back actions for the page.
    *
-   * Only accepts Link components.
+   * Only accepts link components.
    */
   'breadcrumb-actions'?: HTMLElement;
 }
 
 export interface ParagraphSlots {
   /**
-   * The paragraph text content displayed within the Paragraph component, which presents a block of related text with appropriate styling.
+   * The paragraph text content displayed within the paragraph component, which presents a block of related text with appropriate styling.
    */
   children?: HTMLElement;
 }
@@ -9798,14 +9798,14 @@ export interface PopoverEvents {
 
 export interface PopoverSlots {
   /**
-   * The content displayed within the Popover component, which appears in an overlay positioned relative to its trigger element.
+   * The content displayed within the popover component, which appears in an overlay positioned relative to its trigger element.
    */
   children?: HTMLElement;
 }
 
 export interface QueryContainerSlots {
   /**
-   * The content displayed within the QueryContainer component, which enables container queries for responsive styling based on the container's size rather than the viewport.
+   * The content displayed within the query container component, which enables container queries for responsive styling based on the container's size rather than the viewport.
    */
   children?: HTMLElement;
 }
@@ -9839,7 +9839,7 @@ export interface SearchFieldEvents {
 
 export interface SectionSlots {
   /**
-   * The content displayed within the Section component, which groups related elements together in a logical unit with an optional heading.
+   * The content displayed within the section component, which groups related elements together in a logical unit with an optional heading.
    */
   children?: HTMLElement;
 }
@@ -9861,14 +9861,14 @@ export interface SelectEvents {
 
 export interface SelectSlots {
   /**
-   * The selectable options displayed in the dropdown list. Accepts Option components for individual selectable items, and OptionGroup components to organize related options into logical groups with labels.
+   * The selectable options displayed in the dropdown list. Accepts option components for individual selectable items, and option group components to organize related options into logical groups with labels.
    */
   children?: HTMLElement;
 }
 
 export interface StackSlots {
   /**
-   * The child elements displayed within the Stack component, which are arranged vertically or horizontally with consistent spacing.
+   * The child elements displayed within the stack component, which are arranged vertically or horizontally with consistent spacing.
    */
   children?: HTMLElement;
 }
@@ -9903,13 +9903,13 @@ export interface TableSlots {
   /**
    * The table structure defining headers and data rows.
    *
-   * Accepts TableHeaderRow (for column headers) and TableBody (for data rows) components. Structure your table with a TableHeaderRow first, followed by TableBody.
+   * Accepts table header row (for column headers) and table body (for data rows) components. Structure your table with a table header row first, followed by table body.
    */
   children?: HTMLElement;
   /**
    * Filter controls displayed above the table.
    *
-   * Accepts input components like SearchField or Select for filtering table data. These controls appear in a dedicated area above the table content.
+   * Accepts input components like search field or select for filtering table data. These controls appear in a dedicated area above the table content.
    */
   filters?: HTMLElement;
 }
@@ -9918,7 +9918,7 @@ export interface TableBodySlots {
   /**
    * The data rows displayed in the table body.
    *
-   * Accepts TableRow components, with each row representing a single record or entry in the table.
+   * Accepts table row components, with each row representing a single record or entry in the table.
    */
   children?: HTMLElement;
 }
@@ -9945,7 +9945,7 @@ export interface TableHeaderRowSlots {
   /**
    * The column headers displayed in the table header row.
    *
-   * Accepts TableHeader components, with each header defining a column and providing its label.
+   * Accepts table header components, with each header defining a column and providing its label.
    */
   children?: HTMLElement;
 }
@@ -9954,14 +9954,14 @@ export interface TableRowSlots {
   /**
    * The data cells displayed in this table row.
    *
-   * Accepts TableCell components, with each cell containing a data value for the corresponding column.
+   * Accepts table cell components, with each cell containing a data value for the corresponding column.
    */
   children?: HTMLElement;
 }
 
 export interface TextSlots {
   /**
-   * The text content displayed within the Text component, which applies semantic meaning and styling appropriate to the specified text type.
+   * The text content displayed within the text component, which applies semantic meaning and styling appropriate to the specified text type.
    */
   children?: HTMLElement;
 }
@@ -10024,7 +10024,7 @@ export interface TextFieldSlots {
   /**
    * Additional interactive content displayed within the text field.
    *
-   * Accepts Button and Clickable components with text content only. Other component types or complex layouts are not supported.
+   * Accepts button and clickable components with text content only. Other component types or complex layouts are not supported.
    */
   accessory?: HTMLElement;
 }
@@ -10046,9 +10046,9 @@ export interface ThumbnailEvents {
 
 export interface TooltipSlots {
   /**
-   * The informational text or elements displayed within the Tooltip overlay, providing helpful context or explanations when users interact with the associated element.
+   * The informational text or elements displayed within the tooltip overlay, providing helpful context or explanations when users interact with the associated element.
    *
-   * Only accepts Text, Paragraph components, and raw `textContent`.
+   * Only accepts text, paragraph components, and raw `textContent`.
    */
   children?: HTMLElement;
 }
@@ -10082,7 +10082,7 @@ export interface URLFieldEvents {
 
 export interface UnorderedListSlots {
   /**
-   * The list entries displayed within the unordered list, where each item is marked with a bullet point. Only accepts ListItem components as children. Each ListItem represents a single bulleted entry in the list.
+   * The list entries displayed within the unordered list, where each item is marked with a bullet point. Only accepts list item components as children. Each list item represents a single bulleted entry in the list.
    */
   children?: HTMLElement;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/ActionExtensionComponents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ActionExtensionComponents.ts
@@ -1,7 +1,7 @@
 import {StandardComponents} from './StandardComponents';
 
 /**
- * The components available for building action extensions. Includes all standard components plus the AdminAction component required for action extension setup.
+ * The components available for building action extensions. Includes all standard components plus the admin action component required for action extension setup.
  */
 export type ActionExtensionComponents = StandardComponents | 'AdminAction';
 

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
@@ -8,7 +8,7 @@
 import type {ComponentChildren, AdminActionProps$1} from './shared.d.ts';
 
 /**
- * The properties for the AdminAction component. These properties configure the heading and loading state of the admin action extension interface.
+ * The properties for the admin action component. These properties configure the heading and loading state of the admin action extension interface.
  */
 export interface AdminActionProps
   extends Pick<AdminActionProps$1, 'heading' | 'loading'> {}
@@ -16,17 +16,17 @@ export interface AdminActionProps
 declare const tagName = 's-admin-action';
 
 /**
- * The JSX props for the AdminAction component. These properties extend `AdminActionProps` with slots for primary and secondary action buttons that merchants can interact with.
+ * The JSX props for the admin action component. These properties extend `AdminActionProps` with slots for primary and secondary action buttons that merchants can interact with.
  */
 export interface AdminActionJSXProps
   extends Partial<AdminActionProps>,
     Pick<AdminActionProps$1, 'id'> {
   /**
-   * The primary action button or link to display in the admin action area. This is the main call-to-action that appears prominently in the interface. Typically uses a Button component with `variant="primary"` to complete or advance the workflow.
+   * The primary action button or link to display in the admin action area. This is the main call-to-action that appears prominently in the interface. Typically uses a button component with `variant="primary"` to complete or advance the workflow.
    */
   primaryAction: ComponentChildren;
   /**
-   * The secondary action buttons or links to display in the admin action area. These are supporting actions like cancel, back, or alternative operations. Typically uses Button components with `variant="secondary"` or `variant="tertiary"`.
+   * The secondary action buttons or links to display in the admin action area. These are supporting actions like cancel, back, or alternative operations. Typically uses button components with `variant="secondary"` or `variant="tertiary"`.
    */
   secondaryActions: ComponentChildren;
 }
@@ -122,7 +122,7 @@ declare abstract class PreactCustomElement extends BaseClass {
 }
 
 /**
- * The AdminAction custom element class that renders action controls in the Shopify admin interface. This component creates a standardized action area with a heading and slots for primary and secondary action buttons, used exclusively in admin action extensions.
+ * The admin action custom element class that renders action controls in the Shopify admin interface. This component creates a standardized action area with a heading and slots for primary and secondary action buttons, used exclusively in admin action extensions.
  */
 declare class AdminAction
   extends PreactCustomElement

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.ext.doc.ts
@@ -1,9 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'AdminAction',
+  name: 'Admin action',
   description:
-    'The AdminAction component configures the primary action, secondary action, and title for admin action extensions. Use AdminAction to define the core interaction points and header content that merchants see when your extension renders.' +
+    'The admin action component configures the primary action, secondary action, and title for admin action extensions. Use admin action to define the core interaction points and header content that merchants see when your extension renders.' +
     '\n\nLearn how to [build an admin action extension](/docs/apps/build/admin/actions-blocks/build-admin-action).',
   requires:
     'the [Action Extension API](/docs/api/admin-extensions/{API_VERSION}/target-apis/core-apis/action-extension-api) or [Purchase Options Card Configuration API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/purchase-options-card-configuration-api).',
@@ -15,13 +15,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the AdminAction component.',
+        'Configure the following properties on the admin action component.',
       type: 'AdminActionProps',
     },
     {
       title: 'Slots',
       description:
-        'The AdminAction component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'AdminActionSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
@@ -8,7 +8,7 @@
 import type {AdminBlockProps$1, ComponentChildren} from './shared.d.ts';
 
 /**
- * The properties for the AdminBlock component. These properties configure the heading and collapsed summary of collapsible content blocks in the admin interface.
+ * The properties for the admin block component. These properties configure the heading and collapsed summary of collapsible content blocks in the admin interface.
  */
 export interface AdminBlockProps
   extends Pick<AdminBlockProps$1, 'heading' | 'collapsedSummary'> {}
@@ -16,7 +16,7 @@ export interface AdminBlockProps
 declare const tagName = 's-admin-block';
 
 /**
- * The JSX props for the AdminBlock component. These properties extend `AdminBlockProps` with an optional `id` for element identification in JSX rendering.
+ * The JSX props for the admin block component. These properties extend `AdminBlockProps` with an optional `id` for element identification in JSX rendering.
  */
 export interface AdminBlockJSXProps
   extends Partial<AdminBlockProps>,
@@ -113,7 +113,7 @@ declare abstract class PreactCustomElement extends BaseClass {
 }
 
 /**
- * The AdminBlock custom element class that renders a collapsible content block in the Shopify admin interface. This component organizes content into expandable sections with headings and provides a summary when collapsed.
+ * The admin block custom element class that renders a collapsible content block in the Shopify admin interface. This component organizes content into expandable sections with headings and provides a summary when collapsed.
  */
 declare class AdminBlock
   extends PreactCustomElement

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
@@ -1,9 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'AdminBlock',
+  name: 'Admin block',
   description:
-    'The AdminBlock component enables admin block extensions to appear inline on resource pages. Use AdminBlock to create embedded extension experiences that feel native to the Shopify admin interface, with automatic height management, expansion controls, and content overflow handling.' +
+    'The admin block component enables admin block extensions to appear inline on resource pages. Use admin block to create embedded extension experiences that feel native to the Shopify admin interface, with automatic height management, expansion controls, and content overflow handling.' +
     '\n\nLearn how to [build an admin block extension](/docs/apps/build/admin/actions-blocks/build-admin-block).',
   requires:
     'the [Block Extension API](/docs/api/admin-extensions/{API_VERSION}/target-apis/core-apis/block-extension-api), [Product Details Configuration API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/product-details-configuration-api), or [Product Variant Details Configuration API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/product-variant-details-configuration-api).',
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the AdminBlock component.',
+        'Configure the following properties on the admin block component.',
       type: 'AdminBlockProps',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
@@ -8,7 +8,7 @@
 import type {AdminPrintActionProps$1, ComponentChildren} from './shared.d.ts';
 
 /**
- * The properties for the AdminPrintAction component. These properties configure the source URL for printing content within admin extensions.
+ * The properties for the admin print action component. These properties configure the source URL for printing content within admin extensions.
  */
 export interface AdminPrintActionProps
   extends Pick<AdminPrintActionProps$1, 'src'> {}
@@ -16,7 +16,7 @@ export interface AdminPrintActionProps
 declare const tagName = 's-admin-print-action';
 
 /**
- * The JSX props for the AdminPrintAction component. These properties extend `AdminPrintActionProps` with an optional `id` for element identification in JSX rendering.
+ * The JSX props for the admin print action component. These properties extend `AdminPrintActionProps` with an optional `id` for element identification in JSX rendering.
  */
 export interface AdminPrintActionJSXProps
   extends Partial<AdminPrintActionProps>,
@@ -113,7 +113,7 @@ declare abstract class PreactCustomElement extends BaseClass {
 }
 
 /**
- * The AdminPrintAction custom element class that renders a print interface in the Shopify admin. This component enables merchants to print content from a specified source URL using the browser's print functionality.
+ * The admin print action custom element class that renders a print interface in the Shopify admin. This component enables merchants to print content from a specified source URL using the browser's print functionality.
  */
 declare class AdminPrintAction
   extends PreactCustomElement

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.ext.doc.ts
@@ -1,9 +1,9 @@
 import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'AdminPrintAction',
+  name: 'Admin print action',
   description:
-    'The AdminPrintAction component specifies a URL for print operations in admin print action extensions. Use AdminPrintAction to define the print target when merchants trigger print actions from the Shopify admin, enabling custom print views optimized for physical or PDF printing.' +
+    'The admin print action component specifies a URL for print operations in admin print action extensions. Use admin print action to define the print target when merchants trigger print actions from the Shopify admin, enabling custom print views optimized for physical or PDF printing.' +
     '\n\nLearn how to [build an admin print action extension](/docs/apps/build/admin/actions-blocks/build-admin-print-action).',
   requires:
     'the [Print Action Extension API](/docs/api/admin-extensions/{API_VERSION}/target-apis/core-apis/print-action-extension-api).',
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the AdminPrintAction component.',
+        'Configure the following properties on the admin print action component.',
       type: 'AdminPrintActionProps',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar.d.ts
@@ -9,7 +9,7 @@
 import type {AvatarProps$1, ComponentChildren} from './shared.d.ts';
 
 /**
- * The properties for the Avatar component. An Avatar displays a user or entity image with fallback initials when the image isn't available. Properties include `src` for the image URL, `initials` for the fallback text, `alt` for accessibility text, and `size` for controlling the avatar dimensions.
+ * The properties for the avatar component. An avatar displays a user or entity image with fallback initials when the image isn't available. Properties include `src` for the image URL, `initials` for the fallback text, `alt` for accessibility text, and `size` for controlling the avatar dimensions.
  */
 export interface AvatarProps
   extends Required<Pick<AvatarProps$1, 'initials' | 'src' | 'alt' | 'size'>> {
@@ -165,7 +165,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
 }
 
 /**
- * An Avatar displays a user or entity image with fallback initials when the image isn't available.
+ * An avatar displays a user or entity image with fallback initials when the image isn't available.
  */
 declare class Avatar extends PreactCustomElement implements AvatarProps {
   /**
@@ -209,7 +209,7 @@ declare module 'preact' {
 
 declare const tagName = 's-avatar';
 /**
- * The properties for the Avatar component when it's used in JSX.
+ * The properties for the avatar component when it's used in JSX.
  */
 export interface AvatarJSXProps
   extends Partial<AvatarProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar/Avatar.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar/Avatar.doc.ts
@@ -27,13 +27,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Avatar component.',
+        'Configure the following properties on the avatar component.',
       type: 'Avatar',
     },
     {
       title: 'Events',
       description:
-        'The Avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'AvatarEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
@@ -60,7 +60,7 @@ export interface IconProps
 }
 
 /**
- * The properties for the Badge component. Badges display status information through compact visual indicators with customizable tones, sizes, and optional icons.
+ * The properties for the badge component. Badges display status information through compact visual indicators with customizable tones, sizes, and optional icons.
  */
 export interface BadgeProps
   extends Pick<BadgeProps$1, 'color' | 'icon' | 'size' | 'tone'> {
@@ -224,7 +224,7 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * The Badge custom element class that renders status indicators in the Shopify admin interface. This component displays compact visual indicators with customizable tones, sizes, and optional icons to communicate status information to merchants.
+ * The badge custom element class that renders status indicators in the Shopify admin interface. This component displays compact visual indicators with customizable tones, sizes, and optional icons to communicate status information to merchants.
  */
 declare class Badge extends PreactCustomElement implements BadgeProps {
   /**
@@ -260,7 +260,7 @@ declare module 'preact' {
 
 declare const tagName = 's-badge';
 /**
- * The JSX props for the Badge component. These properties extend `BadgeProps` with an optional `id` and `children` for rendering badge content in JSX.
+ * The JSX props for the badge component. These properties extend `BadgeProps` with an optional `id` and `children` for rendering badge content in JSX.
  */
 export interface BadgeJSXProps
   extends Partial<BadgeProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
@@ -28,13 +28,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Badge component.',
+      description: 'Configure the following properties on the badge component.',
       type: 'Badge',
     },
     {
       title: 'Slots',
       description:
-        'The Badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'BadgeSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
@@ -54,11 +54,11 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * All properties for the Banner component marked as required.
+ * All properties for the banner component marked as required.
  */
 export type RequiredBannerProps = Required<BannerProps$1>;
 /**
- * The properties for the Banner component. These properties define an important message or notification with visual styling that conveys its semantic meaning.
+ * The properties for the banner component. These properties define an important message or notification with visual styling that conveys its semantic meaning.
  */
 export interface BannerProps
   extends Pick<
@@ -212,7 +212,7 @@ declare module 'preact' {
 
 declare const tagName = 's-banner';
 /**
- * The JSX properties for the Banner component. These properties define how a banner is rendered in Preact or JSX.
+ * The JSX properties for the banner component. These properties define how a banner is rendered in Preact or JSX.
  */
 export interface BannerJSXProps
   extends Partial<BannerProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
@@ -30,19 +30,19 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Banner component.',
+        'Configure the following properties on the banner component.',
       type: 'Banner',
     },
     {
       title: 'Events',
       description:
-        'The Banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'BannerEvents',
     },
     {
       title: 'Slots',
       description:
-        'The Banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'BannerSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/BlockExtensionComponents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/BlockExtensionComponents.ts
@@ -1,7 +1,7 @@
 import {StandardComponents} from './StandardComponents';
 
 /**
- * The components available for building block extensions. Includes all standard components plus the AdminBlock component required for block extension setup and the Form component for creating forms.
+ * The components available for building block extensions. Includes all standard components plus the admin block component required for block extension setup and the form component for creating forms.
  */
 export type BlockExtensionComponents =
   | StandardComponents

--- a/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
@@ -39,11 +39,11 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * A version of the Box properties with all fields required.
+ * A version of the box properties with all fields required.
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
- * The allowed border radius values for a Box component.
+ * The allowed border radius values for a box component.
  */
 export type BoxBorderRadii = Extract<
   RequiredBoxProps['borderRadius'],
@@ -57,14 +57,14 @@ export type BoxBorderRadii = Extract<
   | 'large-200'
 >;
 /**
- * The allowed border style values for a Box component.
+ * The allowed border style values for a box component.
  */
 export type BoxBorderStyles = Extract<
   RequiredBoxProps['borderStyle'],
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * The Box properties that support responsive values through container queries.
+ * The box properties that support responsive values through container queries.
  */
 export type ResponsiveBoxProps = MakeResponsivePick<
   RequiredBoxProps,
@@ -78,7 +78,7 @@ export type ResponsiveBoxProps = MakeResponsivePick<
   | 'display'
 >;
 /**
- * The properties for the Box component. A Box provides control over layout, spacing, sizing, borders, and background styling for its content.
+ * The properties for the box component. A box provides control over layout, spacing, sizing, borders, and background styling for its content.
  */
 export interface BoxProps
   extends Pick<
@@ -486,7 +486,7 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * A Box is a container component that provides control over layout, spacing, and styling.
+ * A box is a container component that provides control over layout, spacing, and styling.
  */
 declare class Box extends BoxElement implements BoxProps {
   constructor();
@@ -506,13 +506,13 @@ declare module 'preact' {
 
 declare const tagName = 's-box';
 /**
- * The properties for the Box component when it's used in JSX.
+ * The properties for the box component when it's used in JSX.
  */
 export interface BoxJSXProps
   extends Partial<BoxProps>,
     Pick<BoxProps$1, 'id' | 'children'> {
   /**
-   * The child elements to render inside the Box.
+   * The child elements to render inside the box.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
@@ -10,8 +10,8 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [Stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [Grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.
-- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [Section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) or [Banner](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.
+      sectionContent: `- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.
+- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.
 - **Design for different screen sizes:** Layouts that work on desktop might not work on mobile. Use responsive properties to adjust spacing and layout based on available space rather than creating fixed layouts.
 - **Make interactive containers accessible:** When boxes contain interactive content or represent distinct regions, provide appropriate ARIA roles and labels so screen reader users can navigate and understand the interface structure.
 - **Avoid excessive nesting:** Deep nesting of boxes creates complex DOM structures and makes styling harder to manage. Look for opportunities to simplify your layout or use more appropriate layout components.`,
@@ -20,13 +20,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Box component.',
+      description: 'Configure the following properties on the box component.',
       type: 'Box',
     },
     {
       title: 'Slots',
       description:
-        'The Box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'BoxSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
@@ -115,7 +115,7 @@ export type ButtonOnlyProps = Extract<
   }
 >;
 /**
- * The base required properties for the Button component, including all essential button configuration options. This type ensures all button properties have default values.
+ * The base required properties for the button component, including all essential button configuration options. This type ensures all button properties have default values.
  */
 export type ButtonBaseProps = Required<
   Pick<
@@ -137,7 +137,7 @@ export type ButtonBaseProps = Required<
   >
 >;
 /**
- * The properties for the Button component. Buttons trigger actions or navigation when clicked, with customizable visual styles, states, and optional icons.
+ * The properties for the button component. Buttons trigger actions or navigation when clicked, with customizable visual styles, states, and optional icons.
  */
 export interface ButtonProps extends ButtonBaseProps {
   /**
@@ -278,14 +278,14 @@ export interface PreactOverlayControlProps
 }
 
 /**
- * The base class for the Button component, combining Preact custom element functionality with overlay control capabilities.
+ * The base class for the button component, combining Preact custom element functionality with overlay control capabilities.
  */
 declare const Button_base: (abstract new (
   args_0: RenderImpl,
 ) => PreactCustomElement & PreactOverlayControlProps) &
   Pick<typeof PreactCustomElement, 'prototype' | 'observedAttributes'>;
 /**
- * The Button custom element class that renders interactive buttons in the Shopify admin interface. This component triggers actions or navigation when clicked, with customizable visual styles, states, and optional icons.
+ * The button custom element class that renders interactive buttons in the Shopify admin interface. This component triggers actions or navigation when clicked, with customizable visual styles, states, and optional icons.
  */
 declare class Button extends Button_base implements ButtonProps {
   /**
@@ -357,7 +357,7 @@ declare module 'preact' {
 
 declare const tagName = 's-button';
 /**
- * The JSX props for the Button component. These properties extend `ButtonProps` with event callbacks and additional options for rendering buttons in JSX.
+ * The JSX props for the button component. These properties extend `ButtonProps` with event callbacks and additional options for rendering buttons in JSX.
  */
 export interface ButtonJSXProps
   extends Partial<ButtonProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
@@ -30,19 +30,19 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Button component.',
+        'Configure the following properties on the button component.',
       type: 'Button',
     },
     {
       title: 'Events',
       description:
-        'The Button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ButtonEvents',
     },
     {
       title: 'Slots',
       description:
-        'The Button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ButtonSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup.d.ts
@@ -172,7 +172,7 @@ declare module 'preact' {
 declare const tagName = 's-button-group';
 
 /**
- * Properties for using the ButtonGroup component in JSX with React-style props.
+ * Properties for using the button group component in JSX with React-style props.
  */
 export interface ButtonGroupJSXProps
   extends Partial<ButtonGroupProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup/ButtonGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup/ButtonGroup.doc.ts
@@ -22,13 +22,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the ButtonGroup component.',
+        'Configure the following properties on the button group component.',
       type: 'ButtonGroup',
     },
     {
       title: 'Slots',
       description:
-        'The ButtonGroup component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ButtonGroupSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
@@ -297,7 +297,7 @@ declare module 'preact' {
 
 declare const tagName = 's-checkbox';
 /**
- * Props for using the Checkbox component in JSX with React-style event handlers.
+ * Props for using the checkbox component in JSX with React-style event handlers.
  */
 export interface CheckboxJSXProps
   extends Partial<CheckboxProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
@@ -21,13 +21,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Checkbox component.',
+        'Configure the following properties on the checkbox component.',
       type: 'Checkbox',
     },
     {
       title: 'Events',
       description:
-        'The Checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'CheckboxEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Chip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Chip.d.ts
@@ -59,7 +59,7 @@ export interface ChipJSXProps
   extends Partial<ChipProps>,
     Pick<ChipProps$1, 'id' | 'children'> {
   /**
-   * The content of the Chip.
+   * The content of the chip.
    */
   children?: ComponentChildren;
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/Chip/Chip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Chip/Chip.doc.ts
@@ -10,7 +10,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use chips to label and categorize content:** [Chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons.
+      sectionContent: `- **Use chips to label and categorize content:** [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons.
 - **Keep chip text concise and scannable:** Short labels like "Featured" or "On sale" are instantly recognizable. Long chip text defeats the purpose of quick scanning and might truncate, hiding important information.
 - **Choose the right visual weight:** Use subdued chips for secondary metadata, standard chips for typical tags and categories, and strong chips for important or verified information that needs emphasis.
 - **Position chips near what they describe:** Place chips adjacent to the items they categorize for immediate context. In lists, position chips consistently to help merchants scan efficiently.
@@ -28,13 +28,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Chip component.',
+      description: 'Configure the following properties on the chip component.',
       type: 'Chip',
     },
     {
       title: 'Slots',
       description:
-        'The Chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ChipSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
@@ -181,7 +181,7 @@ declare module 'preact' {
 
 declare const tagName = 's-choice';
 /**
- * Properties for using the Choice component in JSX with React-style props.
+ * Properties for using the choice component in JSX with React-style props.
  */
 export interface ChoiceJSXProps
   extends Partial<ChoiceProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
@@ -236,7 +236,7 @@ declare module 'preact' {
 
 declare const tagName = 's-choice-list';
 /**
- * Properties for using the ChoiceList component in JSX with React-style event handlers.
+ * Properties for using the choice list component in JSX with React-style event handlers.
  */
 export interface ChoiceListJSXProps
   extends Partial<ChoiceListProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
@@ -22,23 +22,23 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Limitations',
       type: 'Generic' as const,
       anchorLink: 'limitations',
-      sectionContent: `- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [Select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select) dropdown instead.
+      sectionContent: `- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select) dropdown instead.
 - Rendering 50+ checkboxes or radio buttons can cause noticeable performance issues, especially on mobile devices. Consider pagination, virtualization, or alternative UI patterns for large lists.
 - The component is either single-selection (radio buttons) or multiple-selection (checkboxes) for all choices. You can't mix both types in the same list.
-- Component types other than Choice can't be used as options within the choice list.`,
+- Component types other than choice can't be used as options within the choice list.`,
     },
   ],
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the ChoiceList component.',
+        'Configure the following properties on the choice list component.',
       type: 'ChoiceList',
     },
     {
       title: 'Events',
       description:
-        'The ChoiceList component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ChoiceListEvents',
     },
     {
@@ -49,7 +49,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The ChoiceList component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ChoiceSlots',
     },
   ],
@@ -78,7 +78,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Demonstrates a basic ChoiceList with single selection, showing how to create a group of radio button choices.',
+              'Demonstrates a basic choice list with single selection, showing how to create a group of radio button choices.',
             codeblock: {
               title: 'Basic usage',
               tabs: [
@@ -96,7 +96,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Illustrates a ChoiceList with multiple selection enabled, allowing merchants to choose multiple options with additional descriptive details for each choice.',
+              'Illustrates a choice list with multiple selection enabled, allowing merchants to choose multiple options with additional descriptive details for each choice.',
             codeblock: {
               title: 'Multiple selections',
               tabs: [
@@ -114,7 +114,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Shows how to display an error message in a ChoiceList when an invalid selection is made or a validation constraint is not met.',
+              'Shows how to display an error message in a choice list when an invalid selection is made or a validation constraint is not met.',
             codeblock: {
               title: 'With error state',
               tabs: [
@@ -132,7 +132,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Showcases a multiple-selection ChoiceList with each option including detailed information.',
+              'Showcases a multiple-selection choice list with each option including detailed information.',
             codeblock: {
               title: 'Multiple choices with details',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
@@ -335,7 +335,7 @@ export type ClickableBaseProps = Required<
   >
 >;
 /**
- * The properties for the Clickable component. These properties define a low-level interactive container element that responds to user clicks while inheriting all Box styling capabilities. The component serves as a foundation for building custom interactive components.
+ * The properties for the clickable component. These properties define a low-level interactive container element that responds to user clicks while inheriting all box styling capabilities. The component serves as a foundation for building custom interactive components.
  */
 export interface ClickableProps
   extends Required<BoxProps>,
@@ -487,7 +487,7 @@ declare module 'preact' {
 
 declare const tagName = 's-clickable';
 /**
- * The JSX properties for the Clickable component. These properties define how a clickable container is rendered in Preact or JSX.
+ * The JSX properties for the clickable component. These properties define how a clickable container is rendered in Preact or JSX.
  */
 export interface ClickableJSXProps
   extends Partial<ClickableProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.doc.ts
@@ -20,19 +20,19 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Clickable component.',
+        'Configure the following properties on the clickable component.',
       type: 'Clickable',
     },
     {
       title: 'Events',
       description:
-        'The Clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ClickableEvents',
     },
     {
       title: 'Slots',
       description:
-        'The Clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ClickableSlots',
     },
   ],
@@ -60,7 +60,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'A simple clickable button with a base border and padding, demonstrating the default button behavior of the Clickable component.',
+              'A simple clickable button with a base border and padding, demonstrating the default button behavior of the clickable component.',
             codeblock: {
               title: 'Basic Button Usage',
               tabs: [
@@ -78,7 +78,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              "Demonstrates the Clickable component's ability to function as a link, opening the specified URL in a new browser tab when clicked.",
+              "Demonstrates the clickable component's ability to function as a link, opening the specified URL in a new browser tab when clicked.",
             codeblock: {
               title: 'Link Mode',
               tabs: [
@@ -114,7 +114,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Illustrates how the Clickable component can be integrated into a section layout to provide an interactive action button.',
+              'Illustrates how the clickable component can be integrated into a section layout to provide an interactive action button.',
             codeblock: {
               title: 'Section with Clickable Action',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/ClickableChip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ClickableChip.d.ts
@@ -58,7 +58,7 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * The properties for the ClickableChip component. These properties define an interactive chip that can be clicked or removed.
+ * The properties for the clickable chip component. These properties define an interactive chip that can be clicked or removed.
  */
 export interface ClickableChipProps
   extends Required<
@@ -260,7 +260,7 @@ declare module 'preact' {
 
 declare const tagName = 's-clickable-chip';
 /**
- * The JSX properties for the ClickableChip component. These properties define how a clickable chip is rendered in Preact or JSX.
+ * The JSX properties for the clickable chip component. These properties define how a clickable chip is rendered in Preact or JSX.
  */
 export interface ClickableChipJSXProps
   extends Partial<ClickableChipProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/ClickableChip/ClickableChip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ClickableChip/ClickableChip.doc.ts
@@ -14,26 +14,26 @@ const data: AdminReferenceEntityTemplateSchema = {
       sectionContent: `- **Keep labels to 1-3 words:** Aim for labels like **Electronics**, **Summer sale**, or **Clearance items**.
 - **Choose color variants by importance:** Use \`subdued\` for less important or secondary chips, \`base\` (default) for standard selections, and \`strong\` to emphasize primary or active selections.
 - **Make remove action clear:** When chips are removable, ensure the remove button's visible and has clear hover/focus states.
-- **Group related chips together:** Use an inline [Stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing.`,
+- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing.`,
     },
   ],
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the ClickableChip component.',
+        'Configure the following properties on the clickable chip component.',
       type: 'ClickableChip',
     },
     {
       title: 'Events',
       description:
-        'The ClickableChip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ClickableChipEvents',
     },
     {
       title: 'Slots',
       description:
-        'The ClickableChip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ClickableChipSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorField.d.ts
@@ -329,7 +329,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the ColorField component. These properties configure an input field that allows merchants to select colors using an integrated visual color picker with text input, hex color format, and optional alpha (transparency) channel support.
+ * The properties for the color field component. These properties configure an input field that allows merchants to select colors using an integrated visual color picker with text input, hex color format, and optional alpha (transparency) channel support.
  */
 export type ColorFieldProps = Omit<
   PreactFieldProps<Required<ColorFieldProps$1>['autocomplete']>,
@@ -338,7 +338,7 @@ export type ColorFieldProps = Omit<
   Required<Pick<ColorFieldProps$1, 'alpha' | 'value' | 'defaultValue'>>;
 
 /**
- * The ColorField custom element class that renders a color input field with integrated visual picker in the Shopify admin interface. This component allows merchants to select colors by typing hex values or using an interactive color picker, with optional support for transparency (alpha channel).
+ * The color field custom element class that renders a color input field with integrated visual picker in the Shopify admin interface. This component allows merchants to select colors by typing hex values or using an interactive color picker, with optional support for transparency (alpha channel).
  */
 declare class ColorField
   extends PreactFieldElement<ColorFieldProps['autocomplete']>
@@ -376,7 +376,7 @@ declare module 'preact' {
 
 declare const tagName = 's-color-field';
 /**
- * The JSX props for the ColorField component. These properties extend `ColorFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact, including callbacks for color changes as the merchant interacts with the picker.
+ * The JSX props for the color field component. These properties extend `ColorFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact, including callbacks for color changes as the merchant interacts with the picker.
  */
 export interface ColorFieldJSXProps
   extends Partial<

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorField/ColorField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorField/ColorField.doc.ts
@@ -25,13 +25,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the ColorField component.',
+        'Configure the following properties on the color field component.',
       type: 'ColorField',
     },
     {
       title: 'Events',
       description:
-        'The ColorField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ColorFieldEvents',
     },
   ],
@@ -185,7 +185,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'A multi-color field form section demonstrating how ColorField can be used to capture different color settings in a single form.',
+              'A multi-color field form section demonstrating how color field can be used to capture different color settings in a single form.',
             codeblock: {
               title: 'Form Integration',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
@@ -210,7 +210,7 @@ declare module 'preact' {
 
 declare const tagName = 's-color-picker';
 /**
- * The JSX props interface for the ColorPicker component when used in React/Preact.
+ * The JSX props interface for the color picker component when used in React/Preact.
  */
 export interface ColorPickerJSXProps
   extends Partial<ColorPickerProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.doc.ts
@@ -13,7 +13,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Initialize with current values:** When editing existing colors, always set the picker's initial value to the current color. This shows merchants what they're changing from and maintains context.
 - **Show preview of final result:** If possible, show how the selected color will look in its actual context (like previewing a button color on a button) alongside the picker.
-- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/colorfield) for precise hex input. This gives merchants both visual intuition and exact control.`,
+- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control.`,
     },
     {
       title: 'Limitations',

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.doc.ts
@@ -13,7 +13,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Initialize with current values:** When editing existing colors, always set the picker's initial value to the current color. This shows merchants what they're changing from and maintains context.
 - **Show preview of final result:** If possible, show how the selected color will look in its actual context (like previewing a button color on a button) alongside the picker.
-- **Pair with ColorField for precision:** Use the component for visual selection combined with a [ColorField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/colorfield) for precise hex input. This gives merchants both visual intuition and exact control.`,
+- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/colorfield) for precise hex input. This gives merchants both visual intuition and exact control.`,
     },
     {
       title: 'Limitations',
@@ -28,13 +28,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the ColorPicker component.',
+        'Configure the following properties on the color picker component.',
       type: 'ColorPicker',
     },
     {
       title: 'Events',
       description:
-        'The ColorPicker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ColorPickerEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
@@ -308,7 +308,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the DateField component. These properties configure an input field that allows merchants to select dates using an integrated calendar picker with optional text input, date constraints, and day-of-week restrictions.
+ * The properties for the date field component. These properties configure an input field that allows merchants to select dates using an integrated calendar picker with optional text input, date constraints, and day-of-week restrictions.
  */
 export interface DateFieldProps
   extends Omit<
@@ -330,7 +330,7 @@ export interface DateFieldProps
     > {}
 
 /**
- * The DateField custom element class that renders a date input field with integrated calendar picker in the Shopify admin interface. This component allows merchants to select dates by typing or using a visual calendar, with support for date range restrictions and day-of-week constraints.
+ * The date field custom element class that renders a date input field with integrated calendar picker in the Shopify admin interface. This component allows merchants to select dates by typing or using a visual calendar, with support for date range restrictions and day-of-week constraints.
  */
 declare class DateField
   extends PreactFieldElement<DateFieldProps['autocomplete']>
@@ -389,7 +389,7 @@ declare module 'preact' {
 
 declare const tagName = 's-date-field';
 /**
- * The JSX props for the DateField component. These properties extend `DateFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact, including specialized callbacks for view changes and invalid date attempts.
+ * The JSX props for the date field component. These properties extend `DateFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact, including specialized callbacks for view changes and invalid date attempts.
  */
 export interface DateFieldJSXProps
   extends Partial<Omit<DateFieldProps, 'value' | 'defaultValue'>>,

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
@@ -21,13 +21,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the DateField component.',
+        'Configure the following properties on the date field component.',
       type: 'DateField',
     },
     {
       title: 'Events',
       description:
-        'The DateField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DateFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker.d.ts
@@ -9,7 +9,7 @@
 import type {DatePickerProps$1, ComponentChildren} from './shared.d.ts';
 
 /**
- * The properties for the DatePicker component. These properties configure a standalone calendar interface for selecting single dates or date ranges, with support for date constraints, day-of-week restrictions, and month/year navigation.
+ * The properties for the date picker component. These properties configure a standalone calendar interface for selecting single dates or date ranges, with support for date constraints, day-of-week restrictions, and month/year navigation.
  */
 export interface DatePickerProps
   extends Required<
@@ -178,7 +178,7 @@ declare class BaseClass extends PreactCustomElement {
   [internals]: ElementInternals;
 }
 /**
- * The DatePicker custom element class that renders a standalone calendar interface in the Shopify admin. This component allows merchants to select single dates or date ranges using an interactive calendar with month/year navigation, date constraints, and day-of-week restrictions.
+ * The date picker custom element class that renders a standalone calendar interface in the Shopify admin. This component allows merchants to select single dates or date ranges using an interactive calendar with month/year navigation, date constraints, and day-of-week restrictions.
  */
 declare class DatePicker extends BaseClass implements DatePickerProps {
   /**
@@ -270,7 +270,7 @@ declare module 'preact' {
 
 declare const tagName = 's-date-picker';
 /**
- * The JSX props for the DatePicker component. These properties extend `DatePickerProps` with JSX-specific event callbacks for React-style event handling when used in Preact, including callbacks for date selection, focus events, and view changes.
+ * The JSX props for the date picker component. These properties extend `DatePickerProps` with JSX-specific event callbacks for React-style event handling when used in Preact, including callbacks for date selection, focus events, and view changes.
  */
 export interface DatePickerJSXProps
   extends Partial<DatePickerProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
@@ -23,13 +23,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'DatePicker',
       description:
-        'Configure the following properties on the DatePicker component.',
+        'Configure the following properties on the date picker component.',
       type: 'DatePicker',
     },
     {
       title: 'Events',
       description:
-        'The DatePicker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'DatePickerEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
@@ -9,7 +9,7 @@
 import type {DividerProps$1, ComponentChildren} from './shared.d.ts';
 
 /**
- * The properties for the Divider component. A Divider creates a visual separator to distinguish different sections of content.
+ * The properties for the divider component. A divider creates a visual separator to distinguish different sections of content.
  */
 export interface DividerProps
   extends Pick<DividerProps$1, 'direction' | 'color'> {
@@ -145,7 +145,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
 }
 
 /**
- * A Divider is a visual separator that creates a line between different sections of content.
+ * A divider is a visual separator that creates a line between different sections of content.
  */
 declare class Divider extends PreactCustomElement implements DividerProps {
   /**
@@ -183,7 +183,7 @@ declare module 'preact' {
 
 declare const tagName = 's-divider';
 /**
- * The properties for the Divider component when it's used in JSX.
+ * The properties for the divider component when it's used in JSX.
  */
 export interface DividerJSXProps
   extends Partial<DividerProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.doc.ts
@@ -20,7 +20,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Divider component.',
+        'Configure the following properties on the divider component.',
       type: 'Divider',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
@@ -324,7 +324,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the EmailField component. These properties configure a specialized text input field for entering email addresses with built-in validation and appropriate keyboard support.
+ * The properties for the email field component. These properties configure a specialized text input field for entering email addresses with built-in validation and appropriate keyboard support.
  */
 export type EmailFieldProps = PreactFieldProps<
   Required<EmailFieldProps$1>['autocomplete']
@@ -332,7 +332,7 @@ export type EmailFieldProps = PreactFieldProps<
   Required<Pick<EmailFieldProps$1, 'maxLength' | 'minLength'>>;
 
 /**
- * The EmailField custom element class that renders an email input field in the Shopify admin interface. This component allows merchants to enter email addresses with automatic validation and optimized mobile keyboard layouts.
+ * The email field custom element class that renders an email input field in the Shopify admin interface. This component allows merchants to enter email addresses with automatic validation and optimized mobile keyboard layouts.
  */
 declare class EmailField
   extends PreactFieldElement<EmailFieldProps['autocomplete']>
@@ -374,7 +374,7 @@ declare module 'preact' {
 
 declare const tagName = 's-email-field';
 /**
- * The JSX props for the EmailField component. These properties extend `EmailFieldProps` with JSX-specific event callbacks for React-style event handling.
+ * The JSX props for the email field component. These properties extend `EmailFieldProps` with JSX-specific event callbacks for React-style event handling.
  */
 export interface EmailFieldJSXProps
   extends Partial<Omit<EmailFieldProps, 'accessory'>>,

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
@@ -28,13 +28,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the EmailField component.',
+        'Configure the following properties on the email field component.',
       type: 'EmailField',
     },
     {
       title: 'Events',
       description:
-        'The EmailField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'EmailFieldEvents',
     },
   ],
@@ -63,7 +63,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Demonstrates a simple email field with a label and required attribute, showing the most fundamental way to use the EmailField component.',
+              'Demonstrates a simple email field with a label and required attribute, showing the most fundamental way to use the email field component.',
             codeblock: {
               title: 'Basic usage',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
@@ -50,14 +50,14 @@ export type CallbackExtendableEventListener<
   | null;
 
 /**
- * The properties for the Form component. These properties configure the form's identifier for targeting and referencing within the admin extension.
+ * The properties for the form component. These properties configure the form's identifier for targeting and referencing within the admin extension.
  */
 export interface FormProps extends Pick<FormProps$1, 'id'> {}
 
 declare const tagName = 's-form';
 
 /**
- * The JSX props for the Form component. These properties extend `FormProps` with event callbacks for form submission and reset actions in JSX rendering.
+ * The JSX props for the form component. These properties extend `FormProps` with event callbacks for form submission and reset actions in JSX rendering.
  */
 export interface FormJSXProps extends Partial<FormProps> {
   /**
@@ -161,7 +161,7 @@ declare abstract class PreactCustomElement extends BaseClass {
 }
 
 /**
- * The Form custom element class that renders a form container in the Shopify admin interface. This component manages form submission, validation, and reset behavior for collecting merchant input.
+ * The form custom element class that renders a form container in the Shopify admin interface. This component manages form submission, validation, and reset behavior for collecting merchant input.
  */
 declare class Form extends PreactCustomElement implements FormProps {
   constructor();

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
@@ -14,7 +14,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `- **Group related fields logically:** Organize fields by category or workflow step so merchants can complete forms efficiently.
 - **Validate with specific error messages:** Instead of **Invalid input**, provide actionable feedback like **Email must include @ symbol** or **Password must be at least 8 characters**.
 - **Mark required fields clearly:** Use the \`required\` property and show validation errors only after user interaction or submission attempt.
-- **Choose field types that match data:** Use [EmailField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/emailfield) for emails, [NumberField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/numberfield) for quantities, and [DateField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/datefield) for dates to provide appropriate keyboards and pickers.
+- **Choose field types that match data:** Use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/emailfield) for emails, [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/numberfield) for quantities, and [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/datefield) for dates to provide appropriate keyboards and pickers.
 - **Provide submission feedback:** Show loading states during processing and clear success or error messages after completion. Prevent duplicate submissions while processing.
 - **Handle unsaved changes:** For long or complex forms, consider auto-saving drafts or prompting before navigation when changes exist.`,
     },
@@ -29,7 +29,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The Form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'FormEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
@@ -14,7 +14,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `- **Group related fields logically:** Organize fields by category or workflow step so merchants can complete forms efficiently.
 - **Validate with specific error messages:** Instead of **Invalid input**, provide actionable feedback like **Email must include @ symbol** or **Password must be at least 8 characters**.
 - **Mark required fields clearly:** Use the \`required\` property and show validation errors only after user interaction or submission attempt.
-- **Choose field types that match data:** Use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/emailfield) for emails, [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/numberfield) for quantities, and [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/datefield) for dates to provide appropriate keyboards and pickers.
+- **Choose field types that match data:** Use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/email-field) for emails, [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/number-field) for quantities, and [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-field) for dates to provide appropriate keyboards and pickers.
 - **Provide submission feedback:** Show loading states during processing and clear success or error messages after completion. Prevent duplicate submissions while processing.
 - **Handle unsaved changes:** For long or complex forms, consider auto-saving drafts or prompting before navigation when changes exist.`,
     },

--- a/packages/ui-extensions/src/surfaces/admin/components/FormExtensionComponents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FormExtensionComponents.ts
@@ -1,7 +1,7 @@
 import {StandardComponents} from './StandardComponents';
 
 /**
- * The components available for building form-based extensions. Includes all standard components plus the Form component for creating structured data collection interfaces with submission handling and validation.
+ * The components available for building form-based extensions. Includes all standard components plus the form component for creating structured data collection interfaces with submission handling and validation.
  */
 export type FormExtensionComponents = StandardComponents | 'Form';
 

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings.d.ts
@@ -69,7 +69,7 @@ export type CallbackExtendableEventListener<
   | null;
 
 /**
- * The properties for the FunctionSettings component. These properties configure the form's identifier for configuring Shopify Function settings in the admin interface.
+ * The properties for the function settings component. These properties configure the form's identifier for configuring Shopify Function settings in the admin interface.
  */
 export interface FunctionSettingsProps
   extends Pick<FunctionSettingsProps$1, 'id'> {}
@@ -77,7 +77,7 @@ export interface FunctionSettingsProps
 declare const tagName = 's-function-settings';
 
 /**
- * The JSX props for the FunctionSettings component. These properties extend `FunctionSettingsProps` with event callbacks for form submission, reset, and error handling in JSX rendering.
+ * The JSX props for the function settings component. These properties extend `FunctionSettingsProps` with event callbacks for form submission, reset, and error handling in JSX rendering.
  */
 export interface FunctionSettingsJSXProps
   extends Partial<
@@ -189,14 +189,14 @@ declare abstract class PreactCustomElement extends BaseClass {
 }
 
 /**
- * The error event type that's passed to the `onError` callback of FunctionSettings. This event contains validation errors that occurred when committing function settings to Shopify's servers.
+ * The error event type that's passed to the `onError` callback of function settings. This event contains validation errors that occurred when committing function settings to Shopify's servers.
  */
 export type FunctionSettingsErrorEvent = Parameters<
   NonNullable<FunctionSettingsProps$1['onError']>
 >[0];
 
 /**
- * The FunctionSettings custom element class that renders a specialized form for configuring Shopify Function settings in the admin interface. This component manages function configuration submission, validation, and error handling.
+ * The function settings custom element class that renders a specialized form for configuring Shopify Function settings in the admin interface. This component manages function configuration submission, validation, and error handling.
  */
 declare class FunctionSettings
   extends PreactCustomElement

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.ext.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Label settings clearly:** Instead of technical names like **Max threshold**, use merchant-friendly labels like **Maximum discount amount** or **Order value limit**.
 - **Validate with specific feedback:** Check that percentages are between 0-100, that monetary values are positive, and that required fields are filled. Provide clear error messages when validation fails.
-- **Explain impact with field details:** Use the \`details\` property on individual field components (for example, [TextField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield) or [NumberField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/numberfield)) to explain what each setting does and how it affects the user's workflow.
+- **Explain impact with field details:** Use the \`details\` property on individual field components (for example, [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield) or [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/numberfield)) to explain what each setting does and how it affects the user's workflow.
 - **Set appropriate defaults:** Pre-select the most common configuration to reduce setup friction for merchants.
 - **Group related settings:** Use sections to organize settings by function so merchants can find what they need quickly.`,
     },
@@ -24,7 +24,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The FunctionSettings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'FormEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.ext.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Label settings clearly:** Instead of technical names like **Max threshold**, use merchant-friendly labels like **Maximum discount amount** or **Order value limit**.
 - **Validate with specific feedback:** Check that percentages are between 0-100, that monetary values are positive, and that required fields are filled. Provide clear error messages when validation fails.
-- **Explain impact with field details:** Use the \`details\` property on individual field components (for example, [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield) or [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/numberfield)) to explain what each setting does and how it affects the user's workflow.
+- **Explain impact with field details:** Use the \`details\` property on individual field components (for example, [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) or [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/number-field)) to explain what each setting does and how it affects the user's workflow.
 - **Set appropriate defaults:** Pre-select the most common configuration to reduce setup friction for merchants.
 - **Group related settings:** Use sections to organize settings by function so merchants can find what they need quickly.`,
     },

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettingsComponents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettingsComponents.ts
@@ -1,7 +1,7 @@
 import {FormExtensionComponents} from './FormExtensionComponents';
 
 /**
- * The components available for building function settings extensions. Includes all form components plus the FunctionSettings component required for function settings configuration.
+ * The components available for building function settings extensions. Includes all form components plus the function settings component required for function settings configuration.
  */
 export type FunctionSettingsComponents =
   | FormExtensionComponents

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
@@ -44,11 +44,11 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * A version of the Box properties with all fields required.
+ * A version of the box properties with all fields required.
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
- * The allowed border radius values for a Box component.
+ * The allowed border radius values for a box component.
  */
 export type BoxBorderRadii = Extract<
   RequiredBoxProps['borderRadius'],
@@ -62,14 +62,14 @@ export type BoxBorderRadii = Extract<
   | 'large-200'
 >;
 /**
- * The allowed border style values for a Box component.
+ * The allowed border style values for a box component.
  */
 export type BoxBorderStyles = Extract<
   RequiredBoxProps['borderStyle'],
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * The Box properties that support responsive values through container queries.
+ * The box properties that support responsive values through container queries.
  */
 export type ResponsiveBoxProps = MakeResponsivePick<
   RequiredBoxProps,
@@ -297,18 +297,18 @@ export interface BoxProps
 }
 
 /**
- * A version of the Grid properties with all fields required.
+ * A version of the grid properties with all fields required.
  */
 export type RequiredAlignedProps = Required<GridProps$1>;
 /**
- * The Grid properties that support responsive values through container queries.
+ * The grid properties that support responsive values through container queries.
  */
 export type ResponsiveGridProps = MakeResponsivePick<
   RequiredAlignedProps,
   'rowGap' | 'columnGap' | 'gap' | 'gridTemplateColumns' | 'gridTemplateRows'
 >;
 /**
- * The properties for the Grid component. A Grid provides precise control over rows and columns, with powerful alignment and sizing options for both individual items and the entire grid structure.
+ * The properties for the grid component. A grid provides precise control over rows and columns, with powerful alignment and sizing options for both individual items and the entire grid structure.
  */
 export interface GridProps
   extends BoxProps,
@@ -623,7 +623,7 @@ declare class BoxElement extends PreactCustomElement implements BoxProps {
 }
 
 /**
- * A Grid is a layout component that arranges its children in rows and columns with precise control over sizing and alignment.
+ * A grid is a layout component that arranges its children in rows and columns with precise control over sizing and alignment.
  */
 declare class Grid extends BoxElement implements GridProps {
   constructor();
@@ -687,13 +687,13 @@ declare module 'preact' {
 
 declare const tagName = 's-grid';
 /**
- * The properties for the Grid component when it's used in JSX.
+ * The properties for the grid component when it's used in JSX.
  */
 export interface GridJSXProps
   extends Partial<GridProps>,
     Pick<GridProps$1, 'id' | 'children'> {
   /**
-   * The child elements to render inside the Grid.
+   * The child elements to render inside the grid.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
@@ -26,13 +26,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Grid component.',
+      description: 'Configure the following properties on the grid component.',
       type: 'Grid',
     },
     {
       title: 'Slots',
       description:
-        'The Grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'GridSlots',
     },
     {
@@ -43,7 +43,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The GridItem component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'GridItemSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
@@ -41,11 +41,11 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * A version of the Box properties with all fields required.
+ * A version of the box properties with all fields required.
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
- * The allowed border radius values for a Box component.
+ * The allowed border radius values for a box component.
  */
 export type BoxBorderRadii = Extract<
   RequiredBoxProps['borderRadius'],
@@ -59,14 +59,14 @@ export type BoxBorderRadii = Extract<
   | 'large-200'
 >;
 /**
- * The allowed border style values for a Box component.
+ * The allowed border style values for a box component.
  */
 export type BoxBorderStyles = Extract<
   RequiredBoxProps['borderStyle'],
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * The Box properties that support responsive values through container queries.
+ * The box properties that support responsive values through container queries.
  */
 export type ResponsiveBoxProps = MakeResponsivePick<
   RequiredBoxProps,
@@ -292,11 +292,11 @@ export interface BoxProps
 }
 
 /**
- * A version of the GridItem properties with all fields required.
+ * A version of the grid item properties with all fields required.
  */
 export type RequiredGridItemProps = Required<GridItemProps$1>;
 /**
- * The properties for the GridItem component. A GridItem can be positioned within specific rows and columns of a Grid, with control over how many rows or columns it spans.
+ * The properties for the grid item component. A grid item can be positioned within specific rows and columns of a grid, with control over how many rows or columns it spans.
  */
 export interface GridItemProps
   extends BoxProps,
@@ -541,7 +541,7 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * A GridItem is a child of a Grid that can be positioned within specific rows and columns.
+ * A grid item is a child of a grid that can be positioned within specific rows and columns.
  */
 declare class GridItem extends BoxElement implements GridItemProps {
   /**
@@ -570,13 +570,13 @@ declare module 'preact' {
 
 declare const tagName = 's-grid-item';
 /**
- * The properties for the GridItem component when it's used in JSX.
+ * The properties for the grid item component when it's used in JSX.
  */
 export interface GridItemJSXProps
   extends Partial<GridItemProps>,
     Pick<GridItemProps$1, 'id' | 'children'> {
   /**
-   * The child elements to render inside the GridItem.
+   * The child elements to render inside the grid item.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
@@ -9,7 +9,7 @@
 import type {ComponentChildren, HeadingProps$1} from './shared.d.ts';
 
 /**
- * The properties for the Heading component. These properties define hierarchical section titles and headings with appropriate semantic meaning and visual hierarchy.
+ * The properties for the heading component. These properties define hierarchical section titles and headings with appropriate semantic meaning and visual hierarchy.
  */
 export interface HeadingProps
   extends Required<
@@ -168,7 +168,7 @@ declare module 'preact' {
 
 declare const tagName = 's-heading';
 /**
- * The JSX properties for the Heading component. These properties define how a heading is rendered in Preact or JSX.
+ * The JSX properties for the heading component. These properties define how a heading is rendered in Preact or JSX.
  */
 export interface HeadingJSXProps
   extends Partial<HeadingProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
@@ -28,13 +28,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Heading component.',
+        'Configure the following properties on the heading component.',
       type: 'Heading',
     },
     {
       title: 'Slots',
       description:
-        'The Heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'HeadingSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
@@ -9,7 +9,7 @@
 import type {IconProps$1, IconType, ComponentChildren} from './shared.d.ts';
 
 /**
- * The properties for the Icon component. An Icon displays a graphical symbol with configurable appearance, color, and semantic meaning.
+ * The properties for the icon component. An icon displays a graphical symbol with configurable appearance, color, and semantic meaning.
  */
 export interface IconProps
   extends Pick<
@@ -155,7 +155,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
 }
 
 /**
- * An Icon displays a graphical symbol from the icon library.
+ * An icon displays a graphical symbol from the icon library.
  */
 declare class Icon extends PreactCustomElement implements IconProps {
   /**
@@ -195,7 +195,7 @@ declare module 'preact' {
 
 declare const tagName = 's-icon';
 /**
- * The properties for the Icon component when it's used in JSX.
+ * The properties for the icon component when it's used in JSX.
  */
 export interface IconJSXProps
   extends Partial<IconProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
@@ -28,14 +28,14 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'limitations',
       sectionContent: `- Icons are limited to the predefined set provided by the component. Custom SVG icons, icon fonts, or external icon libraries aren't supported.
-- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [Image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image) component instead.
+- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image) component instead.
 - Icon color is determined by the \`tone\` and \`color\` properties. Custom colors or gradients aren't available.`,
     },
   ],
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Icon component.',
+      description: 'Configure the following properties on the icon component.',
       type: 'Icon',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
@@ -76,7 +76,7 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * The Box properties with all fields marked as required.
+ * The box properties with all fields marked as required.
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
@@ -101,7 +101,7 @@ export type BoxBorderStyles = Extract<
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * The Box properties that support responsive values through container queries.
+ * The box properties that support responsive values through container queries.
  */
 export type ResponsiveBoxProps = MakeResponsivePick<
   RequiredBoxProps,
@@ -327,7 +327,7 @@ export interface BoxProps
 }
 
 /**
- * The properties for the Image component. An Image displays pictures with configurable sizing, loading behavior, and borders. Properties include `src` for the image URL, `alt` for accessibility text, `aspectRatio` for sizing, `loading` for lazy loading, and border styling options.
+ * The properties for the image component. An image displays pictures with configurable sizing, loading behavior, and borders. Properties include `src` for the image URL, `alt` for accessibility text, `aspectRatio` for sizing, `loading` for lazy loading, and border styling options.
  */
 export interface ImageProps
   extends Required<
@@ -506,7 +506,7 @@ declare abstract class PreactCustomElement extends BaseClass {
 }
 
 /**
- * An Image displays pictures with configurable sizing, loading behavior, and borders.
+ * An image displays pictures with configurable sizing, loading behavior, and borders.
  */
 declare class Image extends PreactCustomElement implements ImageProps {
   /**
@@ -590,7 +590,7 @@ declare module 'preact' {
 
 declare const tagName = 's-image';
 /**
- * The properties for the Image component when it's used in JSX.
+ * The properties for the image component when it's used in JSX.
  */
 export interface ImageJSXProps
   extends Partial<ImageProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
@@ -11,7 +11,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'best-practices',
       sectionContent: `- **Always provide descriptive alternative text:** Write alt text that describes what's in the image, not what the image is for. Use "Blue cotton t-shirt with crew neck" instead of "Product image." For decorative images that don't add information, use an empty alt attribute.
-- **Use images for meaningful content, not decoration:** Display product photos, diagrams, charts, or instructional screenshots. For icons or decorative elements, use the [Icon](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/icon) component instead.
+- **Use images for meaningful content, not decoration:** Display product photos, diagrams, charts, or instructional screenshots. For icons or decorative elements, use the [icon](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/icon) component instead.
 - **Ensure images are accessible and performant:** Use appropriate image formats (WebP for photos, PNG for graphics with transparency, SVG for logos). Ensure images load from reliable sources with proper CORS configuration if cross-origin.
 - **Consider the image's purpose and context:** Use images to help merchants understand products, visualize data, or follow instructions. Every image should serve a clear purpose in your interface.`,
     },
@@ -27,13 +27,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Image component.',
+      description: 'Configure the following properties on the image component.',
       type: 'Image',
     },
     {
       title: 'Events',
       description:
-        'The Image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ImageEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
@@ -61,7 +61,7 @@ export type LinkBaseProps = Required<
   >
 >;
 /**
- * The properties for the Link component. These properties define a clickable link that navigates users to different pages or sections with customizable visual styles and semantic meaning.
+ * The properties for the link component. These properties define a clickable link that navigates users to different pages or sections with customizable visual styles and semantic meaning.
  */
 export interface LinkProps extends LinkBaseProps {
   /**
@@ -190,7 +190,7 @@ declare module 'preact' {
 
 declare const tagName = 's-link';
 /**
- * The JSX properties for the Link component. These properties define how a link is rendered in Preact or JSX.
+ * The JSX properties for the link component. These properties define how a link is rendered in Preact or JSX.
  */
 export interface LinkJSXProps
   extends Partial<LinkProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
@@ -25,19 +25,19 @@ const data: AdminReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Link component.',
+      description: 'Configure the following properties on the link component.',
       type: 'Link',
     },
     {
       title: 'Events',
       description:
-        'The Link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'LinkEvents',
     },
     {
       title: 'Slots',
       description:
-        'The Link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'LinkSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
@@ -8,7 +8,7 @@
 import type {ComponentChildren, ListItemProps$1} from './shared.d.ts';
 
 /**
- * The properties that you can set on a ListItem component.
+ * The properties that you can set on a list item component.
  */
 export interface ListItemProps extends ListItemProps$1 {}
 
@@ -129,9 +129,9 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * A component that represents a single item within an OrderedList or UnorderedList.
+ * A component that represents a single item within an ordered list or unordered list.
  *
- * Use ListItem as a child of OrderedList or UnorderedList to create properly structured and accessible list content.
+ * Use list item as a child of ordered list or unordered list to create properly structured and accessible list content.
  */
 declare class ListItem extends PreactCustomElement implements ListItemProps {
   constructor();
@@ -152,7 +152,7 @@ declare module 'preact' {
 
 declare const tagName = 's-list-item';
 /**
- * The JSX properties you can set on a ListItem component.
+ * The JSX properties you can set on a list item component.
  */
 export interface ListItemJSXProps
   extends Partial<ListItemProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
@@ -13,7 +13,7 @@ import type {
 } from './shared.d.ts';
 
 /**
- * The properties you can set on a Menu component.
+ * The properties you can set on a menu component.
  */
 export interface MenuProps
   extends Required<Pick<MenuProps$1, 'id' | 'accessibilityLabel'>> {}
@@ -256,17 +256,17 @@ declare module 'preact' {
 }
 
 /**
- * The custom element tag name for the Menu component.
+ * The custom element tag name for the menu component.
  */
 declare const tagName = 's-menu';
 /**
- * The JSX properties you can set on a Menu component.
+ * The JSX properties you can set on a menu component.
  */
 export interface MenuJSXProps
   extends Partial<MenuProps>,
     Pick<MenuProps$1, 'id' | 'children'> {
   /**
-   * The menu items to display, which should include Button and Section components.
+   * The menu items to display, which should include button and section components.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Menu/Menu.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Menu/Menu.doc.ts
@@ -30,13 +30,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Menu component.',
+      description: 'Configure the following properties on the menu component.',
       type: 'Menu',
     },
     {
       title: 'Slots',
       description:
-        'The Menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'MenuSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
@@ -328,7 +328,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
  */
 export type RequiredMoneyFieldProps = Required<MoneyFieldProps$1>;
 /**
- * The properties for the MoneyField component. These properties configure a specialized input field for entering monetary amounts with automatic currency formatting, decimal handling, and range validation.
+ * The properties for the money field component. These properties configure a specialized input field for entering monetary amounts with automatic currency formatting, decimal handling, and range validation.
  */
 export interface MoneyFieldProps
   extends Omit<PreactFieldProps, 'value'>,
@@ -340,7 +340,7 @@ export interface MoneyFieldProps
 }
 
 /**
- * The MoneyField custom element class that renders a monetary input field in the Shopify admin interface. This component allows merchants to enter currency amounts with automatic formatting, decimal precision, and validation against minimum and maximum values.
+ * The money field custom element class that renders a monetary input field in the Shopify admin interface. This component allows merchants to enter currency amounts with automatic formatting, decimal precision, and validation against minimum and maximum values.
  */
 declare class MoneyField
   extends PreactFieldElement<MoneyFieldProps['autocomplete']>
@@ -376,7 +376,7 @@ declare module 'preact' {
 
 declare const tagName = 's-money-field';
 /**
- * The JSX props for the MoneyField component. These properties extend `MoneyFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
+ * The JSX props for the money field component. These properties extend `MoneyFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
  */
 export interface MoneyFieldJSXProps
   extends Partial<MoneyFieldProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
@@ -31,13 +31,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the MoneyField component.',
+        'Configure the following properties on the money field component.',
       type: 'MoneyField',
     },
     {
       title: 'Events',
       description:
-        'The MoneyField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'MoneyFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
@@ -324,7 +324,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the NumberField component. These properties configure a specialized input field for entering numeric values with support for validation, formatting, range constraints, and optimized mobile input modes.
+ * The properties for the number field component. These properties configure a specialized input field for entering numeric values with support for validation, formatting, range constraints, and optimized mobile input modes.
  */
 export interface NumberFieldProps
   extends Omit<
@@ -344,7 +344,7 @@ export interface NumberFieldProps
 }
 
 /**
- * The NumberField custom element class that renders a numeric input field in the Shopify admin interface. This component allows merchants to enter numbers with automatic validation and prefix/suffix display.
+ * The number field custom element class that renders a numeric input field in the Shopify admin interface. This component allows merchants to enter numbers with automatic validation and prefix/suffix display.
  */
 declare class NumberField
   extends PreactFieldElement<NumberFieldProps['autocomplete']>
@@ -399,7 +399,7 @@ declare module 'preact' {
 
 declare const tagName = 's-number-field';
 /**
- * The JSX props for the NumberField component. These properties extend `NumberFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
+ * The JSX props for the number field component. These properties extend `NumberFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
  */
 export interface NumberFieldJSXProps
   extends Partial<NumberFieldProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
@@ -11,7 +11,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [TextField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield) instead.
+      sectionContent: `- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield) instead.
 - **Provide context with units:** Display units of measurement using prefix or suffix to clarify what the number represents. Without context, merchants might not know if they're entering dollars, kilograms, or percentages.
 - **Set realistic constraints:** Define minimum and maximum values that reflect actual business rules. This guides merchants toward valid inputs and prevents unrealistic values before form submission.
 - **Validate and provide clear feedback:** Always validate numeric input and show specific error messages that explain what went wrong and how to fix it. Generic error messages don't help merchants understand what value to enter.`,
@@ -27,13 +27,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the NumberField component.',
+        'Configure the following properties on the number field component.',
       type: 'NumberField',
     },
     {
       title: 'Events',
       description:
-        'The NumberField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'NumberFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
@@ -11,7 +11,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield) instead.
+      sectionContent: `- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) instead.
 - **Provide context with units:** Display units of measurement using prefix or suffix to clarify what the number represents. Without context, merchants might not know if they're entering dollars, kilograms, or percentages.
 - **Set realistic constraints:** Define minimum and maximum values that reflect actual business rules. This guides merchants toward valid inputs and prevents unrealistic values before form submission.
 - **Validate and provide clear feedback:** Always validate numeric input and show specific error messages that explain what went wrong and how to fix it. Generic error messages don't help merchants understand what value to enter.`,

--- a/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
@@ -164,7 +164,7 @@ declare module 'preact' {
 
 declare const tagName = 's-option';
 /**
- * Properties for using the Option component in JSX with React-style props.
+ * Properties for using the option component in JSX with React-style props.
  */
 export interface OptionJSXProps
   extends Partial<OptionProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
@@ -158,13 +158,13 @@ declare module 'preact' {
 
 declare const tagName = 's-option-group';
 /**
- * Properties for using the OptionGroup component in JSX with React-style props.
+ * Properties for using the option group component in JSX with React-style props.
  */
 export interface OptionGroupJSXProps
   extends Partial<OptionGroupProps>,
     Pick<OptionGroupProps$1, 'id' | 'children'> {
   /**
-   * The selectable options displayed in the dropdown list. Accepts Option components for individual selectable items within this group.
+   * The selectable options displayed in the dropdown list. Accepts option components for individual selectable items within this group.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
@@ -8,7 +8,7 @@
 import type {ComponentChildren, OrderedListProps$1} from './shared.d.ts';
 
 /**
- * The properties for the OrderedList component. These properties define a numbered list of items with automatic numbering and proper list semantics.
+ * The properties for the ordered list component. These properties define a numbered list of items with automatic numbering and proper list semantics.
  */
 export interface OrderedListProps extends OrderedListProps$1 {}
 
@@ -129,7 +129,7 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * A custom element for displaying a numbered list of items with automatic numbering and proper list semantics. Use OrderedList when the sequence or order of items matters, such as instructions, rankings, or step-by-step processes.
+ * A custom element for displaying a numbered list of items with automatic numbering and proper list semantics. Use ordered list when the sequence or order of items matters, such as instructions, rankings, or step-by-step processes.
  */
 declare class OrderedList
   extends PreactCustomElement
@@ -153,13 +153,13 @@ declare module 'preact' {
 
 declare const tagName = 's-ordered-list';
 /**
- * The JSX properties for the OrderedList component. These properties define how an ordered list is rendered in Preact or JSX.
+ * The JSX properties for the ordered list component. These properties define how an ordered list is rendered in Preact or JSX.
  */
 export interface OrderedListJSXProps
   extends Partial<OrderedListProps>,
     Pick<OrderedListProps$1, 'id'> {
   /**
-   * The items in the ordered list. Only ListItem components are accepted.
+   * The items in the ordered list. Only list item components are accepted.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [UnorderedList](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unorderedlist) instead.
+      sectionContent: `- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unorderedlist) instead.
 - **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.
 - **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.
 - **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format.`,
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The OrderedList component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'OrderedListSlots',
     },
     {
@@ -39,7 +39,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The ListItem component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ListItemSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unorderedlist) instead.
+      sectionContent: `- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list) instead.
 - **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.
 - **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.
 - **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format.`,

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
@@ -9,7 +9,7 @@
 import type {ComponentChildren, ParagraphProps$1} from './shared.d.ts';
 
 /**
- * The properties for the Paragraph component. These properties define blocks of text content with consistent spacing and styling for readable body copy.
+ * The properties for the paragraph component. These properties define blocks of text content with consistent spacing and styling for readable body copy.
  */
 export interface ParagraphProps
   extends Required<
@@ -213,7 +213,7 @@ declare module 'preact' {
 
 declare const tagName = 's-paragraph';
 /**
- * The JSX properties for the Paragraph component. These properties define how a paragraph is rendered in Preact or JSX.
+ * The JSX properties for the paragraph component. These properties define how a paragraph is rendered in Preact or JSX.
  */
 export interface ParagraphJSXProps
   extends Partial<ParagraphProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
@@ -29,13 +29,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Paragraph component.',
+        'Configure the following properties on the paragraph component.',
       type: 'Paragraph',
     },
     {
       title: 'Slots',
       description:
-        'The Paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ParagraphSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
@@ -329,7 +329,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the PasswordField component. These properties configure a secure input field that collects sensitive password input from merchants with masked characters.
+ * The properties for the password field component. These properties configure a secure input field that collects sensitive password input from merchants with masked characters.
  */
 export type PasswordFieldProps = PreactFieldProps<
   Required<PasswordFieldProps$1>['autocomplete']
@@ -354,7 +354,7 @@ export type PasswordFieldProps = PreactFieldProps<
   >;
 
 /**
- * The PasswordField custom element class that renders a password input field in the Shopify admin interface. This component allows merchants to enter passwords securely with characters automatically masked for privacy.
+ * The password field custom element class that renders a password input field in the Shopify admin interface. This component allows merchants to enter passwords securely with characters automatically masked for privacy.
  */
 declare class PasswordField
   extends PreactFieldElement<PasswordFieldProps['autocomplete']>
@@ -390,7 +390,7 @@ declare module 'preact' {
 
 declare const tagName = 's-password-field';
 /**
- * The JSX props for the PasswordField component. These properties extend `PasswordFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
+ * The JSX props for the password field component. These properties extend `PasswordFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
  */
 export interface PasswordFieldJSXProps
   extends Partial<PasswordFieldProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -28,13 +28,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the PasswordField component.',
+        'Configure the following properties on the password field component.',
       type: 'PasswordField',
     },
     {
       title: 'Events',
       description:
-        'The PasswordField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'PasswordFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/PrintActionExtensionComponents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PrintActionExtensionComponents.ts
@@ -1,7 +1,7 @@
 import {StandardComponents} from './StandardComponents';
 
 /**
- * The components available for building print action extensions. Includes all standard components plus the AdminPrintAction component required for print action setup.
+ * The components available for building print action extensions. Includes all standard components plus the admin print action component required for print action setup.
  */
 export type PrintActionExtensionComponents =
   | StandardComponents

--- a/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
@@ -124,7 +124,7 @@ declare abstract class PreactCustomElement extends BaseClass {
 }
 
 /**
- * The properties you can set on a QueryContainer component.
+ * The properties you can set on a query container component.
  */
 export interface QueryContainerProps
   extends Required<Pick<QueryContainerProps$1, 'id' | 'containerName'>> {}
@@ -162,11 +162,11 @@ declare module 'preact' {
 }
 
 /**
- * The custom element tag name for the QueryContainer component.
+ * The custom element tag name for the query container component.
  */
 declare const tagName = 's-query-container';
 /**
- * The JSX properties you can set on a QueryContainer component.
+ * The JSX properties you can set on a query container component.
  */
 export interface QueryContainerJSXProps
   extends Partial<QueryContainerProps$1>,

--- a/packages/ui-extensions/src/surfaces/admin/components/QueryContainer/QueryContainer.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/QueryContainer/QueryContainer.doc.ts
@@ -13,28 +13,28 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'best-practices',
       sectionContent: `- **Use for component-level responsiveness:** Query containers allow components to adapt based on their container size rather than viewport size. This is valuable for components that appear in different contexts with varying widths, like a product card that might appear in a sidebar or main content area.
-- **Name containers when you have multiple:** When you have multiple QueryContainer components and need to target specific ones with different queries, provide descriptive container names. Without names, all containers respond to the same queries.
-- **Understand the relationship with CSS:** QueryContainer establishes the containment context, but you must write the actual container query CSS rules. The component doesn't automatically make content responsive - it enables you to write responsive CSS.
-- **Consider performance impact:** Each QueryContainer adds browser work to track container dimensions and apply conditional styles. Use them where you need container-based responsiveness, not as a wrapper for every element.`,
+- **Name containers when you have multiple:** When you have multiple query container components and need to target specific ones with different queries, provide descriptive container names. Without names, all containers respond to the same queries.
+- **Understand the relationship with CSS:** query container establishes the containment context, but you must write the actual container query CSS rules. The component doesn't automatically make content responsive - it enables you to write responsive CSS.
+- **Consider performance impact:** Each query container adds browser work to track container dimensions and apply conditional styles. Use them where you need container-based responsiveness, not as a wrapper for every element.`,
     },
     {
       title: 'Limitations',
       type: 'Generic' as const,
       anchorLink: 'limitations',
-      sectionContent: `- The QueryContainer component doesn't expose the container's current dimensions to JavaScript. It's purely for enabling CSS container queries. If you need to access container dimensions programmatically, you'll need to use the [Resize Observer API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) directly.`,
+      sectionContent: `- The query container component doesn't expose the container's current dimensions to JavaScript. It's purely for enabling CSS container queries. If you need to access container dimensions programmatically, you'll need to use the [Resize Observer API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) directly.`,
     },
   ],
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the QueryContainer component.',
+        'Configure the following properties on the query container component.',
       type: 'QueryContainer',
     },
     {
       title: 'Slots',
       description:
-        'The QueryContainer component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'QueryContainerSlots',
     },
   ],
@@ -66,7 +66,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Demonstrates the simplest way to use QueryContainer, wrapping content with a named container context.',
+              'Demonstrates the simplest way to use query container, wrapping content with a named container context.',
             codeblock: {
               title: 'Basic Usage',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
@@ -383,7 +383,7 @@ declare module 'preact' {
 
 declare const tagName = 's-search-field';
 /**
- * Props for using the SearchField component in JSX with React-style event handlers.
+ * Props for using the search field component in JSX with React-style event handlers.
  */
 export interface SearchFieldJSXProps
   extends Partial<SearchFieldProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
@@ -22,13 +22,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'SearchField',
       description:
-        'Configure the following properties on the SearchField component.',
+        'Configure the following properties on the search field component.',
       type: 'SearchField',
     },
     {
       title: 'Events',
       description:
-        'The SearchField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'SearchFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
@@ -8,11 +8,11 @@
 import type {ComponentChildren, SectionProps$1} from './shared.d.ts';
 
 /**
- * A version of the Section properties with all fields required.
+ * A version of the section properties with all fields required.
  */
 export type RequiredSectionProps = Required<SectionProps$1>;
 /**
- * The properties for the Section component. A Section groups related content together with an optional heading, providing semantic structure and visual separation.
+ * The properties for the section component. A section groups related content together with an optional heading, providing semantic structure and visual separation.
  */
 export interface SectionProps
   extends Pick<
@@ -152,7 +152,7 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * A Section is a container that groups related content together with an optional heading.
+ * A section is a container that groups related content together with an optional heading.
  */
 declare class Section extends PreactCustomElement implements SectionProps {
   constructor();
@@ -186,13 +186,13 @@ declare module 'preact' {
 
 declare const tagName = 's-section';
 /**
- * The properties for the Section component when it's used in JSX.
+ * The properties for the section component when it's used in JSX.
  */
 export interface SectionJSXProps
   extends Partial<SectionProps>,
     Pick<SectionProps$1, 'id' | 'children'> {
   /**
-   * The child elements to render inside the Section.
+   * The child elements to render inside the section.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
@@ -28,13 +28,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Section component.',
+        'Configure the following properties on the section component.',
       type: 'Section',
     },
     {
       title: 'Slots',
       description:
-        'The Section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'SectionSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
@@ -325,7 +325,7 @@ declare module 'preact' {
 
 declare const tagName = 's-select';
 /**
- * Properties for using the Select component in JSX with React-style event handlers.
+ * Properties for using the select component in JSX with React-style event handlers.
  */
 export interface SelectJSXProps
   extends Partial<SelectProps>,
@@ -333,7 +333,7 @@ export interface SelectJSXProps
   /**
    * The selectable options displayed in the dropdown list.
    *
-   * Accepts Option components for individual selectable items, and OptionGroup components to organize related options into logical groups with labels.
+   * Accepts option components for individual selectable items, and option group components to organize related options into logical groups with labels.
    */
   children?: ComponentChildren;
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield) with autocomplete or a searchable dropdown pattern instead.
+      sectionContent: `- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.
 - **Organize options thoughtfully:** The order of options affects how quickly merchants find what they need. Group related options together, put common choices first, or use alphabetical order when no natural hierarchy exists.
 - **Make options scannable:** Merchants should be able to quickly distinguish between options. Include enough context in each option label so merchants don't need to open and read multiple options to find the right one.
 - **Handle default selections appropriately:** Pre-select an option when there's a clear default choice, but use a placeholder when merchants should make an intentional selection. Avoid confusing merchants with unclear initial states.
@@ -23,7 +23,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'limitations',
       sectionContent: `- The component doesn't include search or filtering functionality. For option lists where merchants need to search (like country selection with 200+ countries), implement a custom autocomplete or searchable dropdown pattern.
-- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choicelist) with checkboxes or build a custom multi-select component.
+- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list) with checkboxes or build a custom multi-select component.
 - Rendering 500+ options can cause performance issues, especially on mobile devices. The browser must render all options in the DOM even though only one's visible.
 - Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu).
 - Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu) components.`,

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [TextField](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield) with autocomplete or a searchable dropdown pattern instead.
+      sectionContent: `- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/textfield) with autocomplete or a searchable dropdown pattern instead.
 - **Organize options thoughtfully:** The order of options affects how quickly merchants find what they need. Group related options together, put common choices first, or use alphabetical order when no natural hierarchy exists.
 - **Make options scannable:** Merchants should be able to quickly distinguish between options. Include enough context in each option label so merchants don't need to open and read multiple options to find the right one.
 - **Handle default selections appropriately:** Pre-select an option when there's a clear default choice, but use a placeholder when merchants should make an intentional selection. Avoid confusing merchants with unclear initial states.
@@ -23,29 +23,29 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'limitations',
       sectionContent: `- The component doesn't include search or filtering functionality. For option lists where merchants need to search (like country selection with 200+ countries), implement a custom autocomplete or searchable dropdown pattern.
-- The component only supports selecting one option at a time. For multi-select scenarios, use a [ChoiceList](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choicelist) with checkboxes or build a custom multi-select component.
+- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choicelist) with checkboxes or build a custom multi-select component.
 - Rendering 500+ options can cause performance issues, especially on mobile devices. The browser must render all options in the DOM even though only one's visible.
-- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [Button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) and [Menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu).
-- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [Menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu) components.`,
+- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu).
+- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu) components.`,
     },
   ],
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Select component.',
+        'Configure the following properties on the select component.',
       type: 'Select',
     },
     {
       title: 'Events',
       description:
-        'The Select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'SelectEvents',
     },
     {
       title: 'Slots',
       description:
-        'The Select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'SelectSlots',
     },
     {
@@ -56,7 +56,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The Option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'OptionSlots',
     },
     {
@@ -67,7 +67,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The OptionGroup component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'OptionGroupSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
@@ -9,7 +9,7 @@
 import type {SpinnerProps$1, ComponentChildren} from './shared.d.ts';
 
 /**
- * The properties you can set on a Spinner component.
+ * The properties you can set on a spinner component.
  */
 export interface SpinnerProps
   extends Required<Pick<SpinnerProps$1, 'accessibilityLabel'>> {
@@ -158,11 +158,11 @@ declare module 'preact' {
 }
 
 /**
- * The custom element tag name for the Spinner component.
+ * The custom element tag name for the spinner component.
  */
 declare const tagName = 's-spinner';
 /**
- * The JSX properties you can set on a Spinner component.
+ * The JSX properties you can set on a spinner component.
  */
 export interface SpinnerJSXProps
   extends Partial<SpinnerProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.doc.ts
@@ -22,14 +22,14 @@ const data: AdminReferenceEntityTemplateSchema = {
       sectionContent: `- The component shows indeterminate loading only. It can't display progress percentage or time remaining. For operations with known duration or measurable progress, consider using a progress bar component or custom solution.
 - The component continues spinning indefinitely until you remove it. It doesn't automatically stop after a timeout or show error states. You must implement timeout logic and error handling yourself.
 - Rendering many spinners simultaneously (like in a table with 50+ rows each showing a spinner) can cause performance issues, especially on older mobile devices.
-- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [Button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) alongside the spinner.`,
+- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) alongside the spinner.`,
     },
   ],
   definitions: [
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Spinner component.',
+        'Configure the following properties on the spinner component.',
       type: 'Spinner',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
@@ -43,11 +43,11 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * A version of the Box properties with all fields required.
+ * A version of the box properties with all fields required.
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
- * The allowed border radius values for a Box component.
+ * The allowed border radius values for a box component.
  */
 export type BoxBorderRadii = Extract<
   RequiredBoxProps['borderRadius'],
@@ -61,14 +61,14 @@ export type BoxBorderRadii = Extract<
   | 'large-200'
 >;
 /**
- * The allowed border style values for a Box component.
+ * The allowed border style values for a box component.
  */
 export type BoxBorderStyles = Extract<
   RequiredBoxProps['borderStyle'],
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * The Box properties that support responsive values through container queries.
+ * The box properties that support responsive values through container queries.
  */
 export type ResponsiveBoxProps = MakeResponsivePick<
   RequiredBoxProps,
@@ -296,18 +296,18 @@ export interface BoxProps
 }
 
 /**
- * A version of the Stack properties with all fields required.
+ * A version of the stack properties with all fields required.
  */
 export type AlignedStackProps = Required<StackProps$1>;
 /**
- * The Stack properties that support responsive values through container queries.
+ * The stack properties that support responsive values through container queries.
  */
 export type ResponsiveStackProps = MakeResponsivePick<
   AlignedStackProps,
   'gap' | 'rowGap' | 'columnGap' | 'direction'
 >;
 /**
- * The properties for the Stack component. A Stack arranges its children in a single direction with controlled spacing and alignment along both axes.
+ * The properties for the stack component. A stack arranges its children in a single direction with controlled spacing and alignment along both axes.
  */
 export interface StackProps
   extends BoxProps,
@@ -340,7 +340,7 @@ export interface StackProps
    */
   alignContent: AlignContentKeyword;
   /**
-   * The spacing between children in the Stack. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for the block and inline axes. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between children in the stack. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for the block and inline axes. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */
@@ -358,7 +358,7 @@ export interface StackProps
    */
   columnGap: ResponsiveStackProps['columnGap'];
   /**
-   * The direction in which the Stack's children are laid out. Use `'inline'` to arrange children horizontally (with wrapping enabled), or `'block'` to arrange them vertically (without wrapping). This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The direction in which the stack's children are laid out. Use `'inline'` to arrange children horizontally (with wrapping enabled), or `'block'` to arrange them vertically (without wrapping). This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default 'block'
    *
@@ -597,12 +597,12 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * A Stack is a layout component that arranges its children in a single direction with controlled spacing and alignment.
+ * A stack is a layout component that arranges its children in a single direction with controlled spacing and alignment.
  */
 declare class Stack extends BoxElement implements StackProps {
   constructor();
   /**
-   * The direction in which the Stack's children are arranged.
+   * The direction in which the stack's children are arranged.
    */
   accessor direction: StackProps['direction'];
   /**
@@ -618,15 +618,15 @@ declare class Stack extends BoxElement implements StackProps {
    */
   accessor alignContent: StackProps['alignContent'];
   /**
-   * The spacing between the Stack's children.
+   * The spacing between the stack's children.
    */
   accessor gap: StackProps['gap'];
   /**
-   * The spacing between rows in the Stack.
+   * The spacing between rows in the stack.
    */
   accessor rowGap: StackProps['rowGap'];
   /**
-   * The spacing between columns in the Stack.
+   * The spacing between columns in the stack.
    */
   accessor columnGap: StackProps['columnGap'];
 }
@@ -645,13 +645,13 @@ declare module 'preact' {
 
 declare const tagName = 's-stack';
 /**
- * The properties for the Stack component when it's used in JSX.
+ * The properties for the stack component when it's used in JSX.
  */
 export interface StackJSXProps
   extends Partial<StackProps>,
     Pick<StackProps$1, 'id' | 'children'> {
   /**
-   * The child elements to render inside the Stack.
+   * The child elements to render inside the stack.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.doc.ts
@@ -24,13 +24,13 @@ const data: AdminReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Stack component.',
+      description: 'Configure the following properties on the stack component.',
       type: 'Stack',
     },
     {
       title: 'Slots',
       description:
-        'The Stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'StackSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch.d.ts
@@ -286,7 +286,7 @@ declare module 'preact' {
 
 declare const tagName = 's-switch';
 /**
- * Properties for using the Switch component in JSX with React-style event handlers.
+ * Properties for using the switch component in JSX with React-style event handlers.
  */
 export interface SwitchJSXProps
   extends Partial<SwitchProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
@@ -21,13 +21,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Switch component.',
+        'Configure the following properties on the switch component.',
       type: 'Switch',
     },
     {
       title: 'Events',
       description:
-        'The Switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'SwitchEvents',
     },
   ],
@@ -163,7 +163,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Group of related switches arranged in a vertical stack for settings configuration. This example demonstrates how to use the Stack component to create a clean, organized layout for multiple related switch settings.',
+              'Group of related switches arranged in a vertical stack for settings configuration. This example demonstrates how to use the stack component to create a clean, organized layout for multiple related switch settings.',
             codeblock: {
               title: 'Settings panel with Stack',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
@@ -13,7 +13,7 @@ import type {
 } from './shared.d.ts';
 
 /**
- * The properties you can set on a Table component.
+ * The properties you can set on a table component.
  */
 export interface TableProps
   extends Required<
@@ -36,7 +36,7 @@ export type HeaderFormat = Extract<
   'base' | 'currency' | 'numeric'
 >;
 /**
- * The properties you can set on a TableHeader component.
+ * The properties you can set on a table header component.
  */
 export interface TableHeaderProps
   extends Pick<TableHeaderProps$1, 'listSlot' | 'format'> {
@@ -321,21 +321,21 @@ declare module 'preact' {
 }
 
 /**
- * The custom element tag name for the Table component.
+ * The custom element tag name for the table component.
  */
 declare const tagName = 's-table';
 /**
- * The JSX properties you can set on a Table component.
+ * The JSX properties you can set on a table component.
  */
 export interface TableJSXProps
   extends Partial<TableProps>,
     Pick<TableProps$1, 'id' | 'children' | 'onNextPage' | 'onPreviousPage'> {
   /**
-   * The content to display inside the table, which should include TableHeaderRow, TableBody, and TableRow components.
+   * The content to display inside the table, which should include table header row, table body, and table row components.
    */
   children?: ComponentChildren;
   /**
-   * Additional filters to display in the table. For example, you can use the SearchField component to filter the table data.
+   * Additional filters to display in the table. For example, you can use the search field component to filter the table data.
    */
   filters?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
@@ -26,26 +26,26 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Limitations',
       type: 'Generic' as const,
       anchorLink: 'limitations',
-      sectionContent: `- The component doesn't include built-in sorting or search functionality. You'll need to implement these features yourself if merchants need to organize data within the table. For filtering, use the \`filters\` slot to add filter UI such as a SearchField.
+      sectionContent: `- The component doesn't include built-in sorting or search functionality. You'll need to implement these features yourself if merchants need to organize data within the table. For filtering, use the \`filters\` slot to add filter UI such as a search field.
 - The component doesn't support sticky headers that remain visible during scrolling. If merchants need to reference column headers while viewing data further down the table, consider using pagination to keep datasets smaller.`,
     },
   ],
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Table component.',
+      description: 'Configure the following properties on the table component.',
       type: 'Table',
     },
     {
       title: 'Slots',
       description:
-        'The Table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TableSlots',
     },
     {
       title: 'Events',
       description:
-        'The Table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TableEvents',
     },
     {
@@ -56,7 +56,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The TableBody component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TableBodySlots',
     },
     {
@@ -67,7 +67,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The TableCell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TableCellSlots',
     },
     {
@@ -78,7 +78,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The TableHeader component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TableHeaderSlots',
     },
     {
@@ -89,7 +89,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The TableHeaderRow component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TableHeaderRowSlots',
     },
     {
@@ -100,7 +100,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The TableRow component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TableRowSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
@@ -8,7 +8,7 @@
 import type {ComponentChildren, TableBodyProps$1} from './shared.d.ts';
 
 /**
- * The properties you can set on a TableBody component.
+ * The properties you can set on a table body component.
  */
 export interface TableBodyProps extends TableBodyProps$1 {}
 
@@ -151,17 +151,17 @@ declare module 'preact' {
 }
 
 /**
- * The custom element tag name for the TableBody component.
+ * The custom element tag name for the table body component.
  */
 declare const tagName = 's-table-body';
 /**
- * The JSX properties you can set on a TableBody component.
+ * The JSX properties you can set on a table body component.
  */
 export interface TableBodyJSXProps
   extends Partial<TableBodyProps>,
     Pick<TableBodyProps$1, 'id' | 'children'> {
   /**
-   * The body content of the table, which should include TableRow components. This content might not have any semantic meaning when the table uses the `list` variant.
+   * The body content of the table, which should include table row components. This content might not have any semantic meaning when the table uses the `list` variant.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
@@ -12,7 +12,7 @@ import type {
 } from './shared.d.ts';
 
 /**
- * The properties you can set on a TableCell component.
+ * The properties you can set on a table cell component.
  */
 export interface TableCellProps extends TableCellProps$1 {}
 
@@ -170,11 +170,11 @@ declare module 'preact' {
 }
 
 /**
- * The custom element tag name for the TableCell component.
+ * The custom element tag name for the table cell component.
  */
 declare const tagName = 's-table-cell';
 /**
- * The JSX properties you can set on a TableCell component.
+ * The JSX properties you can set on a table cell component.
  */
 export interface TableCellJSXProps
   extends Partial<TableCellProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
@@ -16,7 +16,7 @@ export type HeaderFormat = Extract<
   'base' | 'currency' | 'numeric'
 >;
 /**
- * The properties you can set on a TableHeader component.
+ * The properties you can set on a table header component.
  */
 export interface TableHeaderProps
   extends Pick<TableHeaderProps$1, 'listSlot' | 'format'> {
@@ -183,11 +183,11 @@ declare module 'preact' {
 }
 
 /**
- * The custom element tag name for the TableHeader component.
+ * The custom element tag name for the table header component.
  */
 declare const tagName = 's-table-header';
 /**
- * The JSX properties you can set on a TableHeader component.
+ * The JSX properties you can set on a table header component.
  */
 export interface TableHeaderJSXProps
   extends Partial<TableHeaderProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
@@ -8,7 +8,7 @@
 import type {ComponentChildren, TableHeaderRowProps$1} from './shared.d.ts';
 
 /**
- * The properties you can set on a TableHeaderRow component.
+ * The properties you can set on a table header row component.
  */
 export interface TableHeaderRowProps extends TableHeaderRowProps$1 {}
 
@@ -128,7 +128,7 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * A component that wraps the header row of a table, which contains the TableHeader components that define the column structure.
+ * A component that wraps the header row of a table, which contains the table header components that define the column structure.
  */
 declare class TableHeaderRow
   extends PreactCustomElement
@@ -158,17 +158,17 @@ declare module 'preact' {
 }
 
 /**
- * The custom element tag name for the TableHeaderRow component.
+ * The custom element tag name for the table header row component.
  */
 declare const tagName = 's-table-header-row';
 /**
- * The JSX properties you can set on a TableHeaderRow component.
+ * The JSX properties you can set on a table header row component.
  */
 export interface TableHeaderRowJSXProps
   extends Partial<TableHeaderRowProps>,
     Pick<TableHeaderRowProps$1, 'id' | 'children'> {
   /**
-   * The content to display inside the table header row, which should include TableHeader components.
+   * The content to display inside the table header row, which should include table header components.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
@@ -8,7 +8,7 @@
 import type {ComponentChildren, TableRowProps$1} from './shared.d.ts';
 
 /**
- * The properties you can set on a TableRow component.
+ * The properties you can set on a table row component.
  */
 export interface TableRowProps
   extends Pick<TableRowProps$1, 'children' | 'clickDelegate'> {}
@@ -156,17 +156,17 @@ declare module 'preact' {
 }
 
 /**
- * The custom element tag name for the TableRow component.
+ * The custom element tag name for the table row component.
  */
 declare const tagName = 's-table-row';
 /**
- * The JSX properties you can set on a TableRow component.
+ * The JSX properties you can set on a table row component.
  */
 export interface TableRowJSXProps
   extends Partial<TableRowProps>,
     Pick<TableRowProps$1, 'id' | 'children'> {
   /**
-   * The content to display inside the row, which should include TableCell components.
+   * The content to display inside the row, which should include table cell components.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
@@ -9,7 +9,7 @@
 import type {ComponentChildren, TextProps$1} from './shared.d.ts';
 
 /**
- * The properties for the Text component. These properties define inline or small blocks of text content with various visual styles and semantic meanings.
+ * The properties for the text component. These properties define inline or small blocks of text content with various visual styles and semantic meanings.
  */
 export interface TextProps
   extends Required<
@@ -253,7 +253,7 @@ declare module 'preact' {
 
 declare const tagName = 's-text';
 /**
- * The JSX properties for the Text component. These properties define how text is rendered in Preact or JSX.
+ * The JSX properties for the text component. These properties define how text is rendered in Preact or JSX.
  */
 export interface TextJSXProps
   extends Partial<TextProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
@@ -19,21 +19,21 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Limitations',
       type: 'Generic' as const,
       anchorLink: 'limitations',
-      sectionContent: `- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [Paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph) component or wrap in layout components.
-- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [Heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading) with line clamping if truncation is needed.
+      sectionContent: `- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph) component or wrap in layout components.
+- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading) with line clamping if truncation is needed.
 - Tone colors are optimized for light backgrounds. Using tones on dark or colored backgrounds might not meet accessibility contrast requirements.`,
     },
   ],
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the Text component.',
+      description: 'Configure the following properties on the text component.',
       type: 'Text',
     },
     {
       title: 'Slots',
       description:
-        'The Text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TextSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
@@ -324,7 +324,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the TextArea component. These properties configure a multi-line text input field that allows merchants to enter and edit longer text content.
+ * The properties for the text area component. These properties configure a multi-line text input field that allows merchants to enter and edit longer text content.
  */
 export type TextAreaProps = PreactFieldProps<
   Required<TextAreaProps$1>['autocomplete']
@@ -332,7 +332,7 @@ export type TextAreaProps = PreactFieldProps<
   Required<Pick<TextAreaProps$1, 'maxLength' | 'minLength' | 'rows'>>;
 
 /**
- * The TextArea custom element class that renders a multi-line text input field in the Shopify admin interface. This component allows merchants to enter and edit longer text content with support for labels, validation, and length constraints.
+ * The text area custom element class that renders a multi-line text input field in the Shopify admin interface. This component allows merchants to enter and edit longer text content with support for labels, validation, and length constraints.
  */
 declare class TextArea
   extends PreactFieldElement<TextAreaProps['autocomplete']>
@@ -372,7 +372,7 @@ declare module 'preact' {
 
 declare const tagName = 's-text-area';
 /**
- * The JSX props for the TextArea component. These properties extend `TextAreaProps` with JSX-specific event callbacks for React-style event handling.
+ * The JSX props for the text area component. These properties extend `TextAreaProps` with JSX-specific event callbacks for React-style event handling.
  */
 export interface TextAreaJSXProps
   extends Partial<TextAreaProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
@@ -27,13 +27,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the TextArea component.',
+        'Configure the following properties on the text area component.',
       type: 'TextArea',
     },
     {
       title: 'Events',
       description:
-        'The TextArea component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TextAreaEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
@@ -320,7 +320,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the TextField component. Extends `PreactFieldProps` with text-specific features like icons, length constraints, and prefix/suffix content.
+ * The properties for the text field component. Extends `PreactFieldProps` with text-specific features like icons, length constraints, and prefix/suffix content.
  */
 export type TextFieldProps = PreactFieldProps<
   /** @default 'on' */
@@ -334,7 +334,7 @@ export type TextFieldProps = PreactFieldProps<
   >;
 
 /**
- * The TextField custom element class that renders a single-line text input field in the Shopify admin interface. This component allows merchants to enter and edit text with support for labels, validation, icons, and prefix/suffix content.
+ * The text field custom element class that renders a single-line text input field in the Shopify admin interface. This component allows merchants to enter and edit text with support for labels, validation, icons, and prefix/suffix content.
  */
 declare class TextField
   extends PreactFieldElement<TextFieldProps['autocomplete']>
@@ -383,7 +383,7 @@ declare module 'preact' {
 
 declare const tagName = 's-text-field';
 /**
- * The JSX props for the TextField component. These properties extend `TextFieldProps` with JSX-specific event callbacks and an accessory slot for rendering additional content at the end of the field.
+ * The JSX props for the text field component. These properties extend `TextFieldProps` with JSX-specific event callbacks and an accessory slot for rendering additional content at the end of the field.
  */
 export interface TextFieldJSXProps
   extends Partial<Omit<TextFieldProps, 'accessory'>>,

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
@@ -21,26 +21,26 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'limitations',
       sectionContent: `- The \`maxLength\` attribute prevents typing beyond the limit, but in some edge cases, pasted or programmatically set content might exceed \`maxLength\`. Always validate length server-side.
-- The \`accessory\` slot renders content at the end of the field. For best results, use [Button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [Clickable](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable) components with text content.`,
+- The \`accessory\` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable) components with text content.`,
     },
   ],
   definitions: [
     {
       title: 'TextField',
       description:
-        'Configure the following properties on the TextField component.',
+        'Configure the following properties on the text field component.',
       type: 'TextField',
     },
     {
       title: 'Slots',
       description:
-        'The TextField component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TextFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'The TextField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'TextFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail.d.ts
@@ -44,7 +44,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
 }
 
 /**
- * The properties for the Thumbnail component. A Thumbnail displays a small preview image with configurable sizing. Properties include `src` for the image URL, `alt` for accessibility text, and `size` for controlling the thumbnail dimensions.
+ * The properties for the thumbnail component. A thumbnail displays a small preview image with configurable sizing. Properties include `src` for the image URL, `alt` for accessibility text, and `size` for controlling the thumbnail dimensions.
  */
 export interface ThumbnailProps
   extends Required<Pick<ThumbnailProps$1, 'src' | 'alt' | 'size'>> {
@@ -161,7 +161,7 @@ declare abstract class PreactCustomElement extends BaseClass {
 }
 
 /**
- * A Thumbnail displays a small preview image with configurable sizing.
+ * A thumbnail displays a small preview image with configurable sizing.
  */
 declare class Thumbnail extends PreactCustomElement implements ThumbnailProps {
   /**
@@ -201,7 +201,7 @@ declare module 'preact' {
 
 declare const tagName = 's-thumbnail';
 /**
- * The properties for the Thumbnail component when it's used in JSX.
+ * The properties for the thumbnail component when it's used in JSX.
  */
 export interface ThumbnailJSXProps
   extends Partial<ThumbnailProps>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/Thumbnail.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/Thumbnail.doc.ts
@@ -30,13 +30,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Properties',
       description:
-        'Configure the following properties on the Thumbnail component.',
+        'Configure the following properties on the thumbnail component.',
       type: 'Thumbnail',
     },
     {
       title: 'Events',
       description:
-        'The Thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'ThumbnailEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip.d.ts
@@ -13,7 +13,7 @@ import type {
 } from './shared.d.ts';
 
 /**
- * The properties you can set on a Tooltip component.
+ * The properties you can set on a tooltip component.
  */
 export interface TooltipProps extends Required<Pick<TooltipProps$1, 'id'>> {}
 
@@ -247,17 +247,17 @@ declare module 'preact' {
 }
 
 /**
- * The custom element tag name for the Tooltip component.
+ * The custom element tag name for the tooltip component.
  */
 declare const tagName = 's-tooltip';
 /**
- * The JSX properties you can set on a Tooltip component.
+ * The JSX properties you can set on a tooltip component.
  */
 export interface TooltipJSXProps
   extends Partial<TooltipProps>,
     Pick<TooltipProps$1, 'id' | 'children'> {
   /**
-   * The content to display inside the tooltip, which should include Text or Paragraph components, or raw text content.
+   * The content to display inside the tooltip, which should include text or paragraph components, or raw text content.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip/Tooltip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip/Tooltip.doc.ts
@@ -29,7 +29,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The Tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'TooltipSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
@@ -329,7 +329,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the URLField component. These properties configure an input field that allows merchants to enter and validate web addresses (URLs) with built-in validation.
+ * The properties for the URL field component. These properties configure an input field that allows merchants to enter and validate web addresses (URLs) with built-in validation.
  */
 export type URLFieldProps = PreactFieldProps<
   Required<URLFieldProps$1>['autocomplete']
@@ -337,7 +337,7 @@ export type URLFieldProps = PreactFieldProps<
   Required<Pick<URLFieldProps$1, 'maxLength' | 'minLength'>>;
 
 /**
- * The URLField custom element class that renders a URL input field in the Shopify admin interface. This component allows merchants to enter web addresses with automatic URL validation and appropriate mobile keyboard layouts.
+ * The URL field custom element class that renders a URL input field in the Shopify admin interface. This component allows merchants to enter web addresses with automatic URL validation and appropriate mobile keyboard layouts.
  */
 declare class URLField
   extends PreactFieldElement<URLFieldProps['autocomplete']>
@@ -379,7 +379,7 @@ declare module 'preact' {
 
 declare const tagName = 's-url-field';
 /**
- * The JSX props for the URLField component. These properties extend `URLFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
+ * The JSX props for the URL field component. These properties extend `URLFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
  */
 export interface URLFieldJSXProps
   extends Partial<Omit<URLFieldProps, 'accessory'>>,

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -31,13 +31,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'URLField',
       description:
-        'Configure the following properties on the URLField component.',
+        'Configure the following properties on the URL field component.',
       type: 'URLField',
     },
     {
       title: 'Events',
       description:
-        'The URLField component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
       type: 'URLFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
@@ -8,7 +8,7 @@
 import type {ComponentChildren, UnorderedListProps$1} from './shared.d.ts';
 
 /**
- * The properties for the UnorderedList component. These properties define a bulleted list of items where the order doesn't matter.
+ * The properties for the unordered list component. These properties define a bulleted list of items where the order doesn't matter.
  */
 export interface UnorderedListProps extends UnorderedListProps$1 {}
 
@@ -129,7 +129,7 @@ export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
 }
 
 /**
- * A custom element for displaying a bulleted list of items where the order doesn't matter. Use UnorderedList when you have a collection of related items without a specific sequence, such as features, options, or bullet points.
+ * A custom element for displaying a bulleted list of items where the order doesn't matter. Use unordered list when you have a collection of related items without a specific sequence, such as features, options, or bullet points.
  */
 declare class UnorderedList
   extends PreactCustomElement
@@ -153,13 +153,13 @@ declare module 'preact' {
 
 declare const tagName = 's-unordered-list';
 /**
- * The JSX properties for the UnorderedList component. These properties define how an unordered list is rendered in Preact or JSX.
+ * The JSX properties for the unordered list component. These properties define how an unordered list is rendered in Preact or JSX.
  */
 export interface UnorderedListJSXProps
   extends Partial<UnorderedListProps>,
     Pick<UnorderedListProps$1, 'id'> {
   /**
-   * The items in the unordered list. Only ListItem components are accepted.
+   * The items in the unordered list. Only list item components are accepted.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/orderedlist) instead.
+      sectionContent: `- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list) instead.
 - **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.
 - **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.
 - **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format.`,

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [OrderedList](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/orderedlist) instead.
+      sectionContent: `- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/orderedlist) instead.
 - **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.
 - **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.
 - **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format.`,
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The UnorderedList component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'UnorderedListSlots',
     },
     {
@@ -39,7 +39,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The ListItem component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
       type: 'ListItemSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
@@ -24,11 +24,11 @@ export interface ActionProps {
 }
 export interface ActionSlots {
   /**
-   * The primary action element, typically a Button or Link component representing the main call-to-action.
+   * The primary action element, typically a button or link component representing the main call-to-action.
    */
   primaryAction?: ComponentChildren;
   /**
-   * The secondary action elements, typically Button or Link components representing alternative or supporting actions.
+   * The secondary action elements, typically button or link components representing alternative or supporting actions.
    */
   secondaryActions?: ComponentChildren;
 }
@@ -875,7 +875,7 @@ export type AnyString = string & {};
 export type optionalSpace = '' | ' ';
 interface BadgeProps$1 extends GlobalProps {
   /**
-   * The text or elements displayed inside the Badge component.
+   * The text or elements displayed inside the badge component.
    */
   children?: ComponentChildren;
   /**
@@ -927,7 +927,7 @@ interface BannerProps$1 extends GlobalProps, ActionSlots {
    */
   heading?: string;
   /**
-   * The main content displayed within the Banner component, typically descriptive text or other elements providing details about the message or alert.
+   * The main content displayed within the banner component, typically descriptive text or other elements providing details about the message or alert.
    */
   children?: ComponentChildren;
   /**
@@ -1073,7 +1073,7 @@ export type AccessibilityRole =
   | 'footer'
   /**
    * Used to indicate a generic section.
-   * Sections should always have a Heading or an accessible name provided in the `accessibilityLabel` property.
+   * Sections should always have a heading or an accessible name provided in the `accessibilityLabel` property.
    *
    * In an HTML host `section` will render a `<section>` element.
    * Learn more about the [`<section>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) in the MDN web docs.
@@ -1465,7 +1465,7 @@ export interface BaseBoxProps
     BorderProps,
     OverflowProps {
   /**
-   * The content of the Box.
+   * The content of the box.
    */
   children?: ComponentChildren;
   /**
@@ -1479,7 +1479,7 @@ export interface BaseBoxPropsWithRole
 interface BoxProps$1 extends BaseBoxPropsWithRole, GlobalProps {}
 export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
   /**
-   * The behavioral type of the Button component, which determines what action it performs when activated.
+   * The behavioral type of the button component, which determines what action it performs when activated.
    *
    * - `submit`: Submits the nearest containing form.
    * - `button`: Performs no default action, relying on the `onClick` handler for behavior.
@@ -1491,7 +1491,7 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
    */
   type?: 'submit' | 'button' | 'reset';
   /**
-   * A callback fired when the Button is activated, before performing the action indicated by `type`. Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
+   * A callback fired when the button is activated, before performing the action indicated by `type`. Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
    */
   onClick?: (event: Event) => void;
   /**
@@ -1501,7 +1501,7 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
    */
   disabled?: boolean;
   /**
-   * Whether the Button is in a loading state, which replaces the button content with a loading indicator and disables interactions.
+   * Whether the button is in a loading state, which replaces the button content with a loading indicator and disables interactions.
    *
    * @default false
    */
@@ -1572,7 +1572,7 @@ interface ButtonProps$1 extends GlobalProps, BaseClickableProps {
    */
   accessibilityLabel?: string;
   /**
-   * The content displayed within the Button component.
+   * The content displayed within the button component.
    */
   children?: ComponentChildren;
   /**
@@ -1584,7 +1584,7 @@ interface ButtonProps$1 extends GlobalProps, BaseClickableProps {
    */
   icon?: IconType | AnyString;
   /**
-   * The inline width (horizontal size) of the Button component.
+   * The inline width (horizontal size) of the button component.
    *
    * - `auto`: The button size depends on the surface and context.
    * - `fill`: The button takes up 100% of the available inline space.
@@ -1594,9 +1594,9 @@ interface ButtonProps$1 extends GlobalProps, BaseClickableProps {
    */
   inlineSize?: 'auto' | 'fill' | 'fit-content';
   /**
-   * The visual style variant of the Button component, which controls its prominence and emphasis in the interface.
+   * The visual style variant of the button component, which controls its prominence and emphasis in the interface.
    *
-   * @default 'auto' - the variant is automatically determined by the Button's context
+   * @default 'auto' - the variant is automatically determined by the button's context
    */
   variant?: 'auto' | 'primary' | 'secondary' | 'tertiary';
   /**
@@ -1616,7 +1616,7 @@ interface ButtonProps$1 extends GlobalProps, BaseClickableProps {
 }
 interface ButtonGroupProps$1 extends GlobalProps, ActionSlots {
   /**
-   * The content of the ButtonGroup, typically a collection of Button or Link components.
+   * The content of the button group, typically a collection of button or link components.
    */
   children?: ComponentChildren;
   /**
@@ -2582,7 +2582,7 @@ export type EmailAutocompleteField = ExtractStrict<
 >;
 interface FormProps$1 extends GlobalProps {
   /**
-   * The form fields and content to be wrapped in the Form element.
+   * The form fields and content to be wrapped in the form element.
    */
   children?: ComponentChildren;
   /**
@@ -2855,7 +2855,7 @@ interface HeadingProps$1
     AccessibilityVisibilityProps,
     BlockTypographyProps {
   /**
-   * The content of the Heading.
+   * The content of the heading.
    */
   children?: ComponentChildren;
   /**
@@ -3077,32 +3077,32 @@ interface ModalProps$1
    */
   accessibilityLabel?: string;
   /**
-   * A title that describes the content of the Modal.
+   * A title that describes the content of the modal.
    *
    */
   heading?: string;
   /**
-   * Adjust the padding around the Modal content.
+   * Adjust the padding around the modal content.
    *
    * `base`: applies padding that is appropriate for the element.
    *
-   * `none`: removes all padding from the element. This can be useful when elements inside the Modal need to span
-   * to the edge of the Modal. For example, a full-width image. In this case, rely on Box with a padding of 'base'
+   * `none`: removes all padding from the element. This can be useful when elements inside the modal need to span
+   * to the edge of the modal. For example, a full-width image. In this case, rely on box with a padding of 'base'
    * to bring back the desired padding for the rest of the content.
    *
    * @default 'base'
    */
   padding?: 'base' | 'none';
   /**
-   * Adjust the size of the Modal.
+   * Adjust the size of the modal.
    *
-   * `max`: expands the Modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
+   * `max`: expands the modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
    *
    * @default 'base'
    */
   size?: SizeKeyword | 'max';
   /**
-   * The content of the Modal.
+   * The content of the modal.
    */
   children?: ComponentChildren;
 }
@@ -3168,14 +3168,14 @@ interface OptionGroupProps$1 extends GlobalProps {
    */
   label?: string;
   /**
-   * The collection of Option components that users can select from within this group.
+   * The collection of option components that users can select from within this group.
    */
   children?: ComponentChildren;
 }
 interface OrderedListProps$1 extends GlobalProps {}
 interface PageProps$1 extends GlobalProps, ActionSlots {
   /**
-   * The content of the Page.
+   * The content of the page.
    */
   children?: ComponentChildren;
   /**
@@ -3288,7 +3288,7 @@ interface QueryContainerProps$1 extends GlobalProps {
 }
 interface SectionProps$1 extends GlobalProps, ActionSlots {
   /**
-   * The content of the Section.
+   * The content of the section.
    */
   children?: ComponentChildren;
   /**
@@ -3420,13 +3420,13 @@ interface TableProps$1 extends GlobalProps, PaginationProps {
   /**
    * The table structure defining headers and data rows.
    *
-   * Accepts TableHeaderRow (for column headers) and TableBody (for data rows) components. Structure your table with a TableHeaderRow first, followed by TableBody.
+   * Accepts table header row (for column headers) and table body (for data rows) components. Structure your table with a table header row first, followed by table body.
    */
   children?: ComponentChildren;
   /**
    * Filter controls displayed above the table.
    *
-   * Accepts input components like SearchField or Select for filtering table data. These controls appear in a dedicated area above the table content.
+   * Accepts input components like search field or select for filtering table data. These controls appear in a dedicated area above the table content.
    */
   filters?: ComponentChildren;
   /**


### PR DESCRIPTION
## Context

In older versions (2025-07 and earlier), components use React/JSX syntax, so PascalCase names like `ButtonGroup` make sense — that's what devs write in their code. But in versions 2025-10+, the syntax shifted to web components (`<s-button-group>`), so PascalCase no longer maps to anything developers actually write in code. We're switching to sentence case for component names in versions 2025-10+.

## This PR:
- Updates all Admin UI component names to use sentence case versus Pascal case in the 2026-01 version
- Closes https://github.com/Shopify/shopify-dev/issues/68402