### PR TITLE
Fix invalid enum for discount classes in 2026-01

### DIFF
--- a/.changeset/fast-llamas-press.md
+++ b/.changeset/fast-llamas-press.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Wrong types for discount classes

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
@@ -24,14 +24,7 @@ interface Metafield {
 /**
  * The discount class that determines where the discount applies in the purchase flow. Use this to understand what type of discount the merchant is configuring (product-level, order-level, or shipping).
  */
-export enum DiscountClass {
-  /** The discount applies to specific products or product variants. Use this for discounts that reduce the price of individual line items (for example, "20% off selected products"). */
-  Product = 'PRODUCT',
-  /** The discount applies to the entire order total. Use this for cart-wide discounts that reduce the subtotal (for example, "$10 off orders over $50"). */
-  Order = 'ORDER',
-  /** The discount applies to shipping costs. Use this for free shipping or reduced shipping rate discounts (for example, "Free shipping on orders over $100"). */
-  Shipping = 'SHIPPING',
-}
+export type DiscountClass = 'product' | 'order' | 'shipping';
 
 /**
  * The method used to apply a discount. Use `'automatic'` for discounts that apply automatically at checkout, or `'code'` for discounts that require a code entered by the customer.


### PR DESCRIPTION
### Background

When updating our internal app to 2026-01, I realized that our ui-extension type contract was wrong and that the type was invalid. The data returned from admin returns a lower cased value, coming from a string union type. 

I will also make a PR to 2026-04-rc. 