### PR TITLE
[2026-01] Fix category for `Abbreviation` and `Time`

### DIFF
--- a/packages/ui-extensions/src/docs/shared/components/Abbreviation.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Abbreviation.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'Displays abbreviated text or acronyms, revealing their full meaning or additional context through a tooltip on hover or focus. Use to clarify shortened terms, initialisms, or technical language without interrupting the reading flow.',
   category: 'Polaris web components',
-  subCategory: 'Titles and text',
+  subCategory: 'Typography and content',
   related: [],
 };
 

--- a/packages/ui-extensions/src/docs/shared/components/Time.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Time.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'Represents a specific point or duration in time. Use to display dates, times, or durations clearly and consistently. May include a machine-readable `datetime` attribute for improved accessibility and functionality.',
   category: 'Polaris web components',
-  subCategory: 'Titles and text',
+  subCategory: 'Typography and content',
   related: [],
 };
 


### PR DESCRIPTION
### Background

Fix category for `Abbreviation` and `Time` components.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
