### PR TITLE
Added imports for preact bindings in POS docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Modal.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Modal.jsx
@@ -1,5 +1,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
+// Allows the use of `shopify.cart.current.value` as a stateful subscription.
+import '@shopify/ui-extensions/preact';
 import {fetchSellingPlans} from './FetchSellingPlans';
 
 export default function extension() {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/check-cart-editable.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/check-cart-editable.jsx
@@ -1,5 +1,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
+// Allows the use of `shopify.cart.current.value` as a stateful subscription.
+import '@shopify/ui-extensions/preact';
 
 export default async () => {
   render(<Extension />, document.body);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/subscribe.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/subscribe.jsx
@@ -1,5 +1,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
+// Allows the use of `shopify.cart.current.value` as a stateful subscription.
+import '@shopify/ui-extensions/preact';
 
 export default async () => {
   render(<Extension />, document.body);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/connectivity-api/subscribe.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/connectivity-api/subscribe.jsx
@@ -1,5 +1,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
+// Allows the use of `shopify.connectivity.current.value` as a stateful subscription.
+import '@shopify/ui-extensions/preact';
 
 export default async () => {
   render(<Extension />, document.body);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/locale-api/subscribe.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/locale-api/subscribe.jsx
@@ -1,5 +1,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
+// Allows the use of `shopify.locale.current.value` as a stateful subscription.
+import '@shopify/ui-extensions/preact';
 
 export default async () => {
   render(<Extension />, document.body);


### PR DESCRIPTION
### Background

This PR adds missing imports for `@shopify/ui-extensions/preact` in several example files to enable stateful subscriptions.

### Solution

Added the import statement `import '@shopify/ui-extensions/preact';` along with an explanatory comment to multiple example files that use stateful subscriptions like `shopify.cart.current.value`. This import is necessary for the subscription functionality to work properly in Preact components.

The changes were made to:
- Subscription example Modal component
- Cart API examples (check-cart-editable and subscribe)
- Connectivity API subscribe example
- Locale API subscribe example

### 🎩

- Verify that all examples now properly handle stateful subscriptions
- Confirm that the added comments clearly explain the purpose of the import

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation