### PR TITLE
[POS]: Remove "Related" section from SearchBar doc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/generated/generated_docs_data.json
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/generated/generated_docs_data.json
@@ -8333,13 +8333,7 @@
     ],
     "category": "UI components",
     "subCategory": "Navigation and content",
-    "related": [
-      {
-        "name": "ProductSearch API",
-        "subtitle": "See how to use the ProductSearch API with a SearchBar to search for products.",
-        "url": "/api/pos-ui-extensions/apis/productsearch-api#example-search-for-products-with-a-search-bar"
-      }
-    ],
+    "related": [],
     "thumbnail": "search-bar-thumbnail.png",
     "defaultExample": {
       "image": "search-bar-default.png",

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/SearchBar.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/components/SearchBar.doc.ts
@@ -18,14 +18,7 @@ const data: ReferenceEntityTemplateSchema = {
   ],
   category: 'UI components',
   subCategory: 'Navigation and content',
-  related: [
-    {
-      name: 'ProductSearch API',
-      subtitle:
-        'See how to use the ProductSearch API with a SearchBar to search for products.',
-      url: '/api/pos-ui-extensions/apis/productsearch-api#example-search-for-products-with-a-search-bar',
-    },
-  ],
+  related: [],
   thumbnail: 'search-bar-thumbnail.png',
   defaultExample: {
     image: 'search-bar-default.png',


### PR DESCRIPTION
## This PR: 
- Removes a "Related" section from the SearchBar component doc in 2025-07, as:
  - We no longer use these sections in the UI extensions docs
  - The link went to an unsupported component
- Relates to https://shopify.slack.com/archives/C099RJCHAKE/p1771995171688549