### PR TITLE
2024-10 gen docs v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@shopify/babel-preset": "^24.1.0",
     "@shopify/browserslist-config": "^3.0.0",
     "@shopify/eslint-plugin": "^42.0.0",
-    "@shopify/generate-docs": "0.16.4",
+    "@shopify/generate-docs": "1.0.0",
     "@shopify/loom": "^1.0.0",
     "@shopify/loom-cli": "^1.0.0",
     "@shopify/loom-plugin-build-library": "^1.0.0",

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/api.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/api.ts
@@ -16,6 +16,8 @@ import {ExtensionApiContext} from '../context';
  * which contains a basic set of properties about the checkout.
  *
  * For a full list of the API available to each extension target, see the [ExtensionTargets type](https://shopify.dev/docs/api/checkout-ui-extensions/apis/extensiontargets).
+ *
+ * @publicDocs
  */
 export function useApi<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -43,6 +45,8 @@ export function useApi<
  * > Caution: This is deprecated, use `useApi` instead.
  *
  * @deprecated This is deprecated, use `useApi` instead.
+ *
+ * @publicDocs
  */
 export function useExtensionApi<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/app-metafields.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/app-metafields.ts
@@ -23,6 +23,8 @@ type AppMetafieldFilterKeys = keyof AppMetafieldFilters;
 /**
  * Returns the metafields configured with `shopify.extension.toml`.
  * @arg {AppMetafieldFilters} - filter the list of returned metafields
+ *
+ * @publicDocs
  */
 export function useAppMetafields<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/attributes.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/attributes.ts
@@ -12,6 +12,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the proposed `attributes` applied to the checkout.
+ *
+ * @publicDocs
  */
 export function useAttributes<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -23,6 +25,8 @@ export function useAttributes<
  * Returns the values for the specified `attributes` applied to the checkout.
  *
  * @param keys - An array of attribute keys.
+ *
+ * @publicDocs
  */
 export function useAttributeValues<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -41,6 +45,8 @@ export function useAttributeValues<
 
 /**
  * Returns a function to mutate the `attributes` property of the checkout.
+ *
+ * @publicDocs
  */
 export function useApplyAttributeChange<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/billing-address.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/billing-address.ts
@@ -10,6 +10,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the proposed `billingAddress` applied to the checkout.
+ *
+ * @publicDocs
  */
 export function useBillingAddress<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/buyer-identity.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/buyer-identity.ts
@@ -13,6 +13,8 @@ import {useSubscription} from './subscription';
  * Returns the current `Customer`.
  *
  * The value is `undefined` if the buyer isn't a known customer for this shop or if they haven't logged in yet.
+ *
+ * @publicDocs
  */
 export function useCustomer<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -31,6 +33,8 @@ export function useCustomer<
 /**
  * Returns the email address of the buyer that is interacting with the cart.
  * The value is `undefined` if the app does not have access to customer data.
+ *
+ * @publicDocs
  */
 export function useEmail<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -49,6 +53,8 @@ export function useEmail<
 /**
  * Returns the phone number of the buyer that is interacting with the cart.
  * The value is `undefined` if the app does not have access to customer data.
+ *
+ * @publicDocs
  */
 export function usePhone<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -70,6 +76,8 @@ export function usePhone<
  * identify both the company and its corresponding location to which the business customer belongs.
  *
  * The value is `undefined` if a business customer isn't logged in. This function throws an error if the app doesn't have access to customer data.
+ *
+ * @publicDocs
  */
 export function usePurchasingCompany<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/buyer-journey.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/buyer-journey.ts
@@ -13,6 +13,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the `buyerJourney` details on buyer progression in checkout.
+ *
+ * @publicDocs
  */
 export function useBuyerJourney<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -33,6 +35,8 @@ export function useBuyerJourney<
  * Returns true if the buyer completed submitting their order.
  *
  * For example, when viewing the **Order status** page after submitting payment, the buyer will have completed their order.
+ *
+ * @publicDocs
  */
 export function useBuyerJourneyCompleted<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -54,6 +58,8 @@ export function useBuyerJourneyCompleted<
  *
  * If you do, then you're expected to inform the buyer why navigation was blocked,
  * either by passing validation errors to the checkout UI or rendering the errors in your extension.
+ *
+ * @publicDocs
  */
 export function useBuyerJourneyIntercept<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -80,6 +86,8 @@ export function useBuyerJourneyIntercept<
 
 /**
  * Returns all possible steps a buyer can take to complete the checkout. These steps may vary depending on the type of checkout or the shop's configuration.
+ *
+ * @publicDocs
  */
 export function useBuyerJourneySteps<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -95,6 +103,8 @@ export function useBuyerJourneySteps<
 
 /**
  * Returns the buyer journey step that the buyer is currently on.
+ *
+ * @publicDocs
  */
 export function useBuyerJourneyActiveStep<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/capabilities.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/capabilities.ts
@@ -5,6 +5,8 @@ import {useApi} from './api';
 
 /**
  * Returns a list of an extension's granted capabilities.
+ *
+ * @publicDocs
  */
 export function useExtensionCapabilities(): Capability[] {
   return useSubscription(useApi().extension.capabilities);
@@ -12,6 +14,8 @@ export function useExtensionCapabilities(): Capability[] {
 
 /**
  * Returns whether or not a given capability of an extension is granted.
+ *
+ * @publicDocs
  */
 export function useExtensionCapability(capability: Capability): boolean {
   return useExtensionCapabilities().includes(capability);

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/cart-line-target.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/cart-line-target.ts
@@ -12,6 +12,8 @@ import {useSubscription} from './subscription';
  * - `purchase.checkout.cart-line-item.render-after`
  * - `purchase.thank-you.cart-line-item.render-after`
  * - 'customer-account.order-status.cart-line-item.render-after'
+ *
+ * @publicDocs
  */
 export function useCartLineTarget(): CartLine {
   const api = useApi<

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/cart-lines.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/cart-lines.ts
@@ -13,6 +13,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the current line items for the checkout, and automatically re-renders
  * your component if line items are added, removed, or updated.
+ *
+ * @publicDocs
  */
 export function useCartLines<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -24,6 +26,8 @@ export function useCartLines<
 
 /**
  * Returns a function to mutate the `lines` property of checkout.
+ *
+ * @publicDocs
  */
 export function useApplyCartLinesChange<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/checkout-settings.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/checkout-settings.ts
@@ -8,6 +8,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the `checkoutSettings` applied to the checkout.
+ *
+ * @publicDocs
  */
 export function useCheckoutSettings<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/checkout-token.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/checkout-token.ts
@@ -11,6 +11,8 @@ import {useSubscription} from './subscription';
  *
  * Matches the `token` field in the [WebPixel checkout payload](https://shopify.dev/docs/api/pixels/customer-events#checkout)
  * and the `checkout_token` field in the [Admin REST API Order resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object).
+ *
+ * @publicDocs
  */
 export function useCheckoutToken<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/cost.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/cost.ts
@@ -9,6 +9,8 @@ import {useSubscription} from './subscription';
 /**
  * A `Money` value representing the subtotal value of the items in the cart at the current
  * step of checkout.
+ *
+ * @publicDocs
  */
 export function useSubtotalAmount<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -20,6 +22,8 @@ export function useSubtotalAmount<
  * A `Money` value representing the total shipping a buyer can expect to pay at the current
  * step of checkout. This value includes shipping discounts. Returns undefined if shipping
  * has not been negotiated yet, such as on the information step.
+ *
+ * @publicDocs
  */
 export function useTotalShippingAmount<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -31,6 +35,8 @@ export function useTotalShippingAmount<
  * A `Money` value representing the total tax a buyer can expect to pay at the current
  * step of checkout or the total tax included in product and shipping prices. Returns
  * undefined if taxes are unavailable.
+ *
+ * @publicDocs
  */
 export function useTotalTaxAmount<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -42,6 +48,8 @@ export function useTotalTaxAmount<
  * Returns a `Money` value representing the minimum a buyer can expect to pay at the current
  * step of checkout. This value excludes amounts yet to be negotiated. For example,
  * the information step might not have delivery costs calculated.
+ *
+ * @publicDocs
  */
 export function useTotalAmount<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/country.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/country.ts
@@ -9,6 +9,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the country of the checkout, and automatically re-renders
  * your component if the country changes.
+ *
+ * @publicDocs
  */
 export function useLocalizationCountry<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/currency.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/currency.ts
@@ -9,6 +9,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the currency of the checkout, and automatically re-renders
  * your component if the currency changes.
+ *
+ * @publicDocs
  */
 export function useCurrency<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/customer-privacy.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/customer-privacy.ts
@@ -9,6 +9,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the current customer privacy settings and metadata and
  * re-renders your component if the customer privacy settings change.
+ *
+ * @publicDocs
  */
 export function useCustomerPrivacy<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/delivery-group-list-target.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/delivery-group-list-target.ts
@@ -8,6 +8,8 @@ import {useSubscription} from './subscription';
  * extension targets:
  * - purchase.checkout.shipping-option-list.render-before
  * - purchase.checkout.shipping-option-list.render-after
+ *
+ * @publicDocs
  */
 export function useDeliveryGroupListTarget(): DeliveryGroupList | undefined {
   const api = useApi<

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/delivery-group-target.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/delivery-group-target.ts
@@ -12,6 +12,8 @@ import {useSubscription} from './subscription';
  * > Caution: Deprecated as of version `2024-07`, use `useDeliveryGroupListTarget()` instead.
  *
  * @deprecated Deprecated as of version `2024-07`, use `useDeliveryGroupListTarget()` instead.
+ *
+ * @publicDocs
  */
 export function useDeliveryGroupTarget(): DeliveryGroup | undefined {
   const api = useApi<

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/delivery-group.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/delivery-group.ts
@@ -13,6 +13,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the full expanded details of a delivery group and automatically re-renders
  * your component when that delivery group changes.
+ *
+ * @publicDocs
  */
 export function useDeliveryGroup<
   ID extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/delivery-groups.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/delivery-groups.ts
@@ -11,6 +11,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the current delivery groups for the checkout, and automatically re-renders
  * your component when delivery address or delivery option selection changes.
+ *
+ * @publicDocs
  */
 export function useDeliveryGroups<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/delivery-selection-groups.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/delivery-selection-groups.ts
@@ -8,6 +8,8 @@ import {useSubscription} from './subscription';
  * extension targets:
  * - purchase.checkout.shipping-option-list.render-before
  * - purchase.checkout.shipping-option-list.render-after
+ *
+ * @publicDocs
  */
 export function useDeliverySelectionGroups():
   | DeliverySelectionGroup[]

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/discounts.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/discounts.ts
@@ -14,6 +14,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the current discount codes applied to the cart, and automatically re-renders
  * your component if discount codes are added or removed.
+ *
+ * @publicDocs
  */
 export function useDiscountCodes<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -26,6 +28,8 @@ export function useDiscountCodes<
 /**
  * Returns the current discount allocations applied to the cart, and automatically re-renders
  * your component if discount allocations changed.
+ *
+ * @publicDocs
  */
 export function useDiscountAllocations<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -40,6 +44,8 @@ export function useDiscountAllocations<
  *
  * > Caution:
  * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves discount codes through a network call.
+ *
+ * @publicDocs
  */
 export function useApplyDiscountCodeChange<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/extension-editor.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/extension-editor.ts
@@ -4,6 +4,8 @@ import {useApi} from './api';
 
 /**
  * Returns information about the editor where the extension is being rendered.
+ *
+ * @publicDocs
  */
 export function useExtensionEditor(): Editor | undefined {
   return useApi().extension.editor;

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/extension-language.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/extension-language.ts
@@ -8,6 +8,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the buyer's language, as supported by the extension.
+ *
+ * @publicDocs
  */
 export function useExtensionLanguage<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/extension.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/extension.ts
@@ -4,6 +4,8 @@ import {useApi} from './api';
 
 /**
  * Returns the metadata about the extension.
+ *
+ * @publicDocs
  */
 export function useExtension(): Extension {
   return useApi().extension as Extension;
@@ -13,6 +15,8 @@ export function useExtension(): Extension {
  * Returns the metadata about the extension.
  * > Caution: This is deprecated, use `useExtension()` instead.
  * @deprecated Use `useExtension()` instead.
+ *
+ * @publicDocs
  */
 export function useExtensionData(): Extension {
   return useExtension();

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/gift-cards.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/gift-cards.ts
@@ -13,6 +13,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the current gift cards applied to the cart, and automatically re-renders
  * your component if gift cards are added or removed.
+ *
+ * @publicDocs
  */
 export function useAppliedGiftCards<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -27,6 +29,8 @@ export function useAppliedGiftCards<
  *
  * > Caution:
  * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves gift card codes through a network call.
+ *
+ * @publicDocs
  */
 export function useApplyGiftCardChange<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/instructions.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/instructions.ts
@@ -8,6 +8,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the cart instructions used to create the checkout and possibly limit extension capabilities.
+ *
+ * @publicDocs
  */
 export function useInstructions<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/language.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/language.ts
@@ -9,6 +9,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the current language of the checkout, and automatically re-renders
  * your component if the language changes.
+ *
+ * @publicDocs
  */
 export function useLanguage<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/market.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/market.ts
@@ -9,6 +9,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the market of the checkout, and automatically re-renders
  * your component if it changes.
+ *
+ * @publicDocs
  */
 export function useLocalizationMarket<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/metafield.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/metafield.ts
@@ -12,6 +12,8 @@ interface MetafieldFilter {
 /**
  * Returns a single filtered `Metafield` or `undefined`.
  * @arg {MetafieldFilter} - filter the list of returned metafields to a single metafield
+ *
+ * @publicDocs
  */
 export function useMetafield(filters: MetafieldFilter): Metafield | undefined {
   const {namespace, key} = filters;

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/metafields.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/metafields.ts
@@ -20,6 +20,8 @@ interface MetafieldsFilters {
  * Returns the current array of `metafields` applied to the checkout.
  * You can optionally filter the list.
  * @arg {MetafieldsFilters} - filter the list of returned metafields
+ *
+ * @publicDocs
  */
 export function useMetafields<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -50,6 +52,8 @@ export function useMetafields<
 
 /**
  * Returns a function to mutate the `metafields` property of the checkout.
+ *
+ * @publicDocs
  */
 export function useApplyMetafieldsChange<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/note.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/note.ts
@@ -11,6 +11,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the proposed `note` applied to the checkout.
+ *
+ * @publicDocs
  */
 export function useNote<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -20,6 +22,8 @@ export function useNote<
 
 /**
  * Returns a function to mutate the `note` property of the checkout.
+ *
+ * @publicDocs
  */
 export function useApplyNoteChange<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/order.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/order.ts
@@ -10,6 +10,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the order information that's available post-checkout.
+ *
+ * @publicDocs
  */
 export function useOrder<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/payment-method.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/payment-method.ts
@@ -11,6 +11,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the proposed `paymentAttributes` applied to the checkout.
+ *
+ * @publicDocs
  */
 export function usePaymentMethodAttributes():
   | PaymentMethodAttribute[]
@@ -33,6 +35,8 @@ export function usePaymentMethodAttributes():
  * Returns the values for the specified `paymentAttributes` applied to the checkout.
  *
  * @param keys - An array of attribute keys.
+ *
+ * @publicDocs
  */
 export function usePaymentMethodAttributeValues(
   keys: string[],
@@ -51,6 +55,8 @@ export function usePaymentMethodAttributeValues(
 
 /**
  * Returns a function to set payment method attributes.
+ *
+ * @publicDocs
  */
 export function useApplyPaymentMethodAttributesChange(): (
   change: PaymentMethodAttributesChange,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/payment-options.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/payment-options.ts
@@ -11,6 +11,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns all available payment options.
+ *
+ * @publicDocs
  */
 export function useAvailablePaymentOptions<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -29,6 +31,8 @@ export function useAvailablePaymentOptions<
 
 /**
  * Returns payment options selected by the buyer.
+ *
+ * @publicDocs
  */
 export function useSelectedPaymentOptions<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/pickup-location-option-target.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/pickup-location-option-target.ts
@@ -10,6 +10,8 @@ import {useSubscription} from './subscription';
  * Returns the pickup location option the extension is attached to. This hook can only be used by extensions in the following
  * extension target:
  * - `purchase.checkout.pickup-location-option-item.render-after`
+ *
+ * @publicDocs
  */
 export function usePickupLocationOptionTarget(): {
   pickupLocationOptionTarget: PickupLocationOption;

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/redeemable.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/redeemable.ts
@@ -9,6 +9,8 @@ import {useApi} from './api';
 
 /**
  * Returns a function to apply a change to add a redeemable.
+ *
+ * @publicDocs
  */
 export function useApplyRedeemableChange(): (
   change: RedeemableChange,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/session-token.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/session-token.ts
@@ -7,6 +7,8 @@ import {useApi} from './api';
 
 /**
  * Provides access to session tokens, which can be used to verify token claims on your app's server.
+ *
+ * @publicDocs
  */
 export function useSessionToken<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/settings.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/settings.ts
@@ -5,6 +5,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the setting values defined by the merchant for the extension.
+ *
+ * @publicDocs
  */
 export function useSettings<
   Settings extends ExtensionSettings,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/shipping-address.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/shipping-address.ts
@@ -12,6 +12,8 @@ import {useSubscription} from './subscription';
 
 /**
  * Returns the proposed `shippingAddress` applied to the checkout.
+ *
+ * @publicDocs
  */
 export function useShippingAddress<
   Target extends RenderExtensionTarget = RenderExtensionTarget,
@@ -29,6 +31,8 @@ export function useShippingAddress<
 
 /**
  * Returns a function to mutate the `shippingAddress` property of checkout.
+ *
+ * @publicDocs
  */
 export function useApplyShippingAddressChange<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/shipping-option-target.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/shipping-option-target.ts
@@ -14,6 +14,8 @@ import {useSubscription} from './subscription';
  * extension targets:
  * - `purchase.checkout.shipping-option-item.render-after`
  * - `purchase.checkout.shipping-option-item.details.render`
+ *
+ * @publicDocs
  */
 export function useShippingOptionTarget(): {
   shippingOptionTarget: ShippingOption;

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/shop.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/shop.ts
@@ -7,6 +7,8 @@ import {useApi} from './api';
 
 /**
  * Returns the `Shop` where the checkout is taking place.
+ *
+ * @publicDocs
  */
 export function useShop<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/storage.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/storage.ts
@@ -12,6 +12,8 @@ import {useApi} from './api';
  *
  * Data is shared across all activated extension targets of this extension. In versions `<=2023-07`,
  * each activated extension target had its own storage.
+ *
+ * @publicDocs
  */
 export function useStorage<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/subscription.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/subscription.ts
@@ -11,6 +11,8 @@ type Subscriber<T> = Parameters<StatefulRemoteSubscribable<T>['subscribe']>[0];
  * > Note:
  * > You generally shouldn’t need to use this directly, as there are dedicated hooks
  * > for accessing the current value of each individual resource in the checkout.
+ *
+ * @publicDocs
  */
 export function useSubscription<Value>(
   subscription: StatefulRemoteSubscribable<Value>,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/target.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/target.ts
@@ -22,6 +22,8 @@ class ExtensionHasNoTargetError extends Error {
  * > Caution: Deprecated as of version `2023-10`, use `useCartLineTarget()` instead.
  *
  * @deprecated Deprecated as of version `2023-10`, use `useCartLineTarget()` instead.
+ *
+ * @publicDocs
  */
 export function useTarget(): CartLine {
   const api = useApi<

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/timezone.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/timezone.ts
@@ -9,6 +9,8 @@ import {useSubscription} from './subscription';
 /**
  * Returns the time zone of the checkout, and automatically re-renders
  * your component if the time zone changes.
+ *
+ * @publicDocs
  */
 export function useTimezone<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions-react/src/surfaces/checkout/hooks/translate.ts
+++ b/packages/ui-extensions-react/src/surfaces/checkout/hooks/translate.ts
@@ -8,6 +8,8 @@ import {useApi} from './api';
 
 /**
  * Returns the `I18nTranslate` interface used to translate strings.
+ *
+ * @publicDocs
  */
 export function useTranslate<
   Target extends RenderExtensionTarget = RenderExtensionTarget,

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.sh
@@ -50,7 +50,7 @@ fi
 
 # Make sure https://shopify.dev URLs are relative so they work in Spin.
 # See https://github.com/Shopify/generate-docs/issues/181
-run_sed 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data.json
+run_sed 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data_v2.json
 sed_exit=$?
 if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
@@ -70,7 +70,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   # Replace 'unstable' with the exact API version in relative doc links
   run_sed \
     "s/\/docs\/api\/admin-extensions\/unstable/\/docs\/api\/admin-extensions\/$API_VERSION/gi" \
-    $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION/generated_docs_data.json
+    $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/admin_extensions/$API_VERSION/generated_docs_data_v2.json
   sed_exit=$?
   if [ $sed_exit -ne 0 ]; then
     fail_and_exit $sed_exit

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -66,7 +66,7 @@ fi
 
 # Make sure https://shopify.dev URLs are relative so they work in Spin.
 # See https://github.com/Shopify/generate-docs/issues/181
-run_sed 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data.json
+run_sed 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data_v2.json
 sed_exit=$?
 if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
@@ -87,7 +87,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   # Replace 'unstable' with the exact API version in relative doc links
   run_sed \
     "s/\/docs\/api\/checkout-ui-extensions\/unstable/\/docs\/api\/checkout-ui-extensions\/$API_VERSION/gi" \
-    $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/generated_docs_data.json
+    $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/generated_docs_data_v2.json
   sed_exit=$?
   if [ $sed_exit -ne 0 ]; then
     fail_and_exit $sed_exit

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs.sh
@@ -64,12 +64,20 @@ fi
 
 find ./ -name '*.doc*.js' -exec rm -r {} \;
 
+# @shopify/generate-docs v1.0.0 outputs generated_docs_data.json; downstream expects generated_docs_data_v2.json
+if [ -f "./$DOCS_PATH/generated/generated_docs_data.json" ]; then
+  cp "./$DOCS_PATH/generated/generated_docs_data.json" "./$DOCS_PATH/generated/generated_docs_data_v2.json"
+fi
+
 # Make sure https://shopify.dev URLs are relative so they work in Spin.
 # See https://github.com/Shopify/generate-docs/issues/181
-run_sed 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data.json
-sed_exit=$?
-if [ $sed_exit -ne 0 ]; then
-  fail_and_exit $sed_exit
+DOCS_JSON="./$DOCS_PATH/generated/generated_docs_data_v2.json"
+if [ -f "$DOCS_JSON" ]; then
+  run_sed 's/https:\/\/shopify.dev//gi' "$DOCS_JSON"
+  sed_exit=$?
+  if [ $sed_exit -ne 0 ]; then
+    fail_and_exit $sed_exit
+  fi
 fi
 
 # Generate targets.json
@@ -83,13 +91,16 @@ fi
 if [ -d $SHOPIFY_DEV_PATH ]; then
   mkdir -p $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/customer_account_ui_extensions/$API_VERSION
   cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/customer_account_ui_extensions/$API_VERSION
-  # Replace 'unstable' with the exact API version in relative doc links
-  run_sed \
-    "s/\/docs\/api\/customer-account-ui-extensions\/unstable/\/docs\/api\/customer-account-ui-extensions\/$API_VERSION/gi" \
-    $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/customer_account_ui_extensions/$API_VERSION/generated_docs_data.json
-  sed_exit=$?
-  if [ $sed_exit -ne 0 ]; then
-    fail_and_exit $sed_exit
+  # Replace 'unstable' with the exact API version in relative doc links (downstream expects generated_docs_data_v2.json)
+  DEST_DOCS_JSON="$SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/customer_account_ui_extensions/$API_VERSION/generated_docs_data_v2.json"
+  if [ -f "$DEST_DOCS_JSON" ]; then
+    run_sed \
+      "s/\/docs\/api\/customer-account-ui-extensions\/unstable/\/docs\/api\/customer-account-ui-extensions\/$API_VERSION/gi" \
+      "$DEST_DOCS_JSON"
+    sed_exit=$?
+    if [ $sed_exit -ne 0 ]; then
+      fail_and_exit $sed_exit
+    fi
   fi
   rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/content/assets/images/templated-apis-screenshots/customer-account-ui-extensions/$API_VERSION
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/authenticated-account.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/authenticated-account.doc.ts
@@ -13,19 +13,19 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.title,
       description: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.description,
-      type: 'Docs_Standard_AuthenticatedAccountApi',
+      type: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.type,
     },
     {
       title: 'useAuthenticatedAccountCustomer',
       description:
         "Returns the current authenticated `Customer`. The value is `undefined` if the customer isn't authenticated.",
-      type: 'UseAuthenticatedAccountCustomerGeneratedType',
+      type: 'UseCustomerGeneratedType',
     },
     {
       title: 'useAuthenticatedAccountPurchasingCompany',
       description:
         "Provides information about the company of the authenticated business customer. The value is `undefined` if a business customer isn't authenticated.",
-      type: 'UseAuthenticatedAccountPurchasingCompanyGeneratedType',
+      type: 'UsePurchasingCompanyGeneratedType',
     },
   ],
   related: [],

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/extension.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/extension.doc.ts
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.title,
       description: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.description,
-      type: 'Docs_Standard_ExtensionApi',
+      type: CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION.type,
     },
     {
       title: 'useExtension',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/localization.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/localization.doc.ts
@@ -30,7 +30,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'useI18n',
       description:
         'Returns utilities for translating content and formatting values according to the current localization of the user.',
-      type: 'UseI18nGeneratedType',
+      type: 'UseTranslateGeneratedType',
     },
     {
       title: 'useTranslate',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/navigation.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/navigation.doc.ts
@@ -31,7 +31,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'useNavigationCurrentEntry',
       description: 'Returns the live navigation current entry',
-      type: 'UseNavigationCurrentEntryGeneratedType',
+      type: 'UseApiGeneratedType',
     },
   ],
   defaultExample: {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/authentication-state.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/authentication-state.doc.ts
@@ -18,7 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'useAuthenticationState',
       description: 'Returns authentication state of Order status page.',
-      type: 'UseAuthenticationStateGeneratedType',
+      type: 'UseApiGeneratedType',
     },
   ],
   related: [],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.sh
@@ -47,10 +47,16 @@ fi
 
 # Make sure https://shopify.dev URLs are relative so they work in Spin.
 # See https://github.com/Shopify/generate-docs/issues/181
-run_sed 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data.json
-sed_exit=$?
-if [ $sed_exit -ne 0 ]; then
-  fail_and_exit $sed_exit
+DOCS_JSON="./$DOCS_PATH/generated/generated_docs_data_v2.json"
+if [ ! -f "$DOCS_JSON" ]; then
+  DOCS_JSON="./$DOCS_PATH/generated/generated_docs_data.json"
+fi
+if [ -f "$DOCS_JSON" ]; then
+  run_sed 's/https:\/\/shopify.dev//gi' "$DOCS_JSON"
+  sed_exit=$?
+  if [ $sed_exit -ne 0 ]; then
+    fail_and_exit $sed_exit
+  fi
 fi
 
 # Generate targets.json
@@ -65,12 +71,18 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   mkdir -p $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/pos_ui_extensions/$API_VERSION
   cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/pos_ui_extensions/$API_VERSION
   # Replace 'unstable' with the exact API version in relative doc links
-  run_sed \
-    "s/\/docs\/api\/pos-ui-extensions\/unstable/\/docs\/api\/pos-ui-extensions\/$API_VERSION/gi" \
-    $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/pos_ui_extensions/$API_VERSION/generated_docs_data.json
-  sed_exit=$?
-  if [ $sed_exit -ne 0 ]; then
-    fail_and_exit $sed_exit
+  DEST_DOCS_JSON="$SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/pos_ui_extensions/$API_VERSION/generated_docs_data_v2.json"
+  if [ ! -f "$DEST_DOCS_JSON" ]; then
+    DEST_DOCS_JSON="$SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/pos_ui_extensions/$API_VERSION/generated_docs_data.json"
+  fi
+  if [ -f "$DEST_DOCS_JSON" ]; then
+    run_sed \
+      "s/\/docs\/api\/pos-ui-extensions\/unstable/\/docs\/api\/pos-ui-extensions\/$API_VERSION/gi" \
+      "$DEST_DOCS_JSON"
+    sed_exit=$?
+    if [ $sed_exit -ne 0 ]; then
+      fail_and_exit $sed_exit
+    fi
   fi
   rsync -a --delete ./$DOCS_PATH/screenshots/ $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/content/assets/images/templated-apis-screenshots/pos-ui-extensions/$API_VERSION
 

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -67,7 +67,7 @@
     "@remote-ui/core": "^2.2.4"
   },
   "devDependencies": {
-    "@shopify/generate-docs": "0.16.4",
+    "@shopify/generate-docs": "1.0.0",
     "typescript": "^4.9.0"
   },
   "publishConfig": {

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/metafields.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/metafields.ts
@@ -104,7 +104,7 @@ type MetafieldChangeResult =
   | MetafieldChangeResultError;
 
 /**
- * A function that applies metafield changes to validation settings. Call this function with an update or removal operation, then await the Promise to receive a result indicating success or failure. Use the result to provide feedback or handle errors in your settings interface.
+ * Applies a [metafield](/docs/apps/build/metafields) change to the validation settings. Use this method to update or remove metafields that store validation function configuration data. The method accepts a change object specifying the operation type, metafield key, namespace, value, and [value type](/docs/apps/build/metafields/list-of-data-types). Returns a promise that resolves to indicate success or provides an error message if the operation fails.
  */
 export type ApplyMetafieldChange = (
   change: MetafieldChange,

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.ts
@@ -5,6 +5,8 @@ import type {RemoteFragment} from '@remote-ui/core';
  * Props for the AdminAction component, used by Admin Action extensions to
  * configure the title, primary and secondary action buttons, and loading
  * state of the action modal.
+ *
+ * @publicDocs
  */
 export interface AdminActionProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ts
@@ -4,6 +4,8 @@ import {createRemoteComponent} from '@remote-ui/core';
  * Props for the AdminBlock component, used by Admin Block extensions to
  * configure the title and collapsed summary of an app block rendered on
  * a resource page in the Shopify admin.
+ *
+ * @publicDocs
  */
 export interface AdminBlockProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.ts
@@ -3,6 +3,8 @@ import {createRemoteComponent} from '@remote-ui/core';
 /**
  * Props for the AdminPrintAction component, used by Admin Print Action
  * extensions to configure a source document to preview and print.
+ *
+ * @publicDocs
  */
 export interface AdminPrintActionProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.ts
@@ -76,6 +76,8 @@ interface BadgeNoIconProps {
  * Props for the Badge component. A badge can optionally include an icon
  * (`BadgeIconProps`) or omit one (`BadgeNoIconProps`). This union ensures
  * type safety so that `iconPosition` can only be set when `icon` is present.
+ *
+ * @publicDocs
  */
 export type BadgeProps = BadgeBaseProps & (BadgeIconProps | BadgeNoIconProps);
 

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.ts
@@ -5,6 +5,8 @@ import {GlobalProps, Tone} from '../shared';
  * Props for the Banner component, which displays a prominent message to
  * the merchant. Banners communicate important information, status updates,
  * warnings, or errors, with optional primary and secondary actions.
+ *
+ * @publicDocs
  */
 export interface BannerProps extends GlobalProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/BlockStack/BlockStack.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/BlockStack/BlockStack.ts
@@ -15,6 +15,8 @@ import {
  * Props for the BlockStack component, which arranges its children in a
  * vertical stack (block axis). Use BlockStack to lay out components
  * vertically with consistent spacing and alignment.
+ *
+ * @publicDocs
  */
 export interface BlockStackProps
   extends AccessibilityRoleProps,

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/Box.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/Box.ts
@@ -10,6 +10,8 @@ import {DisplayProps} from '../shared/display';
  * Props for the Box component, a generic layout container. Box doesn't
  * define any props of its own. It inherits accessibility, sizing, padding,
  * and display props from shared interfaces.
+ *
+ * @publicDocs
  */
 export interface BoxProps
   extends AccessibilityRoleProps,

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.ts
@@ -5,6 +5,8 @@ import type {AccessibilityRole, AnchorProps} from '../shared';
  * Props for the Button component. A button can either be a standard action
  * button (`ButtonBaseProps`) or an anchor-style button that navigates to a
  * URL (`ButtonAnchorProps`).
+ *
+ * @publicDocs
  */
 export type ButtonProps = ButtonBaseProps | ButtonAnchorProps;
 

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.ts
@@ -4,6 +4,8 @@ import {AccessibilityLabelProps} from '../shared';
 /**
  * Props for the Checkbox component, which renders a toggleable input
  * that lets the merchant choose between a checked and unchecked state.
+ *
+ * @publicDocs
  */
 export interface CheckboxProps extends AccessibilityLabelProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.ts
@@ -24,6 +24,8 @@ export interface ChoiceProps
  * Props for the ChoiceList component, which renders a group of selectable
  * choices as either radio buttons (single selection) or checkboxes
  * (multiple selection).
+ *
+ * @publicDocs
  */
 export interface ChoiceListProps
   extends Pick<

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.ts
@@ -4,6 +4,8 @@ import {createRemoteComponent} from '@remote-ui/core';
  * Props for the ColorPicker component, which provides a visual interface
  * for the merchant to select a color, with optional alpha (transparency)
  * support.
+ *
+ * @publicDocs
  */
 export interface ColorPickerProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/CustomerSegmentTemplate.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/CustomerSegmentTemplate/CustomerSegmentTemplate.ts
@@ -11,6 +11,8 @@ type CustomerStandardMetafieldDependency = 'facts.birth_date';
  * Props for the CustomerSegmentTemplate component, which defines a
  * reusable segment template that merchants can apply in the customer
  * segment editor.
+ *
+ * @publicDocs
  */
 export interface CustomerSegmentTemplateProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.ts
@@ -7,6 +7,8 @@ import type {TextFieldProps} from '../TextField/TextField';
  * picker for date selection. Text input props (like `label`, `value`, `onChange`,
  * and `error`) come from `TextFieldProps`, while calendar navigation props (like
  * `yearMonth`, `disabled`, and `onYearMonthChange`) come from `DatePickerProps`.
+ *
+ * @publicDocs
  */
 export interface DateFieldProps
   extends Pick<

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.ts
@@ -4,6 +4,8 @@ import {createRemoteComponent} from '@remote-ui/core';
  * Props for the DatePicker component, a calendar-based date selection control.
  * The generic parameter `T` determines the selection mode: pass a `DateString`
  * for single-date, a `DateString[]` for multi-date, or a `Range` for range selection.
+ *
+ * @publicDocs
  */
 export interface DatePickerProps<T extends Selected> {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider/Divider.ts
@@ -3,6 +3,8 @@ import {createRemoteComponent} from '@remote-ui/core';
 /**
  * Props for the Divider component, a visual separator used to distinguish
  * adjacent sections of content.
+ *
+ * @publicDocs
  */
 export interface DividerProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.ts
@@ -12,6 +12,8 @@ import {
  * addresses. It inherits common input props (like `label`, `value`,
  * `onChange`, and `error`) from `InputProps`, length validation from
  * `MinMaxLengthProps`, and browser autofill hints from `AutocompleteProps`.
+ *
+ * @publicDocs
  */
 export interface EmailFieldProps
   extends InputProps<string>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ts
@@ -4,6 +4,8 @@ import {createRemoteComponent} from '@remote-ui/core';
  * Props for the Form component, a container that groups related input
  * fields and manages submission and reset behavior through the
  * save bar.
+ *
+ * @publicDocs
  */
 export interface FormProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.ts
@@ -4,6 +4,8 @@ import {createRemoteComponent} from '@remote-ui/core';
  * Props for the FunctionSettings component, a form container designed
  * for Shopify Function configuration experiences. It provides hooks for
  * saving settings and handling server-side validation errors.
+ *
+ * @publicDocs
  */
 export interface FunctionSettingsProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.ts
@@ -12,6 +12,8 @@ type Level = 1 | 2 | 3 | 4 | 5 | 6;
  * determined automatically by the nesting depth of HeadingGroup or
  * Section ancestors; use the `size` prop to control its visual
  * appearance independently.
+ *
+ * @publicDocs
  */
 export interface HeadingProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/HeadingGroup/HeadingGroup.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/HeadingGroup/HeadingGroup.ts
@@ -6,6 +6,8 @@ import {createRemoteComponent} from '@remote-ui/core';
  * semantic heading level for any Heading components nested inside it.
  * Each level of HeadingGroup nesting increments the heading level by one
  * (for example, a Heading inside two HeadingGroup components renders as a level-3 heading).
+ *
+ * @publicDocs
  */
 export interface HeadingGroupProps {}
 

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.ts
@@ -5,6 +5,8 @@ import {AccessibilityLabelProps} from '../shared';
 /**
  * Props for the Icon component, which renders a Polaris icon by name.
  * Inherits accessibility label support from `AccessibilityLabelProps`.
+ *
+ * @publicDocs
  */
 export interface IconProps extends AccessibilityLabelProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/IconName.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/IconName.ts
@@ -3,6 +3,8 @@
  * the Polaris icon set. Names follow the pattern `{IconName}{Major|Minor}`,
  * where `Major` icons are intended for primary use and `Minor` icons are
  * smaller variants for inline or secondary use.
+ *
+ * @publicDocs
  */
 export type IconName =
   | 'AbandonedCartFilledMajor'

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/Image.ts
@@ -5,6 +5,8 @@ import type {AccessibilityRole} from '../shared';
  * Props for the Image component. Requires either `accessibilityLabel`
  * or `alt` for alternative text, and either `source` or `src` for the
  * image URL.
+ *
+ * @publicDocs
  */
 export type ImageProps = (ImageAccessibilityLabelProp | ImageAltProp) &
   (ImageSourceProp | ImageSrcProp) &

--- a/packages/ui-extensions/src/surfaces/admin/components/InlineStack/InlineStack.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/InlineStack/InlineStack.ts
@@ -15,6 +15,8 @@ import {
  * Props for the InlineStack component, a horizontal layout container that
  * arranges children in a row along the inline axis. Inherits accessibility,
  * sizing, padding, and gap props from shared utilities.
+ *
+ * @publicDocs
  */
 export interface InlineStackProps
   extends AccessibilityRoleProps,

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/Link.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/Link.ts
@@ -5,6 +5,8 @@ import {AccessibilityLabelProps} from '../shared';
  * Props for the Link component, an interactive text element that navigates
  * to a URL or triggers an action when pressed. Inherits accessibility
  * label support from `AccessibilityLabelProps`.
+ *
+ * @publicDocs
  */
 export interface LinkProps extends AccessibilityLabelProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.ts
@@ -11,6 +11,8 @@ import type {
  * Props for the MoneyField component, a specialized input for entering
  * monetary values. It extends standard input props with number constraints
  * and autocomplete support for transaction amounts.
+ *
+ * @publicDocs
  */
 export interface MoneyFieldProps
   extends InputProps<number | Money>,

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.ts
@@ -13,6 +13,8 @@ import {
  * Props for the NumberField component, a text input for numeric values.
  * Inherits standard input props, number constraints (min, max, step),
  * autocomplete support, and field decoration props.
+ *
+ * @publicDocs
  */
 export interface NumberFieldProps
   extends InputProps<number>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.ts
@@ -5,6 +5,8 @@ import type {BaseTypographyProps, GlobalProps} from '../shared';
  * Props for the Paragraph component, which renders a block of text
  * as a distinct paragraph. Use Paragraph to structure your content
  * into readable sections with appropriate spacing.
+ *
+ * @publicDocs
  */
 export interface ParagraphProps extends BaseTypographyProps, GlobalProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.ts
@@ -11,6 +11,8 @@ import {
  * content for secure entry of sensitive values like passwords or PINs.
  * It extends standard input props with min/max length constraints and
  * autocomplete support for password managers.
+ *
+ * @publicDocs
  */
 export interface PasswordFieldProps
   extends InputProps<string>,

--- a/packages/ui-extensions/src/surfaces/admin/components/Pressable/Pressable.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Pressable/Pressable.ts
@@ -7,6 +7,8 @@ import type {BoxProps} from '../Box/Box';
  * of Box with the interactive behavior of Link. Use Pressable when you
  * need a custom interactive area that can navigate to a URL or respond to
  * press events while supporting flexible layout and styling options.
+ *
+ * @publicDocs
  */
 export interface PressableProps extends BoxProps, LinkProps {}
 

--- a/packages/ui-extensions/src/surfaces/admin/components/ProgressIndicator/ProgressIndicator.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ProgressIndicator/ProgressIndicator.ts
@@ -6,6 +6,8 @@ import {GlobalProps, SizeScale, AccessibilityLabelProps} from '../shared';
  * (such as a spinner) to communicate that a process is underway. Use this
  * component to reassure users that content is loading or an action is being
  * processed.
+ *
+ * @publicDocs
  */
 export interface ProgressIndicatorProps
   extends GlobalProps,

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/Section.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/Section.ts
@@ -5,6 +5,8 @@ import {createRemoteComponent} from '@remote-ui/core';
  * optional heading. Sections provide both visual and semantic structure,
  * making it easier for users (and assistive technologies) to navigate
  * through distinct areas of an extension.
+ *
+ * @publicDocs
  */
 export interface SectionProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.ts
@@ -3,6 +3,8 @@ import {createRemoteComponent} from '@remote-ui/core';
 /**
  * Props for the Select component, a form control that lets the user choose
  * one value from a predefined list of options presented in a dropdown menu.
+ *
+ * @publicDocs
  */
 export interface SelectProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/Text.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/Text.ts
@@ -11,6 +11,8 @@ import type {
  * Props for the Text component, an inline element for rendering and styling
  * a run of text. Use Text to apply typographic treatments such as font
  * weight, style, variant, and overflow behavior to a portion of content.
+ *
+ * @publicDocs
  */
 export interface TextProps {
   /**

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.ts
@@ -11,6 +11,8 @@ import {
  * Props for the TextArea component, a multi-line text input for entering
  * longer-form content such as descriptions, comments, or notes. It extends
  * standard input props with min/max length constraints and autocomplete support.
+ *
+ * @publicDocs
  */
 export interface TextAreaProps
   extends InputProps<string>,

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.ts
@@ -12,6 +12,8 @@ import {
  * short-form content such as names, emails, or search queries. It extends
  * standard input props with min/max length constraints, autocomplete support,
  * and a field decoration option (suffix).
+ *
+ * @publicDocs
  */
 export interface TextFieldProps
   extends InputProps<string>,

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.ts
@@ -12,6 +12,8 @@ import {
  * Props for the URLField component, a text input optimized for entering
  * URLs. It extends standard input props with min/max length constraints
  * and autocomplete support for URL-related fields.
+ *
+ * @publicDocs
  */
 export interface URLFieldProps
   extends InputProps<string>,

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts
@@ -3,6 +3,7 @@ import type {
   AutocompleteAddress,
 } from './shared';
 
+/** @publicDocs */
 export interface AddressAutocompleteFormatSuggestionApi {
   /**
    * The autocomplete suggestion that the buyer selected during checkout.

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
@@ -24,6 +24,7 @@ import type {
   Timezone,
 } from '../../../../shared';
 
+/** @publicDocs */
 export interface AddressAutocompleteStandardApi<
   Target extends
     | 'purchase.address-autocomplete.suggest'

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
@@ -2,6 +2,7 @@ import type {CountryCode} from '../../../checkout';
 
 import type {AddressAutocompleteSuggestion} from './shared';
 
+/** @publicDocs */
 export interface AddressAutocompleteSuggestApi {
   /**
    * The signal that the extension should listen to for cancellation requests.

--- a/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
@@ -2,6 +2,7 @@ import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 import type {CartLine} from '../standard/standard';
 
+/** @publicDocs */
 export interface CartLineItemApi {
   /**
    * The cart line the extension is attached to. Until version `2023-04`, this property was a `StatefulRemoteSubscribable<PresentmentCartLine>`.

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -511,6 +511,7 @@ export type ShippingAddressChangeResult =
   | ShippingAddressChangeResultSuccess
   | ShippingAddressChangeResultError;
 
+/** @publicDocs */
 export interface CheckoutApi {
   /**
    * Performs an update on an attribute attached to the cart and checkout. If

--- a/packages/ui-extensions/src/surfaces/checkout/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/docs.ts
@@ -10,96 +10,130 @@ import type {OrderStatusApi} from './order-status/order-status';
  * Note: These are not exported as part of the package, they are only used for documentation purposes.
  */
 
+/** @publicDocs */
 export interface Docs_Standard_AddressApi
   extends Pick<StandardApi, 'shippingAddress' | 'billingAddress'> {}
+/** @publicDocs */
 export interface Docs_Checkout_AddressApi
   extends Pick<CheckoutApi, 'applyShippingAddressChange'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_AttributesApi
   extends Pick<StandardApi, 'attributes'> {}
+/** @publicDocs */
 export interface Docs_Checkout_AttributesApi
   extends Pick<CheckoutApi, 'applyAttributeChange'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_BuyerIdentityApi
   extends Pick<StandardApi, 'buyerIdentity'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_BuyerJourneyApi
   extends Pick<StandardApi, 'buyerJourney'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_CartInstructionsApi
   extends Pick<StandardApi, 'instructions'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_CartLinesApi
   extends Pick<StandardApi, 'lines'> {}
+/** @publicDocs */
 export interface Docs_Checkout_CartLinesApi
   extends Pick<CheckoutApi, 'applyCartLinesChange'> {}
+/** @publicDocs */
 export interface Docs_CartLineItem_CartLinesApi
   extends Pick<CartLineItemApi, 'target'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_CostApi extends Pick<StandardApi, 'cost'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_LocalizationApi
   extends Pick<StandardApi, 'i18n' | 'localization'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_MetafieldsApi
   extends Pick<StandardApi, 'appMetafields' | 'metafields'> {}
+/** @publicDocs */
 export interface Docs_Checkout_MetafieldsApi
   extends Pick<CheckoutApi, 'applyMetafieldChange'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_DeliveryApi
   extends Pick<StandardApi, 'deliveryGroups'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_CheckoutTokenApi
   extends Pick<StandardApi, 'checkoutToken'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_ExtensionMetaApi
   extends Pick<StandardApi, 'extension'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_CheckoutSettingsApi
   extends Pick<StandardApi, 'checkoutSettings'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_ShopApi extends Pick<StandardApi, 'shop'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_NoteApi extends Pick<StandardApi, 'note'> {}
+/** @publicDocs */
 export interface Docs_Checkout_NoteApi
   extends Pick<CheckoutApi, 'applyNoteChange'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_OrderApi
   extends Pick<OrderStatusApi, 'order'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_PaymentOptionsApi
   extends Pick<
     StandardApi,
     'availablePaymentOptions' | 'selectedPaymentOptions'
   > {}
 
+/** @publicDocs */
 export interface Docs_Standard_GiftCardsApi
   extends Pick<StandardApi, 'appliedGiftCards'> {}
 
+/** @publicDocs */
 export interface Docs_Checkout_GiftCardsApi
   extends Pick<CheckoutApi, 'applyGiftCardChange'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_DiscountsApi
   extends Pick<StandardApi, 'discountAllocations' | 'discountCodes'> {}
 
+/** @publicDocs */
 export interface Docs_Checkout_DiscountsApi
   extends Pick<CheckoutApi, 'applyDiscountCodeChange'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_SessionTokenApi
   extends Pick<StandardApi, 'sessionToken'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_SettingsApi
   extends Pick<StandardApi, 'settings'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_StorageApi
   extends Pick<StandardApi, 'storage'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_QueryApi extends Pick<StandardApi, 'query'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_AnalyticsApi
   extends Pick<StandardApi, 'analytics'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_CustomerPrivacyApi
   extends Pick<StandardApi, 'customerPrivacy' | 'applyTrackingConsentChange'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_Ui extends Pick<StandardApi, 'ui'> {}

--- a/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
@@ -14,6 +14,7 @@ export interface OrderConfirmation {
   number?: string;
 }
 
+/** @publicDocs */
 export interface OrderConfirmationApi {
   /**
    * Order information that's available post-checkout.

--- a/packages/ui-extensions/src/surfaces/checkout/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/order-status/order-status.ts
@@ -30,6 +30,7 @@ export interface Order {
   confirmationNumber?: string;
 }
 
+/** @publicDocs */
 export interface OrderStatusApi {
   /**
    * Order information that's available post-checkout.

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
@@ -2,6 +2,7 @@ import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 import type {PickupLocationOption} from '../standard/standard';
 
+/** @publicDocs */
 export interface PickupLocationItemApi {
   /**
    * The pickup location the extension is attached to.

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-list.ts
@@ -1,5 +1,6 @@
 import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
+/** @publicDocs */
 export interface PickupLocationListApi {
   /**
    * Whether the customer location input form is shown to the buyer.

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
@@ -1,5 +1,6 @@
 import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
+/** @publicDocs */
 export interface PickupPointListApi {
   /**
    * Whether the customer location input form is shown to the buyer.

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
@@ -2,6 +2,7 @@ import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 import type {ShippingOption} from '../standard/standard';
 
+/** @publicDocs */
 export interface ShippingOptionItemApi {
   /**
    * The shipping option the extension is attached to.

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
@@ -7,6 +7,7 @@ import type {
   Money,
 } from '../standard/standard';
 
+/** @publicDocs */
 export interface ShippingOptionListApi {
   /**
    * The delivery group list the extension is attached to. The target will be undefined when there are no groups for a given type.

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -481,6 +481,7 @@ export interface BuyerJourneyStep {
   disabled: boolean;
 }
 
+/** @publicDocs */
 export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Badge/Badge.ts
@@ -5,6 +5,7 @@ import type {IconSource} from '../Icon/Icon';
 
 type Tone = 'default' | 'critical' | 'subdued';
 
+/** @publicDocs */
 export interface BadgeProps extends VisibilityProps {
   /**
    * The tone of the badge being rendered. Indicates its level of importance,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, Status} from '../shared';
 
+/** @publicDocs */
 export interface BannerProps extends IdProps {
   /**
    * Banners have an optional title. Use a title to grab the buyer’s attention

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.ts
@@ -4,6 +4,7 @@ import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {Rows} from '../shared';
 import type {GridProps} from '../Grid/Grid';
 
+/** @publicDocs */
 export interface BlockLayoutProps extends Omit<GridProps, 'columns' | 'rows'> {
   /**
    * Sizes for each row of the layout.

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockSpacer/BlockSpacer.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockSpacer/BlockSpacer.ts
@@ -3,6 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {IdProps, Spacing} from '../shared';
 
+/** @publicDocs */
 export interface BlockSpacerProps extends IdProps {
   /**
    * Adjust size of the spacer

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.ts
@@ -13,6 +13,7 @@ import type {
 } from '../shared';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 
+/** @publicDocs */
 export interface BlockStackProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Button/Button.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Button/Button.ts
@@ -9,6 +9,7 @@ import type {
   DisclosureActivatorProps,
 } from '../shared';
 
+/** @publicDocs */
 export interface ButtonProps
   extends OverlayActivatorProps,
     DisclosureActivatorProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Chat/Chat.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Chat/Chat.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface ChatProps extends IdProps {
   /**
    * Adjust the inline size.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/Checkbox.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/Checkbox.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {DisclosureActivatorProps} from '../shared';
 
+/** @publicDocs */
 export interface CheckboxProps extends DisclosureActivatorProps {
   /**
    * A unique identifier for the field. When no `id` is set,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Choice/Choice.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Choice/Choice.ts
@@ -1,6 +1,7 @@
 import type {RemoteFragment} from '@remote-ui/core';
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface ChoiceProps {
   /**
    * A unique identifier for the choice.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ChoiceList/ChoiceList.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ChoiceList/ChoiceList.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface ChoiceListProps<T extends string | string[]> {
   /**
    * A unique identifier for the field in the closest `Form` component.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/ConsentCheckbox.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/ConsentCheckbox.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {CheckboxProps} from '../Checkbox/Checkbox';
 
+/** @publicDocs */
 export interface ConsentCheckboxProps extends Omit<CheckboxProps, 'value'> {
   /**
    * The policy for which buyer consent is being collected for.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/ConsentPhoneField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/ConsentPhoneField.ts
@@ -4,6 +4,7 @@ import type {PhoneFieldProps} from '../PhoneField/PhoneField';
 
 export type ConsentPolicy = 'sms-marketing';
 
+/** @publicDocs */
 export interface ConsentPhoneFieldProps extends Omit<PhoneFieldProps, 'value'> {
   /**
    * The policy for which buyer consent is being collected for.

--- a/packages/ui-extensions/src/surfaces/checkout/components/DateField/DateField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DateField/DateField.ts
@@ -3,6 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {DatePickerProps, SelectedDate} from '../DatePicker/DatePicker';
 import type {TextFieldProps} from '../TextField/TextField';
 
+/** @publicDocs */
 export interface DateFieldProps
   extends Pick<
       TextFieldProps<string>,

--- a/packages/ui-extensions/src/surfaces/checkout/components/DatePicker/DatePicker.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DatePicker/DatePicker.ts
@@ -28,6 +28,7 @@ export type YearMonth = {year: number; month: number} | YearMonthString;
 export type SelectedDate = DateString | DateString[] | DateRange;
 export type DisabledDate = DateString | DateRange | DayString;
 
+/** @publicDocs */
 export interface DatePickerProps<T extends SelectedDate> {
   /**
    * [Controlled](https://reactjs.org/docs/forms.html#controlled-components) year and month to display.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Disclosure/Disclosure.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Disclosure/Disclosure.ts
@@ -3,6 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {DisclosureOpen} from '../shared';
 
+/** @publicDocs */
 export interface DisclosureProps {
   /**
    * For uncontrolled disclosure components, the default `open` state on the initial render.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Divider/Divider.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Divider/Divider.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {Alignment, Direction, IdProps, Size} from '../shared';
 
+/** @publicDocs */
 export interface DividerProps extends IdProps {
   /**
    * Use to create dividers with varying widths.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface FormProps {
   /**
    * Whether the form is able to be submitted. When set to `true`, this will

--- a/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.ts
@@ -16,6 +16,7 @@ import type {
   ViewLikeAccessibilityRole,
 } from '../shared';
 
+/** @publicDocs */
 export interface GridProps
   extends Pick<BackgroundProps, 'background'>,
     IdProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.ts
@@ -11,6 +11,7 @@ import type {
   ViewLikeAccessibilityRole,
 } from '../shared';
 
+/** @publicDocs */
 export interface GridItemProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.ts
@@ -4,6 +4,7 @@ import type {InlineAlignment, AccessibilityRole} from '../shared';
 
 type Level = 1 | 2 | 3 | 4;
 
+/** @publicDocs */
 export interface HeadingProps {
   /**
    * Unique identifier.

--- a/packages/ui-extensions/src/surfaces/checkout/components/HeadingGroup/HeadingGroup.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/HeadingGroup/HeadingGroup.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface HeadingGroupProps {}
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.ts
@@ -75,6 +75,7 @@ export type IconSource =
   | 'warning'
   | 'warningFill';
 
+/** @publicDocs */
 export interface IconProps extends IdProps {
   /**
    * A label that describes the purpose or contents of the icon. When set,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.ts
@@ -15,6 +15,7 @@ import type {
   IdProps,
 } from '../shared';
 
+/** @publicDocs */
 export interface ImageProps extends BorderProps, CornerProps, IdProps {
   /**
    * The URL of the image. Supports the `resolution` and `viewportInlineSize` conditional styles only.

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineLayout/InlineLayout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineLayout/InlineLayout.ts
@@ -10,6 +10,7 @@ import type {
 } from '../shared';
 import type {GridProps} from '../Grid/Grid';
 
+/** @publicDocs */
 export interface InlineLayoutProps
   extends Omit<GridProps, 'columns' | 'rows'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineSpacer/InlineSpacer.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineSpacer/InlineSpacer.ts
@@ -3,6 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {IdProps, Spacing} from '../shared';
 
+/** @publicDocs */
 export interface InlineSpacerProps extends IdProps {
   /**
    * Adjust size of the spacer

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.ts
@@ -14,6 +14,7 @@ import type {
   ViewLikeAccessibilityRole,
 } from '../shared';
 
+/** @publicDocs */
 export interface InlineStackProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.ts
@@ -6,6 +6,7 @@ import type {
   DisclosureActivatorProps,
 } from '../shared';
 
+/** @publicDocs */
 export interface LinkProps
   extends OverlayActivatorProps,
     DisclosureActivatorProps {

--- a/packages/ui-extensions/src/surfaces/checkout/components/List/List.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/List/List.ts
@@ -5,6 +5,7 @@ import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 
 export type Marker = 'none' | 'bullet' | 'number';
 
+/** @publicDocs */
 export interface ListProps extends IdProps {
   /**
    * Adjust spacing between list items

--- a/packages/ui-extensions/src/surfaces/checkout/components/ListItem/ListItem.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ListItem/ListItem.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface ListItemProps extends IdProps {}
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/LoginWithShop/LoginWithShop.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/LoginWithShop/LoginWithShop.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface LoginWithShopProps {
   open: boolean;
   openLogin?: boolean;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Map/Map.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Map/Map.ts
@@ -31,6 +31,7 @@ export interface MapBounds {
   northEast: MapLocation;
   southWest: MapLocation;
 }
+/** @publicDocs */
 export interface MapProps
   extends Pick<
     SizingProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapMarker/MapMarker.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapMarker/MapMarker.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {OverlayActivatorProps} from '../shared';
 
+/** @publicDocs */
 export interface MapMarkerProps extends OverlayActivatorProps {
   /**
    * The latitude of the marker.

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapPopover/MapPopover.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapPopover/MapPopover.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface MapPopoverProps extends IdProps {
   /**
    * Callback to run when the Popover is closed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.ts
@@ -1,6 +1,7 @@
 import type {RemoteFragment} from '@remote-ui/core';
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface ModalProps {
   /**
    * A unique identifier for the Modal. When no `id` is set,

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 // Copied from https://github.com/Shopify/ui-api-design/blob/main/components/PaymentIcon/PaymentIcon.ts
 // NOTE: Add new entries to the PaymentMethod type in alphabetical order
+/** @publicDocs */
 export type PaymentMethod =
   | '7-eleven'
   | 'acima-leasing'
@@ -448,6 +449,7 @@ export type PaymentMethod =
   | 'zip'
   | 'zoodpay';
 
+/** @publicDocs */
 export interface PaymentIconProps {
   /**
    * The name of the payment method.

--- a/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/PhoneField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/PhoneField.ts
@@ -4,6 +4,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {Autocomplete} from '../shared';
 import type {IconSource} from '../Icon/Icon';
 
+/** @publicDocs */
 export interface PhoneFieldProps {
   /**
    * Any content to render at the end of the text field. Commonly used

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover/Popover.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover/Popover.ts
@@ -8,6 +8,7 @@ export type PopoverPosition =
   | 'blockStart'
   | 'blockEnd';
 
+/** @publicDocs */
 export interface PopoverProps
   extends IdProps,
     Pick<SizingProps, 'maxInlineSize' | 'minInlineSize'>,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.ts
@@ -17,6 +17,7 @@ import type {
   IdProps,
 } from '../shared';
 
+/** @publicDocs */
 export interface PressableProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../style/types';
 import type {Size} from '../shared';
 
+/** @publicDocs */
 export interface ProductThumbnailProps {
   /**
    * An alternative text description that describe the image for the reader to

--- a/packages/ui-extensions/src/surfaces/checkout/components/Progress/Progress.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Progress/Progress.ts
@@ -4,6 +4,7 @@ import type {IdProps} from '../shared';
 
 type Tone = 'auto' | 'critical';
 
+/** @publicDocs */
 export interface ProgressProps extends IdProps {
   /**
    * Specify how much of the task that has been completed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, BorderStyle} from '../shared';
 
+/** @publicDocs */
 export interface QRCodeProps extends IdProps {
   /**
    * The content to be encoded in the QR code, which can be any string such as a URL, email address, plain text, etc.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.ts
@@ -31,6 +31,7 @@ export interface ScrollViewEvent {
   };
 }
 
+/** @publicDocs */
 export interface ScrollViewProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Select/Select.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Select/Select.ts
@@ -18,6 +18,7 @@ export interface SelectOptionProps {
   disabled?: boolean;
 }
 
+/** @publicDocs */
 export interface SelectProps {
   /**
    * A unique identifier for the field. When no `id` is set,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.ts
@@ -3,6 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface SheetProps extends IdProps {
   /**
    * A label to describe the purpose of the sheet that is announced by screen readers.

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonImage/SkeletonImage.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonImage/SkeletonImage.ts
@@ -3,6 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface SkeletonImageProps extends IdProps {
   /**
    * Adjust the block size of the skeleton.

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonText/SkeletonText.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonText/SkeletonText.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, TextSize, Size} from '../shared';
 
+/** @publicDocs */
 export interface SkeletonTextProps extends IdProps {
   /**
    * @private

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonTextBlock/SkeletonTextBlock.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonTextBlock/SkeletonTextBlock.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, TextSize} from '../shared';
 
+/** @publicDocs */
 export interface SkeletonTextBlockProps extends IdProps {
   /**
    * @private

--- a/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {Appearance, IdProps, Size} from '../shared';
 
+/** @publicDocs */
 export interface SpinnerProps extends IdProps {
   /**
    * Adjusts the size of the icon.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Stepper/Stepper.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Stepper/Stepper.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IconSource} from '../Icon/Icon';
 
+/** @publicDocs */
 export interface StepperProps {
   /**
    * A detailed description for screen readers.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Switch/Switch.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Switch/Switch.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, DisclosureActivatorProps} from '../shared';
 
+/** @publicDocs */
 export interface SwitchProps extends IdProps, DisclosureActivatorProps {
   /**
    * An identifier for the field that is unique within the nearest

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tag/Tag.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tag/Tag.ts
@@ -3,6 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {IconSource} from '../Icon/Icon';
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface TagProps extends IdProps {
   children?: string;
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Text/Text.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Text/Text.ts
@@ -8,6 +8,7 @@ import type {
   VisibilityProps,
 } from '../shared';
 
+/** @publicDocs */
 export interface TextProps extends VisibilityProps {
   /**
    * Size of the text

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextBlock/TextBlock.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextBlock/TextBlock.ts
@@ -8,6 +8,7 @@ import type {
   TextSize,
 } from '../shared';
 
+/** @publicDocs */
 export interface TextBlockProps extends IdProps {
   /**
    * Size of the text

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.ts
@@ -6,6 +6,7 @@ import type {IconSource} from '../Icon/Icon';
 
 type Type = 'text' | 'email' | 'number' | 'telephone';
 
+/** @publicDocs */
 export interface TextFieldProps<T extends string | number | undefined> {
   /**
    * A unique identifier for the field. When no `id` is set,

--- a/packages/ui-extensions/src/surfaces/checkout/components/ToggleButton/ToggleButton.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ToggleButton/ToggleButton.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface ToggleButtonProps {
   /**
    * A unique identifier for the toggle button.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ToggleButtonGroup/ToggleButtonGroup.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ToggleButtonGroup/ToggleButtonGroup.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface ToggleButtonGroupProps<T extends string> {
   /**
    * An id of the selected button.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/Tooltip.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/Tooltip.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface TooltipProps extends IdProps {}
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/View/View.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/View/View.ts
@@ -125,6 +125,7 @@ export interface Translate {
   inline?: number | `${number}%`;
 }
 
+/** @publicDocs */
 export interface ViewProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/globals.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/globals.ts
@@ -1,5 +1,8 @@
 import type {ExtensionTargets} from './targets';
 
+/**
+ * @publicDocs
+ */
 export interface ShopifyGlobal {
   extend<ExtensionTarget extends keyof ExtensionTargets>(
     target: ExtensionTarget,

--- a/packages/ui-extensions/src/surfaces/checkout/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/shared.ts
@@ -2,7 +2,9 @@ import type {ComponentsBuilder, AnyComponentBuilder} from '../../shared';
 
 import type * as ComponentsModule from './components';
 
+/** @publicDocs */
 export type Components = ComponentsBuilder<typeof ComponentsModule>;
+/** @publicDocs */
 export type AnyComponent = AnyComponentBuilder<typeof ComponentsModule>;
 
 export type AllowedComponents<Allowed extends keyof typeof ComponentsModule> =

--- a/packages/ui-extensions/src/surfaces/checkout/style/style.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/style/style.ts
@@ -88,6 +88,7 @@ const when: WhenFunction = function when<
 
 // This interface is only used to provide documentation for the Style helper.
 // It is not used in the implementation.
+/** @publicDocs */
 export interface DocsStyle {
   /**
    * Sets an optional default value to use when no other condition is met.

--- a/packages/ui-extensions/src/surfaces/checkout/targets.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/targets.ts
@@ -32,6 +32,8 @@ import type {
  * and is expected to return a value in a specific shape.
  * The input arguments and the output type are different
  * for each extension target.
+ *
+ * @publicDocs
  */
 export interface RenderExtensionTargets {
   /**
@@ -743,6 +745,7 @@ export interface RenderExtensionTargets {
   >;
 }
 
+/** @publicDocs */
 export interface RunnableExtensionTargets {
   /**
    * An extension target that provides address autocomplete suggestions. These suggestions are shown to buyers as they
@@ -774,9 +777,11 @@ export interface RunnableExtensionTargets {
   >;
 }
 
+/** @publicDocs */
 export type ExtensionTargets = RenderExtensionTargets &
   RunnableExtensionTargets;
 
+/** @publicDocs */
 export type ExtensionTarget = keyof ExtensionTargets;
 
 export type AvailableExtensionDefinitions<Api> =
@@ -786,6 +791,8 @@ export type AvailableExtensionDefinitions<Api> =
 /**
  * For a given extension target, returns the value that is expected to be
  * returned by that extension target’s callback type.
+ *
+ * @publicDocs
  */
 export type ReturnTypeForExtension<Target extends keyof ExtensionTargets> =
   ReturnType<ExtensionTargets[Target]>;
@@ -793,6 +800,8 @@ export type ReturnTypeForExtension<Target extends keyof ExtensionTargets> =
 /**
  * For a given extension target, returns the tuple of arguments that would
  * be provided to that extension target’s callback type.
+ *
+ * @publicDocs
  */
 export type ArgumentsForExtension<Target extends keyof ExtensionTargets> =
   Parameters<ExtensionTargets[Target]>;
@@ -800,6 +809,8 @@ export type ArgumentsForExtension<Target extends keyof ExtensionTargets> =
 /**
  * For a given extension target, returns the type of the API that the
  * extension will receive at runtime.
+ *
+ * @publicDocs
  */
 export type ApiForExtension<Target extends ExtensionTarget> =
   ExtractedApiFromExtensionDefinition<ExtensionTargets[Target]>;
@@ -812,11 +823,15 @@ type ExtractedApiFromExtensionDefinition<T> =
  * accepting a [`@remote-ui/core` `RemoteRoot`](https://github.com/Shopify/remote-dom/tree/remote-ui/packages/core)
  * and an additional `api` argument, and using those arguments to render
  * UI.
+ *
+ * @publicDocs
  */
 export type RenderExtensionTarget = keyof RenderExtensionTargets;
 
 /**
  * A mapping of each “render extension” name to its callback type.
+ *
+ * @publicDocs
  */
 export type RenderExtensions = {
   [Target in RenderExtensionTarget]: RenderExtensionTargets[Target];
@@ -827,6 +842,8 @@ type ExtractedAllowedComponentsFromRenderExtension<T> =
 
 /**
  * @deprecated Use `ExtractedApiFromExtensionDefinition` instead.
+ *
+ * @publicDocs
  */
 type ExtractedApiFromRenderExtension<T> = T extends RenderExtension<
   infer Api,
@@ -844,6 +861,8 @@ type ExtractedApiFromRenderExtension<T> = T extends RenderExtension<
  * extension targets each receive a `RemoteRoot` object.
  *
  * @deprecated  Use `ApiForExtension` instead.
+ *
+ * @publicDocs
  */
 export type ApiForRenderExtension<Target extends keyof RenderExtensions> =
   ExtractedApiFromRenderExtension<RenderExtensions[Target]>;
@@ -851,13 +870,17 @@ export type ApiForRenderExtension<Target extends keyof RenderExtensions> =
 /**
  * For a given rendering extension target, returns the UI components that the
  * extension target supports.
+ *
+ * @publicDocs
  */
 export type AllowedComponentsForRenderExtension<
   Target extends keyof RenderExtensions,
 > = ExtractedAllowedComponentsFromRenderExtension<RenderExtensions[Target]>;
 
+/** @publicDocs */
 export type RunnableExtensionTarget = keyof RunnableExtensionTargets;
 
+/** @publicDocs */
 export type RunnableExtensions = {
   [Target in RunnableExtensionTarget]: RunnableExtensionTargets[Target];
 };
@@ -865,6 +888,8 @@ export type RunnableExtensions = {
 /**
  * The part of the standard API implemented for customer-account targets. Must
  * match the types defined in the `surfaces/customer-account` section of this package.
+ *
+ * @publicDocs
  */
 export interface CustomerAccountStandardApi<
   Target extends keyof ExtensionTargets,

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -3,85 +3,129 @@ import {StandardApi} from './standard-api/standard-api';
 import {CartLineItemApi} from './cart-line/cart-line-item';
 import {FullPageApi} from '../targets';
 import {ButtonProps} from '../components';
+import type {AuthenticatedAccount} from './shared';
+import type {I18n} from './shared';
+import type {NavigationHistoryEntry} from './standard-api/standard-api';
 
+/** @publicDocs */
+export type UseCustomerGeneratedType = AuthenticatedAccount['customer'];
+
+/** @publicDocs */
+export type UsePurchasingCompanyGeneratedType =
+  AuthenticatedAccount['purchasingCompany'];
+
+/** @publicDocs */
+export type UseTranslateGeneratedType = I18n;
+
+/** @publicDocs */
+export type UseApiGeneratedType = NavigationHistoryEntry;
+
+/** @publicDocs */
 export interface Docs_OrderStatus_MetafieldsApi
   extends Pick<OrderStatusApi<any>, 'appMetafields' | 'metafields'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_AttributesApi
   extends Pick<OrderStatusApi<any>, 'attributes'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_BuyerIdentityApi
   extends Pick<OrderStatusApi<any>, 'buyerIdentity'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_CheckoutSettingsApi
   extends Pick<OrderStatusApi<any>, 'checkoutSettings'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_CostApi
   extends Pick<OrderStatusApi<any>, 'cost'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_LocalizationApi
   extends Pick<OrderStatusApi<any>, 'localization'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_DiscountsApi
   extends Pick<OrderStatusApi<any>, 'discountAllocations' | 'discountCodes'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_GiftCardsApi
   extends Pick<OrderStatusApi<any>, 'appliedGiftCards'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_NoteApi
   extends Pick<OrderStatusApi<any>, 'note'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_AddressApi
   extends Pick<OrderStatusApi<any>, 'shippingAddress' | 'billingAddress'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_ShopApi
   extends Pick<OrderStatusApi<any>, 'shop'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_RequireLoginApi
   extends Pick<OrderStatusApi<any>, 'requireLogin'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_AuthenticationStateApi
   extends Pick<OrderStatusApi<any>, 'authenticationState'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_CartLinesApi
   extends Pick<OrderStatusApi<any>, 'lines'> {}
 
+/** @publicDocs */
 export interface Docs_CartLineItem_CartLinesApi
   extends Pick<CartLineItemApi, 'target'> {}
 
+/** @publicDocs */
 export interface Docs_OrderStatus_OrderApi
   extends Pick<OrderStatusApi<any>, 'order'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_ExtensionApi
   extends Pick<StandardApi<any>, 'extension'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_AuthenticatedAccountApi
   extends Pick<StandardApi<any>, 'authenticatedAccount'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_VersionApi
   extends Pick<StandardApi<any>, 'version'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_LocalizationApi
   extends Pick<StandardApi<any>, 'localization' | 'i18n'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_SessionTokenApi
   extends Pick<StandardApi<any>, 'sessionToken'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_SettingsApi
   extends Pick<StandardApi, 'settings'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_StorageApi
   extends Pick<StandardApi<any>, 'storage'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_UIApi extends Pick<StandardApi<any>, 'ui'> {}
 
+/** @publicDocs */
 export interface Docs_Standard_QueryApi
   extends Pick<StandardApi<any>, 'query'> {}
 
+/** @publicDocs */
 export interface Docs_StandardApi extends Omit<StandardApi<any>, 'router'> {}
 
+/** @publicDocs */
 export interface Docs_FullPageApi extends FullPageApi {}
 
+/** @publicDocs */
 export interface Docs_Page_Button_PrimaryAction
   extends Pick<
     ButtonProps,
@@ -93,6 +137,7 @@ export interface Docs_Page_Button_PrimaryAction
     | 'disabled'
     | 'accessibilityLabel'
   > {}
+/** @publicDocs */
 export interface Docs_Page_Button_SecondaryAction
   extends Pick<ButtonProps, 'onPress' | 'to'> {
   /**
@@ -101,6 +146,7 @@ export interface Docs_Page_Button_SecondaryAction
   accessibilityLabel: ButtonProps['accessibilityLabel'];
 }
 
+/** @publicDocs */
 export interface Docs_ResourceItem_Button_Action
   extends Pick<
     ButtonProps,
@@ -114,12 +160,14 @@ export interface Docs_ResourceItem_Button_Action
     | 'kind'
   > {}
 
+/** @publicDocs */
 export interface Docs_Menu_Button_Action
   extends Omit<
     ButtonProps,
     'kind' | 'textDecoration' | 'inlineAlignment' | 'inlineSize' | 'size'
   > {}
 
+/** @publicDocs */
 export interface Docs_OrderActionMenu_Button
   extends Pick<
     ButtonProps,
@@ -133,6 +181,7 @@ export interface Docs_OrderActionMenu_Button
   to: ButtonProps['to'];
 }
 
+/** @publicDocs */
 export interface Docs_CustomerAccountAction_Button_PrimaryAction
   extends Pick<
     ButtonProps,
@@ -144,6 +193,7 @@ export interface Docs_CustomerAccountAction_Button_PrimaryAction
     | 'accessibilityRole'
   > {}
 
+/** @publicDocs */
 export interface Docs_CustomerAccountAction_Button_SecondaryAction
   extends Pick<
     ButtonProps,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/action-api/action-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/action-api/action-api.ts
@@ -1,3 +1,4 @@
+/** @publicDocs */
 export interface ActionApiContent {
   /**
    * Presents the corresponding action (modal) target on top of the current view as a full-screen modal. For example, calling this method from `pos.purchase.post.action.menu-item.render` presents `pos.purchase.post.action.render`. Use to launch detailed workflows, complex forms, or multi-step processes that require more screen space than simple components provide.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/action-api/action-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/action-api/action-api.ts
@@ -1,4 +1,8 @@
-/** @publicDocs */
+/**
+ * The `ActionApi` object provides properties for presenting modal interfaces. Access these properties through `api.action` to launch full-screen modal experiences.
+ *
+ * @publicDocs
+ */
 export interface ActionApiContent {
   /**
    * Presents the corresponding action (modal) target on top of the current view as a full-screen modal. For example, calling this method from `pos.purchase.post.action.menu-item.render` presents `pos.purchase.post.action.render`. Use to launch detailed workflows, complex forms, or multi-step processes that require more screen space than simple components provide.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -36,7 +36,11 @@ export type CartDiscountType = 'Percentage' | 'FixedAmount' | 'Code';
  */
 export type LineItemDiscountType = 'Percentage' | 'FixedAmount';
 
-/** @publicDocs */
+/**
+ * The `CartApi` object provides access to cart management and subscribable cart state. Access these properties through `api.cart` to build cart-aware extensions that respond to real-time cart updates.
+ *
+ * @publicDocs
+ */
 export interface CartApiContent {
   /**
    * Subscribes to real-time cart state changes. Provides initial cart value and triggers callbacks on updates. Supports only one active subscription—use `makeStatefulSubscribable` for multiple subscribers.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -36,6 +36,7 @@ export type CartDiscountType = 'Percentage' | 'FixedAmount' | 'Code';
  */
 export type LineItemDiscountType = 'Percentage' | 'FixedAmount';
 
+/** @publicDocs */
 export interface CartApiContent {
   /**
    * Subscribes to real-time cart state changes. Provides initial cart value and triggers callbacks on updates. Supports only one active subscription—use `makeStatefulSubscribable` for multiple subscribers.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/connectivity-api/connectivity-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/connectivity-api/connectivity-api.ts
@@ -16,6 +16,7 @@ export interface ConnectivityState {
   internetConnected: ConnectivityStateSeverity;
 }
 
+/** @publicDocs */
 export interface ConnectivityApiContent {
   /**
    * Creates a subscription to changes in connectivity. Provides an initial value and a callback to subscribe to value changes. Use for implementing offline-aware functionality and reactive connectivity handling.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/connectivity-api/connectivity-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/connectivity-api/connectivity-api.ts
@@ -16,7 +16,11 @@ export interface ConnectivityState {
   internetConnected: ConnectivityStateSeverity;
 }
 
-/** @publicDocs */
+/**
+ * The `ConnectivityApi` object provides properties for monitoring network connectivity. Access these properties through `api.connectivity` to check connection status and subscribe to connectivity changes.
+ *
+ * @publicDocs
+ */
 export interface ConnectivityApiContent {
   /**
    * Creates a subscription to changes in connectivity. Provides an initial value and a callback to subscribe to value changes. Use for implementing offline-aware functionality and reactive connectivity handling.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/customer-api/customer-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/customer-api/customer-api.ts
@@ -5,7 +5,11 @@ export interface CustomerApi {
   customer: CustomerApiContent;
 }
 
-/** @publicDocs */
+/**
+ * The `CustomerApi` object provides access to customer data. Access these properties through `api.customer` to interact with the current customer context.
+ *
+ * @publicDocs
+ */
 export interface CustomerApiContent {
   /**
    * The unique identifier for the customer. Use for customer lookups, applying customer-specific pricing, enabling personalized features, and integrating with external systems.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/customer-api/customer-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/customer-api/customer-api.ts
@@ -5,6 +5,7 @@ export interface CustomerApi {
   customer: CustomerApiContent;
 }
 
+/** @publicDocs */
 export interface CustomerApiContent {
   /**
    * The unique identifier for the customer. Use for customer lookups, applying customer-specific pricing, enabling personalized features, and integrating with external systems.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
@@ -1,3 +1,4 @@
+/** @publicDocs */
 export interface DeviceApiContent {
   /**
    * The name of the device as configured by the merchant or system. Use for displaying device information in interfaces, logging, or support contexts where device identification is helpful.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
@@ -1,4 +1,8 @@
-/** @publicDocs */
+/**
+ * The `DeviceApi` object provides access to device information and capabilities. Access these properties through `api.device` to retrieve device details and check device characteristics.
+ *
+ * @publicDocs
+ */
 export interface DeviceApiContent {
   /**
    * The name of the device as configured by the merchant or system. Use for displaying device information in interfaces, logging, or support contexts where device identification is helpful.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/draft-order-api/draft-order-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/draft-order-api/draft-order-api.ts
@@ -5,6 +5,7 @@ export interface DraftOrderApi {
   draftOrder: DraftOrderApiContent;
 }
 
+/** @publicDocs */
 export interface DraftOrderApiContent {
   /**
    * The unique identifier for the draft order. Use for draft order lookups, implementing order-specific functionality, and integrating with external systems.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/draft-order-api/draft-order-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/draft-order-api/draft-order-api.ts
@@ -5,7 +5,11 @@ export interface DraftOrderApi {
   draftOrder: DraftOrderApiContent;
 }
 
-/** @publicDocs */
+/**
+ * The `DraftOrderApi` object provides access to draft order data. Access these properties through `api.draftOrder` to interact with the current draft order context.
+ *
+ * @publicDocs
+ */
 export interface DraftOrderApiContent {
   /**
    * The unique identifier for the draft order. Use for draft order lookups, implementing order-specific functionality, and integrating with external systems.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/locale-api/locale-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/locale-api/locale-api.ts
@@ -1,5 +1,6 @@
 import type {RemoteSubscribable} from '@remote-ui/async-subscription';
 
+/** @publicDocs */
 export interface LocaleApiContent {
   /**
    * Provides the current IETF-formatted locale (for example, "en-US") and allows you to subscribe to locale changes. Supports only one subscription at a time. To enable multiple subscriptions, use `makeStatefulSubscribable` on the `RemoteSubscribable` object. Using `makeStatefulSubscribable` or related hooks counts as an active subscription.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/locale-api/locale-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/locale-api/locale-api.ts
@@ -1,6 +1,10 @@
 import type {RemoteSubscribable} from '@remote-ui/async-subscription';
 
-/** @publicDocs */
+/**
+ * The `LocaleApi` object provides access to current locale information and change notifications. Access these properties through `api.locale` to retrieve and monitor locale data.
+ *
+ * @publicDocs
+ */
 export interface LocaleApiContent {
   /**
    * Provides the current IETF-formatted locale (for example, "en-US") and allows you to subscribe to locale changes. Supports only one subscription at a time. To enable multiple subscriptions, use `makeStatefulSubscribable` on the `RemoteSubscribable` object. Using `makeStatefulSubscribable` or related hooks counts as an active subscription.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -1,4 +1,8 @@
-/** @publicDocs */
+/**
+ * The global `navigation` object provides web-standard navigation functionality. Access these properties directly through the global `navigation` object to manage navigation within modal interfaces.
+ *
+ * @publicDocs
+ */
 export interface NavigationApiContent {
   /**
    * Navigate to a route in current navigation tree. Pushes the specified screen if it isn't present in the navigation tree, goes back to a created screen otherwise. Use for implementing multi-screen workflows with parameter passing between screens.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/navigation-api/navigation-api.ts
@@ -1,3 +1,4 @@
+/** @publicDocs */
 export interface NavigationApiContent {
   /**
    * Navigate to a route in current navigation tree. Pushes the specified screen if it isn't present in the navigation tree, goes back to a created screen otherwise. Use for implementing multi-screen workflows with parameter passing between screens.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.tsx
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.tsx
@@ -5,7 +5,11 @@ export interface OrderApi {
   order: OrderApiContent;
 }
 
-/** @publicDocs */
+/**
+ * The `OrderApi` object provides access to order data. Access these properties through `api.order` to interact with the current order context.
+ *
+ * @publicDocs
+ */
 export interface OrderApiContent {
   /**
    * The unique identifier for the order. Use for order lookups, implementing order-specific functionality, and integrating with external systems.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.tsx
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/order-api/order-api.tsx
@@ -5,6 +5,7 @@ export interface OrderApi {
   order: OrderApiContent;
 }
 
+/** @publicDocs */
 export interface OrderApiContent {
   /**
    * The unique identifier for the order. Use for order lookups, implementing order-specific functionality, and integrating with external systems.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/product-api/product-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/product-api/product-api.ts
@@ -5,6 +5,7 @@ export interface ProductApi {
   product: ProductApiContent;
 }
 
+/** @publicDocs */
 export interface ProductApiContent {
   /**
    * The unique identifier for the product. Use for product lookups, implementing product-specific functionality, and integrating with external systems.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/product-api/product-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/product-api/product-api.ts
@@ -5,7 +5,11 @@ export interface ProductApi {
   product: ProductApiContent;
 }
 
-/** @publicDocs */
+/**
+ * The `ProductApi` object provides access to product data. Access these properties through `api.product` to interact with the current product context.
+ *
+ * @publicDocs
+ */
 export interface ProductApiContent {
   /**
    * The unique identifier for the product. Use for product lookups, implementing product-specific functionality, and integrating with external systems.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
@@ -41,6 +41,7 @@ export interface ProductSearchParams extends PaginationParams {
   sortType?: ProductSortType;
 }
 
+/** @publicDocs */
 export interface ProductSearchApiContent {
   /**
    * Searches for products on the POS device using text queries and sorting options. Returns paginated results with up to 50 products per page. When a query string is provided, results are sorted by relevance. Use for implementing custom search interfaces, product discovery features, or filtered product listings.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/product-search-api/product-search-api.ts
@@ -41,7 +41,11 @@ export interface ProductSearchParams extends PaginationParams {
   sortType?: ProductSortType;
 }
 
-/** @publicDocs */
+/**
+ * The `ProductSearchApi` object provides properties for searching and fetching product data. Access these properties through `api.productSearch` to perform product searches and lookups.
+ *
+ * @publicDocs
+ */
 export interface ProductSearchApiContent {
   /**
    * Searches for products on the POS device using text queries and sorting options. Returns paginated results with up to 50 products per page. When a query string is provided, results are sorted by relevance. Use for implementing custom search interfaces, product discovery features, or filtered product listings.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
@@ -23,7 +23,11 @@ export interface ScannerSubscriptionResult {
   source?: ScannerSource;
 }
 
-/** @publicDocs */
+/**
+ * The `ScannerApi` object provides access to scanning functionality and scanner source information. Access these properties through `api.scanner` to monitor scan events and available scanner sources.
+ *
+ * @publicDocs
+ */
 export interface ScannerApiContent {
   /**
    * Subscribe to scan events to receive barcode and QR code data when scanned. Supports one subscription at a time. Use for receiving real-time scan results.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
@@ -23,6 +23,7 @@ export interface ScannerSubscriptionResult {
   source?: ScannerSource;
 }
 
+/** @publicDocs */
 export interface ScannerApiContent {
   /**
    * Subscribe to scan events to receive barcode and QR code data when scanned. Supports one subscription at a time. Use for receiving real-time scan results.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
@@ -1,6 +1,10 @@
 import type {Session} from '../types/session';
 
-/** @publicDocs */
+/**
+ * The `SessionApi` object provides access to current session information and authentication. Access these properties through `api.session` to retrieve shop data and generate secure tokens. These properties enable secure API calls while maintaining user privacy and [app permissions](https://help.shopify.com/manual/your-account/users/roles/permissions/store-permissions#apps-and-channels-permissions).
+ *
+ * @publicDocs
+ */
 export interface SessionApiContent {
   /**
    * Provides comprehensive information about the current POS session including shop details, user authentication, location data, staff member information, currency settings, and POS version. This data is static for the duration of the session and updates when users switch locations or staff members change.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
@@ -1,5 +1,6 @@
 import type {Session} from '../types/session';
 
+/** @publicDocs */
 export interface SessionApiContent {
   /**
    * Provides comprehensive information about the current POS session including shop details, user authentication, location data, staff member information, currency settings, and POS version. This data is static for the duration of the session and updates when users switch locations or staff members change.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
@@ -10,6 +10,7 @@ export interface ShowToastOptions {
   duration?: number;
 }
 
+/** @publicDocs */
 export interface ToastApiContent {
   /**
    * Displays a toast notification with the specified text content. The message appears as a temporary overlay that automatically dismisses after the specified duration. Use for providing immediate user feedback, confirming actions, or communicating status updates without interrupting the user's workflow.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/toast-api/toast-api.ts
@@ -10,7 +10,11 @@ export interface ShowToastOptions {
   duration?: number;
 }
 
-/** @publicDocs */
+/**
+ * The `ToastApi` object provides properties for displaying temporary notification messages. Access these properties through `api.toast` to show user feedback and status updates.
+ *
+ * @publicDocs
+ */
 export interface ToastApiContent {
   /**
    * Displays a toast notification with the specified text content. The message appears as a temporary overlay that automatically dismisses after the specified duration. Use for providing immediate user feedback, confirming actions, or communicating status updates without interrupting the user's workflow.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.ts
@@ -8,7 +8,11 @@ export type BadgeVariant =
   | 'highlight';
 
 export type BadgeStatus = 'empty' | 'partial' | 'complete';
-/** @publicDocs */
+/**
+ * Configure the following properties on the Badge component.
+ *
+ * @publicDocs
+ */
 export interface BadgeProps {
   /**
    * The text content displayed within the badge. Keep this concise and descriptive to clearly communicate status or category information. Examples include "Paid," "Pending," "Out of Stock," or "VIP Customer."

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.ts
@@ -8,6 +8,7 @@ export type BadgeVariant =
   | 'highlight';
 
 export type BadgeStatus = 'empty' | 'partial' | 'complete';
+/** @publicDocs */
 export interface BadgeProps {
   /**
    * The text content displayed within the badge. Keep this concise and descriptive to clearly communicate status or category information. Examples include "Paid," "Pending," "Out of Stock," or "VIP Customer."

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.ts
@@ -2,7 +2,11 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export type BannerVariant = 'confirmation' | 'alert' | 'error' | 'information';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Banner component.
+ *
+ * @publicDocs
+ */
 export interface BannerProps {
   /**
    * The title text displayed prominently on the banner. This should be concise and clearly communicate the main message or purpose of the banner to merchants.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export type BannerVariant = 'confirmation' | 'alert' | 'error' | 'information';
 
+/** @publicDocs */
 export interface BannerProps {
   /**
    * The title text displayed prominently on the banner. This should be concise and clearly communicate the main message or purpose of the banner to merchants.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.ts
@@ -7,7 +7,11 @@ export type ButtonType =
   /** @deprecated No longer supported as of POS 10.0.0. */
   | 'plain';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Button component.
+ *
+ * @publicDocs
+ */
 export interface ButtonProps {
   /**
    * The text set on the button. When using a button for action (menu item) targets, the title will be ignored. The text on the menu item will be the extension's description.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.ts
@@ -7,6 +7,7 @@ export type ButtonType =
   /** @deprecated No longer supported as of POS 10.0.0. */
   | 'plain';
 
+/** @publicDocs */
 export interface ButtonProps {
   /**
    * The text set on the button. When using a button for action (menu item) targets, the title will be ignored. The text on the menu item will be the extension's description.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/CameraScanner/CameraScanner.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/CameraScanner/CameraScanner.ts
@@ -17,6 +17,7 @@ export interface CameraScannerBannerProps {
   visible: boolean;
 }
 
+/** @publicDocs */
 export interface CameraScannerProps {
   /**
    * An optional banner configuration object that displays contextual messages during scanning operations.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/CameraScanner/CameraScanner.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/CameraScanner/CameraScanner.ts
@@ -17,7 +17,11 @@ export interface CameraScannerBannerProps {
   visible: boolean;
 }
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the CameraScanner component.
+ *
+ * @publicDocs
+ */
 export interface CameraScannerProps {
   /**
    * An optional banner configuration object that displays contextual messages during scanning operations.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.ts
@@ -1,7 +1,11 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import {InputProps} from '../shared/InputField';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the DateField component.
+ *
+ * @publicDocs
+ */
 export interface DateFieldProps
   extends Pick<
     InputProps,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import {InputProps} from '../shared/InputField';
 
+/** @publicDocs */
 export interface DateFieldProps
   extends Pick<
     InputProps,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the DatePicker component.
+ *
+ * @publicDocs
+ */
 export interface DatePickerProps {
   /**
    * The currently selected date value. Defaults to the current date when not specified.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface DatePickerProps {
   /**
    * The currently selected date value. Defaults to the current date when not specified.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Dialog/Dialog.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Dialog/Dialog.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export type DialogType = 'default' | 'alert' | 'error' | 'destructive';
 
+/** @publicDocs */
 export interface DialogProps {
   /**
    * The text displayed in the title of the dialog. This should be concise and clearly communicate the purpose or action being confirmed.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Dialog/Dialog.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Dialog/Dialog.ts
@@ -2,7 +2,11 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 export type DialogType = 'default' | 'alert' | 'error' | 'destructive';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Dialog component.
+ *
+ * @publicDocs
+ */
 export interface DialogProps {
   /**
    * The text displayed in the title of the dialog. This should be concise and clearly communicate the purpose or action being confirmed.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.ts
@@ -1,7 +1,11 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import type {InputProps} from '../shared/InputField';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the EmailField component.
+ *
+ * @publicDocs
+ */
 export interface EmailFieldProps extends InputProps {}
 
 export const EmailField = createRemoteComponent<'EmailField', EmailFieldProps>(

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import type {InputProps} from '../shared/InputField';
 
+/** @publicDocs */
 export interface EmailFieldProps extends InputProps {}
 
 export const EmailField = createRemoteComponent<'EmailField', EmailFieldProps>(

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/FormattedTextField/FormattedTextField.ts
@@ -2,7 +2,9 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {AutoCapitalizationType} from '../shared/auto-capitalization-type';
 import type {BaseTextFieldProps} from '../shared/BaseTextField';
 
+/** @publicDocs */
 export type InputType = 'text' | 'number' | 'currency' | 'giftcard' | 'email';
+/** @publicDocs */
 export interface FormattedTextFieldProps extends BaseTextFieldProps {
   /**
    * Defines the input type options that determine which specialized keyboard layout is displayed.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.ts
@@ -96,7 +96,11 @@ export type IconName =
  */
 export type IconSize = 'minor' | 'major' | 'spot' | 'caption' | 'badge';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Icon component.
+ *
+ * @publicDocs
+ */
 export interface IconProps {
   /**
    * A name used to render the icon. Choose from the available icon set including commerce-specific symbols like `'cart'`, `'payment'`, `'search'`, navigation arrows, and system indicators.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.ts
@@ -96,6 +96,7 @@ export type IconName =
  */
 export type IconSize = 'minor' | 'major' | 'spot' | 'caption' | 'badge';
 
+/** @publicDocs */
 export interface IconProps {
   /**
    * A name used to render the icon. Choose from the available icon set including commerce-specific symbols like `'cart'`, `'payment'`, `'search'`, navigation arrows, and system indicators.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface ImageProps {
   /**
    * The source of the image to be displayed.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Image component.
+ *
+ * @publicDocs
+ */
 export interface ImageProps {
   /**
    * The source of the image to be displayed.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/List/List.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/List/List.ts
@@ -107,7 +107,11 @@ export interface ListRow {
   onPress?: () => void;
 }
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the List component.
+ *
+ * @publicDocs
+ */
 export interface ListProps {
   /**
    * A large display title shown at the top of the list.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/List/List.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/List/List.ts
@@ -107,6 +107,7 @@ export interface ListRow {
   onPress?: () => void;
 }
 
+/** @publicDocs */
 export interface ListProps {
   /**
    * A large display title shown at the top of the list.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Navigator/Navigator.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Navigator/Navigator.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Navigator component.
+ *
+ * @publicDocs
+ */
 export interface NavigatorProps {
   /**
    * The name of the initial Screen component to display when the Navigator is first rendered. Must match the `name` property of a child Screen component.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Navigator/Navigator.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Navigator/Navigator.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface NavigatorProps {
   /**
    * The name of the initial Screen component to display when the Navigator is first rendered. Must match the `name` property of a child Screen component.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.ts
@@ -1,7 +1,11 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import type {InputProps} from '../shared/InputField';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the NumberField component.
+ *
+ * @publicDocs
+ */
 export interface NumberFieldProps extends InputProps {
   /**
    * The virtual keyboard layout to display:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import type {InputProps} from '../shared/InputField';
 
+/** @publicDocs */
 export interface NumberFieldProps extends InputProps {
   /**
    * The virtual keyboard layout to display:

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlock.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlock.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface POSBlockProps {
   /**
    * An optional action button configuration to be displayed on the POSBlock.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlock.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlock.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the POSBlock component.
+ *
+ * @publicDocs
+ */
 export interface POSBlockProps {
   /**
    * An optional action button configuration to be displayed on the POSBlock.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlockRow.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlockRow.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the POSBlockRow component.
+ *
+ * @publicDocs
+ */
 export interface POSBlockRowProps {
   /**
    * A callback function executed when the user taps the row. Use this to handle row-specific interactions or navigation.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlockRow.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/POSBlock/POSBlockRow.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface POSBlockRowProps {
   /**
    * A callback function executed when the user taps the row. Use this to handle row-specific interactions or navigation.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PinPad/PinPad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PinPad/PinPad.ts
@@ -37,6 +37,7 @@ export interface PinPadActionType {
   onPress: () => Promise<number[]>;
 }
 
+/** @publicDocs */
 export interface PinPadProps {
   /**
    * Whether the entered PIN should be masked with dots or asterisks to protect privacy and security.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PinPad/PinPad.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PinPad/PinPad.ts
@@ -37,7 +37,11 @@ export interface PinPadActionType {
   onPress: () => Promise<number[]>;
 }
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the PinPad component.
+ *
+ * @publicDocs
+ */
 export interface PinPadProps {
   /**
    * Whether the entered PIN should be masked with dots or asterisks to protect privacy and security.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/RadioButtonList/RadioButtonList.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/RadioButtonList/RadioButtonList.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface RadioButtonListProps {
   /**
    * An array of string values representing the radio button options available for selection.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/RadioButtonList/RadioButtonList.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/RadioButtonList/RadioButtonList.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the RadioButtonList component.
+ *
+ * @publicDocs
+ */
 export interface RadioButtonListProps {
   /**
    * An array of string values representing the radio button options available for selection.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Screen/Screen.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Screen/Screen.ts
@@ -28,6 +28,7 @@ export interface SecondaryActionProps {
   isEnabled?: boolean;
 }
 
+/** @publicDocs */
 export interface ScreenProps {
   /**
    * The unique identifier used to identify this screen as a destination in the navigation stack.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Screen/Screen.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Screen/Screen.ts
@@ -28,7 +28,11 @@ export interface SecondaryActionProps {
   isEnabled?: boolean;
 }
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Screen component.
+ *
+ * @publicDocs
+ */
 export interface ScreenProps {
   /**
    * The unique identifier used to identify this screen as a destination in the navigation stack.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchBar/SearchBar.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchBar/SearchBar.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface SearchBarProps {
   /**
    * The initial text value displayed in the search bar when first rendered. This differs from placeholder text which appears when the field is empty.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchBar/SearchBar.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchBar/SearchBar.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the SearchBar component.
+ *
+ * @publicDocs
+ */
 export interface SearchBarProps {
   /**
    * The initial text value displayed in the search bar when first rendered. This differs from placeholder text which appears when the field is empty.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.ts
@@ -14,6 +14,7 @@ export interface SectionHeaderAction {
   onPress: () => void;
 }
 
+/** @publicDocs */
 export interface SectionProps {
   /**
    * The title text displayed at the top of the section to describe its content.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.ts
@@ -14,7 +14,11 @@ export interface SectionHeaderAction {
   onPress: () => void;
 }
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Section component.
+ *
+ * @publicDocs
+ */
 export interface SectionProps {
   /**
    * The title text displayed at the top of the section to describe its content.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface SectionHeaderProps {
   /**
    * The title text displayed in the section header. Provide clear, descriptive text that accurately represents the content section below.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SectionHeader/SectionHeader.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the SectionHeader component.
+ *
+ * @publicDocs
+ */
 export interface SectionHeaderProps {
   /**
    * The title text displayed in the section header. Provide clear, descriptive text that accurately represents the content section below.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SegmentedControl/SegmentedControl.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SegmentedControl/SegmentedControl.ts
@@ -17,7 +17,11 @@ export interface Segment {
   disabled: boolean;
 }
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the SegmentedControl component.
+ *
+ * @publicDocs
+ */
 export interface SegmentedControlProps {
   /**
    * An array of segment objects that define the available options in the segmented control.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SegmentedControl/SegmentedControl.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SegmentedControl/SegmentedControl.ts
@@ -17,6 +17,7 @@ export interface Segment {
   disabled: boolean;
 }
 
+/** @publicDocs */
 export interface SegmentedControlProps {
   /**
    * An array of segment objects that define the available options in the segmented control.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Selectable/Selectable.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Selectable/Selectable.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface SelectableProps {
   /**
    * The callback function that's executed when the user taps or presses the selectable component. This is the primary way to handle user interactions with the wrapped content. The function receives no parameters and should contain the logic for what happens when the selection occurs, such as navigation, state updates, or triggering other actions.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Selectable/Selectable.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Selectable/Selectable.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Selectable component.
+ *
+ * @publicDocs
+ */
 export interface SelectableProps {
   /**
    * The callback function that's executed when the user taps or presses the selectable component. This is the primary way to handle user interactions with the wrapped content. The function receives no parameters and should contain the logic for what happens when the selection occurs, such as navigation, state updates, or triggering other actions.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Spacing/Spacing.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Spacing/Spacing.ts
@@ -1,3 +1,4 @@
+/** @publicDocs */
 export type VerticalSpacing =
   | 'HalfPoint'
   | 'ExtraSmall'
@@ -6,6 +7,7 @@ export type VerticalSpacing =
   | 'Large'
   | 'ExtraLarge';
 
+/** @publicDocs */
 export type HorizontalSpacing =
   | 'HalfPoint'
   | 'ExtraSmall'

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Spacing/Spacing.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Spacing/Spacing.ts
@@ -1,4 +1,8 @@
-/** @publicDocs */
+/**
+ * The spacing values for controlling vertical space between elements.
+ *
+ * @publicDocs
+ */
 export type VerticalSpacing =
   | 'HalfPoint'
   | 'ExtraSmall'
@@ -7,7 +11,11 @@ export type VerticalSpacing =
   | 'Large'
   | 'ExtraLarge';
 
-/** @publicDocs */
+/**
+ * The spacing values for controlling horizontal space between elements.
+ *
+ * @publicDocs
+ */
 export type HorizontalSpacing =
   | 'HalfPoint'
   | 'ExtraSmall'

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.ts
@@ -17,7 +17,11 @@ export type Spacing =
   | 13
   | 16;
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Stack component.
+ *
+ * @publicDocs
+ */
 export interface StackProps {
   /**
    * The direction of the stack.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.ts
@@ -17,6 +17,7 @@ export type Spacing =
   | 13
   | 16;
 
+/** @publicDocs */
 export interface StackProps {
   /**
    * The direction of the stack.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stepper/Stepper.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stepper/Stepper.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Stepper component.
+ *
+ * @publicDocs
+ */
 export interface StepperProps {
   /**
    * The initial value of the stepper that sets the starting numeric value when the component is first rendered.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stepper/Stepper.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stepper/Stepper.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface StepperProps {
   /**
    * The initial value of the stepper that sets the starting numeric value when the component is first rendered.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.ts
@@ -46,6 +46,7 @@ export type ColorType =
   | 'TextInteractive'
   | 'TextHighlight';
 
+/** @publicDocs */
 export interface TextProps {
   /**
    * The typography variant that determines the size, weight, and styling of the text within the design system hierarchy.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.ts
@@ -46,7 +46,11 @@ export type ColorType =
   | 'TextInteractive'
   | 'TextHighlight';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Text component.
+ *
+ * @publicDocs
+ */
 export interface TextProps {
   /**
    * The typography variant that determines the size, weight, and styling of the text within the design system hierarchy.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.ts
@@ -1,7 +1,11 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import type {InputProps} from '../shared/InputField';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the TextArea component.
+ *
+ * @publicDocs
+ */
 export interface TextAreaProps extends InputProps {
   /**
    * The initial number of visible text lines to be displayed. Maximum of 8 lines.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import type {InputProps} from '../shared/InputField';
 
+/** @publicDocs */
 export interface TextAreaProps extends InputProps {
   /**
    * The initial number of visible text lines to be displayed. Maximum of 8 lines.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.ts
@@ -60,6 +60,7 @@ export type EmbeddedElementProps =
   | SuccessProps
   | PasswordProps;
 
+/** @publicDocs */
 export interface NewTextFieldProps extends InputProps {}
 
 /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.ts
@@ -60,7 +60,11 @@ export type EmbeddedElementProps =
   | SuccessProps
   | PasswordProps;
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the TextField component.
+ *
+ * @publicDocs
+ */
 export interface NewTextFieldProps extends InputProps {}
 
 /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface TileProps {
   /**
    * The text displayed as the main label of the tile.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the Tile component.
+ *
+ * @publicDocs
+ */
 export interface TileProps {
   /**
    * The text displayed as the main label of the tile.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.ts
@@ -1,6 +1,7 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import {InputProps} from '../shared/InputField';
 
+/** @publicDocs */
 export interface TimeFieldProps
   extends Pick<
     InputProps,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.ts
@@ -1,7 +1,11 @@
 import {createRemoteComponent} from '@remote-ui/core';
 import {InputProps} from '../shared/InputField';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the TimeField component.
+ *
+ * @publicDocs
+ */
 export interface TimeFieldProps
   extends Pick<
     InputProps,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface TimePickerProps {
   /**
    * The currently selected time value. Defaults to the current time when not specified.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.ts
@@ -1,6 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/** @publicDocs */
+/**
+ * Configure the following properties on the TimePicker component.
+ *
+ * @publicDocs
+ */
 export interface TimePickerProps {
   /**
    * The currently selected time value. Defaults to the current time when not specified.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/shared/auto-capitalization-type.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/shared/auto-capitalization-type.ts
@@ -1,3 +1,4 @@
+/** @publicDocs */
 export type AutoCapitalizationType =
   | 'none'
   | 'sentences'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,10 +1910,10 @@
     pkg-dir "^5.0.0"
     pluralize "^8.0.0"
 
-"@shopify/generate-docs@0.16.4":
-  version "0.16.4"
-  resolved "https://registry.yarnpkg.com/@shopify/generate-docs/-/generate-docs-0.16.4.tgz#4e9c6348f080217e59be34ca6fbde850769eccef"
-  integrity sha512-lYtnB2gPPSBf73YvbrNM9u6p1cm/qbg1uEqkMW9sG4/dORb5tBPDDC/KkckaCaMF7soHg9PsinNXHAa0/Hlf4g==
+"@shopify/generate-docs@1.0.0":
+  version "1.0.0"
+  resolved "https://npm.shopify.io/node/@shopify/generate-docs/-/generate-docs-1.0.0.tgz#2aaa894e8e09ff1acea9ac49eb1ab212088f30c8"
+  integrity sha512-DOkWeqGjVg3xxS6slNuyYpegvRLMn1o9VPwZm1fIzsRsJRAHy12TZM3Bq3yMimx5IU3J34y+iD/jPb/S/gFU5g==
   dependencies:
     "@types/react" "^18.0.21"
     globby "^11.1.0"


### PR DESCRIPTION
### Background

Closes https://github.com/Shopify/temp-project-mover-Archetypically-20260312105649/issues/388

**TL;DR:** We are ready to begin the migration of POS docs to the latest major gen docs release.

### Solution

- **Doc generation:** Added `/** @publicDocs */` immediately before every top level interface for POS ONLY.

- **Why this approach:** The existing doc pipeline uses `@publicDocs` to decide what to include; adding the tag is the minimal, consistent fix and matches how other public API surfaces are documented.

`yarn docs:point-of-sale 2024-10` to generate the generated docs data v2 json file in the shopify-dev repo

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation


