### PR TITLE
Add Settings intents to Admin intents API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ packages/**/*.mjs
 !components.d.ts
 packages/**/*.js
 !packages/**/__mocks__/**/*.js
+!packages/**/intents/examples/*.js
 packages/**/bin
 !packages/**/.eslintrc.js
 *.log

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-location.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-location.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('create:shopify/Location');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Location created:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-location.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/create-location.jsx
@@ -1,0 +1,35 @@
+import {render} from 'preact';
+import {useState} from 'preact/hooks';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleAction = async () => {
+    setLoading(true);
+
+    const activity = await shopify.intents.invoke('create:shopify/Location');
+    const response = await activity.complete;
+
+    setResult(response);
+    setLoading(false);
+  };
+
+  return (
+    <s-admin-block heading="Create Location">
+      <s-button onClick={handleAction} disabled={loading}>
+        {loading ? 'Creating...' : 'Launch Location Creator'}
+      </s-button>
+      {result?.code === 'ok' && (
+        <s-banner status="success">Location created successfully!</s-banner>
+      )}
+      {result?.code === 'closed' && (
+        <s-text>Creation cancelled</s-text>
+      )}
+    </s-admin-block>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location-default.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location-default.js
@@ -1,0 +1,9 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:settings/LocationDefault');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Default location updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location-default.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location-default.js
@@ -5,5 +5,5 @@ const activity = await intents.invoke('edit:settings/LocationDefault');
 const response = await activity.complete;
 
 if (response.code === 'ok') {
-  console.log('Default location updated:', response.data);
+  console.log('Settings updated:', response.data);
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location-default.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location-default.jsx
@@ -25,7 +25,7 @@ function Extension() {
         {loading ? 'Editing...' : 'Launch Default Location Editor'}
       </s-button>
       {result?.code === 'ok' && (
-        <s-banner status="success">Default location updated successfully!</s-banner>
+        <s-banner status="success">Settings updated</s-banner>
       )}
       {result?.code === 'closed' && (
         <s-text>Edit default location cancelled</s-text>

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location-default.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location-default.jsx
@@ -1,0 +1,35 @@
+import {render} from 'preact';
+import {useState} from 'preact/hooks';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleAction = async () => {
+    setLoading(true);
+
+    const activity = await shopify.intents.invoke('edit:settings/LocationDefault');
+    const response = await activity.complete;
+
+    setResult(response);
+    setLoading(false);
+  };
+
+  return (
+    <s-admin-block heading="Edit Default Location">
+      <s-button onClick={handleAction} disabled={loading}>
+        {loading ? 'Editing...' : 'Launch Default Location Editor'}
+      </s-button>
+      {result?.code === 'ok' && (
+        <s-banner status="success">Default location updated successfully!</s-banner>
+      )}
+      {result?.code === 'closed' && (
+        <s-text>Edit default location cancelled</s-text>
+      )}
+    </s-admin-block>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location.js
@@ -1,0 +1,11 @@
+const {intents} = useApi(TARGET);
+
+const activity = await intents.invoke('edit:shopify/Location', {
+  value: 'gid://shopify/Location/123456789',
+});
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Location updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-location.jsx
@@ -1,0 +1,41 @@
+import {render} from 'preact';
+import {useState} from 'preact/hooks';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  const {data} = shopify;
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const resourceId = data.selected[0]?.id || 'gid://shopify/Location/123456789';
+
+  const handleAction = async () => {
+    setLoading(true);
+
+    const activity = await shopify.intents.invoke('edit:shopify/Location', {
+      value: resourceId,
+    });
+
+    const response = await activity.complete;
+    setResult(response);
+    setLoading(false);
+  };
+
+  return (
+    <s-admin-block heading="Edit Location">
+      <s-text>Editing: {resourceId}</s-text>
+      <s-button onClick={handleAction} disabled={loading}>
+        {loading ? 'Opening...' : 'Edit Location'}
+      </s-button>
+      {result?.code === 'ok' && (
+        <s-banner status="success">Location updated!</s-banner>
+      )}
+      {result?.code === 'closed' && (
+        <s-text>Edit cancelled</s-text>
+      )}
+    </s-admin-block>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-id-format.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-id-format.js
@@ -5,5 +5,5 @@ const activity = await intents.invoke('edit:settings/OrderIdFormat');
 const response = await activity.complete;
 
 if (response.code === 'ok') {
-  console.log('Order ID format updated:', response.data);
+  console.log('Settings updated:', response.data);
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-id-format.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-id-format.js
@@ -1,0 +1,9 @@
+const { intents } = useApi(TARGET);
+
+const activity = await intents.invoke('edit:settings/OrderIdFormat');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Order ID format updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-id-format.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-id-format.jsx
@@ -1,0 +1,35 @@
+import { render } from 'preact';
+import { useState } from 'preact/hooks';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleAction = async () => {
+    setLoading(true);
+
+    const activity = await shopify.intents.invoke('edit:settings/OrderIdFormat');
+    const response = await activity.complete;
+
+    setResult(response);
+    setLoading(false);
+  };
+
+  return (
+    <s-admin-block heading="Edit Order ID Format">
+      <s-button onClick={handleAction} disabled={loading}>
+        {loading ? 'Editing...' : 'Launch Order ID Format Editor'}
+      </s-button>
+      {result?.code === 'ok' && (
+        <s-banner status="success">Order ID format updated successfully!</s-banner>
+      )}
+      {result?.code === 'closed' && (
+        <s-text>Edit order ID format cancelled</s-text>
+      )}
+    </s-admin-block>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-id-format.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-id-format.jsx
@@ -25,7 +25,7 @@ function Extension() {
         {loading ? 'Editing...' : 'Launch Order ID Format Editor'}
       </s-button>
       {result?.code === 'ok' && (
-        <s-banner status="success">Order ID format updated successfully!</s-banner>
+        <s-banner status="success">Settings updated</s-banner>
       )}
       {result?.code === 'closed' && (
         <s-text>Edit order ID format cancelled</s-text>

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-processing.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-processing.js
@@ -5,5 +5,5 @@ const activity = await intents.invoke('edit:settings/OrderProcessing');
 const response = await activity.complete;
 
 if (response.code === 'ok') {
-  console.log('Order processing updated:', response.data);
+  console.log('Settings updated:', response.data);
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-processing.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-processing.js
@@ -1,0 +1,9 @@
+const { intents } = useApi(TARGET);
+
+const activity = await intents.invoke('edit:settings/OrderProcessing');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Order processing updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-processing.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-processing.jsx
@@ -25,7 +25,7 @@ function Extension() {
         {loading ? 'Editing...' : 'Launch Order Processing Editor'}
       </s-button>
       {result?.code === 'ok' && (
-        <s-banner status="success">Order processing updated successfully!</s-banner>
+        <s-banner status="success">Settings updated</s-banner>
       )}
       {result?.code === 'closed' && (
         <s-text>Edit order processing cancelled</s-text>

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-processing.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-order-processing.jsx
@@ -1,0 +1,35 @@
+import { render } from 'preact';
+import { useState } from 'preact/hooks';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleAction = async () => {
+    setLoading(true);
+
+    const activity = await shopify.intents.invoke('edit:settings/OrderProcessing');
+    const response = await activity.complete;
+
+    setResult(response);
+    setLoading(false);
+  };
+
+  return (
+    <s-admin-block heading="Edit Order Processing">
+      <s-button onClick={handleAction} disabled={loading}>
+        {loading ? 'Editing...' : 'Launch Order Processing Editor'}
+      </s-button>
+      {result?.code === 'ok' && (
+        <s-banner status="success">Order processing updated successfully!</s-banner>
+      )}
+      {result?.code === 'closed' && (
+        <s-text>Edit order processing cancelled</s-text>
+      )}
+    </s-admin-block>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-store-defaults.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-store-defaults.js
@@ -1,0 +1,9 @@
+const { intents } = useApi(TARGET);
+
+const activity = await intents.invoke('edit:settings/StoreDefaults');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Store defaults updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-store-defaults.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-store-defaults.jsx
@@ -1,0 +1,35 @@
+import { render } from 'preact';
+import { useState } from 'preact/hooks';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleAction = async () => {
+    setLoading(true);
+
+    const activity = await shopify.intents.invoke('edit:settings/StoreDetails');
+    const response = await activity.complete;
+
+    setResult(response);
+    setLoading(false);
+  };
+
+  return (
+    <s-admin-block heading="Edit Store Details">
+      <s-button onClick={handleAction} disabled={loading}>
+        {loading ? 'Editing...' : 'Launch Store Details Editor'}
+      </s-button>
+      {result?.code === 'ok' && (
+        <s-banner status="success">Store details updated successfully!</s-banner>
+      )}
+      {result?.code === 'closed' && (
+        <s-text>Edit store details cancelled</s-text>
+      )}
+    </s-admin-block>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-store-details.js
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-store-details.js
@@ -1,0 +1,9 @@
+const { intents } = useApi(TARGET);
+
+const activity = await intents.invoke('edit:settings/StoreDetails');
+
+const response = await activity.complete;
+
+if (response.code === 'ok') {
+  console.log('Store details updated:', response.data);
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-store-details.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/examples/edit-store-details.jsx
@@ -1,0 +1,37 @@
+import { render } from 'preact';
+import { useState } from 'preact/hooks';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleAction = async () => {
+    setLoading(true);
+
+    const activity = await shopify.intents.invoke('edit:settings/StoreDetails');
+    const response = await activity.complete;
+
+    setResult(response);
+    setLoading(false);
+  };
+
+  return (
+    <s-admin-block heading="Edit Store Details">
+      <s-button onClick={handleAction} disabled={loading}>
+        {loading ? 'Editing...' : 'Launch Store Details Editor'}
+      </s-button>
+      {result?.code === 'ok' && (
+        <s-banner status="success">
+          Store details updated successfully!
+        </s-banner>
+      )}
+      {result?.code === 'closed' && (
+        <s-text>Edit store details cancelled</s-text>
+      )}
+    </s-admin-block>
+  );
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
@@ -796,7 +796,7 @@ Settings are the configuration options for the store. Use this to invoke and edi
         examples: [
           {
             description:
-              'Launch locations in Settings to update the store\'s default location.',
+              'Launch locations in Settings to update the default location of the store.',
             codeblock: {
               title: 'Edit default location',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
@@ -166,7 +166,19 @@ The following tables show which resource types you can create or edit, and what 
 | \`edit\` | \`shopify/ProductVariant\` | \`gid://shopify/ProductVariant/{id}\` | \`{ productId: 'gid://shopify/Product/{id}' }\` |
 
 > Note:
-> When editing products with variants, query the [\`product.hasOnlyDefaultVariant\`](/docs/api/admin-graphql/latest/objects/Product#field-Product.fields.hasOnlyDefaultVariant) field first. If \`true\`, then use the \`shopify/Product\` edit intent. If \`false\`, then use the \`shopify/ProductVariant\` edit intent for specific variants.`,
+> When editing products with variants, query the [\`product.hasOnlyDefaultVariant\`](/docs/api/admin-graphql/latest/objects/Product#field-Product.fields.hasOnlyDefaultVariant) field first. If \`true\`, then use the \`shopify/Product\` edit intent. If \`false\`, then use the \`shopify/ProductVariant\` edit intent for specific variants.
+
+#### Settings
+
+Settings are the configuration options for the store. Use this to invoke and edit settings.
+
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`edit\` | \`settings/StoreDetails\` | — | — |
+| \`edit\` | \`settings/StoreDefaults\` | — | — |
+| \`edit\` | \`settings/OrderIdFormat\` | — | — |
+| \`edit\` | \`settings/OrderProcessing\` | — | — |`,
+
       type: 'IntentInvokeApi',
     },
     {
@@ -589,6 +601,67 @@ The following tables show which resource types you can create or edit, and what 
                 {
                   title: 'jsx',
                   code: './examples/edit-variant.jsx',
+                  language: 'jsx',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: '',
+        examples: [
+          {
+            description:
+              'Launch the store details editor to update the store name, email, or phone number. This example invokes the edit intent, manages loading state, and displays feedback on completion.',
+            codeblock: {
+              title: 'Edit store details',
+              tabs: [
+                {
+                  title: 'jsx',
+                  code: './examples/edit-store-details.jsx',
+                  language: 'jsx',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              'Open the store defaults editor to update the store currency, timezone, or country. This example retrieves the store defaults GID from extension context, invokes the edit intent, and handles the completion response.',
+            codeblock: {
+              title: 'Edit store defaults',
+              tabs: [
+                {
+                  title: 'jsx',
+                  code: './examples/edit-store-defaults.jsx',
+                  language: 'jsx',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              'Launch the order id format editor to update the order id format. This example invokes the edit intent, manages loading state, and displays feedback on completion.',
+            codeblock: {
+              title: 'Edit Order ID Format',
+              tabs: [
+                {
+                  title: 'jsx',
+                  code: './examples/edit-order-id-format.jsx',
+                  language: 'jsx',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              'Open the order processing editor to update the order processing settings. This example retrieves the order processing GID from extension context, invokes the edit intent, and handles the completion response.',
+            codeblock: {
+              title: 'Edit order processing',
+              tabs: [
+                {
+                  title: 'jsx',
+                  code: './examples/edit-order-processing.jsx',
                   language: 'jsx',
                 },
               ],

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
@@ -98,6 +98,15 @@ The following tables show which resource types you can create or edit, and what 
 | \`create\` | \`shopify/Discount\` | — | \`{ type: 'amount-off-product' \\| 'amount-off-order' \\| 'buy-x-get-y' \\| 'free-shipping' }\` |
 | \`edit\` | \`shopify/Discount\` | \`gid://shopify/Discount/{id}\` | — |
 
+#### Location
+
+[Locations](/docs/api/admin-graphql/latest/objects/Location) are physical or virtual places where merchants store inventory and fulfill orders. Use this to create or edit locations for managing stock and fulfillment.
+
+| Action | Type | Value | Data |
+|--------|------|-------|------|
+| \`create\` | \`shopify/Location\` | — | — |
+| \`edit\` | \`shopify/Location\` | \`gid://shopify/Location/{id}\` | — |
+
 #### Market
 
 [Markets](/docs/api/admin-graphql/latest/objects/Market) are geographic regions with customized pricing, languages, and domains. Use this to create or edit markets for international selling.
@@ -179,10 +188,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
 
 | Action | Type | Value | Data |
 |--------|------|-------|------|
-| \`edit\` | \`settings/StoreDetails\` | — | — |
-| \`edit\` | \`settings/StoreDefaults\` | — | — |
+| \`edit\` | \`settings/LocationDefault\` | — | — |
 | \`edit\` | \`settings/OrderIdFormat\` | — | — |
-| \`edit\` | \`settings/OrderProcessing\` | — | — |`,
+| \`edit\` | \`settings/OrderProcessing\` | — | — |
+| \`edit\` | \`settings/StoreDefaults\` | — | — |
+| \`edit\` | \`settings/StoreDetails\` | — | — |`,
 
       type: 'IntentInvokeApi',
     },
@@ -387,6 +397,49 @@ Settings are the configuration options for the store. Use this to invoke and edi
                 {
                   title: 'js',
                   code: './examples/edit-discount.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        title: '',
+        examples: [
+          {
+            description:
+              'Launch the location creation workflow to add a new physical or virtual fulfillment location. This example invokes the create intent, manages loading state, and displays feedback on completion.',
+            codeblock: {
+              title: 'Create a new location',
+              tabs: [
+                {
+                  title: 'jsx',
+                  code: './examples/create-location.jsx',
+                  language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/create-location.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
+          {
+            description:
+              'Open the location editor to update address details, fulfillment settings, or inventory tracking. This example retrieves the location GID from extension context, invokes the edit intent, and handles the completion response.',
+            codeblock: {
+              title: 'Edit an existing location',
+              tabs: [
+                {
+                  title: 'jsx',
+                  code: './examples/edit-location.jsx',
+                  language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-location.js',
                   language: 'js',
                 },
               ],
@@ -741,6 +794,25 @@ Settings are the configuration options for the store. Use this to invoke and edi
       {
         title: '',
         examples: [
+          {
+            description:
+              'Launch locations in Settings to update the store\'s default location.',
+            codeblock: {
+              title: 'Edit default location',
+              tabs: [
+                {
+                  title: 'jsx',
+                  code: './examples/edit-location-default.jsx',
+                  language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-location-default.js',
+                  language: 'js',
+                },
+              ],
+            },
+          },
           {
             description:
               'Launch store details in Settings to update the store name, email, or phone number.',

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/intents.doc.ts
@@ -25,6 +25,11 @@ Use this API to build workflows like adding products to collections from bulk ac
           code: './examples/create-article.jsx',
           language: 'jsx',
         },
+        {
+          title: 'js',
+          code: './examples/create-article.js',
+          language: 'js',
+        },
       ],
     },
   },
@@ -207,6 +212,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/edit-article.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/edit-article.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -226,6 +236,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-catalog.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-catalog.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -239,6 +254,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-catalog.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-catalog.js',
+                  language: 'js',
                 },
               ],
             },
@@ -259,6 +279,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-collection.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-collection.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -272,6 +297,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-collection.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-collection.js',
+                  language: 'js',
                 },
               ],
             },
@@ -292,6 +322,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-customer.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-customer.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -305,6 +340,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-customer.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-customer.js',
+                  language: 'js',
                 },
               ],
             },
@@ -325,6 +365,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-discount.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-discount.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -338,6 +383,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-discount.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-discount.js',
+                  language: 'js',
                 },
               ],
             },
@@ -358,6 +408,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-market.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-market.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -371,6 +426,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-market.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-market.js',
+                  language: 'js',
                 },
               ],
             },
@@ -391,6 +451,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-menu.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-menu.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -404,6 +469,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-menu.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-menu.js',
+                  language: 'js',
                 },
               ],
             },
@@ -424,6 +494,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-metafield-definition.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-metafield-definition.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -437,6 +512,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-metafield-definition.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-metafield-definition.js',
+                  language: 'js',
                 },
               ],
             },
@@ -457,6 +537,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-metaobject.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-metaobject.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -470,6 +555,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-metaobject.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-metaobject.js',
+                  language: 'js',
                 },
               ],
             },
@@ -490,6 +580,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-metaobject-definition.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-metaobject-definition.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -503,6 +598,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-metaobject-definition.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-metaobject-definition.js',
+                  language: 'js',
                 },
               ],
             },
@@ -523,6 +623,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-page.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-page.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -536,6 +641,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-page.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-page.js',
+                  language: 'js',
                 },
               ],
             },
@@ -556,6 +666,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-product.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-product.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -569,6 +684,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-product.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-product.js',
+                  language: 'js',
                 },
               ],
             },
@@ -589,6 +709,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/create-variant.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/create-variant.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -603,6 +728,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/edit-variant.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/edit-variant.js',
+                  language: 'js',
+                },
               ],
             },
           },
@@ -613,7 +743,7 @@ Settings are the configuration options for the store. Use this to invoke and edi
         examples: [
           {
             description:
-              'Launch the store details editor to update the store name, email, or phone number. This example invokes the edit intent, manages loading state, and displays feedback on completion.',
+              'Launch store details in Settings to update the store name, email, or phone number.',
             codeblock: {
               title: 'Edit store details',
               tabs: [
@@ -622,12 +752,17 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/edit-store-details.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/edit-store-details.js',
+                  language: 'js',
+                },
               ],
             },
           },
           {
             description:
-              'Open the store defaults editor to update the store currency, timezone, or country. This example retrieves the store defaults GID from extension context, invokes the edit intent, and handles the completion response.',
+              'Launch store defaults in Settings to update the store currency, timezone, or country.',
             codeblock: {
               title: 'Edit store defaults',
               tabs: [
@@ -636,12 +771,16 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/edit-store-defaults.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/edit-store-defaults.js',
+                  language: 'js',
+                },
               ],
             },
           },
           {
-            description:
-              'Launch the order id format editor to update the order id format. This example invokes the edit intent, manages loading state, and displays feedback on completion.',
+            description: 'Launch order ID in Settings to update the format.',
             codeblock: {
               title: 'Edit Order ID Format',
               tabs: [
@@ -650,12 +789,17 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   code: './examples/edit-order-id-format.jsx',
                   language: 'jsx',
                 },
+                {
+                  title: 'js',
+                  code: './examples/edit-order-id-format.js',
+                  language: 'js',
+                },
               ],
             },
           },
           {
             description:
-              'Open the order processing editor to update the order processing settings. This example retrieves the order processing GID from extension context, invokes the edit intent, and handles the completion response.',
+              'Launch order processing in Settings to update the store order processing preferences.',
             codeblock: {
               title: 'Edit order processing',
               tabs: [
@@ -663,6 +807,11 @@ Settings are the configuration options for the store. Use this to invoke and edi
                   title: 'jsx',
                   code: './examples/edit-order-processing.jsx',
                   language: 'jsx',
+                },
+                {
+                  title: 'js',
+                  code: './examples/edit-order-processing.js',
+                  language: 'js',
                 },
               ],
             },

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/intents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/intents.ts
@@ -67,6 +67,7 @@ export type IntentType =
   | 'shopify/Collection'
   | 'shopify/Customer'
   | 'shopify/Discount'
+  | 'shopify/Location'
   | 'shopify/Market'
   | 'shopify/Menu'
   | 'shopify/MetafieldDefinition'


### PR DESCRIPTION
## Summary
- Add four new Settings intent types to the Intents API documentation: `settings/StoreDetails`, `settings/StoreDefaults`, `settings/OrderIdFormat`, and `settings/OrderProcessing`
- Add three new Location intent types: `create:shopify/Location`, `edit:shopify/Location`, and `edit:settings/LocationDefault`
- Add code examples for each new Settings and Location intent
- Regenerate `generated_docs_data.json` to reflect the changes

## Details
Updates the Admin intents documentation to include new `edit` actions for store settings and new `create`/`edit` actions for locations. Each intent gets its own example file showing the invoke + complete pattern. The supported resources table in the invoke API description is updated with a new "Settings" section and a new "Location" section. `shopify/Location` is also added to the `IntentType` union in `intents.ts`.

## Related
- https://github.com/Shopify/extensibility/pull/1020
- https://github.com/Shopify/shopify-dev/pull/68548

## Resolves
- https://github.com/shop/issues-admin-extensibility/issues/2259

## Test plan
- [ ] Verify the generated docs JSON files are valid and contain the new Settings intents
- [ ] Confirm the example files render correctly on shopify.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)