### PR TITLE
Ren and laurel straight chillin like villians

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -89,11 +89,16 @@ fi
 
 # Make sure https://shopify.dev URLs are relative.
 # See https://github.com/Shopify/generate-docs/issues/181
-run_sed 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data.json
-sed_exit=$?
-if [ $sed_exit -ne 0 ]; then
-  fail_and_exit $sed_exit
-fi
+# Process both array format (generated_docs_data.json) and type-map v2 format when present.
+for docs_file in generated_docs_data.json generated_docs_data_v2.json; do
+  if [ -f "./$DOCS_PATH/generated/$docs_file" ]; then
+    run_sed 's|https://shopify.dev||gi' "./$DOCS_PATH/generated/$docs_file"
+    sed_exit=$?
+    if [ $sed_exit -ne 0 ]; then
+      fail_and_exit $sed_exit
+    fi
+  fi
+done
 
 # Generate targets.json
 echo "Generating targets.json..."
@@ -111,13 +116,15 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
 
   # Replace 'latest' with the exact API version in relative doc links
-  for file in generated_docs_data.json generated_static_pages.json; do
-    run_sed \
-      "s/\/docs\/api\/checkout-ui-extensions\/latest/\/docs\/api\/checkout-ui-extensions\/$API_VERSION/gi" \
-      "$SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/$file"
-    sed_exit=$?
-    if [ $sed_exit -ne 0 ]; then
-      fail_and_exit $sed_exit
+  for file in generated_docs_data.json generated_docs_data_v2.json generated_static_pages.json; do
+    if [ -f "$SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/$file" ]; then
+      run_sed \
+        "s/\/docs\/api\/checkout-ui-extensions\/latest/\/docs\/api\/checkout-ui-extensions\/$API_VERSION/gi" \
+        "$SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/$file"
+      sed_exit=$?
+      if [ $sed_exit -ne 0 ]; then
+        fail_and_exit $sed_exit
+      fi
     fi
   done
 

--- a/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data_v2.json
@@ -1,0 +1,5505 @@
+{
+  "DataGeneratedType": {
+    "docs/surfaces/checkout/reference/apis/address.doc.ts": {
+      "filePath": "docs/surfaces/checkout/reference/apis/address.doc.ts",
+      "name": "DataGeneratedType",
+      "description": "Template schema for reference entity documentation pages.",
+      "isPublicDocs": true,
+      "value": "data: ReferenceEntityTemplateSchema = {\n  name: 'Addresses',\n  description: 'The API for interacting with addresses.',\n  isVisualComponent: false,\n  requires: REQUIRES_PROTECTED_CUSTOMER_DATA_LEVEL_2,\n  category: 'APIs',\n  type: 'API',\n  definitions: [\n    {\n      title: 'StandardApi',\n      description: STANDARD_API_PROPERTIES_DESCRIPTION,\n      type: 'Docs_Standard_AddressApi',\n    },\n    {\n      title: 'CheckoutApi',\n      description: CHECKOUT_API_PROPERTIES_DESCRIPTION,\n      type: 'Docs_Checkout_AddressApi',\n    },\n    {\n      title: 'useBillingAddress',\n      description:\n        'Returns the proposed `billingAddress` applied to the checkout.',\n      type: 'UseBillingAddressGeneratedType',\n    },\n    {\n      title: 'useShippingAddress',\n      description:\n        'Returns the proposed `shippingAddress` applied to the checkout.',\n      type: 'UseShippingAddressGeneratedType',\n    },\n    {\n      title: 'useApplyShippingAddressChange',\n      description:\n        'Returns a function to mutate the `shippingAddress` property of checkout.',\n      type: 'UseApplyShippingAddressChangeGeneratedType',\n    },\n  ],\n  related: getLinksByTag('apis'),\n}"
+    }
+  },
+  "StandardApi": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "StandardApi",
+      "description": "The base API object provided to checkout extension targets.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "analytics",
+          "value": "Analytics",
+          "description": "The methods for interacting with [Web Pixels](/docs/apps/marketing), such as emitting an event."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "appliedGiftCards",
+          "value": "SubscribableSignalLike<AppliedGiftCard[]>",
+          "description": "Gift Cards that have been applied to the checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "applyTrackingConsentChange",
+          "value": "ApplyTrackingConsentChangeType",
+          "description": "Allows setting and updating customer privacy consent settings and tracking consent metafields.\n\n> Note: Requires the [`customer_privacy` capability](/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) to be set to `true`.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "appMetafields",
+          "value": "SubscribableSignalLike<AppMetafieldEntry[]>",
+          "description": "The metafields requested in the [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file. These metafields are updated when there's a change in the merchandise items being purchased by the customer.\n\nApp owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` is not supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "attributes",
+          "value": "SubscribableSignalLike<Attribute[]>",
+          "description": "The custom attributes left by the customer to the merchant, either in their cart or during checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "availablePaymentOptions",
+          "value": "SubscribableSignalLike<PaymentOption[]>",
+          "description": "All available payment options."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billingAddress",
+          "value": "SubscribableSignalLike<MailingAddress | undefined>",
+          "description": "The proposed customer billing address. The address updates when the field is committed (on change) rather than every keystroke.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "buyerIdentity",
+          "value": "BuyerIdentity",
+          "description": "Information about the buyer that is interacting with the checkout.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "buyerJourney",
+          "value": "BuyerJourney",
+          "description": "Provides details on the buyer's progression through the checkout.\n\nRefer to [buyer journey](/docs/api/checkout-ui-extensions/apis/buyer-journey#examples) examples for more information."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "checkoutSettings",
+          "value": "SubscribableSignalLike<CheckoutSettings>",
+          "description": "Settings applied to the buyer's checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "checkoutToken",
+          "value": "SubscribableSignalLike<CheckoutToken | undefined>",
+          "description": "A stable ID that represents the current checkout.\n\nThis matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data) and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cost",
+          "value": "CartCost",
+          "description": "Details on the costs the buyer will pay for this checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "customerPrivacy",
+          "value": "SubscribableSignalLike<CustomerPrivacy>",
+          "description": "Customer privacy consent settings and a flag denoting if consent has previously been collected."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryGroups",
+          "value": "SubscribableSignalLike<DeliveryGroup[]>",
+          "description": "A list of delivery groups containing information about the delivery of the items the customer intends to purchase."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountAllocations",
+          "value": "SubscribableSignalLike<CartDiscountAllocation[]>",
+          "description": "Discounts that have been applied to the entire cart."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountCodes",
+          "value": "SubscribableSignalLike<CartDiscountCode[]>",
+          "description": "A list of discount codes currently applied to the checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "extension",
+          "value": "Extension<Target>",
+          "description": "The meta information about the extension."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "extensionPoint",
+          "value": "Target",
+          "description": "The identifier that specifies where in Shopify’s UI your code is being injected. This will be one of the targets you have included in your extension’s configuration file.",
+          "deprecationMessage": "Deprecated as of version `2023-07`, use `extension.target` instead.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'purchase.checkout.block.render'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "i18n",
+          "value": "I18n",
+          "description": "Utilities for translating content and formatting values according to the current [`localization`](/docs/api/checkout-ui-extensions/apis/localization) of the checkout.\n\nRefer to [`localization` examples](/docs/api/checkout-ui-extensions/apis/localization#examples) for more information."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "instructions",
+          "value": "SubscribableSignalLike<CartInstructions>",
+          "description": "The cart instructions used to create the checkout and possibly limit extension capabilities.\n\nThese instructions should be checked prior to performing any actions that may be affected by them.\n\nFor example, if you intend to add a discount code via the `applyDiscountCodeChange` method, check `discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.\n\n> Caution: As of version `2024-07`, UI extension code must check for instructions before calling select APIs in case those APIs are not available.  See the [update guide](/docs/api/checkout-ui-extensions/apis/cart-instructions#examples) for more information."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lines",
+          "value": "SubscribableSignalLike<CartLine[]>",
+          "description": "A list of lines containing information about the items the customer intends to purchase."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "localization",
+          "value": "Localization",
+          "description": "The details about the location, language, and currency of the customer. For utilities to easily format and translate content based on these details, you can use the [`i18n`](/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-i18n) object instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "localizedFields",
+          "value": "SubscribableSignalLike<LocalizedField[]>",
+          "description": "The API for reading additional fields that are required in checkout under certain circumstances. For example, some countries require additional fields for customs information or tax identification numbers.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "SubscribableSignalLike<Metafield[]>",
+          "description": "The metafields that apply to the current checkout.\n\nMetafields are stored locally on the client and are applied to the order object after the checkout completes.\n\nThese metafields are shared by all extensions running on checkout, and persist for as long as the customer is working on this checkout.\n\nOnce the order is created, you can query these metafields using the [GraphQL Admin API](/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)\n\n> Caution: `metafields` is deprecated. Use `appMetafields` with cart metafields instead.",
+          "deprecationMessage": "Use `appMetafields` with cart metafields instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "note",
+          "value": "SubscribableSignalLike<string | undefined>",
+          "description": "A note left by the customer to the merchant, either in their cart or during checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "query",
+          "value": "<Data = unknown, Variables = Record<string, unknown>>(query: string, options?: { variables?: Variables; version?: StorefrontApiVersion; }) => Promise<{ data?: Data; errors?: GraphQLError[]; }>",
+          "description": "The method used to query the Storefront GraphQL API with a prefetched token.\n\nRefer to [Storefront API access examples](/docs/api/checkout-ui-extensions/apis/storefront-api) for more information."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "selectedPaymentOptions",
+          "value": "SubscribableSignalLike<SelectedPaymentOption[]>",
+          "description": "Payment options selected by the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sessionToken",
+          "value": "SessionToken",
+          "description": "The session token providing a set of claims as a signed JSON Web Token (JWT).\n\nThe token has a TTL of 5 minutes.\n\nIf the previous token expires, this value will reflect a new session token with a new signature and expiry.\n\nRefer to [session token examples](/docs/api/checkout-ui-extensions/apis/session-token) for more information."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "settings",
+          "value": "SubscribableSignalLike<ExtensionSettings>",
+          "description": "The settings matching the settings definition written in the [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file.\n\n Refer to [settings examples](/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.\n\n> Note: When an extension is being installed in the editor, the settings will be empty until a merchant sets a value. In that case, this object will be updated in real time as a merchant fills in the settings."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shippingAddress",
+          "value": "SubscribableSignalLike<ShippingAddress | undefined>",
+          "description": "The proposed customer shipping address. During the information step, the address updates when the field is committed (on change) rather than every keystroke. An address value is only present if delivery is required. Otherwise, the subscribable value is undefined.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shop",
+          "value": "Shop",
+          "description": "The shop where the checkout is taking place."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storage",
+          "value": "Storage",
+          "description": "The key-value storage for the extension.\n\nIt uses `localStorage` and should persist across the customer's current checkout session.\n\n> Caution: Data persistence isn't guaranteed and storage is reset when the customer starts a new checkout.\n\nData is shared across all activated extension targets of this extension. In versions 2023-07 and earlier, each activated extension target had its own storage."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "ui",
+          "value": "Ui",
+          "description": "Methods to interact with the extension’s UI."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "version",
+          "value": "Version",
+          "description": "The renderer version being used for the extension.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'2025-10'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {\n  /**\n   * The methods for interacting with [Web Pixels](/docs/apps/marketing), such as emitting an event.\n   */\n  analytics: Analytics;\n\n  /**\n   * Gift Cards that have been applied to the checkout.\n   */\n  appliedGiftCards: SubscribableSignalLike<AppliedGiftCard[]>;\n\n  /**\n   * The cart instructions used to create the checkout and possibly limit extension capabilities.\n   *\n   * These instructions should be checked prior to performing any actions that may be affected by them.\n   *\n   * For example, if you intend to add a discount code via the `applyDiscountCodeChange` method,\n   * check `discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.\n   *\n   * > Caution: As of version `2024-07`, UI extension code must check for instructions before calling select APIs in case those APIs are not available.\n   *  See the [update guide](/docs/api/checkout-ui-extensions/apis/cart-instructions#examples) for more information.\n   *\n   */\n  instructions: SubscribableSignalLike<CartInstructions>;\n\n  /**\n   * The metafields requested in the\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration)\n   * file. These metafields are updated when there's a change in the merchandise items\n   * being purchased by the customer.\n   *\n   * App owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` is not supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  appMetafields: SubscribableSignalLike<AppMetafieldEntry[]>;\n\n  /**\n   * The custom attributes left by the customer to the merchant, either in their cart or during checkout.\n   */\n  attributes: SubscribableSignalLike<Attribute[]>;\n\n  /**\n   * All available payment options.\n   */\n  availablePaymentOptions: SubscribableSignalLike<PaymentOption[]>;\n\n  /**\n   * Information about the buyer that is interacting with the checkout.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  buyerIdentity?: BuyerIdentity;\n\n  /**\n   * Provides details on the buyer's progression through the checkout.\n   *\n   * Refer to [buyer journey](/docs/api/checkout-ui-extensions/apis/buyer-journey#examples)\n   * examples for more information.\n   */\n  buyerJourney: BuyerJourney;\n\n  /**\n   * Settings applied to the buyer's checkout.\n   */\n  checkoutSettings: SubscribableSignalLike<CheckoutSettings>;\n\n  /**\n   * A stable ID that represents the current checkout.\n   *\n   * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)\n   * and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object).\n   */\n  checkoutToken: SubscribableSignalLike<CheckoutToken | undefined>;\n\n  /**\n   * Details on the costs the buyer will pay for this checkout.\n   */\n  cost: CartCost;\n\n  /**\n   * A list of delivery groups containing information about the delivery of the items the customer intends to purchase.\n   */\n  deliveryGroups: SubscribableSignalLike<DeliveryGroup[]>;\n\n  /**\n   * A list of discount codes currently applied to the checkout.\n   */\n  discountCodes: SubscribableSignalLike<CartDiscountCode[]>;\n\n  /**\n   * Discounts that have been applied to the entire cart.\n   */\n  discountAllocations: SubscribableSignalLike<CartDiscountAllocation[]>;\n\n  /**\n   * The meta information about the extension.\n   */\n  extension: Extension<Target>;\n\n  /**\n   * The identifier that specifies where in Shopify’s UI your code is being\n   * injected. This will be one of the targets you have included in your\n   * extension’s configuration file.\n   *\n   * @example 'purchase.checkout.block.render'\n   * @see /docs/api/checkout-ui-extensions/latest/extension-targets-overview\n   * @see /docs/apps/app-extensions/configuration#targets\n   *\n   * @deprecated Deprecated as of version `2023-07`, use `extension.target` instead.\n   */\n  extensionPoint: Target;\n\n  /**\n   * Utilities for translating content and formatting values according to the current\n   * [`localization`](/docs/api/checkout-ui-extensions/apis/localization)\n   * of the checkout.\n   *\n   * Refer to [`localization` examples](/docs/api/checkout-ui-extensions/apis/localization#examples)\n   * for more information.\n   */\n  i18n: I18n;\n\n  /**\n   * A list of lines containing information about the items the customer intends to purchase.\n   */\n  lines: SubscribableSignalLike<CartLine[]>;\n\n  /**\n   * The details about the location, language, and currency of the customer. For utilities to easily\n   * format and translate content based on these details, you can use the\n   * [`i18n`](/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-i18n)\n   * object instead.\n   */\n  localization: Localization;\n\n  /**\n   * The metafields that apply to the current checkout.\n   *\n   * Metafields are stored locally on the client and are applied to the order object after the checkout completes.\n   *\n   * These metafields are shared by all extensions running on checkout, and\n   * persist for as long as the customer is working on this checkout.\n   *\n   * Once the order is created, you can query these metafields using the\n   * [GraphQL Admin API](/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)\n   *\n   * > Caution:\n   * `metafields` is deprecated. Use `appMetafields` with cart metafields instead.\n   *\n   * @deprecated Use `appMetafields` with cart metafields instead.\n   */\n  metafields: SubscribableSignalLike<Metafield[]>;\n\n  /**\n   * A note left by the customer to the merchant, either in their cart or during checkout.\n   */\n  note: SubscribableSignalLike<string | undefined>;\n\n  /**\n   * The method used to query the Storefront GraphQL API with a prefetched token.\n   *\n   * Refer to [Storefront API access examples](/docs/api/checkout-ui-extensions/apis/storefront-api) for more information.\n   */\n  query: <Data = unknown, Variables = Record<string, unknown>>(\n    query: string,\n    options?: {variables?: Variables; version?: StorefrontApiVersion},\n  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;\n\n  /**\n   * Payment options selected by the buyer.\n   */\n  selectedPaymentOptions: SubscribableSignalLike<SelectedPaymentOption[]>;\n\n  /**\n   * The session token providing a set of claims as a signed JSON Web Token (JWT).\n   *\n   * The token has a TTL of 5 minutes.\n   *\n   * If the previous token expires, this value will reflect a new session token with a new signature and expiry.\n   *\n   * Refer to [session token examples](/docs/api/checkout-ui-extensions/apis/session-token) for more information.\n   */\n  sessionToken: SessionToken;\n\n  /**\n   * The settings matching the settings definition written in the\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file.\n   *\n   *  Refer to [settings examples](/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.\n   *\n   * > Note: When an extension is being installed in the editor, the settings will be empty until\n   * a merchant sets a value. In that case, this object will be updated in real time as a merchant fills in the settings.\n   */\n  settings: SubscribableSignalLike<ExtensionSettings>;\n\n  /**\n   * The proposed customer shipping address. During the information step, the address\n   * updates when the field is committed (on change) rather than every keystroke.\n   * An address value is only present if delivery is required. Otherwise, the\n   * subscribable value is undefined.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  shippingAddress?: SubscribableSignalLike<ShippingAddress | undefined>;\n\n  /**\n   * The proposed customer billing address. The address updates when the field is\n   * committed (on change) rather than every keystroke.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  billingAddress?: SubscribableSignalLike<MailingAddress | undefined>;\n\n  /** The shop where the checkout is taking place. */\n  shop: Shop;\n\n  /**\n   * The key-value storage for the extension.\n   *\n   * It uses `localStorage` and should persist across the customer's current checkout session.\n   *\n   * > Caution: Data persistence isn't guaranteed and storage is reset when the customer starts a new checkout.\n   *\n   * Data is shared across all activated extension targets of this extension. In versions 2023-07 and earlier,\n   * each activated extension target had its own storage.\n   */\n  storage: Storage;\n\n  /**\n   * Methods to interact with the extension’s UI.\n   */\n  ui: Ui;\n\n  /**\n   * The renderer version being used for the extension.\n   *\n   * @example '2025-10'\n   */\n  version: Version;\n\n  /**\n   * Customer privacy consent settings and a flag denoting if consent has previously been collected.\n   */\n  customerPrivacy: SubscribableSignalLike<CustomerPrivacy>;\n\n  /**\n   * Allows setting and updating customer privacy consent settings and tracking consent metafields.\n   *\n   * > Note: Requires the [`customer_privacy` capability](/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) to be set to `true`.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  applyTrackingConsentChange: ApplyTrackingConsentChangeType;\n\n  /**\n   * The API for reading additional fields that are required in checkout under certain circumstances.\n   * For example, some countries require additional fields for customs information or tax identification numbers.\n   */\n  localizedFields?: SubscribableSignalLike<LocalizedField[]>;\n}"
+    }
+  },
+  "Analytics": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Analytics",
+      "description": "The API for interacting with web pixels.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "publish",
+          "value": "(name: string, data: Record<string, unknown>) => Promise<boolean>",
+          "description": "Publish method to emit analytics events to [Web Pixels](/docs/apps/marketing)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "visitor",
+          "value": "(data: { email?: string; phone?: string; }) => Promise<VisitorResult>",
+          "description": "A method for capturing details about a visitor on the online store."
+        }
+      ],
+      "value": "export interface Analytics {\n  /**\n   * Publish method to emit analytics events to [Web Pixels](/docs/apps/marketing).\n   */\n  publish(name: string, data: Record<string, unknown>): Promise<boolean>;\n\n  /**\n   * A method for capturing details about a visitor on the online store.\n   */\n  visitor(data: {email?: string; phone?: string}): Promise<VisitorResult>;\n}"
+    }
+  },
+  "VisitorResult": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "VisitorResult",
+      "value": "VisitorSuccess | VisitorError",
+      "description": "The API for interacting with web pixels.\n\nRepresents a visitor result.",
+      "isPublicDocs": true
+    }
+  },
+  "VisitorSuccess": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "VisitorSuccess",
+      "description": "The API for interacting with web pixels.\n\nRepresents a successful visitor result.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'success'",
+          "description": "Indicates that the visitor information was validated and submitted."
+        }
+      ],
+      "value": "export interface VisitorSuccess {\n  /**\n   * Indicates that the visitor information was validated and submitted.\n   */\n  type: 'success';\n}"
+    }
+  },
+  "VisitorError": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "VisitorError",
+      "description": "The API for interacting with web pixels.\n\nRepresents an unsuccessful visitor result.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It's **not** localized, and therefore should not be presented directly to the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'error'",
+          "description": "Indicates that the visitor information is invalid and wasn't submitted. Examples are using the wrong data type or missing a required property."
+        }
+      ],
+      "value": "export interface VisitorError {\n  /**\n   * Indicates that the visitor information is invalid and wasn't submitted.\n   * Examples are using the wrong data type or missing a required property.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It's **not** localized, and therefore should not be presented directly\n   * to the buyer.\n   */\n  message: string;\n}"
+    }
+  },
+  "SubscribableSignalLike": {
+    "src/surfaces/checkout/shared.ts": {
+      "filePath": "src/surfaces/checkout/shared.ts",
+      "name": "SubscribableSignalLike",
+      "description": "Represents a read-only value managed on the main thread that an extension can subscribe to.\n\nExample: Checkout uses this to manage the state of an object and communicate state changes to extensions running in a sandboxed web worker.\n\nThis interface is compatible with [Preact's ReadonlySignal](https://github.com/preactjs/signals/blob/a023a132a81bd4ba4a0bebb8cbbeffbd8c8bbafc/packages/core/src/index.ts#L700-L709).\n\nSome fields are deprecated but still supported for backwards compatibility. In version 2025-10, [`StatefulRemoteSubscribable`](https://github.com/Shopify/remote-dom/blob/03929aa8418a89d41d294005f219837582718df8/packages/async-subscription/src/types.ts#L17) was replaced with `ReadonlySignalLike`. Checkout will remove the old fields some time in the future.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "current",
+          "value": "T",
+          "description": "",
+          "deprecationMessage": "Use `.value` instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/shared.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "destroy",
+          "value": "() => Promise<void>",
+          "description": "",
+          "deprecationMessage": "No longer needed. Use Preact Signal management instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/shared.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "subscribe",
+          "value": "(fn: (value: T) => void) => () => void",
+          "description": "Subscribes to value changes and calls the provided function whenever the value updates. Returns an unsubscribe function to clean up the subscription. Use to automatically react to changes in the signal's value."
+        },
+        {
+          "filePath": "src/surfaces/checkout/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "T",
+          "description": "The current value of the signal. This property provides immediate access to the current value without requiring subscription setup. Use for one-time value checks or initial setup."
+        }
+      ],
+      "value": "export interface SubscribableSignalLike<T> extends ReadonlySignalLike<T> {\n  /**\n   * @deprecated Use `.value` instead.\n   */\n  readonly current: T;\n  /**\n   * @deprecated No longer needed. Use Preact Signal management instead.\n   */\n  destroy(): Promise<void>;\n}"
+    }
+  },
+  "AppliedGiftCard": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AppliedGiftCard",
+      "description": "The API for interacting with gift cards.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "amountUsed",
+          "value": "Money",
+          "description": "The amount of the applied gift card that will be used when the checkout is completed."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "balance",
+          "value": "Money",
+          "description": "The current balance of the applied gift card prior to checkout completion."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lastCharacters",
+          "value": "string",
+          "description": "The last four characters of the applied gift card's code."
+        }
+      ],
+      "value": "export interface AppliedGiftCard {\n  /**\n   * The last four characters of the applied gift card's code.\n   */\n  lastCharacters: string;\n\n  /**\n   * The amount of the applied gift card that will be used when the checkout is completed.\n   */\n  amountUsed: Money;\n\n  /**\n   * The current balance of the applied gift card prior to checkout completion.\n   */\n  balance: Money;\n}"
+    }
+  },
+  "Money": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Money",
+      "description": "The API for interacting with the cost of a checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "amount",
+          "value": "number",
+          "description": "The price amount."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "currencyCode",
+          "value": "CurrencyCode",
+          "description": "The ISO 4217 format for the currency.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'CAD' for Canadian dollar",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface Money {\n  /**\n   * The price amount.\n   */\n  amount: number;\n  /**\n   * The ISO 4217 format for the currency.\n   * @example 'CAD' for Canadian dollar\n   */\n  currencyCode: CurrencyCode;\n}"
+    }
+  },
+  "CurrencyCode": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CurrencyCode",
+      "value": "'AED' | 'AFN' | 'ALL' | 'AMD' | 'ANG' | 'AOA' | 'ARS' | 'AUD' | 'AWG' | 'AZN' | 'BAM' | 'BBD' | 'BDT' | 'BGN' | 'BHD' | 'BIF' | 'BMD' | 'BND' | 'BOB' | 'BOV' | 'BRL' | 'BSD' | 'BTN' | 'BWP' | 'BYN' | 'BZD' | 'CAD' | 'CDF' | 'CHE' | 'CHF' | 'CHW' | 'CLF' | 'CLP' | 'CNY' | 'COP' | 'COU' | 'CRC' | 'CUC' | 'CUP' | 'CVE' | 'CZK' | 'DJF' | 'DKK' | 'DOP' | 'DZD' | 'EGP' | 'ERN' | 'ETB' | 'EUR' | 'FJD' | 'FKP' | 'GBP' | 'GEL' | 'GHS' | 'GIP' | 'GMD' | 'GNF' | 'GTQ' | 'GYD' | 'HKD' | 'HNL' | 'HRK' | 'HTG' | 'HUF' | 'IDR' | 'ILS' | 'INR' | 'IQD' | 'IRR' | 'ISK' | 'JMD' | 'JOD' | 'JPY' | 'KES' | 'KGS' | 'KHR' | 'KMF' | 'KPW' | 'KRW' | 'KWD' | 'KYD' | 'KZT' | 'LAK' | 'LBP' | 'LKR' | 'LRD' | 'LSL' | 'LYD' | 'MAD' | 'MDL' | 'MGA' | 'MKD' | 'MMK' | 'MNT' | 'MOP' | 'MRU' | 'MUR' | 'MVR' | 'MWK' | 'MXN' | 'MXV' | 'MYR' | 'MZN' | 'NAD' | 'NGN' | 'NIO' | 'NOK' | 'NPR' | 'NZD' | 'OMR' | 'PAB' | 'PEN' | 'PGK' | 'PHP' | 'PKR' | 'PLN' | 'PYG' | 'QAR' | 'RON' | 'RSD' | 'RUB' | 'RWF' | 'SAR' | 'SBD' | 'SCR' | 'SDG' | 'SEK' | 'SGD' | 'SHP' | 'SLL' | 'SOS' | 'SRD' | 'SSP' | 'STN' | 'SVC' | 'SYP' | 'SZL' | 'THB' | 'TJS' | 'TMT' | 'TND' | 'TOP' | 'TRY' | 'TTD' | 'TWD' | 'TZS' | 'UAH' | 'UGX' | 'USD' | 'USN' | 'UYI' | 'UYU' | 'UYW' | 'UZS' | 'VES' | 'VND' | 'VUV' | 'WST' | 'XAF' | 'XAG' | 'XAU' | 'XBA' | 'XBB' | 'XBC' | 'XBD' | 'XCD' | 'XDR' | 'XOF' | 'XPD' | 'XPF' | 'XPT' | 'XSU' | 'XTS' | 'XUA' | 'XXX' | 'YER' | 'ZAR' | 'ZMW' | 'ZWL'",
+      "description": ""
+    }
+  },
+  "ApplyTrackingConsentChangeType": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "ApplyTrackingConsentChangeType",
+      "description": "The API for interacting with a customer's privacy consent.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "visitorConsent",
+          "description": "",
+          "value": "VisitorConsentChange",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+        "description": "",
+        "name": "Promise<TrackingConsentChangeResult>",
+        "value": "Promise<TrackingConsentChangeResult>"
+      },
+      "value": "(\n  visitorConsent: VisitorConsentChange,\n) => Promise<TrackingConsentChangeResult>"
+    }
+  },
+  "VisitorConsentChange": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "VisitorConsentChange",
+      "description": "The API for interacting with a customer's privacy consent.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "analytics",
+          "value": "boolean",
+          "description": "Visitor consents to recording data to understand how customers interact with the site.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "marketing",
+          "value": "boolean",
+          "description": "Visitor consents to ads and marketing communications based on customer interests.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "TrackingConsentMetafieldChange[]",
+          "description": "Tracking consent metafield data to be saved.\n\nIf the value is `null`, the metafield will be deleted.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "`[{key: 'granularAnalytics', value: 'true'}, {key: 'granularMarketing', value: 'false'}]`",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "preferences",
+          "value": "boolean",
+          "description": "Visitor consent to remembering customer preferences, such as country or language, to personalize visits to the website.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "saleOfData",
+          "value": "boolean",
+          "description": "Opts the visitor out of data sharing / sales.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'changeVisitorConsent'",
+          "description": ""
+        }
+      ],
+      "value": "export interface VisitorConsentChange extends VisitorConsent {\n  /**\n   * Tracking consent metafield data to be saved.\n   *\n   * If the value is `null`, the metafield will be deleted.\n   *\n   * @example `[{key: 'granularAnalytics', value: 'true'}, {key: 'granularMarketing', value: 'false'}]`\n   */\n  metafields?: TrackingConsentMetafieldChange[];\n  type: 'changeVisitorConsent';\n}"
+    }
+  },
+  "TrackingConsentMetafieldChange": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "TrackingConsentMetafieldChange",
+      "description": "The API for interacting with a customer's privacy consent.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "The name of the metafield. It must be between 3 and 30 characters in length (inclusive)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string | null",
+          "description": "The information to be stored as metadata. If the value is `null`, the metafield will be deleted.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'any string', `null`, or a stringified JSON object",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface TrackingConsentMetafieldChange {\n  /**\n   * The name of the metafield. It must be between 3 and 30 characters in\n   * length (inclusive).\n   */\n  key: string;\n  /**\n   * The information to be stored as metadata. If the value is `null`, the metafield will be deleted.\n   *\n   * @example 'any string', `null`, or a stringified JSON object\n   */\n  value: string | null;\n}"
+    }
+  },
+  "VisitorConsent": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "VisitorConsent",
+      "description": "The API for interacting with a customer's privacy consent.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "analytics",
+          "value": "boolean",
+          "description": "Visitor consents to recording data to understand how customers interact with the site.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "marketing",
+          "value": "boolean",
+          "description": "Visitor consents to ads and marketing communications based on customer interests.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "preferences",
+          "value": "boolean",
+          "description": "Visitor consent to remembering customer preferences, such as country or language, to personalize visits to the website.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "saleOfData",
+          "value": "boolean",
+          "description": "Opts the visitor out of data sharing / sales.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface VisitorConsent {\n  /**\n   * Visitor consents to recording data to understand how customers interact with the site.\n   */\n  analytics?: boolean;\n  /**\n   * Visitor consents to ads and marketing communications based on customer interests.\n   */\n  marketing?: boolean;\n  /**\n   * Visitor consent to remembering customer preferences, such as country or language, to personalize visits to the website.\n   */\n  preferences?: boolean;\n  /**\n   * Opts the visitor out of data sharing / sales.\n   */\n  saleOfData?: boolean;\n}"
+    }
+  },
+  "TrackingConsentChangeResult": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "TrackingConsentChangeResult",
+      "value": "TrackingConsentChangeResultSuccess | TrackingConsentChangeResultError",
+      "description": "The API for interacting with a customer's privacy consent.",
+      "isPublicDocs": true
+    }
+  },
+  "TrackingConsentChangeResultSuccess": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "TrackingConsentChangeResultSuccess",
+      "description": "The API for interacting with a customer's privacy consent.\n\nThe returned result of a successful tracking consent preference update.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'success'",
+          "description": "The type of the `TrackingConsentChangeResultSuccess` API."
+        }
+      ],
+      "value": "export interface TrackingConsentChangeResultSuccess {\n  /**\n   * The type of the `TrackingConsentChangeResultSuccess` API.\n   */\n  type: 'success';\n}"
+    }
+  },
+  "TrackingConsentChangeResultError": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "TrackingConsentChangeResultError",
+      "description": "The API for interacting with a customer's privacy consent.\n\nThe returned result of an unsuccessful tracking consent preference update with a message detailing the type of error that occurred.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It is **not** localized, and therefore should not be presented directly to the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'error'",
+          "description": "The type of the `TrackingConsentChangeResultError` API."
+        }
+      ],
+      "value": "export interface TrackingConsentChangeResultError {\n  /**\n   * The type of the `TrackingConsentChangeResultError` API.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It is **not** localized, and therefore should not be presented directly\n   * to the buyer.\n   */\n  message: string;\n}"
+    }
+  },
+  "AppMetafieldEntry": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AppMetafieldEntry",
+      "description": "The API for interacting with metafields.\n\nA metafield associated with the shop or a resource on the checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafield",
+          "value": "AppMetafield",
+          "description": "The metadata information."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "AppMetafieldEntryTarget",
+          "description": "The target that is associated to the metadata.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`."
+        }
+      ],
+      "value": "export interface AppMetafieldEntry {\n  /**\n   * The target that is associated to the metadata.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.\n   */\n  target: AppMetafieldEntryTarget;\n\n  /** The metadata information. */\n  metafield: AppMetafield;\n}"
+    }
+  },
+  "AppMetafield": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AppMetafield",
+      "description": "The API for interacting with metafields.\n\nRepresents a custom metadata attached to a resource.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "The key name of a metafield."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "namespace",
+          "value": "string",
+          "description": "The namespace for a metafield.\n\nApp owned metafield namespaces are returned using the `$app` format. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "string",
+          "description": "The metafield's type name."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The value of a metafield."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "valueType",
+          "value": "'boolean' | 'float' | 'integer' | 'json_string' | 'string'",
+          "description": "The metafield’s information type."
+        }
+      ],
+      "value": "export interface AppMetafield {\n  /** The key name of a metafield. */\n  key: string;\n\n  /**\n   * The namespace for a metafield.\n   *\n   * App owned metafield namespaces are returned using the `$app` format. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n   */\n  namespace: string;\n\n  /** The value of a metafield. */\n  value: string;\n\n  /** The metafield’s information type. */\n  valueType: 'boolean' | 'float' | 'integer' | 'json_string' | 'string';\n\n  /** The metafield's type name. */\n  type: string;\n}"
+    }
+  },
+  "AppMetafieldEntryTarget": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AppMetafieldEntryTarget",
+      "description": "The API for interacting with metafields.\n\nThe metafield owner.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "The numeric owner ID that is associated with the metafield."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "| 'customer'\n    | 'product'\n    | 'shop'\n    | 'shopUser'\n    | 'variant'\n    | 'company'\n    | 'companyLocation'\n    | 'cart'",
+          "description": "The type of the metafield owner.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`."
+        }
+      ],
+      "value": "export interface AppMetafieldEntryTarget {\n  /**\n   * The type of the metafield owner.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.\n   */\n  type:\n    | 'customer'\n    | 'product'\n    | 'shop'\n    | 'shopUser'\n    | 'variant'\n    | 'company'\n    | 'companyLocation'\n    | 'cart';\n\n  /** The numeric owner ID that is associated with the metafield. */\n  id: string;\n}"
+    }
+  },
+  "Attribute": {
+    "src/surfaces/checkout/api/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/shared.ts",
+      "name": "Attribute",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "The key for the attribute."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The value for the attribute."
+        }
+      ],
+      "value": "export interface Attribute {\n  /**\n   * The key for the attribute.\n   */\n  key: string;\n\n  /**\n   * The value for the attribute.\n   */\n  value: string;\n}"
+    }
+  },
+  "PaymentOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PaymentOption",
+      "description": "The API for interacting with the payment options.\n\nA payment option presented to the buyer.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The unique handle for the payment option.\n\nThis is not a globally unique identifier. It may be an identifier specific to the given checkout session or the current shop."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "| 'creditCard'\n    | 'deferred'\n    | 'local'\n    | 'manualPayment'\n    | 'offsite'\n    | 'other'\n    | 'paymentOnDelivery'\n    | 'redeemable'\n    | 'wallet'\n    | 'customOnsite'",
+          "description": "The type of the payment option.\n\nShops can be configured to support many different payment options. Some options are only available to buyers in specific regions.\n\n| Type  | Description  |\n|---|---|\n| `creditCard`  |  A vaulted or manually entered credit card.  |\n| `deferred`  |  A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecting payment at a later time.  |\n| `local`  |  A [local payment option](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market  |\n| `manualPayment`  |  A manual payment option such as an in-person retail transaction.  |\n| `offsite`  |  A payment processed outside of Shopify's checkout, excluding integrated wallets.  |\n| `other`  |  Another type of payment not defined here.  |\n| `paymentOnDelivery`  |  A payment that will be collected on delivery.  |\n| `redeemable`  |  A redeemable payment option such as a gift card or store credit.  |\n| `wallet`  |  An integrated wallet such as PayPal, Google Pay, Apple Pay, etc.  |\n| `customOnsite` | A custom payment option that is processed through a checkout extension with a payments app. |"
+        }
+      ],
+      "value": "export interface PaymentOption {\n  /**\n   * The type of the payment option.\n   *\n   * Shops can be configured to support many different payment options. Some options are only available to buyers in specific regions.\n   *\n   * | Type  | Description  |\n   * |---|---|\n   * | `creditCard`  |  A vaulted or manually entered credit card.  |\n   * | `deferred`  |  A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecting payment at a later time.  |\n   * | `local`  |  A [local payment option](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market  |\n   * | `manualPayment`  |  A manual payment option such as an in-person retail transaction.  |\n   * | `offsite`  |  A payment processed outside of Shopify's checkout, excluding integrated wallets.  |\n   * | `other`  |  Another type of payment not defined here.  |\n   * | `paymentOnDelivery`  |  A payment that will be collected on delivery.  |\n   * | `redeemable`  |  A redeemable payment option such as a gift card or store credit.  |\n   * | `wallet`  |  An integrated wallet such as PayPal, Google Pay, Apple Pay, etc.  |\n   * | `customOnsite` | A custom payment option that is processed through a checkout extension with a payments app. |\n   */\n  type:\n    | 'creditCard'\n    | 'deferred'\n    | 'local'\n    | 'manualPayment'\n    | 'offsite'\n    | 'other'\n    | 'paymentOnDelivery'\n    | 'redeemable'\n    | 'wallet'\n    | 'customOnsite';\n\n  /**\n   * The unique handle for the payment option.\n   *\n   * This is not a globally unique identifier. It may be an identifier specific to the given checkout session or the current shop.\n   */\n  handle: string;\n}"
+    }
+  },
+  "MailingAddress": {
+    "src/surfaces/checkout/api/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/shared.ts",
+      "name": "MailingAddress",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address1",
+          "value": "string",
+          "description": "The first line of the buyer's address, including street name and number.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'151 O'Connor Street'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address2",
+          "value": "string",
+          "description": "The second line of the buyer's address, like apartment number, suite, etc.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Ground floor'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "city",
+          "value": "string",
+          "description": "The buyer's city.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Ottawa'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "company",
+          "value": "string",
+          "description": "The buyer's company name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Shopify'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "countryCode",
+          "value": "CountryCode",
+          "description": "The ISO 3166 Alpha-2 format for the buyer's country. Refer to https://www.iso.org/iso-3166-country-codes.html.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'CA' for Canada.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "firstName",
+          "value": "string",
+          "description": "The buyer's first name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'John'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lastName",
+          "value": "string",
+          "description": "The buyer's last name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Doe'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The buyer's full name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'John Doe'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "phone",
+          "value": "string",
+          "description": "The buyer's phone number.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'+1 613 111 2222'.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "provinceCode",
+          "value": "string",
+          "description": "The buyer's province code, such as state, province, prefecture, or region.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'ON' for Ontario.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "zip",
+          "value": "string",
+          "description": "The buyer's postal or ZIP code.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'K2P 2L8'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface MailingAddress {\n  /**\n   * The buyer's full name.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'John Doe'\n   */\n  name?: string;\n\n  /**\n   * The buyer's first name.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'John'\n   */\n  firstName?: string;\n\n  /**\n   * The buyer's last name.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'Doe'\n   */\n  lastName?: string;\n\n  /**\n   * The buyer's company name.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'Shopify'\n   */\n  company?: string;\n\n  /**\n   * The first line of the buyer's address, including street name and number.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example '151 O'Connor Street'\n   */\n  address1?: string;\n\n  /**\n   * The second line of the buyer's address, like apartment number, suite, etc.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'Ground floor'\n   */\n  address2?: string;\n\n  /**\n   * The buyer's city.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'Ottawa'\n   */\n  city?: string;\n\n  /**\n   * The buyer's postal or ZIP code.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'K2P 2L8'\n   */\n  zip?: string;\n\n  /**\n   * The ISO 3166 Alpha-2 format for the buyer's country. Refer to https://www.iso.org/iso-3166-country-codes.html.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'CA' for Canada.\n   */\n  countryCode?: CountryCode;\n\n  /**\n   * The buyer's province code, such as state, province, prefecture, or region.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'ON' for Ontario.\n   */\n  provinceCode?: string;\n\n  /**\n   * The buyer's phone number.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example '+1 613 111 2222'.\n   */\n  phone?: string;\n}"
+    }
+  },
+  "CountryCode": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CountryCode",
+      "value": "'AC' | 'AD' | 'AE' | 'AF' | 'AG' | 'AI' | 'AL' | 'AM' | 'AN' | 'AO' | 'AR' | 'AT' | 'AU' | 'AW' | 'AX' | 'AZ' | 'BA' | 'BB' | 'BD' | 'BE' | 'BF' | 'BG' | 'BH' | 'BI' | 'BJ' | 'BL' | 'BM' | 'BN' | 'BO' | 'BQ' | 'BR' | 'BS' | 'BT' | 'BV' | 'BW' | 'BY' | 'BZ' | 'CA' | 'CC' | 'CD' | 'CF' | 'CG' | 'CH' | 'CI' | 'CK' | 'CL' | 'CM' | 'CN' | 'CO' | 'CR' | 'CU' | 'CV' | 'CW' | 'CX' | 'CY' | 'CZ' | 'DE' | 'DJ' | 'DK' | 'DM' | 'DO' | 'DZ' | 'EC' | 'EE' | 'EG' | 'EH' | 'ER' | 'ES' | 'ET' | 'FI' | 'FJ' | 'FK' | 'FO' | 'FR' | 'GA' | 'GB' | 'GD' | 'GE' | 'GF' | 'GG' | 'GH' | 'GI' | 'GL' | 'GM' | 'GN' | 'GP' | 'GQ' | 'GR' | 'GS' | 'GT' | 'GW' | 'GY' | 'HK' | 'HM' | 'HN' | 'HR' | 'HT' | 'HU' | 'ID' | 'IE' | 'IL' | 'IM' | 'IN' | 'IO' | 'IQ' | 'IR' | 'IS' | 'IT' | 'JE' | 'JM' | 'JO' | 'JP' | 'KE' | 'KG' | 'KH' | 'KI' | 'KM' | 'KN' | 'KP' | 'KR' | 'KW' | 'KY' | 'KZ' | 'LA' | 'LB' | 'LC' | 'LI' | 'LK' | 'LR' | 'LS' | 'LT' | 'LU' | 'LV' | 'LY' | 'MA' | 'MC' | 'MD' | 'ME' | 'MF' | 'MG' | 'MK' | 'ML' | 'MM' | 'MN' | 'MO' | 'MQ' | 'MR' | 'MS' | 'MT' | 'MU' | 'MV' | 'MW' | 'MX' | 'MY' | 'MZ' | 'NA' | 'NC' | 'NE' | 'NF' | 'NG' | 'NI' | 'NL' | 'NO' | 'NP' | 'NR' | 'NU' | 'NZ' | 'OM' | 'PA' | 'PE' | 'PF' | 'PG' | 'PH' | 'PK' | 'PL' | 'PM' | 'PN' | 'PS' | 'PT' | 'PY' | 'QA' | 'RE' | 'RO' | 'RS' | 'RU' | 'RW' | 'SA' | 'SB' | 'SC' | 'SD' | 'SE' | 'SG' | 'SH' | 'SI' | 'SJ' | 'SK' | 'SL' | 'SM' | 'SN' | 'SO' | 'SR' | 'SS' | 'ST' | 'SV' | 'SX' | 'SY' | 'SZ' | 'TA' | 'TC' | 'TD' | 'TF' | 'TG' | 'TH' | 'TJ' | 'TK' | 'TL' | 'TM' | 'TN' | 'TO' | 'TR' | 'TT' | 'TV' | 'TW' | 'TZ' | 'UA' | 'UG' | 'UM' | 'US' | 'UY' | 'UZ' | 'VA' | 'VC' | 'VE' | 'VG' | 'VN' | 'VU' | 'WF' | 'WS' | 'XK' | 'YE' | 'YT' | 'ZA' | 'ZM' | 'ZW' | 'ZZ'",
+      "description": ""
+    }
+  },
+  "BuyerIdentity": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "BuyerIdentity",
+      "description": "The API for interacting with the buyer identity.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "customer",
+          "value": "SubscribableSignalLike<Customer | undefined>",
+          "description": "The buyer's customer account. The value is undefined if the buyer isn’t a known customer for this shop or if they haven't logged in yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "email",
+          "value": "SubscribableSignalLike<string | undefined>",
+          "description": "The email address of the buyer that is interacting with the cart. The value is `undefined` if the app does not have access to customer data.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "phone",
+          "value": "SubscribableSignalLike<string | undefined>",
+          "description": "The phone number of the buyer that is interacting with the cart. The value is `undefined` if the app does not have access to customer data.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchasingCompany",
+          "value": "SubscribableSignalLike<PurchasingCompany | undefined>",
+          "description": "Provides details of the company and the company location that the business customer is purchasing on behalf of. This includes information that can be used to identify the company and the company location that the business customer belongs to.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        }
+      ],
+      "value": "export interface BuyerIdentity {\n  /**\n   * The buyer's customer account. The value is undefined if the buyer isn’t a\n   * known customer for this shop or if they haven't logged in yet.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  customer: SubscribableSignalLike<Customer | undefined>;\n\n  /**\n   * The email address of the buyer that is interacting with the cart.\n   * The value is `undefined` if the app does not have access to customer data.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  email: SubscribableSignalLike<string | undefined>;\n\n  /**\n   * The phone number of the buyer that is interacting with the cart.\n   * The value is `undefined` if the app does not have access to customer data.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  phone: SubscribableSignalLike<string | undefined>;\n\n  /**\n   * Provides details of the company and the company location that the business customer is purchasing on behalf of.\n   * This includes information that can be used to identify the company and the company location that the business\n   * customer belongs to.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  purchasingCompany: SubscribableSignalLike<PurchasingCompany | undefined>;\n}"
+    }
+  },
+  "Customer": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Customer",
+      "description": "The API for interacting with the buyer identity.\n\nInformation about a customer who has previously purchased from this shop.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "acceptsEmailMarketing",
+          "value": "boolean",
+          "description": "Defines if the customer accepts email marketing activities.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "acceptsMarketing",
+          "value": "boolean",
+          "description": "Defines if the customer email accepts marketing activities.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n\n> Caution: This field is deprecated and will be removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.",
+          "deprecationMessage": "Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "acceptsSmsMarketing",
+          "value": "boolean",
+          "description": "Defines if the customer accepts SMS marketing activities.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "email",
+          "value": "string",
+          "description": "The email of the customer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "firstName",
+          "value": "string",
+          "description": "The first name of the customer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "fullName",
+          "value": "string",
+          "description": "The full name of the customer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "Customer ID.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/Customer/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "image",
+          "value": "ImageDetails",
+          "description": "The image associated with the customer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lastName",
+          "value": "string",
+          "description": "The last name of the customer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "ordersCount",
+          "value": "number",
+          "description": "The number of previous orders made by this customer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "phone",
+          "value": "string",
+          "description": "The phone number of the customer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storeCreditAccounts",
+          "value": "StoreCreditAccount[]",
+          "description": "The Store Credit Accounts owned by the customer and usable during the checkout process.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isPrivate": true
+        }
+      ],
+      "value": "export interface Customer {\n  /**\n   * Customer ID.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'gid://shopify/Customer/123'\n   */\n  id: string;\n  /**\n   * The email of the customer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  email?: string;\n  /**\n   * The phone number of the customer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  phone?: string;\n  /**\n   * The full name of the customer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  fullName?: string;\n  /**\n   * The first name of the customer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  firstName?: string;\n  /**\n   * The last name of the customer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  lastName?: string;\n  /**\n   * The image associated with the customer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  image: ImageDetails;\n  /**\n   * Defines if the customer email accepts marketing activities.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * > Caution: This field is deprecated and will be removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.\n   *\n   * @deprecated Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.\n   */\n  acceptsMarketing: boolean;\n  /**\n   * Defines if the customer accepts email marketing activities.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  acceptsEmailMarketing: boolean;\n  /**\n   * Defines if the customer accepts SMS marketing activities.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  acceptsSmsMarketing: boolean;\n  /**\n   * The Store Credit Accounts owned by the customer and usable during the checkout process.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @private\n   */\n  storeCreditAccounts: StoreCreditAccount[];\n  /**\n   * The number of previous orders made by this customer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  ordersCount: number;\n}"
+    }
+  },
+  "ImageDetails": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "ImageDetails",
+      "description": "The API for interacting with the cart lines.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "altText",
+          "value": "string",
+          "description": "The alternative text for the image.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "url",
+          "value": "string",
+          "description": "The image URL."
+        }
+      ],
+      "value": "export interface ImageDetails {\n  /**\n   * The image URL.\n   */\n  url: string;\n\n  /**\n   * The alternative text for the image.\n   */\n  altText?: string;\n}"
+    }
+  },
+  "StoreCreditAccount": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "StoreCreditAccount",
+      "description": "The API for interacting with the buyer identity.\n\nInformation about a Store Credit Account.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "balance",
+          "value": "Money",
+          "description": "The current balance of the Store Credit Account."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/StoreCreditAccount/1'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface StoreCreditAccount {\n  /**\n   * A globally-unique identifier.\n   * @example 'gid://shopify/StoreCreditAccount/1'\n   */\n  id: string;\n  /**\n   * The current balance of the Store Credit Account.\n   */\n  balance: Money;\n}"
+    }
+  },
+  "PurchasingCompany": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PurchasingCompany",
+      "description": "The API for interacting with the buyer identity.\n\nThe information about a company that the business customer is purchasing on behalf of.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "company",
+          "value": "Company",
+          "description": "Includes information of the company that the business customer is purchasing on behalf of.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "location",
+          "value": "CompanyLocation",
+          "description": "Includes information of the company location that the business customer is purchasing on behalf of.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        }
+      ],
+      "value": "export interface PurchasingCompany {\n  /**\n   * Includes information of the company that the business customer is purchasing on behalf of.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  company: Company;\n  /**\n   * Includes information of the company location that the business customer is purchasing on behalf of.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  location: CompanyLocation;\n}"
+    }
+  },
+  "Company": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Company",
+      "description": "The API for interacting with the buyer identity.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "externalId",
+          "value": "string",
+          "description": "The external ID of the company that can be set by the merchant.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "The company ID.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the company.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        }
+      ],
+      "value": "export interface Company {\n  /**\n   * The company ID.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  id: string;\n  /**\n   * The name of the company.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  name: string;\n  /**\n   * The external ID of the company that can be set by the merchant.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  externalId?: string;\n}"
+    }
+  },
+  "CompanyLocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CompanyLocation",
+      "description": "The API for interacting with the buyer identity.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "externalId",
+          "value": "string",
+          "description": "The external ID of the company location that can be set by the merchant.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "The company location ID.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the company location.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        }
+      ],
+      "value": "export interface CompanyLocation {\n  /**\n   * The company location ID.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  id: string;\n  /**\n   * The name of the company location.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  name: string;\n  /**\n   * The external ID of the company location that can be set by the merchant.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  externalId?: string;\n}"
+    }
+  },
+  "BuyerJourney": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "BuyerJourney",
+      "description": "The API for interacting with the buyer journey.\n\nProvides details on the buyer's progression through the checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "activeStep",
+          "value": "SubscribableSignalLike<BuyerJourneyStepReference | undefined>",
+          "description": "What step of checkout the buyer is currently on."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "completed",
+          "value": "SubscribableSignalLike<boolean>",
+          "description": "This subscribable value will be true if the buyer completed submitting their order.\n\nFor example, when viewing the **Order status** page after submitting payment, the buyer will have completed their order."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "intercept",
+          "value": "(interceptor: Interceptor) => Promise<() => void>",
+          "description": "Installs a function for intercepting and preventing progress on checkout.\n\nThis returns a promise that resolves to a teardown function. Calling the teardown function will remove the interceptor.\n\nTo block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/configuration#block-progress) capability in your extension's configuration.\n\nIf you do, then you're expected to inform the buyer why navigation was blocked, either by passing validation errors to the checkout UI or rendering the errors in your extension.\n\nIt is good practice to show a warning in the checkout editor when the merchant has not given permission for your extension to block checkout progress."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "steps",
+          "value": "SubscribableSignalLike<BuyerJourneyStep[]>",
+          "description": "All possible steps a buyer can take to complete the checkout. These steps may vary depending on the type of checkout or the shop's configuration."
+        }
+      ],
+      "value": "export interface BuyerJourney {\n  /**\n   * Installs a function for intercepting and preventing progress on checkout.\n   *\n   * This returns a promise that resolves to a teardown function. Calling the\n   * teardown function will remove the interceptor.\n   *\n   * To block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/configuration#block-progress)\n   * capability in your extension's configuration.\n   *\n   * If you do, then you're expected to inform the buyer why navigation was blocked,\n   * either by passing validation errors to the checkout UI or rendering the errors in your extension.\n   *\n   * It is good practice to show a warning in the checkout editor when the merchant has not given permission for your extension\n   * to block checkout progress.\n   */\n  intercept(interceptor: Interceptor): Promise<() => void>;\n\n  /**\n   * This subscribable value will be true if the buyer completed submitting their order.\n   *\n   * For example, when viewing the **Order status** page after submitting payment, the buyer will have completed their order.\n   */\n  completed: SubscribableSignalLike<boolean>;\n  /**\n   * All possible steps a buyer can take to complete the checkout. These steps may vary depending on the type of checkout or the shop's configuration.\n   */\n  steps: SubscribableSignalLike<BuyerJourneyStep[]>;\n  /**\n   * What step of checkout the buyer is currently on.\n   */\n  activeStep: SubscribableSignalLike<BuyerJourneyStepReference | undefined>;\n}"
+    }
+  },
+  "BuyerJourneyStepReference": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "BuyerJourneyStepReference",
+      "description": "What step of checkout the buyer is currently on.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "BuyerJourneyStepHandle",
+          "description": "The handle that uniquely identifies the buyer journey step."
+        }
+      ],
+      "value": "interface BuyerJourneyStepReference {\n  /**\n   * The handle that uniquely identifies the buyer journey step.\n   */\n  handle: BuyerJourneyStepHandle;\n}"
+    }
+  },
+  "BuyerJourneyStepHandle": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "BuyerJourneyStepHandle",
+      "value": "'cart' | 'checkout' | 'information' | 'shipping' | 'payment' | 'review' | 'thank-you' | 'unknown'",
+      "description": "| handle  | Description  |\n|---|---|\n| `cart`  |  The cart page.  |\n| `checkout`  |  A one-page checkout, including Shop Pay.  |\n| `information`  |  The contact information step of a three-page checkout.  |\n| `shipping`  |  The shipping step of a three-page checkout.  |\n| `payment`  |  The payment step of a three-page checkout.  |\n| `review`  |  The step after payment where the buyer confirms the purchase. Not all shops are configured to have a review step.  |\n| `thank-you`  |  The page displayed after the purchase, thanking the buyer.  |\n| `unknown` |  An unknown step in the buyer journey.  |"
+    }
+  },
+  "Interceptor": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Interceptor",
+      "description": "The API for interacting with the buyer journey.\n\nA function for intercepting and preventing navigation on checkout. You can block navigation by returning an object with `{behavior: 'block', reason: InvalidResultReason.InvalidExtensionState, errors?: ValidationErrors[]}`. If you do, then you're expected to also update some part of your UI to reflect the reason why navigation was blocked, either by targeting checkout UI fields, passing errors to the page level or rendering the errors in your extension.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "interceptorProps",
+          "description": "",
+          "value": "InterceptorProps",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+        "description": "",
+        "name": "InterceptorRequest | Promise<InterceptorRequest>",
+        "value": "InterceptorRequest | Promise<InterceptorRequest>"
+      },
+      "value": "(\n  interceptorProps: InterceptorProps,\n) => InterceptorRequest | Promise<InterceptorRequest>"
+    }
+  },
+  "InterceptorProps": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "InterceptorProps",
+      "description": "The API for interacting with the buyer journey.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canBlockProgress",
+          "value": "boolean",
+          "description": "Whether the interceptor has the capability to block a buyer's progress through checkout. This ability might be granted by a merchant in differing checkout contexts."
+        }
+      ],
+      "value": "export interface InterceptorProps {\n  /**\n   * Whether the interceptor has the capability to block a buyer's progress through\n   * checkout. This ability might be granted by a merchant in differing checkout contexts.\n   */\n  canBlockProgress: boolean;\n}"
+    }
+  },
+  "InterceptorRequest": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "InterceptorRequest",
+      "value": "InterceptorRequestAllow | InterceptorRequestBlock",
+      "description": "The API for interacting with the buyer journey.",
+      "isPublicDocs": true
+    }
+  },
+  "InterceptorRequestAllow": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "InterceptorRequestAllow",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "behavior",
+          "value": "'allow'",
+          "description": "Indicates that the interceptor will allow the buyer's journey to continue."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "perform",
+          "value": "(result: InterceptorResult) => void | Promise<void>",
+          "description": "This callback is called when all interceptors finish. We recommend setting errors or reasons for blocking at this stage, so that all the errors in the UI show up at once.",
+          "isOptional": true
+        }
+      ],
+      "value": "interface InterceptorRequestAllow {\n  /**\n   * Indicates that the interceptor will allow the buyer's journey to continue.\n   */\n  behavior: 'allow';\n\n  /**\n   * This callback is called when all interceptors finish. We recommend\n   * setting errors or reasons for blocking at this stage, so that all the errors in\n   * the UI show up at once.\n   * @param result InterceptorResult with behavior as either 'allow' or 'block'\n   */\n  perform?(result: InterceptorResult): void | Promise<void>;\n}"
+    }
+  },
+  "InterceptorResult": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "InterceptorResult",
+      "value": "InterceptorResultAllow | InterceptorResultBlock",
+      "description": ""
+    }
+  },
+  "InterceptorResultAllow": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "InterceptorResultAllow",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "behavior",
+          "value": "'allow'",
+          "description": "Indicates that the buyer was allowed to progress through checkout."
+        }
+      ],
+      "value": "interface InterceptorResultAllow {\n  /**\n   * Indicates that the buyer was allowed to progress through checkout.\n   */\n  behavior: 'allow';\n}"
+    }
+  },
+  "InterceptorResultBlock": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "InterceptorResultBlock",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "behavior",
+          "value": "'block'",
+          "description": "Indicates that some part of the checkout UI intercepted and prevented the buyer’s progress. The buyer typically needs to take some action to resolve this issue and to move on to the next step."
+        }
+      ],
+      "value": "interface InterceptorResultBlock {\n  /**\n   * Indicates that some part of the checkout UI intercepted and prevented\n   * the buyer’s progress. The buyer typically needs to take some action\n   * to resolve this issue and to move on to the next step.\n   */\n  behavior: 'block';\n}"
+    }
+  },
+  "InterceptorRequestBlock": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "InterceptorRequestBlock",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "behavior",
+          "value": "'block'",
+          "description": "Indicates that the interceptor will block the buyer's journey from continuing."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "errors",
+          "value": "ValidationError[]",
+          "description": "Used to pass errors to the checkout UI, outside your extension's UI boundaries.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "perform",
+          "value": "(result: InterceptorResult) => void | Promise<void>",
+          "description": "This callback is called when all interceptors finish. We recommend setting errors or reasons for blocking at this stage, so that all the errors in the UI show up at once.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "reason",
+          "value": "string",
+          "description": "The reason for blocking the interceptor request. This value isn't presented to the buyer, so it doesn't need to be localized. The value is used only for Shopify’s own internal debugging and metrics."
+        }
+      ],
+      "value": "interface InterceptorRequestBlock {\n  /**\n   * Indicates that the interceptor will block the buyer's journey from continuing.\n   */\n  behavior: 'block';\n\n  /**\n   * The reason for blocking the interceptor request. This value isn't presented to\n   * the buyer, so it doesn't need to be localized. The value is used only for Shopify’s\n   * own internal debugging and metrics.\n   */\n  reason: string;\n\n  /**\n   * Used to pass errors to the checkout UI, outside your extension's UI boundaries.\n   */\n  errors?: ValidationError[];\n\n  /**\n   * This callback is called when all interceptors finish. We recommend\n   * setting errors or reasons for blocking at this stage, so that all the errors in\n   * the UI show up at once.\n   * @param result InterceptorResult with behavior as either 'allow' or 'block'\n   */\n  perform?(result: InterceptorResult): void | Promise<void>;\n}"
+    }
+  },
+  "ValidationError": {
+    "src/surfaces/checkout/api/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/shared.ts",
+      "name": "ValidationError",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "Error message to be displayed to the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "string",
+          "description": "The checkout UI field that the error is associated with.\n\nExample: `$.cart.deliveryGroups[0].deliveryAddress.countryCode`\n\nSee the [supported targets](/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets) for more information.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface ValidationError {\n  /**\n   * Error message to be displayed to the buyer.\n   */\n  message: string;\n  /**\n   * The checkout UI field that the error is associated with.\n   *\n   * Example: `$.cart.deliveryGroups[0].deliveryAddress.countryCode`\n   *\n   * See the [supported targets](/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets)\n   * for more information.\n   */\n  target?: string;\n}"
+    }
+  },
+  "BuyerJourneyStep": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "BuyerJourneyStep",
+      "description": "The API for interacting with the buyer journey.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "disabled",
+          "value": "boolean",
+          "description": "The disabled state of the buyer journey step. This value will be true if the buyer has not reached the step yet.\n\nFor example, if the buyer has not reached the `shipping` step yet, `shipping` would be disabled."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "BuyerJourneyStepHandle",
+          "description": "The handle that uniquely identifies the buyer journey step."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "label",
+          "value": "string",
+          "description": "The localized label of the buyer journey step."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "to",
+          "value": "string",
+          "description": "The url of the buyer journey step. This property leverages the `shopify:` protocol E.g. `shopify:cart` or `shopify:checkout/information`."
+        }
+      ],
+      "value": "export interface BuyerJourneyStep {\n  /**\n   * The handle that uniquely identifies the buyer journey step.\n   */\n  handle: BuyerJourneyStepHandle;\n  /**\n   * The localized label of the buyer journey step.\n   */\n  label: string;\n  /**\n   * The url of the buyer journey step. This property leverages the `shopify:` protocol\n   * E.g. `shopify:cart` or `shopify:checkout/information`.\n   */\n  to: string;\n  /**\n   * The disabled state of the buyer journey step. This value will be true if the buyer has not reached the step yet.\n   *\n   * For example, if the buyer has not reached the `shipping` step yet, `shipping` would be disabled.\n   */\n  disabled: boolean;\n}"
+    }
+  },
+  "CheckoutSettings": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CheckoutSettings",
+      "description": "The API for interacting with merchant settings.\n\nSettings describing the behavior of the buyer's checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "orderSubmission",
+          "value": "'DRAFT_ORDER' | 'ORDER'",
+          "description": "The type of order that will be created once the buyer completes checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "paymentTermsTemplate",
+          "value": "PaymentTermsTemplate",
+          "description": "Represents the merchant configured payment terms.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shippingAddress",
+          "value": "ShippingAddressSettings",
+          "description": "Settings describing the behavior of the shipping address."
+        }
+      ],
+      "value": "export interface CheckoutSettings {\n  /**\n   * The type of order that will be created once the buyer completes checkout.\n   */\n  orderSubmission: 'DRAFT_ORDER' | 'ORDER';\n  /**\n   * Represents the merchant configured payment terms.\n   */\n  paymentTermsTemplate?: PaymentTermsTemplate;\n  /**\n   * Settings describing the behavior of the shipping address.\n   */\n  shippingAddress: ShippingAddressSettings;\n}"
+    }
+  },
+  "PaymentTermsTemplate": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PaymentTermsTemplate",
+      "description": "The API for interacting with merchant settings.\n\nRepresents the payment terms template object.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "dueDate",
+          "value": "string",
+          "description": "The due date for net payment terms as a ISO 8601 formatted string `YYYY-MM-DDTHH:mm:ss.sssZ`.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "dueInDays",
+          "value": "number",
+          "description": "The number of days between the issued date and due date if using net payment terms.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique ID.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/PaymentTermsTemplate/1'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the payment terms translated to the buyer's current language. Refer to [localization.language](/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-localization)."
+        }
+      ],
+      "value": "export interface PaymentTermsTemplate {\n  /**\n   * A globally-unique ID.\n   * @example 'gid://shopify/PaymentTermsTemplate/1'\n   */\n  id: string;\n  /**\n   * The name of the payment terms translated to the buyer's current language. Refer to [localization.language](/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-localization).\n   */\n  name: string;\n  /**\n   * The due date for net payment terms as a ISO 8601 formatted string `YYYY-MM-DDTHH:mm:ss.sssZ`.\n   */\n  dueDate?: string;\n  /**\n   * The number of days between the issued date and due date if using net payment terms.\n   */\n  dueInDays?: number;\n}"
+    }
+  },
+  "ShippingAddressSettings": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "ShippingAddressSettings",
+      "description": "The API for interacting with merchant settings.\n\nSettings describing the behavior of the shipping address.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isEditable",
+          "value": "boolean",
+          "description": "Describes whether the buyer can ship to any address during checkout."
+        }
+      ],
+      "value": "export interface ShippingAddressSettings {\n  /**\n   * Describes whether the buyer can ship to any address during checkout.\n   */\n  isEditable: boolean;\n}"
+    }
+  },
+  "CheckoutToken": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CheckoutToken",
+      "value": "string",
+      "description": "The API for interacting with the token of a checkout.",
+      "isPublicDocs": true
+    }
+  },
+  "CartCost": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartCost",
+      "description": "The API for interacting with the cost of a checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "subtotalAmount",
+          "value": "SubscribableSignalLike<Money>",
+          "description": "A `Money` value representing the subtotal value of the items in the cart at the current step of checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "totalAmount",
+          "value": "SubscribableSignalLike<Money>",
+          "description": "A `Money` value representing the minimum a buyer can expect to pay at the current step of checkout. This value excludes amounts yet to be negotiated. For example, the information step might not have delivery costs calculated."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "totalShippingAmount",
+          "value": "SubscribableSignalLike<Money | undefined>",
+          "description": "A `Money` value representing the total shipping a buyer can expect to pay at the current step of checkout. This value includes shipping discounts. Returns undefined if shipping has not been negotiated yet, such as on the information step."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "totalTaxAmount",
+          "value": "SubscribableSignalLike<Money | undefined>",
+          "description": "A `Money` value representing the total tax a buyer can expect to pay at the current step of checkout or the total tax included in product and shipping prices. Returns undefined if taxes are unavailable."
+        }
+      ],
+      "value": "export interface CartCost {\n  /**\n   * A `Money` value representing the subtotal value of the items in the cart at the current\n   * step of checkout.\n   */\n  subtotalAmount: SubscribableSignalLike<Money>;\n\n  /**\n   * A `Money` value representing the total shipping a buyer can expect to pay at the current\n   * step of checkout. This value includes shipping discounts. Returns undefined if shipping\n   * has not been negotiated yet, such as on the information step.\n   */\n  totalShippingAmount: SubscribableSignalLike<Money | undefined>;\n\n  /**\n   * A `Money` value representing the total tax a buyer can expect to pay at the current\n   * step of checkout or the total tax included in product and shipping prices. Returns\n   * undefined if taxes are unavailable.\n   */\n  totalTaxAmount: SubscribableSignalLike<Money | undefined>;\n\n  /**\n   * A `Money` value representing the minimum a buyer can expect to pay at the current\n   * step of checkout. This value excludes amounts yet to be negotiated. For example,\n   * the information step might not have delivery costs calculated.\n   */\n  totalAmount: SubscribableSignalLike<Money>;\n}"
+    }
+  },
+  "CustomerPrivacy": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CustomerPrivacy",
+      "description": "The API for interacting with a customer's privacy consent. It is similar to the [Customer Privacy API in storefront](/docs/api/customer-privacy).",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "allowedProcessing",
+          "value": "AllowedProcessing",
+          "description": "An object containing flags for each consent property denoting whether they can be processed based on visitor consent, merchant configuration, and user location."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "TrackingConsentMetafield[]",
+          "description": "Stored tracking consent metafield data.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "`[{key: 'analyticsType', value: 'granular'}, {key: 'marketingType', value: 'granular'}]`, or `[]`",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "region",
+          "value": "CustomerPrivacyRegion",
+          "description": "Details about the visitor's current location for use in evaluating if more granular consent controls should render.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "`{countryCode: 'CA', provinceCode: 'ON'}` for a visitor in Ontario, Canada; `{countryCode: 'US', provinceCode: undefined}` for a visitor in the United States if geolocation fails to detect the state; or `undefined` if neither country nor province is detected or geolocation fails.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "saleOfDataRegion",
+          "value": "boolean",
+          "description": "Whether the visitor is in a region requiring data sale opt-outs."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shouldShowBanner",
+          "value": "boolean",
+          "description": "Whether a consent banner should be displayed by default when the page loads. Use this as the initial open/expanded state of the consent banner.\n\nThis is determined by the visitor's current privacy consent, the shop's [region visibility configuration](https://help.shopify.com/en/manual/privacy-and-security/privacy/customer-privacy-settings/privacy-settings#add-a-cookie-banner) settings, and the region in which the visitor is located."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "visitorConsent",
+          "value": "VisitorConsent",
+          "description": "An object containing the customer's current privacy consent settings. *",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "`true` — the customer has actively granted consent, `false` — the customer has actively denied consent, or `undefined` — the customer has not yet made a decision.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface CustomerPrivacy {\n  /**\n   * An object containing flags for each consent property denoting whether they can be processed based on visitor consent, merchant configuration, and user location.\n   */\n  allowedProcessing: AllowedProcessing;\n  /**\n   * Stored tracking consent metafield data.\n   *\n   * @example `[{key: 'analyticsType', value: 'granular'}, {key: 'marketingType', value: 'granular'}]`, or `[]`\n   */\n  metafields: TrackingConsentMetafield[];\n  /**\n   * An object containing the customer's current privacy consent settings.\n   * *\n   * @example `true` — the customer has actively granted consent, `false` — the customer has actively denied consent, or `undefined` — the customer has not yet made a decision.\n   */\n  visitorConsent: VisitorConsent;\n  /**\n   * Whether a consent banner should be displayed by default when the page loads. Use this as the initial open/expanded state of the consent banner.\n   *\n   * This is determined by the visitor's current privacy consent, the shop's [region visibility configuration](https://help.shopify.com/en/manual/privacy-and-security/privacy/customer-privacy-settings/privacy-settings#add-a-cookie-banner) settings, and the region in which the visitor is located.\n   */\n  shouldShowBanner: boolean;\n  /**\n   * Whether the visitor is in a region requiring data sale opt-outs.\n   */\n  saleOfDataRegion: boolean;\n  /**\n   * Details about the visitor's current location for use in evaluating if more granular consent controls should render.\n   *\n   * @example `{countryCode: 'CA', provinceCode: 'ON'}` for a visitor in Ontario, Canada; `{countryCode: 'US', provinceCode: undefined}` for a visitor in the United States if geolocation fails to detect the state; or `undefined` if neither country nor province is detected or geolocation fails.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  region?: CustomerPrivacyRegion;\n}"
+    }
+  },
+  "AllowedProcessing": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AllowedProcessing",
+      "description": "The API for interacting with a customer's privacy consent.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "analytics",
+          "value": "boolean",
+          "description": "Can collect customer analytics about how the shop was used and interactions made on the shop."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "marketing",
+          "value": "boolean",
+          "description": "Can collect customer preference for marketing, attribution and targeted advertising from the merchant."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "preferences",
+          "value": "boolean",
+          "description": "Can collect customer preferences such as language, currency, size, and more."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "saleOfData",
+          "value": "boolean",
+          "description": "Can collect customer preference for sharing data with third parties, usually for behavioral advertising."
+        }
+      ],
+      "value": "export interface AllowedProcessing {\n  /**\n   * Can collect customer analytics about how the shop was used and interactions made on the shop.\n   */\n  analytics: boolean;\n  /**\n   * Can collect customer preference for marketing, attribution and targeted advertising from the merchant.\n   */\n  marketing: boolean;\n  /**\n   * Can collect customer preferences such as language, currency, size, and more.\n   */\n  preferences: boolean;\n  /**\n   * Can collect customer preference for sharing data with third parties, usually for behavioral advertising.\n   */\n  saleOfData: boolean;\n}"
+    }
+  },
+  "TrackingConsentMetafield": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "TrackingConsentMetafield",
+      "description": "The API for interacting with a customer's privacy consent.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "The name of the metafield. It must be between 3 and 30 characters in length (inclusive)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The information to be stored as metadata.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'any string', '', or a stringified JSON object",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface TrackingConsentMetafield {\n  /**\n   * The name of the metafield. It must be between 3 and 30 characters in\n   * length (inclusive).\n   */\n  key: string;\n  /**\n   * The information to be stored as metadata.\n   *\n   * @example 'any string', '', or a stringified JSON object\n   */\n  value: string;\n}"
+    }
+  },
+  "CustomerPrivacyRegion": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CustomerPrivacyRegion",
+      "description": "The API for interacting with a customer's privacy consent.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "countryCode",
+          "value": "CountryCode",
+          "description": "The [ISO 3166 Alpha-2 format](https://www.iso.org/iso-3166-country-codes.html) for the buyer's country.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'CA' for Canada, 'US' for United States, 'GB' for Great Britain, or undefined if geolocation failed.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "provinceCode",
+          "value": "string",
+          "description": "The buyer's province code, such as state, province, prefecture, or region.\n\nProvince codes can be found by clicking on the `Subdivisions assigned codes` column for countries listed [here](https://en.wikipedia.org/wiki/ISO_3166-2).\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'ON' for Ontario, 'ENG' for England, 'CA' for California, or undefined if geolocation failed or only the country was detected.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface CustomerPrivacyRegion {\n  /**\n   * The [ISO 3166 Alpha-2 format](https://www.iso.org/iso-3166-country-codes.html) for the buyer's country.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'CA' for Canada, 'US' for United States, 'GB' for Great Britain, or undefined if geolocation failed.\n   */\n  countryCode?: CountryCode;\n  /**\n   * The buyer's province code, such as state, province, prefecture, or region.\n   *\n   * Province codes can be found by clicking on the `Subdivisions assigned codes` column for countries listed [here](https://en.wikipedia.org/wiki/ISO_3166-2).\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'ON' for Ontario, 'ENG' for England, 'CA' for California, or undefined if geolocation failed or only the country was detected.\n   */\n  provinceCode?: string;\n}"
+    }
+  },
+  "DeliveryGroup": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "DeliveryGroup",
+      "description": "The APIs for interacting with delivery and shipping options.\n\nRepresents the delivery information and options available for one or more cart lines.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryOptions",
+          "value": "DeliveryOption[]",
+          "description": "The delivery options available for the delivery group."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "groupType",
+          "value": "DeliveryGroupType",
+          "description": "The type of the delivery group."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "The unique identifier of the delivery group. On the Thank You page this value is undefined.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isDeliveryRequired",
+          "value": "boolean",
+          "description": "Whether delivery is required for the delivery group."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "selectedDeliveryOption",
+          "value": "DeliveryOptionReference",
+          "description": "The selected delivery option for the delivery group.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "targetedCartLines",
+          "value": "CartLineReference[]",
+          "description": "The cart line references associated to the delivery group."
+        }
+      ],
+      "value": "export interface DeliveryGroup {\n  /**\n   * The unique identifier of the delivery group. On the Thank You page this value is undefined.\n   */\n  id?: string;\n  /**\n   * The cart line references associated to the delivery group.\n   */\n  targetedCartLines: CartLineReference[];\n\n  /**\n   * The delivery options available for the delivery group.\n   */\n  deliveryOptions: DeliveryOption[];\n\n  /**\n   * The selected delivery option for the delivery group.\n   */\n  selectedDeliveryOption?: DeliveryOptionReference;\n\n  /**\n   * The type of the delivery group.\n   */\n  groupType: DeliveryGroupType;\n\n  /**\n   * Whether delivery is required for the delivery group.\n   */\n  isDeliveryRequired: boolean;\n}"
+    }
+  },
+  "DeliveryOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "DeliveryOption",
+      "value": "ShippingOption | PickupPointOption | PickupLocationOption",
+      "description": "The APIs for interacting with delivery and shipping options.",
+      "isPublicDocs": true
+    }
+  },
+  "ShippingOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "ShippingOption",
+      "description": "The APIs for interacting with delivery and shipping options.\n\nRepresents a delivery option that is a shipping option.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "carrier",
+          "value": "ShippingOptionCarrier",
+          "description": "Information about the carrier."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The code of the delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cost",
+          "value": "Money",
+          "description": "The cost of the delivery."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "costAfterDiscounts",
+          "value": "Money",
+          "description": "The cost of the delivery including discounts."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryEstimate",
+          "value": "DeliveryEstimate",
+          "description": "Information about the estimated delivery time."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "description",
+          "value": "string",
+          "description": "The description of the delivery option.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The unique identifier of the delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "Metafield[]",
+          "description": "The metafields associated with this delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The title of the delivery option.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'shipping' | 'local'",
+          "description": "The type of this delivery option."
+        }
+      ],
+      "value": "export interface ShippingOption extends DeliveryOptionBase {\n  /**\n   * The type of this delivery option.\n   */\n  type: 'shipping' | 'local';\n\n  /**\n   * Information about the carrier.\n   */\n  carrier: ShippingOptionCarrier;\n\n  /**\n   * The cost of the delivery.\n   */\n  cost: Money;\n\n  /**\n   * The cost of the delivery including discounts.\n   */\n  costAfterDiscounts: Money;\n\n  /**\n   * Information about the estimated delivery time.\n   */\n  deliveryEstimate: DeliveryEstimate;\n}"
+    }
+  },
+  "ShippingOptionCarrier": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "ShippingOptionCarrier",
+      "description": "The APIs for interacting with delivery and shipping options.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the carrier.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface ShippingOptionCarrier {\n  /**\n   * The name of the carrier.\n   */\n  name?: string;\n}"
+    }
+  },
+  "DeliveryEstimate": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "DeliveryEstimate",
+      "description": "The APIs for interacting with delivery and shipping options.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "timeInTransit",
+          "value": "NumberRange",
+          "description": "The estimated time in transit for the delivery in seconds.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface DeliveryEstimate {\n  /**\n   * The estimated time in transit for the delivery in seconds.\n   */\n  timeInTransit?: NumberRange;\n}"
+    }
+  },
+  "NumberRange": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "NumberRange",
+      "description": "The APIs for interacting with delivery and shipping options.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lower",
+          "value": "number",
+          "description": "The lower bound of the number range.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "upper",
+          "value": "number",
+          "description": "The upper bound of the number range.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface NumberRange {\n  /**\n   * The lower bound of the number range.\n   */\n  lower?: number;\n\n  /**\n   * The upper bound of the number range.\n   */\n  upper?: number;\n}"
+    }
+  },
+  "Metafield": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Metafield",
+      "description": "The API for interacting with metafields.\n\nMetadata associated with the checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "The name of the metafield. It must be between 3 and 30 characters in length (inclusive)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "namespace",
+          "value": "string",
+          "description": "A container for a set of metafields. You need to define a custom namespace for your metafields to distinguish them from the metafields used by other apps. This must be between 2 and 20 characters in length (inclusive)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string | number",
+          "description": "The information to be stored as metadata. Always stored as a string, regardless of the metafield's type."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "valueType",
+          "value": "'integer' | 'string' | 'json_string'",
+          "description": "The metafield’s information type."
+        }
+      ],
+      "value": "export interface Metafield {\n  /**\n   * The name of the metafield. It must be between 3 and 30 characters in\n   * length (inclusive).\n   */\n  key: string;\n\n  /**\n   * A container for a set of metafields. You need to define a custom\n   * namespace for your metafields to distinguish them from the metafields\n   * used by other apps. This must be between 2 and 20 characters in length (inclusive).\n   */\n  namespace: string;\n\n  /**\n   * The information to be stored as metadata. Always stored as a string, regardless of the metafield's type.\n   */\n  value: string | number;\n\n  /** The metafield’s information type. */\n  valueType: 'integer' | 'string' | 'json_string';\n}"
+    }
+  },
+  "PickupPointOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PickupPointOption",
+      "description": "The APIs for interacting with delivery and shipping options.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "carrier",
+          "value": "PickupPointCarrier",
+          "description": "Information about the carrier that ships to the pickup point."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The code of the delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cost",
+          "value": "Money",
+          "description": "The cost to ship to this pickup point."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "costAfterDiscounts",
+          "value": "Money",
+          "description": "The cost to ship to this pickup point including discounts."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "description",
+          "value": "string",
+          "description": "The description of the delivery option.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The unique identifier of the delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "location",
+          "value": "PickupPointLocation",
+          "description": "The location details of the pickup point."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "Metafield[]",
+          "description": "The metafields associated with this delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The title of the delivery option.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'pickupPoint'",
+          "description": "The type of this delivery option."
+        }
+      ],
+      "value": "export interface PickupPointOption extends DeliveryOptionBase {\n  /**\n   * The type of this delivery option.\n   */\n  type: 'pickupPoint';\n\n  /**\n   * Information about the carrier that ships to the pickup point.\n   */\n  carrier: PickupPointCarrier;\n\n  /**\n   * The cost to ship to this pickup point.\n   */\n  cost: Money;\n\n  /**\n   * The cost to ship to this pickup point including discounts.\n   */\n  costAfterDiscounts: Money;\n\n  /**\n   * The location details of the pickup point.\n   */\n  location: PickupPointLocation;\n}"
+    }
+  },
+  "PickupPointCarrier": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PickupPointCarrier",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The code identifying the carrier.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the carrier.",
+          "isOptional": true
+        }
+      ],
+      "value": "interface PickupPointCarrier {\n  /**\n   * The code identifying the carrier.\n   */\n  code?: string;\n\n  /**\n   * The name of the carrier.\n   */\n  name?: string;\n}"
+    }
+  },
+  "PickupPointLocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PickupPointLocation",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address",
+          "value": "MailingAddress",
+          "description": "The address of the pickup point."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The unique identifier of the pickup point."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the pickup point.",
+          "isOptional": true
+        }
+      ],
+      "value": "interface PickupPointLocation {\n  /**\n   * The name of the pickup point.\n   */\n  name?: string;\n\n  /**\n   * The unique identifier of the pickup point.\n   */\n  handle: string;\n\n  /**\n   * The address of the pickup point.\n   */\n  address: MailingAddress;\n}"
+    }
+  },
+  "PickupLocationOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PickupLocationOption",
+      "description": "The APIs for interacting with delivery and shipping options.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The code of the delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "description",
+          "value": "string",
+          "description": "The description of the delivery option.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The unique identifier of the delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "location",
+          "value": "PickupLocation",
+          "description": "The location details of the pickup location."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "Metafield[]",
+          "description": "The metafields associated with this delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The title of the delivery option.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'pickup'",
+          "description": "The type of this delivery option."
+        }
+      ],
+      "value": "export interface PickupLocationOption extends DeliveryOptionBase {\n  /**\n   * The type of this delivery option.\n   */\n  type: 'pickup';\n\n  /**\n   * The location details of the pickup location.\n   */\n  location: PickupLocation;\n}"
+    }
+  },
+  "PickupLocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PickupLocation",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address",
+          "value": "MailingAddress",
+          "description": "The address of the pickup location."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the pickup location.",
+          "isOptional": true
+        }
+      ],
+      "value": "interface PickupLocation {\n  /**\n   * The name of the pickup location.\n   */\n  name?: string;\n\n  /**\n   * The address of the pickup location.\n   */\n  address: MailingAddress;\n}"
+    }
+  },
+  "DeliveryGroupType": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "DeliveryGroupType",
+      "value": "'oneTimePurchase' | 'subscription'",
+      "description": "The APIs for interacting with delivery and shipping options.\n\nThe possible types of a delivery group.",
+      "isPublicDocs": true
+    }
+  },
+  "DeliveryOptionReference": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "DeliveryOptionReference",
+      "description": "The APIs for interacting with delivery and shipping options.\n\nRepresents a reference to a delivery option.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The unique identifier of the referenced delivery option."
+        }
+      ],
+      "value": "export interface DeliveryOptionReference {\n  /**\n   * The unique identifier of the referenced delivery option.\n   */\n  handle: string;\n}"
+    }
+  },
+  "CartLineReference": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartLineReference",
+      "description": "The APIs for interacting with delivery and shipping options.\n\nRepresents a reference to a cart line.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "The unique identifier of the referenced cart line."
+        }
+      ],
+      "value": "export interface CartLineReference {\n  /**\n   * The unique identifier of the referenced cart line.\n   */\n  id: string;\n}"
+    }
+  },
+  "CartDiscountAllocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CartDiscountAllocation",
+      "value": "CartCodeDiscountAllocation | CartAutomaticDiscountAllocation | CartCustomDiscountAllocation",
+      "description": "The API for interacting with discounts.",
+      "isPublicDocs": true
+    }
+  },
+  "CartCodeDiscountAllocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartCodeDiscountAllocation",
+      "description": "The API for interacting with discounts.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The code for the discount"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountedAmount",
+          "value": "Money",
+          "description": "The money amount that has been discounted from the order"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'code'",
+          "description": "The type of the code discount"
+        }
+      ],
+      "value": "export interface CartCodeDiscountAllocation extends CartDiscountAllocationBase {\n  /**\n   * The code for the discount\n   */\n  code: string;\n\n  /**\n   * The type of the code discount\n   */\n  type: 'code';\n}"
+    }
+  },
+  "CartAutomaticDiscountAllocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartAutomaticDiscountAllocation",
+      "description": "The API for interacting with discounts.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountedAmount",
+          "value": "Money",
+          "description": "The money amount that has been discounted from the order"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The title of the automatic discount"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'automatic'",
+          "description": "The type of the automatic discount"
+        }
+      ],
+      "value": "export interface CartAutomaticDiscountAllocation\n  extends CartDiscountAllocationBase {\n  /**\n   * The title of the automatic discount\n   */\n  title: string;\n\n  /**\n   * The type of the automatic discount\n   */\n  type: 'automatic';\n}"
+    }
+  },
+  "CartCustomDiscountAllocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartCustomDiscountAllocation",
+      "description": "The API for interacting with discounts.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountedAmount",
+          "value": "Money",
+          "description": "The money amount that has been discounted from the order"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The title of the custom discount"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'custom'",
+          "description": "The type of the custom discount"
+        }
+      ],
+      "value": "export interface CartCustomDiscountAllocation\n  extends CartDiscountAllocationBase {\n  /**\n   * The title of the custom discount\n   */\n  title: string;\n\n  /**\n   * The type of the custom discount\n   */\n  type: 'custom';\n}"
+    }
+  },
+  "CartDiscountCode": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartDiscountCode",
+      "description": "The API for interacting with discounts.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The code for the discount"
+        }
+      ],
+      "value": "export interface CartDiscountCode {\n  /**\n   * The code for the discount\n   */\n  code: string;\n}"
+    }
+  },
+  "Extension": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Extension",
+      "description": "The API for interacting with the metadata of an extension.\n\nThe meta information about an extension target.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiVersion",
+          "value": "ApiVersion",
+          "description": "The API version that was set in the extension config file.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'2024-10', '2025-01', '2025-04', '2025-07', '2025-10'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "capabilities",
+          "value": "SubscribableSignalLike<Capability[]>",
+          "description": "The allowed capabilities of the extension, defined in your [shopify.extension.toml](/docs/api/checkout-ui-extensions/configuration) file.\n\n* [`api_access`](/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.\n\n* [`network_access`](/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.\n\n* [`block_progress`](/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a customer's progress and the merchant has allowed this blocking behavior.\n\n* [`collect_buyer_consent.sms_marketing`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.\n\n* [`collect_buyer_consent.customer_privacy`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that will be honored on Shopify-managed services.\n\n* [`iframe.sources`](/docs/api/checkout-ui-extensions/configuration#iframe): the extension can embed an external URL in an iframe."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "editor",
+          "value": "Editor",
+          "description": "Information about the editor where the extension is being rendered.\n\nIf the value is undefined, then the extension is not running in an editor.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rendered",
+          "value": "SubscribableSignalLike<boolean>",
+          "description": "A Boolean to show whether your extension is currently rendered to the screen.\n\nShopify might render your extension before it's visible in the UI, typically to pre-render extensions that will appear on a later step of the checkout.\n\nYour extension might also continue to run after the customer has navigated away from where it was rendered. The extension continues running so that your extension is immediately available to render if the customer navigates back."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "scriptUrl",
+          "value": "string",
+          "description": "The URL to the script that started the extension target."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "Target",
+          "description": "The identifier that specifies where in Shopify’s UI your code is being injected. This will be one of the targets you have included in your extension’s configuration file.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'purchase.checkout.block.render'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "version",
+          "value": "string",
+          "description": "The published version of the running extension target.\n\nFor unpublished extensions, the value is `undefined`.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "3.0.10",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {\n  /**\n   * The API version that was set in the extension config file.\n   *\n   * @example '2024-10', '2025-01', '2025-04', '2025-07', '2025-10'\n   */\n  apiVersion: ApiVersion;\n\n  /**\n   * The allowed capabilities of the extension, defined\n   * in your [shopify.extension.toml](/docs/api/checkout-ui-extensions/configuration) file.\n   *\n   * * [`api_access`](/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.\n   *\n   * * [`network_access`](/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.\n   *\n   * * [`block_progress`](/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a customer's progress and the merchant has allowed this blocking behavior.\n   *\n   * * [`collect_buyer_consent.sms_marketing`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.\n   *\n   * * [`collect_buyer_consent.customer_privacy`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that will be honored on Shopify-managed services.\n   *\n   * * [`iframe.sources`](/docs/api/checkout-ui-extensions/configuration#iframe): the extension can embed an external URL in an iframe.\n   */\n  capabilities: SubscribableSignalLike<Capability[]>;\n\n  /**\n   * Information about the editor where the extension is being rendered.\n   *\n   * If the value is undefined, then the extension is not running in an editor.\n   */\n  editor?: Editor;\n\n  /**\n   * A Boolean to show whether your extension is currently rendered to the screen.\n   *\n   * Shopify might render your extension before it's visible in the UI,\n   * typically to pre-render extensions that will appear on a later step of the\n   * checkout.\n   *\n   * Your extension might also continue to run after the customer has navigated away\n   * from where it was rendered. The extension continues running so that\n   * your extension is immediately available to render if the customer navigates back.\n   */\n  rendered: SubscribableSignalLike<boolean>;\n\n  /**\n   * The URL to the script that started the extension target.\n   */\n  scriptUrl: string;\n\n  /**\n   * The identifier that specifies where in Shopify’s UI your code is being\n   * injected. This will be one of the targets you have included in your\n   * extension’s configuration file.\n   *\n   * @example 'purchase.checkout.block.render'\n   * @see /docs/api/checkout-ui-extensions/latest/extension-targets-overview\n   * @see /docs/apps/app-extensions/configuration#targets\n   */\n  target: Target;\n\n  /**\n   * The published version of the running extension target.\n   *\n   * For unpublished extensions, the value is `undefined`.\n   *\n   * @example 3.0.10\n   */\n  version?: string;\n}"
+    }
+  },
+  "ApiVersion": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ApiVersion",
+      "value": "'2023-04' | '2023-07' | '2023-10' | '2024-01' | '2024-04' | '2024-07' | '2024-10' | '2025-01' | '2025-04' | 'unstable' | '2025-07' | '2025-10' | '2026-01'",
+      "description": "The supported GraphQL Admin API versions. Use this to specify which API version your GraphQL queries should execute against. Each version includes specific features, bug fixes, and breaking changes. The `unstable` version provides access to the latest features but may change without notice."
+    }
+  },
+  "Capability": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "Capability",
+      "value": "'api_access' | 'network_access' | 'block_progress' | 'collect_buyer_consent.sms_marketing' | 'collect_buyer_consent.customer_privacy' | 'iframe.sources'",
+      "description": "The capabilities an extension has access to.\n\n* [`api_access`](/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.\n\n* [`network_access`](/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.\n\n* [`block_progress`](/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a buyer's progress and the merchant has allowed this blocking behavior.\n\n* [`collect_buyer_consent.sms_marketing`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect buyer consent for SMS marketing.\n\n* [`collect_buyer_consent.customer_privacy`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register buyer consent decisions that will be honored on Shopify-managed services.\n\n* [`iframe.sources`](/docs/api/checkout-ui-extensions/configuration#iframe): the extension can embed an external URL in an iframe."
+    }
+  },
+  "Editor": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Editor",
+      "description": "Information about the editor where the extension is being rendered.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'checkout'",
+          "description": "Indicates whether the extension is rendering in the checkout editor."
+        }
+      ],
+      "value": "export interface Editor {\n  /**\n   * Indicates whether the extension is rendering in the checkout editor.\n   */\n  type: 'checkout';\n}"
+    }
+  },
+  "I18n": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "I18n",
+      "description": "The APIs for localizing your extension.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "formatCurrency",
+          "value": "(number: number | bigint, options?: { inExtensionLocale?: boolean; } & NumberFormatOptions) => string",
+          "description": "Returns a localized currency value.\n\nThis function behaves like the standard `Intl.NumberFormat()` with a style of `currency` applied. It uses the buyer's locale by default."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "formatDate",
+          "value": "(date: Date, options?: { inExtensionLocale?: boolean; } & DateTimeFormatOptions) => string",
+          "description": "Returns a localized date value.\n\nThis function behaves like the standard `Intl.DateTimeFormatOptions()` and uses the buyer's locale by default. Formatting options can be passed in as options."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "formatNumber",
+          "value": "(number: number | bigint, options?: { inExtensionLocale?: boolean; } & NumberFormatOptions) => string",
+          "description": "Returns a localized number.\n\nThis function behaves like the standard `Intl.NumberFormat()` with a style of `decimal` applied. It uses the buyer's locale by default."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "translate",
+          "value": "I18nTranslate",
+          "description": "Returns translated content in the buyer's locale, as supported by the extension.\n\n- `options.count` is a special numeric value used in pluralization.\n- The other option keys and values are treated as replacements for interpolation.\n- If the replacements are all primitives, then `translate()` returns a single string.\n- If replacements contain UI components, then `translate()` returns an array of elements."
+        }
+      ],
+      "value": "export interface I18n {\n  /**\n   * Returns a localized number.\n   *\n   * This function behaves like the standard `Intl.NumberFormat()`\n   * with a style of `decimal` applied. It uses the buyer's locale by default.\n   *\n   * @param options.inExtensionLocale - if true, use the extension's locale\n   */\n  formatNumber: (\n    number: number | bigint,\n    options?: {inExtensionLocale?: boolean} & Intl.NumberFormatOptions,\n  ) => string;\n\n  /**\n   * Returns a localized currency value.\n   *\n   * This function behaves like the standard `Intl.NumberFormat()`\n   * with a style of `currency` applied. It uses the buyer's locale by default.\n   *\n   * @param options.inExtensionLocale - if true, use the extension's locale\n   */\n  formatCurrency: (\n    number: number | bigint,\n    options?: {inExtensionLocale?: boolean} & Intl.NumberFormatOptions,\n  ) => string;\n\n  /**\n   * Returns a localized date value.\n   *\n   * This function behaves like the standard `Intl.DateTimeFormatOptions()` and uses\n   * the buyer's locale by default. Formatting options can be passed in as\n   * options.\n   *\n   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat0\n   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#using_options\n   *\n   * @param options.inExtensionLocale - if true, use the extension's locale\n   */\n  formatDate: (\n    date: Date,\n    options?: {inExtensionLocale?: boolean} & Intl.DateTimeFormatOptions,\n  ) => string;\n\n  /**\n   * Returns translated content in the buyer's locale,\n   * as supported by the extension.\n   *\n   * - `options.count` is a special numeric value used in pluralization.\n   * - The other option keys and values are treated as replacements for interpolation.\n   * - If the replacements are all primitives, then `translate()` returns a single string.\n   * - If replacements contain UI components, then `translate()` returns an array of elements.\n   */\n  translate: I18nTranslate;\n}"
+    }
+  },
+  "I18nTranslate": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "I18nTranslate",
+      "description": "The APIs for localizing your extension.\n\nThis returns a translated string matching a key in a locale file.",
+      "isPublicDocs": true,
+      "members": [],
+      "value": "export interface I18nTranslate {\n  <ReplacementType = string>(\n    key: string,\n    options?: Record<string, ReplacementType | string | number>,\n  ): ReplacementType extends string | number\n    ? string\n    : (string | ReplacementType)[];\n}"
+    }
+  },
+  "CartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartInstructions",
+      "description": "Instructions used to create the checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "attributes",
+          "value": "AttributesCartInstructions",
+          "description": "Cart instructions related to cart attributes."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "delivery",
+          "value": "DeliveryCartInstructions",
+          "description": "Cart instructions related to delivery."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discounts",
+          "value": "DiscountsCartInstructions",
+          "description": "Cart instructions related to discounts."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lines",
+          "value": "CartLinesCartInstructions",
+          "description": "Cart instructions related to cart lines."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "MetafieldsCartInstructions",
+          "description": "Cart instructions related to metafields."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "notes",
+          "value": "NotesCartInstructions",
+          "description": "Cart instructions related to notes."
+        }
+      ],
+      "value": "export interface CartInstructions {\n  /**\n   * Cart instructions related to cart attributes.\n   */\n  attributes: AttributesCartInstructions;\n\n  /**\n   * Cart instructions related to delivery.\n   */\n  delivery: DeliveryCartInstructions;\n\n  /**\n   * Cart instructions related to discounts.\n   */\n  discounts: DiscountsCartInstructions;\n\n  /**\n   * Cart instructions related to cart lines.\n   */\n  lines: CartLinesCartInstructions;\n\n  /**\n   * Cart instructions related to metafields.\n   */\n  metafields: MetafieldsCartInstructions;\n\n  /**\n   * Cart instructions related to notes.\n   */\n  notes: NotesCartInstructions;\n}"
+    }
+  },
+  "AttributesCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AttributesCartInstructions",
+      "description": "Instructions used to create the checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canUpdateAttributes",
+          "value": "boolean",
+          "description": "Indicates whether or not cart attributes can be updated."
+        }
+      ],
+      "value": "export interface AttributesCartInstructions {\n  /**\n   * Indicates whether or not cart attributes can be updated.\n   */\n  canUpdateAttributes: boolean;\n}"
+    }
+  },
+  "DeliveryCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "DeliveryCartInstructions",
+      "description": "Instructions used to create the checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canSelectCustomAddress",
+          "value": "boolean",
+          "description": "Indicates whether a buyer can select a custom address.\n\nWhen true, this implies extensions can update the delivery address."
+        }
+      ],
+      "value": "export interface DeliveryCartInstructions {\n  /**\n   * Indicates whether a buyer can select a custom address.\n   *\n   * When true, this implies extensions can update the delivery address.\n   */\n  canSelectCustomAddress: boolean;\n}"
+    }
+  },
+  "DiscountsCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "DiscountsCartInstructions",
+      "description": "Instructions used to create the checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canUpdateDiscountCodes",
+          "value": "boolean",
+          "description": "Indicates whether or not discount codes can be updated."
+        }
+      ],
+      "value": "export interface DiscountsCartInstructions {\n  /**\n   * Indicates whether or not discount codes can be updated.\n   */\n  canUpdateDiscountCodes: boolean;\n}"
+    }
+  },
+  "CartLinesCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartLinesCartInstructions",
+      "description": "Instructions used to create the checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canAddCartLine",
+          "value": "boolean",
+          "description": "Indicates whether or not new cart lines can be added."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canRemoveCartLine",
+          "value": "boolean",
+          "description": "Indicates whether or not cart lines can be removed."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canUpdateCartLine",
+          "value": "boolean",
+          "description": "Indicates whether or not cart lines can be updated."
+        }
+      ],
+      "value": "export interface CartLinesCartInstructions {\n  /**\n   * Indicates whether or not new cart lines can be added.\n   */\n  canAddCartLine: boolean;\n\n  /**\n   * Indicates whether or not cart lines can be removed.\n   */\n  canRemoveCartLine: boolean;\n\n  /**\n   * Indicates whether or not cart lines can be updated.\n   */\n  canUpdateCartLine: boolean;\n}"
+    }
+  },
+  "MetafieldsCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "MetafieldsCartInstructions",
+      "description": "Instructions used to create the checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canDeleteCartMetafield",
+          "value": "boolean",
+          "description": "Indicates whether or not cart metafields can be deleted."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canSetCartMetafields",
+          "value": "boolean",
+          "description": "Indicates whether or not cart metafields can be added or updated."
+        }
+      ],
+      "value": "export interface MetafieldsCartInstructions {\n  /**\n   * Indicates whether or not cart metafields can be added or updated.\n   */\n  canSetCartMetafields: boolean;\n\n  /**\n   * Indicates whether or not cart metafields can be deleted.\n   */\n  canDeleteCartMetafield: boolean;\n}"
+    }
+  },
+  "NotesCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "NotesCartInstructions",
+      "description": "Instructions used to create the checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canUpdateNote",
+          "value": "boolean",
+          "description": "Indicates whether or not notes can be updated."
+        }
+      ],
+      "value": "export interface NotesCartInstructions {\n  /**\n   * Indicates whether or not notes can be updated.\n   */\n  canUpdateNote: boolean;\n}"
+    }
+  },
+  "CartLine": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartLine",
+      "description": "The API for interacting with the cart lines.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "attributes",
+          "value": "Attribute[]",
+          "description": "The line item additional custom attributes."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cost",
+          "value": "CartLineCost",
+          "description": "The details about the cost components attributed to the cart line."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountAllocations",
+          "value": "CartDiscountAllocation[]",
+          "description": "Discounts applied to the cart line."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "These line item IDs are not stable at the moment, they might change after any operations on the line items. You should always look up for an updated ID before any call to `applyCartLinesChange` because you'll need the ID to create a `CartLineChange` object.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/CartLine/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lineComponents",
+          "value": "CartBundleLineComponent[]",
+          "description": "Sub lines of the merchandise line. If no sub lines are present, this will be an empty array."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "merchandise",
+          "value": "Merchandise",
+          "description": "The merchandise being purchased."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "parentRelationship",
+          "value": "CartLineParentRelationship | null",
+          "description": "The relationship details between cart lines."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "quantity",
+          "value": "number",
+          "description": "The quantity of the merchandise being purchased."
+        }
+      ],
+      "value": "export interface CartLine {\n  /**\n   * These line item IDs are not stable at the moment, they might change after\n   * any operations on the line items. You should always look up for an updated\n   * ID before any call to `applyCartLinesChange` because you'll need the ID to\n   * create a `CartLineChange` object.\n   * @example 'gid://shopify/CartLine/123'\n   */\n  id: string;\n\n  /**\n   * The merchandise being purchased.\n   */\n  merchandise: Merchandise;\n\n  /**\n   * The quantity of the merchandise being purchased.\n   */\n  quantity: number;\n\n  /**\n   * The details about the cost components attributed to the cart line.\n   */\n  cost: CartLineCost;\n\n  /**\n   * The line item additional custom attributes.\n   */\n  attributes: Attribute[];\n\n  /**\n   * Discounts applied to the cart line.\n   */\n  discountAllocations: CartDiscountAllocation[];\n\n  /**\n   * Sub lines of the merchandise line. If no sub lines are present, this will be an empty array.\n   */\n  lineComponents: CartLineComponentType[];\n\n  /**\n   * The relationship details between cart lines.\n   */\n  parentRelationship: CartLineParentRelationship | null;\n}"
+    }
+  },
+  "CartLineCost": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartLineCost",
+      "description": "The API for interacting with the cost of a checkout.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "totalAmount",
+          "value": "Money",
+          "description": "The total amount after reductions the buyer can expect to pay that is directly attributable to a single cart line."
+        }
+      ],
+      "value": "export interface CartLineCost {\n  /**\n   * The total amount after reductions the buyer can expect to pay that is directly attributable to a single\n   * cart line.\n   */\n  totalAmount: Money;\n}"
+    }
+  },
+  "CartBundleLineComponent": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartBundleLineComponent",
+      "description": "The API for interacting with the cart lines.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "attributes",
+          "value": "Attribute[]",
+          "description": "Additional custom attributes for the bundle line component.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "[{key: 'engraving', value: 'hello world'}]",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cost",
+          "value": "CartLineCost",
+          "description": "The cost attributed to this bundle line component."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A unique identifier for the bundle line component.\n\nThis ID is not stable. If an operation updates the line items in any way, all IDs could change.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/CartLineComponent/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "merchandise",
+          "value": "Merchandise",
+          "description": "The merchandise of this bundle line component."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "quantity",
+          "value": "number",
+          "description": "The quantity of merchandise being purchased."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'bundle'",
+          "description": ""
+        }
+      ],
+      "value": "export interface CartBundleLineComponent {\n  type: 'bundle';\n\n  /**\n   * A unique identifier for the bundle line component.\n   *\n   * This ID is not stable. If an operation updates the line items in any way, all IDs could change.\n   *\n   * @example 'gid://shopify/CartLineComponent/123'\n   */\n  id: string;\n\n  /**\n   * The merchandise of this bundle line component.\n   */\n  merchandise: Merchandise;\n\n  /**\n   * The quantity of merchandise being purchased.\n   */\n  quantity: number;\n\n  /**\n   * The cost attributed to this bundle line component.\n   */\n  cost: CartLineCost;\n\n  /**\n   * Additional custom attributes for the bundle line component.\n   *\n   * @example [{key: 'engraving', value: 'hello world'}]\n   */\n  attributes: Attribute[];\n}"
+    }
+  },
+  "Merchandise": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "Merchandise",
+      "value": "ProductVariant",
+      "description": "The API for interacting with the cart lines.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/ProductVariant/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "image",
+          "value": "ImageDetails",
+          "description": "Image associated with the product variant. This field falls back to the product image if no image is available.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "product",
+          "value": "Product",
+          "description": "The product object that the product variant belongs to."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "requiresShipping",
+          "value": "boolean",
+          "description": "Whether or not the product requires shipping."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "selectedOptions",
+          "value": "SelectedOption[]",
+          "description": "List of product options applied to the variant."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sellingPlan",
+          "value": "SellingPlan",
+          "description": "The selling plan associated with the merchandise.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sku",
+          "value": "string",
+          "description": "The product variant's sku.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "subtitle",
+          "value": "string",
+          "description": "The product variant's subtitle.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The product variant’s title."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'variant'",
+          "description": ""
+        }
+      ]
+    }
+  },
+  "Product": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Product",
+      "description": "The API for interacting with the cart lines.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "productType",
+          "value": "string",
+          "description": "A categorization that a product can be tagged with, commonly used for filtering and searching."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "vendor",
+          "value": "string",
+          "description": "The product’s vendor name."
+        }
+      ],
+      "value": "export interface Product {\n  /**\n   * A globally-unique identifier.\n   */\n  id: string;\n\n  /**\n   * The product’s vendor name.\n   */\n  vendor: string;\n\n  /**\n   * A categorization that a product can be tagged with, commonly used for filtering and searching.\n   */\n  productType: string;\n}"
+    }
+  },
+  "SelectedOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "SelectedOption",
+      "description": "The API for interacting with the cart lines.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the merchandise option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The value of the merchandise option."
+        }
+      ],
+      "value": "export interface SelectedOption {\n  /**\n   * The name of the merchandise option.\n   */\n  name: string;\n\n  /**\n   * The value of the merchandise option.\n   */\n  value: string;\n}"
+    }
+  },
+  "SellingPlan": {
+    "src/surfaces/checkout/api/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/shared.ts",
+      "name": "SellingPlan",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/SellingPlan/1'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "recurringDeliveries",
+          "value": "boolean",
+          "description": "Whether purchasing the selling plan will result in multiple deliveries."
+        }
+      ],
+      "value": "export interface SellingPlan {\n  /**\n   * A globally-unique identifier.\n   * @example 'gid://shopify/SellingPlan/1'\n   */\n  id: string;\n\n  /**\n   * Whether purchasing the selling plan will result in multiple deliveries.\n   */\n  recurringDeliveries: boolean;\n}"
+    }
+  },
+  "CartLineParentRelationship": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartLineParentRelationship",
+      "description": "The API for interacting with the cart lines.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "parent",
+          "value": "{ id: string; }",
+          "description": "The parent cart line that a cart line is associated with."
+        }
+      ],
+      "value": "export interface CartLineParentRelationship {\n  /**\n   * The parent cart line that a cart line is associated with.\n   */\n  parent: {\n    /**\n     * These line item IDs are not stable at the moment, they might change after\n     * any operations on the line items. You should always look up for an updated\n     * ID before any call to `applyCartLinesChange` because you'll need the ID to\n     * create a `CartLineChange` object.\n     * @example 'gid://shopify/CartLine/123'\n     */\n    id: string;\n  };\n}"
+    }
+  },
+  "Localization": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Localization",
+      "description": "The APIs for localizing your extension.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "country",
+          "value": "SubscribableSignalLike<Country | undefined>",
+          "description": "The country context of the checkout. This value carries over from the context of the cart, where it was used to contextualize the storefront experience. It will update if the buyer changes the country of their shipping address. If the country is unknown, then the value is undefined."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "currency",
+          "value": "SubscribableSignalLike<Currency>",
+          "description": "The currency that the customer sees for money amounts in the checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "extensionLanguage",
+          "value": "SubscribableSignalLike<Language>",
+          "description": "This is the customer's language, as supported by the extension. If the customer's actual language is not supported by the extension, then this is the language that is used for translations.\n\nFor example, if the customer's language is 'fr-CA' but your extension only supports translations for 'fr', then the `isoCode` for this language is 'fr'. If your extension does not provide french translations at all, then this value is the default locale for your extension (that is, the one matching your .default.json file)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "language",
+          "value": "SubscribableSignalLike<Language>",
+          "description": "The language the customer sees in the checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "market",
+          "value": "SubscribableSignalLike<Market | undefined>",
+          "description": "The [market](/docs/apps/markets) context of the checkout. This value carries over from the context of the cart, where it was used to contextualize the storefront experience. It will update if the buyer changes the country of their shipping address.  If the market is unknown, then the value is undefined.\n\n> Caution: This field is deprecated and will be removed in a future version.",
+          "deprecationMessage": "Deprecated as of version `2025-04`"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "timezone",
+          "value": "SubscribableSignalLike<Timezone>",
+          "description": "The buyer’s time zone."
+        }
+      ],
+      "value": "export interface Localization {\n  /**\n   * The currency that the customer sees for money amounts in the checkout.\n   */\n  currency: SubscribableSignalLike<Currency>;\n\n  /**\n   * The buyer’s time zone.\n   */\n  timezone: SubscribableSignalLike<Timezone>;\n\n  /**\n   * The language the customer sees in the checkout.\n   */\n  language: SubscribableSignalLike<Language>;\n\n  /**\n   * This is the customer's language, as supported by the extension.\n   * If the customer's actual language is not supported by the extension,\n   * then this is the language that is used for translations.\n   *\n   * For example, if the customer's language is 'fr-CA' but your extension\n   * only supports translations for 'fr', then the `isoCode` for this\n   * language is 'fr'. If your extension does not provide french\n   * translations at all, then this value is the default locale for your\n   * extension (that is, the one matching your .default.json file).\n   */\n  extensionLanguage: SubscribableSignalLike<Language>;\n\n  /**\n   * The country context of the checkout. This value carries over from the\n   * context of the cart, where it was used to contextualize the storefront\n   * experience. It will update if the buyer changes the country of their\n   * shipping address. If the country is unknown, then the value is undefined.\n   */\n  country: SubscribableSignalLike<Country | undefined>;\n\n  /**\n   * The [market](/docs/apps/markets) context of the\n   * checkout. This value carries over from the context of the cart, where it\n   * was used to contextualize the storefront experience. It will update if the\n   * buyer changes the country of their shipping address.  If the market is unknown,\n   * then the value is undefined.\n   *\n   * > Caution: This field is deprecated and will be removed in a future version.\n   *\n   * @deprecated Deprecated as of version `2025-04`\n   */\n  market: SubscribableSignalLike<Market | undefined>;\n}"
+    }
+  },
+  "Country": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "name": "Country",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isoCode",
+          "value": "CountryCode",
+          "description": "The ISO-3166-1 code for this country."
+        }
+      ],
+      "value": "export interface Country {\n  /**\n   * The ISO-3166-1 code for this country.\n   * @see https://www.iso.org/iso-3166-country-codes.html\n   */\n  isoCode: CountryCode;\n}"
+    }
+  },
+  "Currency": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Currency",
+      "description": "The APIs for localizing your extension.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isoCode",
+          "value": "CurrencyCode",
+          "description": "The ISO-4217 code for this currency."
+        }
+      ],
+      "value": "export interface Currency {\n  /**\n   * The ISO-4217 code for this currency.\n   * @see https://www.iso.org/iso-4217-currency-codes.html\n   */\n  isoCode: CurrencyCode;\n}"
+    }
+  },
+  "Language": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Language",
+      "description": "The APIs for localizing your extension.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isoCode",
+          "value": "string",
+          "description": "The BCP-47 language tag. It may contain a dash followed by an ISO 3166-1 alpha-2 region code.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'en' for English, or 'en-US' for English local to United States.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface Language {\n  /**\n   * The BCP-47 language tag. It may contain a dash followed by an ISO 3166-1 alpha-2 region code.\n   *\n   * @example 'en' for English, or 'en-US' for English local to United States.\n   * @see https://en.wikipedia.org/wiki/IETF_language_tag\n   * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\n   */\n  isoCode: string;\n}"
+    }
+  },
+  "Market": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Market",
+      "description": "The APIs for localizing your extension.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The human-readable, shop-scoped identifier for the market."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier for a market."
+        }
+      ],
+      "value": "export interface Market {\n  /**\n   * A globally-unique identifier for a market.\n   */\n  id: string;\n\n  /**\n   * The human-readable, shop-scoped identifier for the market.\n   */\n  handle: string;\n}"
+    }
+  },
+  "Timezone": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "Timezone",
+      "value": "'Africa/Abidjan' | 'Africa/Algiers' | 'Africa/Bissau' | 'Africa/Cairo' | 'Africa/Casablanca' | 'Africa/Ceuta' | 'Africa/El_Aaiun' | 'Africa/Johannesburg' | 'Africa/Juba' | 'Africa/Khartoum' | 'Africa/Lagos' | 'Africa/Maputo' | 'Africa/Monrovia' | 'Africa/Nairobi' | 'Africa/Ndjamena' | 'Africa/Sao_Tome' | 'Africa/Tripoli' | 'Africa/Tunis' | 'Africa/Windhoek' | 'America/Adak' | 'America/Anchorage' | 'America/Araguaina' | 'America/Argentina/Buenos_Aires' | 'America/Argentina/Catamarca' | 'America/Argentina/Cordoba' | 'America/Argentina/Jujuy' | 'America/Argentina/La_Rioja' | 'America/Argentina/Mendoza' | 'America/Argentina/Rio_Gallegos' | 'America/Argentina/Salta' | 'America/Argentina/San_Juan' | 'America/Argentina/San_Luis' | 'America/Argentina/Tucuman' | 'America/Argentina/Ushuaia' | 'America/Asuncion' | 'America/Bahia' | 'America/Bahia_Banderas' | 'America/Barbados' | 'America/Belem' | 'America/Belize' | 'America/Boa_Vista' | 'America/Bogota' | 'America/Boise' | 'America/Cambridge_Bay' | 'America/Campo_Grande' | 'America/Cancun' | 'America/Caracas' | 'America/Cayenne' | 'America/Chicago' | 'America/Chihuahua' | 'America/Costa_Rica' | 'America/Cuiaba' | 'America/Danmarkshavn' | 'America/Dawson' | 'America/Dawson_Creek' | 'America/Denver' | 'America/Detroit' | 'America/Edmonton' | 'America/Eirunepe' | 'America/El_Salvador' | 'America/Fort_Nelson' | 'America/Fortaleza' | 'America/Glace_Bay' | 'America/Goose_Bay' | 'America/Grand_Turk' | 'America/Guatemala' | 'America/Guayaquil' | 'America/Guyana' | 'America/Halifax' | 'America/Havana' | 'America/Hermosillo' | 'America/Indiana/Indianapolis' | 'America/Indiana/Knox' | 'America/Indiana/Marengo' | 'America/Indiana/Petersburg' | 'America/Indiana/Tell_City' | 'America/Indiana/Vevay' | 'America/Indiana/Vincennes' | 'America/Indiana/Winamac' | 'America/Inuvik' | 'America/Iqaluit' | 'America/Jamaica' | 'America/Juneau' | 'America/Kentucky/Louisville' | 'America/Kentucky/Monticello' | 'America/La_Paz' | 'America/Lima' | 'America/Los_Angeles' | 'America/Maceio' | 'America/Managua' | 'America/Manaus' | 'America/Martinique' | 'America/Matamoros' | 'America/Mazatlan' | 'America/Menominee' | 'America/Merida' | 'America/Metlakatla' | 'America/Mexico_City' | 'America/Miquelon' | 'America/Moncton' | 'America/Monterrey' | 'America/Montevideo' | 'America/New_York' | 'America/Nipigon' | 'America/Nome' | 'America/Noronha' | 'America/North_Dakota/Beulah' | 'America/North_Dakota/Center' | 'America/North_Dakota/New_Salem' | 'America/Nuuk' | 'America/Ojinaga' | 'America/Panama' | 'America/Pangnirtung' | 'America/Paramaribo' | 'America/Phoenix' | 'America/Port-au-Prince' | 'America/Porto_Velho' | 'America/Puerto_Rico' | 'America/Punta_Arenas' | 'America/Rainy_River' | 'America/Rankin_Inlet' | 'America/Recife' | 'America/Regina' | 'America/Resolute' | 'America/Rio_Branco' | 'America/Santarem' | 'America/Santiago' | 'America/Santo_Domingo' | 'America/Sao_Paulo' | 'America/Scoresbysund' | 'America/Sitka' | 'America/St_Johns' | 'America/Swift_Current' | 'America/Tegucigalpa' | 'America/Thule' | 'America/Thunder_Bay' | 'America/Tijuana' | 'America/Toronto' | 'America/Vancouver' | 'America/Whitehorse' | 'America/Winnipeg' | 'America/Yakutat' | 'America/Yellowknife' | 'Antarctica/Casey' | 'Antarctica/Davis' | 'Antarctica/Macquarie' | 'Antarctica/Mawson' | 'Antarctica/Palmer' | 'Antarctica/Rothera' | 'Antarctica/Troll' | 'Antarctica/Vostok' | 'Asia/Almaty' | 'Asia/Amman' | 'Asia/Anadyr' | 'Asia/Aqtau' | 'Asia/Aqtobe' | 'Asia/Ashgabat' | 'Asia/Atyrau' | 'Asia/Baghdad' | 'Asia/Baku' | 'Asia/Bangkok' | 'Asia/Barnaul' | 'Asia/Beirut' | 'Asia/Bishkek' | 'Asia/Brunei' | 'Asia/Chita' | 'Asia/Choibalsan' | 'Asia/Colombo' | 'Asia/Damascus' | 'Asia/Dhaka' | 'Asia/Dili' | 'Asia/Dubai' | 'Asia/Dushanbe' | 'Asia/Famagusta' | 'Asia/Gaza' | 'Asia/Hebron' | 'Asia/Ho_Chi_Minh' | 'Asia/Hong_Kong' | 'Asia/Hovd' | 'Asia/Irkutsk' | 'Asia/Jakarta' | 'Asia/Jayapura' | 'Asia/Jerusalem' | 'Asia/Kabul' | 'Asia/Kamchatka' | 'Asia/Karachi' | 'Asia/Kathmandu' | 'Asia/Khandyga' | 'Asia/Kolkata' | 'Asia/Krasnoyarsk' | 'Asia/Kuala_Lumpur' | 'Asia/Kuching' | 'Asia/Macau' | 'Asia/Magadan' | 'Asia/Makassar' | 'Asia/Manila' | 'Asia/Nicosia' | 'Asia/Novokuznetsk' | 'Asia/Novosibirsk' | 'Asia/Omsk' | 'Asia/Oral' | 'Asia/Pontianak' | 'Asia/Pyongyang' | 'Asia/Qatar' | 'Asia/Qostanay' | 'Asia/Qyzylorda' | 'Asia/Riyadh' | 'Asia/Sakhalin' | 'Asia/Samarkand' | 'Asia/Seoul' | 'Asia/Shanghai' | 'Asia/Singapore' | 'Asia/Srednekolymsk' | 'Asia/Taipei' | 'Asia/Tashkent' | 'Asia/Tbilisi' | 'Asia/Tehran' | 'Asia/Thimphu' | 'Asia/Tokyo' | 'Asia/Tomsk' | 'Asia/Ulaanbaatar' | 'Asia/Urumqi' | 'Asia/Ust-Nera' | 'Asia/Vladivostok' | 'Asia/Yakutsk' | 'Asia/Yangon' | 'Asia/Yekaterinburg' | 'Asia/Yerevan' | 'Atlantic/Azores' | 'Atlantic/Bermuda' | 'Atlantic/Canary' | 'Atlantic/Cape_Verde' | 'Atlantic/Faroe' | 'Atlantic/Madeira' | 'Atlantic/Reykjavik' | 'Atlantic/South_Georgia' | 'Atlantic/Stanley' | 'Australia/Adelaide' | 'Australia/Brisbane' | 'Australia/Broken_Hill' | 'Australia/Darwin' | 'Australia/Eucla' | 'Australia/Hobart' | 'Australia/Lindeman' | 'Australia/Lord_Howe' | 'Australia/Melbourne' | 'Australia/Perth' | 'Australia/Sydney' | 'CET' | 'CST6CDT' | 'EET' | 'EST' | 'EST5EDT' | 'Etc/GMT' | 'Etc/GMT-1' | 'Etc/GMT-10' | 'Etc/GMT-11' | 'Etc/GMT-12' | 'Etc/GMT-13' | 'Etc/GMT-14' | 'Etc/GMT-2' | 'Etc/GMT-3' | 'Etc/GMT-4' | 'Etc/GMT-5' | 'Etc/GMT-6' | 'Etc/GMT-7' | 'Etc/GMT-8' | 'Etc/GMT-9' | 'Etc/GMT+1' | 'Etc/GMT+10' | 'Etc/GMT+11' | 'Etc/GMT+12' | 'Etc/GMT+2' | 'Etc/GMT+3' | 'Etc/GMT+4' | 'Etc/GMT+5' | 'Etc/GMT+6' | 'Etc/GMT+7' | 'Etc/GMT+8' | 'Etc/GMT+9' | 'Etc/UTC' | 'Europe/Amsterdam' | 'Europe/Andorra' | 'Europe/Astrakhan' | 'Europe/Athens' | 'Europe/Belgrade' | 'Europe/Berlin' | 'Europe/Brussels' | 'Europe/Bucharest' | 'Europe/Budapest' | 'Europe/Chisinau' | 'Europe/Copenhagen' | 'Europe/Dublin' | 'Europe/Gibraltar' | 'Europe/Helsinki' | 'Europe/Istanbul' | 'Europe/Kaliningrad' | 'Europe/Kiev' | 'Europe/Kirov' | 'Europe/Lisbon' | 'Europe/London' | 'Europe/Luxembourg' | 'Europe/Madrid' | 'Europe/Malta' | 'Europe/Minsk' | 'Europe/Monaco' | 'Europe/Moscow' | 'Europe/Oslo' | 'Europe/Paris' | 'Europe/Prague' | 'Europe/Riga' | 'Europe/Rome' | 'Europe/Samara' | 'Europe/Saratov' | 'Europe/Simferopol' | 'Europe/Sofia' | 'Europe/Stockholm' | 'Europe/Tallinn' | 'Europe/Tirane' | 'Europe/Ulyanovsk' | 'Europe/Uzhgorod' | 'Europe/Vienna' | 'Europe/Vilnius' | 'Europe/Volgograd' | 'Europe/Warsaw' | 'Europe/Zaporozhye' | 'Europe/Zurich' | 'HST' | 'Indian/Chagos' | 'Indian/Christmas' | 'Indian/Cocos' | 'Indian/Kerguelen' | 'Indian/Mahe' | 'Indian/Maldives' | 'Indian/Mauritius' | 'Indian/Reunion' | 'MET' | 'MST' | 'MST7MDT' | 'Pacific/Apia' | 'Pacific/Auckland' | 'Pacific/Bougainville' | 'Pacific/Chatham' | 'Pacific/Chuuk' | 'Pacific/Easter' | 'Pacific/Efate' | 'Pacific/Fakaofo' | 'Pacific/Fiji' | 'Pacific/Funafuti' | 'Pacific/Galapagos' | 'Pacific/Gambier' | 'Pacific/Guadalcanal' | 'Pacific/Guam' | 'Pacific/Honolulu' | 'Pacific/Kanton' | 'Pacific/Kiritimati' | 'Pacific/Kosrae' | 'Pacific/Kwajalein' | 'Pacific/Majuro' | 'Pacific/Marquesas' | 'Pacific/Nauru' | 'Pacific/Niue' | 'Pacific/Norfolk' | 'Pacific/Noumea' | 'Pacific/Pago_Pago' | 'Pacific/Palau' | 'Pacific/Pitcairn' | 'Pacific/Pohnpei' | 'Pacific/Port_Moresby' | 'Pacific/Rarotonga' | 'Pacific/Tahiti' | 'Pacific/Tarawa' | 'Pacific/Tongatapu' | 'Pacific/Wake' | 'Pacific/Wallis' | 'PST8PDT' | 'WET'",
+      "description": ""
+    }
+  },
+  "LocalizedField": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "LocalizedField",
+      "description": "The API for interacting with localized fields.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "LocalizedFieldKey",
+          "description": ""
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface LocalizedField {\n  key: LocalizedFieldKey;\n  title: string;\n  value: string;\n}"
+    }
+  },
+  "LocalizedFieldKey": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "LocalizedFieldKey",
+      "value": "'SHIPPING_CREDENTIAL_BR' | 'SHIPPING_CREDENTIAL_CL' | 'SHIPPING_CREDENTIAL_CN' | 'SHIPPING_CREDENTIAL_CO' | 'SHIPPING_CREDENTIAL_CR' | 'SHIPPING_CREDENTIAL_EC' | 'SHIPPING_CREDENTIAL_ES' | 'SHIPPING_CREDENTIAL_GT' | 'SHIPPING_CREDENTIAL_ID' | 'SHIPPING_CREDENTIAL_KR' | 'SHIPPING_CREDENTIAL_MY' | 'SHIPPING_CREDENTIAL_MX' | 'SHIPPING_CREDENTIAL_PE' | 'SHIPPING_CREDENTIAL_PT' | 'SHIPPING_CREDENTIAL_PY' | 'SHIPPING_CREDENTIAL_TR' | 'SHIPPING_CREDENTIAL_TW' | 'SHIPPING_CREDENTIAL_TYPE_CO' | 'TAX_CREDENTIAL_BR' | 'TAX_CREDENTIAL_CL' | 'TAX_CREDENTIAL_CO' | 'TAX_CREDENTIAL_CR' | 'TAX_CREDENTIAL_EC' | 'TAX_CREDENTIAL_ES' | 'TAX_CREDENTIAL_GT' | 'TAX_CREDENTIAL_ID' | 'TAX_CREDENTIAL_IT' | 'TAX_CREDENTIAL_MX' | 'TAX_CREDENTIAL_MY' | 'TAX_CREDENTIAL_PE' | 'TAX_CREDENTIAL_PT' | 'TAX_CREDENTIAL_PY' | 'TAX_CREDENTIAL_TR' | 'TAX_CREDENTIAL_TYPE_CO' | 'TAX_CREDENTIAL_TYPE_MX' | 'TAX_CREDENTIAL_USE_MX' | 'TAX_EMAIL_IT'",
+      "description": "A union of keys for the localized fields that are required by certain countries."
+    }
+  },
+  "StorefrontApiVersion": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "StorefrontApiVersion",
+      "value": "'2022-04' | '2022-07' | '2022-10' | '2023-01' | '2023-04' | '2023-07' | '2024-01' | '2024-04' | '2024-07' | '2024-10' | '2025-01' | '2025-04' | 'unstable' | '2025-07' | '2025-10'",
+      "description": "Union of supported storefront API versions"
+    }
+  },
+  "GraphQLError": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "name": "GraphQLError",
+      "description": "GraphQL error returned by the Shopify Storefront APIs.",
+      "members": [
+        {
+          "filePath": "src/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "extensions",
+          "value": "{ requestId: string; code: string; }",
+          "description": ""
+        },
+        {
+          "filePath": "src/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface GraphQLError {\n  message: string;\n  extensions: {\n    requestId: string;\n    code: string;\n  };\n}"
+    }
+  },
+  "SelectedPaymentOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "SelectedPaymentOption",
+      "value": "PaymentOption",
+      "description": "The API for interacting with the payment options.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The unique handle for the payment option.\n\nThis is not a globally unique identifier. It may be an identifier specific to the given checkout session or the current shop."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "| 'creditCard'\n    | 'deferred'\n    | 'local'\n    | 'manualPayment'\n    | 'offsite'\n    | 'other'\n    | 'paymentOnDelivery'\n    | 'redeemable'\n    | 'wallet'\n    | 'customOnsite'",
+          "description": "The type of the payment option.\n\nShops can be configured to support many different payment options. Some options are only available to buyers in specific regions.\n\n| Type  | Description  |\n|---|---|\n| `creditCard`  |  A vaulted or manually entered credit card.  |\n| `deferred`  |  A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecting payment at a later time.  |\n| `local`  |  A [local payment option](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market  |\n| `manualPayment`  |  A manual payment option such as an in-person retail transaction.  |\n| `offsite`  |  A payment processed outside of Shopify's checkout, excluding integrated wallets.  |\n| `other`  |  Another type of payment not defined here.  |\n| `paymentOnDelivery`  |  A payment that will be collected on delivery.  |\n| `redeemable`  |  A redeemable payment option such as a gift card or store credit.  |\n| `wallet`  |  An integrated wallet such as PayPal, Google Pay, Apple Pay, etc.  |\n| `customOnsite` | A custom payment option that is processed through a checkout extension with a payments app. |"
+        }
+      ]
+    }
+  },
+  "SessionToken": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "SessionToken",
+      "description": "The API for interacting with session tokens.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "get",
+          "value": "() => Promise<string>",
+          "description": "Requests a session token that hasn't expired. You should call this method every time you need to make a request to your backend in order to get a valid token. This method will return cached tokens when possible, so you don’t need to worry about storing these tokens yourself."
+        }
+      ],
+      "value": "export interface SessionToken {\n  /**\n   * Requests a session token that hasn't expired. You should call this method every\n   * time you need to make a request to your backend in order to get a valid token.\n   * This method will return cached tokens when possible, so you don’t need to worry\n   * about storing these tokens yourself.\n   */\n  get(): Promise<string>;\n}"
+    }
+  },
+  "ExtensionSettings": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ExtensionSettings",
+      "value": "Record<\n  string,\n  string | number | boolean | undefined\n>",
+      "description": "The API for interacting with merchant settings.\n\nThe merchant-defined setting values for the extension.",
+      "isPublicDocs": true,
+      "members": []
+    }
+  },
+  "ShippingAddress": {
+    "src/surfaces/checkout/api/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/shared.ts",
+      "name": "ShippingAddress",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address1",
+          "value": "string",
+          "description": "The first line of the buyer's address, including street name and number.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'151 O'Connor Street'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address2",
+          "value": "string",
+          "description": "The second line of the buyer's address, like apartment number, suite, etc.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Ground floor'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "city",
+          "value": "string",
+          "description": "The buyer's city.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Ottawa'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "company",
+          "value": "string",
+          "description": "The buyer's company name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Shopify'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "countryCode",
+          "value": "CountryCode",
+          "description": "The ISO 3166 Alpha-2 format for the buyer's country. Refer to https://www.iso.org/iso-3166-country-codes.html.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'CA' for Canada.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "firstName",
+          "value": "string",
+          "description": "The buyer's first name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'John'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lastName",
+          "value": "string",
+          "description": "The buyer's last name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Doe'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The buyer's full name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'John Doe'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "oneTimeUse",
+          "value": "boolean",
+          "description": "Specifies whether the address should be saved to the buyer's account.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "phone",
+          "value": "string",
+          "description": "The buyer's phone number.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'+1 613 111 2222'.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "provinceCode",
+          "value": "string",
+          "description": "The buyer's province code, such as state, province, prefecture, or region.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'ON' for Ontario.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "zip",
+          "value": "string",
+          "description": "The buyer's postal or ZIP code.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'K2P 2L8'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface ShippingAddress extends MailingAddress {\n  /**\n   * Specifies whether the address should be saved to the buyer's account.\n   */\n  oneTimeUse?: boolean;\n}"
+    }
+  },
+  "Shop": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Shop",
+      "description": "The API for interacting with shop.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "The shop ID.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/Shop/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "myshopifyDomain",
+          "value": "string",
+          "description": "The shop's myshopify.com domain."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the shop."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storefrontUrl",
+          "value": "string",
+          "description": "The primary storefront URL.\n\n> Caution: > As of version `2024-04` this value will no longer have a trailing slash.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface Shop {\n  /**\n   * The shop ID.\n   * @example 'gid://shopify/Shop/123'\n   */\n  id: string;\n  /**\n   * The name of the shop.\n   */\n  name: string;\n  /**\n   * The primary storefront URL.\n   *\n   * > Caution:\n   * > As of version `2024-04` this value will no longer have a trailing slash.\n   */\n  storefrontUrl?: string;\n  /**\n   * The shop's myshopify.com domain.\n   */\n  myshopifyDomain: string;\n}"
+    }
+  },
+  "Storage": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Storage",
+      "description": "The API for interacting with local storage.\n\nA key-value storage object for the extension.\n\nStored data is only available to this specific extension and any of its instances.\n\nThe storage backend is implemented with `localStorage` and should persist across the buyer's checkout session. However, data persistence isn't guaranteed.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "delete",
+          "value": "(key: string) => Promise<void>",
+          "description": "Delete stored data by key."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "read",
+          "value": "<T = unknown>(key: string) => Promise<T>",
+          "description": "Read and return a stored value by key.\n\nThe stored data is deserialized from JSON and returned as its original primitive.\n\nReturns `null` if no stored data exists."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "write",
+          "value": "(key: string, data: any) => Promise<void>",
+          "description": "Write stored data for this key.\n\nThe data must be serializable to JSON."
+        }
+      ],
+      "value": "export interface Storage {\n  /**\n   * Read and return a stored value by key.\n   *\n   * The stored data is deserialized from JSON and returned as\n   * its original primitive.\n   *\n   * Returns `null` if no stored data exists.\n   */\n  read<T = unknown>(key: string): Promise<T | null>;\n\n  /**\n   * Write stored data for this key.\n   *\n   * The data must be serializable to JSON.\n   */\n  write(key: string, data: any): Promise<void>;\n\n  /**\n   * Delete stored data by key.\n   */\n  delete(key: string): Promise<void>;\n}"
+    }
+  },
+  "Ui": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Ui",
+      "description": "Methods to interact with the extension's UI.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "overlay",
+          "value": "Overlay",
+          "description": "Allows the extension to close an overlay programmatically.\n\nSupported overlay components are [Modal](/docs/api/checkout-ui-extensions/latest/components/overlays/modal), [Sheet](/docs/api/checkout-ui-extensions/latest/components/overlays/sheet) and [Popover](/docs/api/checkout-ui-extensions/latest/components/overlays/popover)."
+        }
+      ],
+      "value": "export interface Ui {\n  /**\n   * Allows the extension to close an overlay programmatically.\n   *\n   * Supported overlay components are [Modal](/docs/api/checkout-ui-extensions/latest/components/overlays/modal), [Sheet](/docs/api/checkout-ui-extensions/latest/components/overlays/sheet) and [Popover](/docs/api/checkout-ui-extensions/latest/components/overlays/popover).\n   */\n  overlay: Overlay;\n}"
+    }
+  },
+  "Overlay": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Overlay",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "close",
+          "value": "(overlayId: string) => void",
+          "description": "Closes the overlay with the given ID."
+        }
+      ],
+      "value": "interface Overlay {\n  /**\n   * Closes the overlay with the given ID.\n   */\n  close(overlayId: string): void;\n}"
+    }
+  },
+  "Version": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "Version",
+      "value": "string",
+      "description": "The renderer version being used for the extension.",
+      "isPublicDocs": true
+    }
+  },
+  "CheckoutApi": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "CheckoutApi",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "applyAttributeChange",
+          "value": "(change: AttributeChange) => Promise<AttributeChangeResult>",
+          "description": "Performs an update on an attribute attached to the cart and checkout. If successful, this mutation results in an update to the value retrieved through the [`attributes`](/docs/api/checkout-ui-extensions/apis/attributes#standardapi-propertydetail-attributes) property.\n\n> Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.",
+          "deprecationMessage": "- Consumers should use cart metafields instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "applyCartLinesChange",
+          "value": "(change: CartLineChange) => Promise<CartLineChangeResult>",
+          "description": "Performs an update on the merchandise line items. It resolves when the new line items have been negotiated and results in an update to the value retrieved through the [`lines`](/docs/api/checkout-ui-extensions/apis/cart-lines#standardapi-propertydetail-lines) property.\n\n> Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "applyDiscountCodeChange",
+          "value": "(change: DiscountCodeChange) => Promise<DiscountCodeChangeResult>",
+          "description": "Performs an update on the discount codes. It resolves when the new discount codes have been negotiated and results in an update to the value retrieved through the [`discountCodes`](/docs/api/checkout-ui-extensions/apis/discounts#standardapi-propertydetail-discountcodes) property.\n\n> Caution: > See [security considerations](/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves discount codes through a network call.\n\n> Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `discounts.canUpdateDiscountCodes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "applyGiftCardChange",
+          "value": "(change: GiftCardChange) => Promise<GiftCardChangeResult>",
+          "description": "Performs an update on the gift cards. It resolves when gift card change have been negotiated and results in an update to the value retrieved through the [`appliedGiftCards`](/docs/api/checkout-ui-extensions/apis/gift-cards#standardapi-propertydetail-appliedgiftcards) property.\n\n> Caution: > See [security considerations](/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves gift card codes through a network call.\n\n> Note: This method will return an error if the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "applyMetafieldChange",
+          "value": "(change: MetafieldChange) => Promise<MetafieldChangeResult>",
+          "description": "Performs an update on a piece of metadata attached to the checkout. If successful, this mutation results in an update to the value retrieved through the [`metafields`](/docs/api/checkout-ui-extensions/apis/metafields#standardapi-propertydetail-metafields) property.\n\nCart metafields will be copied to order metafields at order creation time if there is a matching order metafield definition with the [`cart to order copyable`](/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable) capability enabled.\n\n> Caution: `MetafieldRemoveChange` and `MetafieldUpdateChange` are deprecated. Use cart metafields with `MetafieldRemoveCartChange` and `MetafieldUpdateCartChange` instead. If `MetafieldUpdateChange` writes a metafield with the same namespace and key as a cart metafield that’s configured to copy, the cart metafield won’t be copied.\n\n> Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "applyNoteChange",
+          "value": "(change: NoteChange) => Promise<NoteChangeResult>",
+          "description": "Performs an update on the note attached to the cart and checkout. If successful, this mutation results in an update to the value retrieved through the [`note`](/docs/api/checkout-ui-extensions/apis/note#standardapi-propertydetail-note) property.\n\n> Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `notes.canUpdateNote` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "applyShippingAddressChange",
+          "value": "(change: ShippingAddressUpdateChange) => Promise<ShippingAddressChangeResult>",
+          "description": "Performs an update of the shipping address. Shipping address changes will completely overwrite the existing shipping address added by the user without any prompts. If successful, this mutation results in an update to the value retrieved through the `shippingAddress` property.\n\n> Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `delivery.canSelectCustomAddress` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "experimentalIsShopAppStyle",
+          "value": "boolean",
+          "description": "",
+          "isOptional": true,
+          "isPrivate": true
+        }
+      ],
+      "value": "export interface CheckoutApi {\n  /**\n   * Performs an update on an attribute attached to the cart and checkout. If\n   * successful, this mutation results in an update to the value retrieved\n   * through the [`attributes`](/docs/api/checkout-ui-extensions/apis/attributes#standardapi-propertydetail-attributes) property.\n   *\n   * > Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.\n   *\n   * @deprecated - Consumers should use cart metafields instead.\n   */\n  applyAttributeChange(change: AttributeChange): Promise<AttributeChangeResult>;\n\n  /**\n   * Performs an update on the merchandise line items. It resolves when the new\n   * line items have been negotiated and results in an update to the value\n   * retrieved through the\n   * [`lines`](/docs/api/checkout-ui-extensions/apis/cart-lines#standardapi-propertydetail-lines)\n   * property.\n   *\n   * > Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.\n   */\n  applyCartLinesChange(change: CartLineChange): Promise<CartLineChangeResult>;\n\n  /**\n   * Performs an update on the discount codes.\n   * It resolves when the new discount codes have been negotiated and results in an update\n   * to the value retrieved through the [`discountCodes`](/docs/api/checkout-ui-extensions/apis/discounts#standardapi-propertydetail-discountcodes) property.\n   *\n   * > Caution:\n   * > See [security considerations](/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves discount codes through a network call.\n   *\n   * > Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `discounts.canUpdateDiscountCodes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.\n   */\n  applyDiscountCodeChange(\n    change: DiscountCodeChange,\n  ): Promise<DiscountCodeChangeResult>;\n\n  /**\n   * Performs an update on the gift cards.\n   * It resolves when gift card change have been negotiated and results in an update\n   * to the value retrieved through the [`appliedGiftCards`](/docs/api/checkout-ui-extensions/apis/gift-cards#standardapi-propertydetail-appliedgiftcards) property.\n   *\n   * > Caution:\n   * > See [security considerations](/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves gift card codes through a network call.\n   *\n   * > Note: This method will return an error if the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.\n   */\n  applyGiftCardChange(change: GiftCardChange): Promise<GiftCardChangeResult>;\n\n  /**\n   * Performs an update on a piece of metadata attached to the checkout. If\n   * successful, this mutation results in an update to the value retrieved\n   * through the [`metafields`](/docs/api/checkout-ui-extensions/apis/metafields#standardapi-propertydetail-metafields) property.\n   *\n   * Cart metafields will be copied to order metafields at order creation time if there is a matching order metafield definition with the [`cart to order copyable`](/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable) capability enabled.\n   *\n   * > Caution: `MetafieldRemoveChange` and `MetafieldUpdateChange` are deprecated. Use cart metafields with `MetafieldRemoveCartChange` and `MetafieldUpdateCartChange` instead. If `MetafieldUpdateChange` writes a metafield with the same namespace and key as a cart metafield that’s configured to copy, the cart metafield won’t be copied.\n   *\n   * > Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.\n   */\n  applyMetafieldChange(change: MetafieldChange): Promise<MetafieldChangeResult>;\n\n  /**\n   * Performs an update on the note attached to the cart and checkout. If\n   * successful, this mutation results in an update to the value retrieved\n   * through the [`note`](/docs/api/checkout-ui-extensions/apis/note#standardapi-propertydetail-note) property.\n   *\n   * > Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `notes.canUpdateNote` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.\n   */\n  applyNoteChange(change: NoteChange): Promise<NoteChangeResult>;\n\n  /**\n   * @private\n   */\n  experimentalIsShopAppStyle?: boolean;\n\n  /**\n   * Performs an update of the shipping address. Shipping address changes will\n   * completely overwrite the existing shipping address added by the user without\n   * any prompts. If successful, this mutation results in an update to the value\n   * retrieved through the `shippingAddress` property.\n   *\n   * > Note: This method will return an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `delivery.canSelectCustomAddress` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  applyShippingAddressChange?(\n    change: ShippingAddressChange,\n  ): Promise<ShippingAddressChangeResult>;\n}"
+    }
+  },
+  "AttributeChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AttributeChange",
+      "value": "AttributeUpdateChange | AttributeRemoveChange",
+      "description": ""
+    }
+  },
+  "AttributeUpdateChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "AttributeUpdateChange",
+      "description": "Updates an attribute on the order. If an attribute with the provided key does not already exist, it gets created.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "Key of the attribute to add or update"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'updateAttribute'",
+          "description": "The type of the `AttributeUpdateChange` API."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "Value for the attribute to add or update"
+        }
+      ],
+      "value": "export interface AttributeUpdateChange {\n  /**\n   * The type of the `AttributeUpdateChange` API.\n   */\n  type: 'updateAttribute';\n\n  /**\n   * Key of the attribute to add or update\n   */\n  key: string;\n\n  /**\n   * Value for the attribute to add or update\n   */\n  value: string;\n}"
+    }
+  },
+  "AttributeRemoveChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "AttributeRemoveChange",
+      "description": "Removes an attribute on the order if an attribute with the provided key already exists.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "Key of the attribute to remove"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'removeAttribute'",
+          "description": "The type of the `AttributeRemoveChange` API."
+        }
+      ],
+      "value": "export interface AttributeRemoveChange {\n  /**\n   * The type of the `AttributeRemoveChange` API.\n   */\n  type: 'removeAttribute';\n\n  /**\n   * Key of the attribute to remove\n   */\n  key: string;\n}"
+    }
+  },
+  "AttributeChangeResult": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AttributeChangeResult",
+      "value": "AttributeChangeResultSuccess | AttributeChangeResultError",
+      "description": ""
+    }
+  },
+  "AttributeChangeResultSuccess": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "AttributeChangeResultSuccess",
+      "description": "The returned result of a successful update to an attribute.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'success'",
+          "description": "The type of the `AttributeChangeResultSuccess` API."
+        }
+      ],
+      "value": "export interface AttributeChangeResultSuccess {\n  /**\n   * The type of the `AttributeChangeResultSuccess` API.\n   */\n  type: 'success';\n}"
+    }
+  },
+  "AttributeChangeResultError": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "AttributeChangeResultError",
+      "description": "The returned result of an unsuccessful update to an attribute with a message detailing the type of error that occurred.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It is **not** localized, and therefore should not be presented directly to the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'error'",
+          "description": "The type of the `AttributeChangeResultError` API."
+        }
+      ],
+      "value": "export interface AttributeChangeResultError {\n  /**\n   * The type of the `AttributeChangeResultError` API.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It is **not** localized, and therefore should not be presented directly\n   * to the buyer.\n   */\n  message: string;\n}"
+    }
+  },
+  "CartLineChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CartLineChange",
+      "value": "CartLineAddChange | CartLineRemoveChange | CartLineUpdateChange",
+      "description": ""
+    }
+  },
+  "CartLineAddChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "CartLineAddChange",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "attributes",
+          "value": "Attribute[]",
+          "description": "The attributes associated with the line item.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "merchandiseId",
+          "value": "string",
+          "description": "The merchandise ID being added.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/ProductVariant/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "parent",
+          "value": "{lineId: string} | {merchandiseId: string}",
+          "description": "The identifier for the associated parent cart line.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "quantity",
+          "value": "number",
+          "description": "The quantity of the merchandise being added."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sellingPlanId",
+          "value": "string",
+          "description": "The identifier of the selling plan that the merchandise is being purchased with.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'addCartLine'",
+          "description": "An identifier for changes that add line items."
+        }
+      ],
+      "value": "export interface CartLineAddChange {\n  /**\n   * An identifier for changes that add line items.\n   */\n  type: 'addCartLine';\n\n  /**\n   * The merchandise ID being added.\n   * @example 'gid://shopify/ProductVariant/123'\n   */\n  merchandiseId: string;\n\n  /**\n   * The quantity of the merchandise being added.\n   */\n  quantity: number;\n\n  /**\n   * The attributes associated with the line item.\n   */\n  attributes?: Attribute[];\n\n  /**\n   * The identifier of the selling plan that the merchandise is being purchased\n   * with.\n   */\n  sellingPlanId?: SellingPlan['id'];\n\n  /**\n   * The identifier for the associated parent cart line.\n   */\n  parent?: {lineId: string} | {merchandiseId: string};\n}"
+    }
+  },
+  "CartLineRemoveChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "CartLineRemoveChange",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "Line Item ID.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/CartLine/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "quantity",
+          "value": "number",
+          "description": "The quantity being removed for this line item."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'removeCartLine'",
+          "description": "An identifier for changes that remove line items."
+        }
+      ],
+      "value": "export interface CartLineRemoveChange {\n  /**\n   * An identifier for changes that remove line items.\n   */\n  type: 'removeCartLine';\n\n  /**\n   * Line Item ID.\n   * @example 'gid://shopify/CartLine/123'\n   */\n  id: string;\n\n  /**\n   * The quantity being removed for this line item.\n   */\n  quantity: number;\n}"
+    }
+  },
+  "CartLineUpdateChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "CartLineUpdateChange",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "attributes",
+          "value": "Attribute[]",
+          "description": "The new attributes for the line item.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "Line Item ID.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/CartLine/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "merchandiseId",
+          "value": "string",
+          "description": "The new merchandise ID for the line item.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/ProductVariant/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "parent",
+          "value": "{lineId: string} | {merchandiseId: string}",
+          "description": "The identifier for the associated parent cart line.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "quantity",
+          "value": "number",
+          "description": "The new quantity for the line item.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sellingPlanId",
+          "value": "SellingPlan['id'] | null",
+          "description": "The identifier of the selling plan that the merchandise is being purchased with or `null` to remove the the product from the selling plan.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'updateCartLine'",
+          "description": "An identifier for changes that update line items."
+        }
+      ],
+      "value": "export interface CartLineUpdateChange {\n  /**\n   * An identifier for changes that update line items.\n   */\n  type: 'updateCartLine';\n\n  /**\n   * Line Item ID.\n   * @example 'gid://shopify/CartLine/123'\n   */\n  id: string;\n\n  /**\n   * The new merchandise ID for the line item.\n   * @example 'gid://shopify/ProductVariant/123'\n   */\n\n  merchandiseId?: string;\n  /**\n   * The new quantity for the line item.\n   */\n  quantity?: number;\n\n  /**\n   * The new attributes for the line item.\n   */\n  attributes?: Attribute[];\n\n  /**\n   * The identifier of the selling plan that the merchandise is being purchased\n   * with or `null` to remove the the product from the selling plan.\n   */\n  sellingPlanId?: SellingPlan['id'] | null;\n\n  /**\n   * The identifier for the associated parent cart line.\n   */\n  parent?: {lineId: string} | {merchandiseId: string};\n}"
+    }
+  },
+  "CartLineChangeResult": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CartLineChangeResult",
+      "value": "CartLineChangeResultSuccess | CartLineChangeResultError",
+      "description": ""
+    }
+  },
+  "CartLineChangeResultSuccess": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "CartLineChangeResultSuccess",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'success'",
+          "description": "Indicates that the line item was changed successfully."
+        }
+      ],
+      "value": "export interface CartLineChangeResultSuccess {\n  /**\n   * Indicates that the line item was changed successfully.\n   */\n  type: 'success';\n}"
+    }
+  },
+  "CartLineChangeResultError": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "CartLineChangeResultError",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It is **not** localized, and therefore should not be presented directly to the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'error'",
+          "description": "Indicates that the line item was not changed successfully. Refer to the `message` property for details about the error."
+        }
+      ],
+      "value": "export interface CartLineChangeResultError {\n  /**\n   * Indicates that the line item was not changed successfully. Refer to the `message` property for details about the error.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It is **not** localized, and therefore should not be presented directly\n   * to the buyer.\n   */\n  message: string;\n}"
+    }
+  },
+  "DiscountCodeChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "DiscountCodeChange",
+      "value": "DiscountCodeAddChange | DiscountCodeRemoveChange",
+      "description": ""
+    }
+  },
+  "DiscountCodeAddChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "DiscountCodeAddChange",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The code for the discount (case-insensitive)"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'addDiscountCode'",
+          "description": "The type of the `DiscountCodeChange` API."
+        }
+      ],
+      "value": "export interface DiscountCodeAddChange {\n  /**\n   * The type of the `DiscountCodeChange` API.\n   */\n  type: 'addDiscountCode';\n\n  /**\n   * The code for the discount (case-insensitive)\n   */\n  code: string;\n}"
+    }
+  },
+  "DiscountCodeRemoveChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "DiscountCodeRemoveChange",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The code for the discount (case-insensitive)"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'removeDiscountCode'",
+          "description": "The type of the `DiscountCodeChange` API."
+        }
+      ],
+      "value": "export interface DiscountCodeRemoveChange {\n  /**\n   * The type of the `DiscountCodeChange` API.\n   */\n  type: 'removeDiscountCode';\n\n  /**\n   * The code for the discount (case-insensitive)\n   */\n  code: string;\n}"
+    }
+  },
+  "DiscountCodeChangeResult": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "DiscountCodeChangeResult",
+      "value": "DiscountCodeChangeResultSuccess | DiscountCodeChangeResultError",
+      "description": ""
+    }
+  },
+  "DiscountCodeChangeResultSuccess": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "DiscountCodeChangeResultSuccess",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'success'",
+          "description": "Indicates that the discount code change was applied successfully."
+        }
+      ],
+      "value": "export interface DiscountCodeChangeResultSuccess {\n  /**\n   * Indicates that the discount code change was applied successfully.\n   */\n  type: 'success';\n}"
+    }
+  },
+  "DiscountCodeChangeResultError": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "DiscountCodeChangeResultError",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It is **not** localized, and therefore should not be presented directly to the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'error'",
+          "description": "Indicates that the discount code change failed."
+        }
+      ],
+      "value": "export interface DiscountCodeChangeResultError {\n  /**\n   * Indicates that the discount code change failed.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It is **not** localized, and therefore should not be presented directly\n   * to the buyer.\n   */\n  message: string;\n}"
+    }
+  },
+  "GiftCardChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "GiftCardChange",
+      "value": "GiftCardAddChange | GiftCardRemoveChange",
+      "description": ""
+    }
+  },
+  "GiftCardAddChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "GiftCardAddChange",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "Gift card code."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'addGiftCard'",
+          "description": "The type of the `GiftCardChange` API."
+        }
+      ],
+      "value": "export interface GiftCardAddChange {\n  /**\n   * The type of the `GiftCardChange` API.\n   */\n  type: 'addGiftCard';\n\n  /**\n   * Gift card code.\n   */\n  code: string;\n}"
+    }
+  },
+  "GiftCardRemoveChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "GiftCardRemoveChange",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The full gift card code, or the last four digits of the code."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'removeGiftCard'",
+          "description": "The type of the `GiftCardChange` API."
+        }
+      ],
+      "value": "export interface GiftCardRemoveChange {\n  /**\n   * The type of the `GiftCardChange` API.\n   */\n  type: 'removeGiftCard';\n\n  /**\n   * The full gift card code, or the last four digits of the code.\n   */\n  code: string;\n}"
+    }
+  },
+  "GiftCardChangeResult": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "GiftCardChangeResult",
+      "value": "GiftCardChangeResultSuccess | GiftCardChangeResultError",
+      "description": ""
+    }
+  },
+  "GiftCardChangeResultSuccess": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "GiftCardChangeResultSuccess",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'success'",
+          "description": "Indicates that the gift card change was applied successfully."
+        }
+      ],
+      "value": "export interface GiftCardChangeResultSuccess {\n  /**\n   * Indicates that the gift card change was applied successfully.\n   */\n  type: 'success';\n}"
+    }
+  },
+  "GiftCardChangeResultError": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "GiftCardChangeResultError",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It is **not** localized, and therefore should not be presented directly to the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'error'",
+          "description": "Indicates that the gift card change failed."
+        }
+      ],
+      "value": "export interface GiftCardChangeResultError {\n  /**\n   * Indicates that the gift card change failed.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It is **not** localized, and therefore should not be presented directly\n   * to the buyer.\n   */\n  message: string;\n}"
+    }
+  },
+  "MetafieldChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "MetafieldChange",
+      "value": "MetafieldRemoveChange | MetafieldUpdateChange | MetafieldRemoveCartChange | MetafieldUpdateCartChange",
+      "description": ""
+    }
+  },
+  "MetafieldRemoveChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "MetafieldRemoveChange",
+      "description": "Removes a metafield. This change type is deprecated and will be removed in a future API version. Use `MetafieldRemoveCartChange` instead.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "The name of the metafield to remove."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "namespace",
+          "value": "string",
+          "description": "The namespace of the metafield to remove."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'removeMetafield'",
+          "description": "The type of the `MetafieldRemoveChange` API."
+        }
+      ],
+      "value": "export interface MetafieldRemoveChange {\n  /**\n   * The type of the `MetafieldRemoveChange` API.\n   */\n  type: 'removeMetafield';\n\n  /**\n   * The name of the metafield to remove.\n   */\n  key: string;\n\n  /**\n   * The namespace of the metafield to remove.\n   */\n  namespace: string;\n}"
+    }
+  },
+  "MetafieldUpdateChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "MetafieldUpdateChange",
+      "description": "Updates a metafield. If a metafield with the provided key and namespace does not already exist, it gets created. This change type is deprecated and will be removed in a future API version. Use `MetafieldUpdateCartChange` instead.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "The name of the metafield to update."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "namespace",
+          "value": "string",
+          "description": "The namespace of the metafield to add."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'updateMetafield'",
+          "description": "The type of the `MetafieldUpdateChange` API."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string | number",
+          "description": "The new information to store in the metafield."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "valueType",
+          "value": "'integer' | 'string' | 'json_string'",
+          "description": "The metafield’s information type."
+        }
+      ],
+      "value": "export interface MetafieldUpdateChange {\n  /**\n   * The type of the `MetafieldUpdateChange` API.\n   */\n  type: 'updateMetafield';\n\n  /** The name of the metafield to update. */\n  key: string;\n\n  /** The namespace of the metafield to add. */\n  namespace: string;\n\n  /** The new information to store in the metafield. */\n  value: string | number;\n\n  /**\n   * The metafield’s information type.\n   */\n  valueType: 'integer' | 'string' | 'json_string';\n}"
+    }
+  },
+  "MetafieldRemoveCartChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "MetafieldRemoveCartChange",
+      "description": "Removes a cart metafield.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "The name of the metafield to remove."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "namespace",
+          "value": "string",
+          "description": "The namespace of the metafield to remove.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'removeCartMetafield'",
+          "description": "The type of the `MetafieldRemoveChange` API."
+        }
+      ],
+      "value": "export interface MetafieldRemoveCartChange {\n  /**\n   * The type of the `MetafieldRemoveChange` API.\n   */\n  type: 'removeCartMetafield';\n\n  /**\n   * The name of the metafield to remove.\n   */\n  key: string;\n\n  /**\n   * The namespace of the metafield to remove.\n   */\n  namespace?: string;\n}"
+    }
+  },
+  "CartMetafield": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartMetafield",
+      "description": "The API for interacting with metafields.\n\nRepresents a custom metadata attached to a resource.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "The key name of a metafield."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "namespace",
+          "value": "string",
+          "description": "The namespace for a metafield."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "string",
+          "description": "The metafield's type name."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The value of a metafield."
+        }
+      ],
+      "value": "export interface CartMetafield {\n  /** The key name of a metafield. */\n  key: string;\n\n  /** The namespace for a metafield. */\n  namespace: string;\n\n  /** The value of a metafield. */\n  value: string;\n\n  /** The metafield's type name. */\n  type: string;\n}"
+    }
+  },
+  "MetafieldUpdateCartChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "MetafieldUpdateCartChange",
+      "description": "Updates a cart metafield. If a metafield with the provided key and namespace does not already exist, it gets created.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafield",
+          "value": "{ key: string; namespace?: string; value: string; type: string; }",
+          "description": ""
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'updateCartMetafield'",
+          "description": "The type of the `MetafieldUpdateChange` API."
+        }
+      ],
+      "value": "export interface MetafieldUpdateCartChange {\n  /**\n   * The type of the `MetafieldUpdateChange` API.\n   */\n  type: 'updateCartMetafield';\n\n  metafield: {\n    /** The name of the metafield to update. */\n    key: string;\n\n    /** The namespace of the metafield to add. */\n    namespace?: string;\n\n    /** The new information to store in the metafield. */\n    value: string;\n\n    /**\n     * The metafield’s information type.\n     * See the [`metafields documentation`](/docs/apps/custom-data/metafields/types) for a list of supported types.\n     */\n    type: string;\n  };\n}"
+    }
+  },
+  "MetafieldChangeResult": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "MetafieldChangeResult",
+      "value": "MetafieldChangeResultSuccess | MetafieldChangeResultError",
+      "description": ""
+    }
+  },
+  "MetafieldChangeResultSuccess": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "MetafieldChangeResultSuccess",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'success'",
+          "description": "The type of the `MetafieldChangeResultSuccess` API."
+        }
+      ],
+      "value": "export interface MetafieldChangeResultSuccess {\n  /**\n   * The type of the `MetafieldChangeResultSuccess` API.\n   */\n  type: 'success';\n}"
+    }
+  },
+  "MetafieldChangeResultError": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "MetafieldChangeResultError",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It is **not** localized, and therefore should not be presented directly to the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'error'",
+          "description": "The type of the `MetafieldChangeResultError` API."
+        }
+      ],
+      "value": "export interface MetafieldChangeResultError {\n  /**\n   * The type of the `MetafieldChangeResultError` API.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It is **not** localized, and therefore should not be presented directly\n   * to the buyer.\n   */\n  message: string;\n}"
+    }
+  },
+  "NoteChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "NoteChange",
+      "value": "NoteRemoveChange | NoteUpdateChange",
+      "description": ""
+    }
+  },
+  "NoteRemoveChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "NoteRemoveChange",
+      "description": "Removes a note",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'removeNote'",
+          "description": "The type of the `NoteRemoveChange` API."
+        }
+      ],
+      "value": "export interface NoteRemoveChange {\n  /**\n   * The type of the `NoteRemoveChange` API.\n   */\n  type: 'removeNote';\n}"
+    }
+  },
+  "NoteUpdateChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "NoteUpdateChange",
+      "description": "An Update to a note on the order. for example, the buyer could request detailed packaging instructions in an order note",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "note",
+          "value": "string",
+          "description": "The new value of the note."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'updateNote'",
+          "description": "The type of the `NoteUpdateChange` API."
+        }
+      ],
+      "value": "export interface NoteUpdateChange {\n  /**\n   * The type of the `NoteUpdateChange` API.\n   */\n  type: 'updateNote';\n  /**\n   * The new value of the note.\n   */\n  note: string;\n}"
+    }
+  },
+  "NoteChangeResult": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "NoteChangeResult",
+      "value": "NoteChangeResultSuccess | NoteChangeResultError",
+      "description": ""
+    }
+  },
+  "NoteChangeResultSuccess": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "NoteChangeResultSuccess",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'success'",
+          "description": "The type of the `NoteChangeResultSuccess` API."
+        }
+      ],
+      "value": "export interface NoteChangeResultSuccess {\n  /**\n   * The type of the `NoteChangeResultSuccess` API.\n   */\n  type: 'success';\n}"
+    }
+  },
+  "NoteChangeResultError": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "NoteChangeResultError",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It is **not** localized, and therefore should not be presented directly to the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'error'",
+          "description": "The type of the `NoteChangeResultError` API."
+        }
+      ],
+      "value": "export interface NoteChangeResultError {\n  /**\n   * The type of the `NoteChangeResultError` API.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It is **not** localized, and therefore should not be presented directly\n   * to the buyer.\n   */\n  message: string;\n}"
+    }
+  },
+  "ShippingAddressUpdateChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "ShippingAddressUpdateChange",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address",
+          "value": "Partial<ShippingAddress>",
+          "description": "Fields to update in the shipping address. You only need to provide values for the fields you want to update — any fields you do not list will keep their current values."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'updateShippingAddress'",
+          "description": "The type of the `ShippingAddressUpdateChange` API."
+        }
+      ],
+      "value": "export interface ShippingAddressUpdateChange {\n  /**\n   * The type of the `ShippingAddressUpdateChange` API.\n   */\n  type: 'updateShippingAddress';\n\n  /**\n   * Fields to update in the shipping address. You only need to provide\n   * values for the fields you want to update — any fields you do not list\n   * will keep their current values.\n   */\n  address: Partial<ShippingAddress>;\n}"
+    }
+  },
+  "ShippingAddressChangeResult": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShippingAddressChangeResult",
+      "value": "ShippingAddressChangeResultSuccess | ShippingAddressChangeResultError",
+      "description": ""
+    }
+  },
+  "ShippingAddressChangeResultSuccess": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "ShippingAddressChangeResultSuccess",
+      "description": "The returned result of a successful update to the shipping address.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "errors",
+          "value": "null",
+          "description": ""
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'success'",
+          "description": "The type of the `ShippingAddressChangeResultSuccess` API."
+        }
+      ],
+      "value": "export interface ShippingAddressChangeResultSuccess {\n  /**\n   * The type of the `ShippingAddressChangeResultSuccess` API.\n   */\n  type: 'success';\n\n  errors: null;\n}"
+    }
+  },
+  "ShippingAddressChangeResultError": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "ShippingAddressChangeResultError",
+      "description": "The returned result of an update to the shipping address with a messages detailing the type of errors that occurred.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "errors",
+          "value": "ShippingAddressChangeFieldError[]",
+          "description": "The errors corresponding to particular fields from a given change"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'error'",
+          "description": "The type of the `ShippingAddressChangeResultError` API."
+        }
+      ],
+      "value": "export interface ShippingAddressChangeResultError {\n  /**\n   * The type of the `ShippingAddressChangeResultError` API.\n   */\n  type: 'error';\n\n  /**\n   * The errors corresponding to particular fields from a given change\n   */\n  errors: ShippingAddressChangeFieldError[];\n}"
+    }
+  },
+  "ShippingAddressChangeFieldError": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "name": "ShippingAddressChangeFieldError",
+      "description": "An error corresponding to a particular field from a given change",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "field",
+          "value": "keyof MailingAddress",
+          "description": "field key from MailingAddress where the error occurred",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It is **not** localized, and therefore should not be presented directly to the buyer."
+        }
+      ],
+      "value": "export interface ShippingAddressChangeFieldError {\n  /**\n   * field key from MailingAddress where the error occurred\n   */\n  field?: keyof MailingAddress;\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It is **not** localized, and therefore should not be presented directly\n   * to the buyer.\n   */\n  message: string;\n}"
+    }
+  },
+  "UseBillingAddressGeneratedType": {
+    "src/surfaces/checkout/preact/billing-address.ts": {
+      "filePath": "src/surfaces/checkout/preact/billing-address.ts",
+      "name": "UseBillingAddressGeneratedType",
+      "description": "Returns the proposed `billingAddress` applied to the checkout.",
+      "params": [],
+      "returns": {
+        "filePath": "src/surfaces/checkout/preact/billing-address.ts",
+        "description": "",
+        "name": "MailingAddress | undefined",
+        "value": "MailingAddress | undefined"
+      },
+      "value": "export function useBillingAddress<\n  Target extends RenderExtensionTarget = RenderExtensionTarget,\n>(): MailingAddress | undefined {\n  const billingAddress = useApi<Target>().billingAddress;\n\n  if (!billingAddress) {\n    throw new ScopeNotGrantedError(\n      'Using billing address requires having billing address permissions granted to your app.',\n    );\n  }\n\n  return useSubscription(billingAddress);\n}"
+    }
+  },
+  "UseShippingAddressGeneratedType": {
+    "src/surfaces/checkout/preact/shipping-address.ts": {
+      "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
+      "name": "UseShippingAddressGeneratedType",
+      "description": "Returns the proposed `shippingAddress` applied to the checkout.",
+      "params": [],
+      "returns": {
+        "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
+        "description": "",
+        "name": "ShippingAddress | undefined",
+        "value": "ShippingAddress | undefined"
+      },
+      "value": "export function useShippingAddress<\n  Target extends RenderExtensionTarget = RenderExtensionTarget,\n>(): ShippingAddress | undefined {\n  const shippingAddress = useApi<Target>().shippingAddress;\n\n  if (!shippingAddress) {\n    throw new ScopeNotGrantedError(\n      'Using shipping address requires having shipping address permissions granted to your app.',\n    );\n  }\n\n  return useSubscription(shippingAddress);\n}"
+    }
+  },
+  "UseApplyShippingAddressChangeGeneratedType": {
+    "src/surfaces/checkout/preact/shipping-address.ts": {
+      "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
+      "name": "UseApplyShippingAddressChangeGeneratedType",
+      "description": "Returns a function to mutate the `shippingAddress` property of checkout.",
+      "params": [],
+      "returns": {
+        "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
+        "description": "",
+        "name": "(change: ShippingAddressChange) => Promise<ShippingAddressChangeResult> | undefined",
+        "value": "(change: ShippingAddressChange) => Promise<ShippingAddressChangeResult> | undefined"
+      },
+      "value": "export function useApplyShippingAddressChange<\n  Target extends RenderExtensionTarget = RenderExtensionTarget,\n>():\n  | ((change: ShippingAddressChange) => Promise<ShippingAddressChangeResult>)\n  | undefined {\n  const api = useApi<Target>();\n\n  if ('applyShippingAddressChange' in api) {\n    return api.applyShippingAddressChange;\n  }\n\n  throw new ExtensionHasNoMethodError(\n    'applyShippingAddressChange',\n    api.extension.target,\n  );\n}"
+    }
+  },
+  "ShippingAddressChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShippingAddressChange",
+      "value": "ShippingAddressUpdateChange",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address",
+          "value": "Partial<ShippingAddress>",
+          "description": "Fields to update in the shipping address. You only need to provide values for the fields you want to update — any fields you do not list will keep their current values."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'updateShippingAddress'",
+          "description": "The type of the `ShippingAddressUpdateChange` API."
+        }
+      ]
+    }
+  },
+  "BaseMerchandise": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "BaseMerchandise",
+      "description": "The API for interacting with the cart lines.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "The merchandise ID."
+        }
+      ],
+      "value": "export interface BaseMerchandise {\n  /**\n   * The merchandise ID.\n   */\n  id: string;\n}"
+    }
+  },
+  "ProductVariant": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "ProductVariant",
+      "description": "The API for interacting with the cart lines.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/ProductVariant/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "image",
+          "value": "ImageDetails",
+          "description": "Image associated with the product variant. This field falls back to the product image if no image is available.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "product",
+          "value": "Product",
+          "description": "The product object that the product variant belongs to."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "requiresShipping",
+          "value": "boolean",
+          "description": "Whether or not the product requires shipping."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "selectedOptions",
+          "value": "SelectedOption[]",
+          "description": "List of product options applied to the variant."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sellingPlan",
+          "value": "SellingPlan",
+          "description": "The selling plan associated with the merchandise.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sku",
+          "value": "string",
+          "description": "The product variant's sku.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "subtitle",
+          "value": "string",
+          "description": "The product variant's subtitle.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The product variant’s title."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'variant'",
+          "description": ""
+        }
+      ],
+      "value": "export interface ProductVariant extends BaseMerchandise {\n  type: 'variant';\n\n  /**\n   * A globally-unique identifier.\n   * @example 'gid://shopify/ProductVariant/123'\n   */\n  id: string;\n\n  /**\n   * The product variant’s title.\n   */\n  title: string;\n\n  /**\n   * The product variant's subtitle.\n   */\n  subtitle?: string;\n\n  /**\n   * Image associated with the product variant. This field falls back to the product\n   * image if no image is available.\n   */\n  image?: ImageDetails;\n\n  /**\n   * List of product options applied to the variant.\n   */\n  selectedOptions: SelectedOption[];\n\n  /**\n   * The product object that the product variant belongs to.\n   */\n  product: Product;\n\n  /**\n   * Whether or not the product requires shipping.\n   */\n  requiresShipping: boolean;\n\n  /**\n   * The selling plan associated with the merchandise.\n   */\n  sellingPlan?: SellingPlan;\n\n  /**\n   * The product variant's sku.\n   */\n  sku?: string;\n}"
+    }
+  },
+  "CartDiscountAllocationBase": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartDiscountAllocationBase",
+      "description": "The API for interacting with discounts.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountedAmount",
+          "value": "Money",
+          "description": "The money amount that has been discounted from the order"
+        }
+      ],
+      "value": "export interface CartDiscountAllocationBase {\n  /**\n   * The money amount that has been discounted from the order\n   */\n  discountedAmount: Money;\n}"
+    }
+  },
+  "DeliveryOptionBase": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "DeliveryOptionBase",
+      "description": "The APIs for interacting with delivery and shipping options.\n\nRepresents a base interface for a single delivery option.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The code of the delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "description",
+          "value": "string",
+          "description": "The description of the delivery option.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The unique identifier of the delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "Metafield[]",
+          "description": "The metafields associated with this delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The title of the delivery option.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface DeliveryOptionBase {\n  /**\n   * The unique identifier of the delivery option.\n   */\n  handle: string;\n\n  /**\n   * The title of the delivery option.\n   */\n  title?: string;\n\n  /**\n   * The description of the delivery option.\n   */\n  description?: string;\n\n  /**\n   * The code of the delivery option.\n   */\n  code: string;\n\n  /**\n   * The metafields associated with this delivery option.\n   */\n  metafields: Metafield[];\n}"
+    }
+  },
+  "DeliveryGroupDetails": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "DeliveryGroupDetails",
+      "description": "The APIs for interacting with delivery and shipping options.\n\nRepresents a DeliveryGroup with expanded reference fields and full details.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryOptions",
+          "value": "DeliveryOption[]",
+          "description": "The delivery options available for the delivery group."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "groupType",
+          "value": "DeliveryGroupType",
+          "description": "The type of the delivery group."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "The unique identifier of the delivery group. On the Thank You page this value is undefined.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isDeliveryRequired",
+          "value": "boolean",
+          "description": "Whether delivery is required for the delivery group."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "selectedDeliveryOption",
+          "value": "DeliveryOption",
+          "description": "The selected delivery option for the delivery group.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "targetedCartLines",
+          "value": "CartLine[]",
+          "description": "The cart lines associated to the delivery group."
+        }
+      ],
+      "value": "export interface DeliveryGroupDetails extends DeliveryGroup {\n  /**\n   * The selected delivery option for the delivery group.\n   */\n  selectedDeliveryOption?: DeliveryOption;\n\n  /**\n   * The cart lines associated to the delivery group.\n   */\n  targetedCartLines: CartLine[];\n}"
+    }
+  }
+}

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -129,7 +129,7 @@
   ],
   "devDependencies": {
     "@remote-ui/async-subscription": "^2.1.16",
-    "@shopify/generate-docs": "https://registry.npmjs.org/@shopify/generate-docs/-/generate-docs-0.19.8.tgz",
+    "@shopify/generate-docs": "^1.0.0",
     "@quilted/react-testing": "^0.6.11",
     "typescript": "^4.9.0",
     "@faker-js/faker": "^8.4.1",

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -22,6 +22,8 @@ import type {SubscribableSignalLike} from '../../shared';
 export type {ApiVersion, Capability} from '../../../../shared';
 
 /**
+ * The API for interacting with local storage.
+ *
  * A key-value storage object for the extension.
  *
  * Stored data is only available to this specific extension
@@ -30,6 +32,8 @@ export type {ApiVersion, Capability} from '../../../../shared';
  * The storage backend is implemented with `localStorage` and
  * should persist across the buyer's checkout session.
  * However, data persistence isn't guaranteed.
+ *
+ * @publicDocs
  */
 export interface Storage {
   /**
@@ -56,7 +60,11 @@ export interface Storage {
 }
 
 /**
+ * The API for interacting with the metadata of an extension.
+ *
  * The meta information about an extension target.
+ *
+ * @publicDocs
  */
 export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
   /**
@@ -130,6 +138,11 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
   version?: string;
 }
 
+/**
+ * Information about the editor where the extension is being rendered.
+ *
+ * @publicDocs
+ */
 export interface Editor {
   /**
    * Indicates whether the extension is rendering in the checkout editor.
@@ -138,7 +151,11 @@ export interface Editor {
 }
 
 /**
+ * The API for interacting with metafields.
+ *
  * Metadata associated with the checkout.
+ *
+ * @publicDocs
  */
 export interface Metafield {
   /**
@@ -164,7 +181,11 @@ export interface Metafield {
 }
 
 /**
+ * The API for interacting with metafields.
+ *
  * Represents a custom metadata attached to a resource.
+ *
+ * @publicDocs
  */
 export interface AppMetafield {
   /** The key name of a metafield. */
@@ -188,7 +209,11 @@ export interface AppMetafield {
 }
 
 /**
+ * The API for interacting with metafields.
+ *
  * Represents a custom metadata attached to a resource.
+ *
+ * @publicDocs
  */
 export interface CartMetafield {
   /** The key name of a metafield. */
@@ -205,7 +230,11 @@ export interface CartMetafield {
 }
 
 /**
+ * The API for interacting with metafields.
+ *
  * The metafield owner.
+ *
+ * @publicDocs
  */
 export interface AppMetafieldEntryTarget {
   /**
@@ -228,7 +257,11 @@ export interface AppMetafieldEntryTarget {
 }
 
 /**
+ * The API for interacting with metafields.
+ *
  * A metafield associated with the shop or a resource on the checkout.
+ *
+ * @publicDocs
  */
 export interface AppMetafieldEntry {
   /**
@@ -242,13 +275,28 @@ export interface AppMetafieldEntry {
   metafield: AppMetafield;
 }
 
+/**
+ * The renderer version being used for the extension.
+ *
+ * @publicDocs
+ */
 export type Version = string;
+
+/**
+ * The API for interacting with the token of a checkout.
+ *
+ * @publicDocs
+ */
 export type CheckoutToken = string;
 
 /**
+ * The APIs for localizing your extension.
+ *
  * This returns a translated string matching a key in a locale file.
  *
  * @example translate("banner.title")
+ *
+ * @publicDocs
  */
 export interface I18nTranslate {
   <ReplacementType = string>(
@@ -259,6 +307,11 @@ export interface I18nTranslate {
     : (string | ReplacementType)[];
 }
 
+/**
+ * The APIs for localizing your extension.
+ *
+ * @publicDocs
+ */
 export interface I18n {
   /**
    * Returns a localized number.
@@ -315,6 +368,11 @@ export interface I18n {
   translate: I18nTranslate;
 }
 
+/**
+ * The APIs for localizing your extension.
+ *
+ * @publicDocs
+ */
 export interface Language {
   /**
    * The BCP-47 language tag. It may contain a dash followed by an ISO 3166-1 alpha-2 region code.
@@ -326,6 +384,11 @@ export interface Language {
   isoCode: string;
 }
 
+/**
+ * The APIs for localizing your extension.
+ *
+ * @publicDocs
+ */
 export interface Currency {
   /**
    * The ISO-4217 code for this currency.
@@ -334,6 +397,11 @@ export interface Currency {
   isoCode: CurrencyCode;
 }
 
+/**
+ * The APIs for localizing your extension.
+ *
+ * @publicDocs
+ */
 export interface Market {
   /**
    * A globally-unique identifier for a market.
@@ -346,6 +414,11 @@ export interface Market {
   handle: string;
 }
 
+/**
+ * The APIs for localizing your extension.
+ *
+ * @publicDocs
+ */
 export interface Localization {
   /**
    * The currency that the customer sees for money amounts in the checkout.
@@ -397,6 +470,11 @@ export interface Localization {
   market: SubscribableSignalLike<Market | undefined>;
 }
 
+/**
+ * The API for interacting with localized fields.
+ *
+ * @publicDocs
+ */
 export interface LocalizedField {
   key: LocalizedFieldKey;
   title: string;
@@ -404,7 +482,11 @@ export interface LocalizedField {
 }
 
 /**
+ * The API for interacting with the buyer journey.
+ *
  * Provides details on the buyer's progression through the checkout.
+ *
+ * @publicDocs
  */
 export interface BuyerJourney {
   /**
@@ -472,6 +554,11 @@ interface BuyerJourneyStepReference {
   handle: BuyerJourneyStepHandle;
 }
 
+/**
+ * The API for interacting with the buyer journey.
+ *
+ * @publicDocs
+ */
 export interface BuyerJourneyStep {
   /**
    * The handle that uniquely identifies the buyer journey step.
@@ -494,6 +581,11 @@ export interface BuyerJourneyStep {
   disabled: boolean;
 }
 
+/**
+ * The base API object provided to checkout extension targets.
+ *
+ * @publicDocs
+ */
 export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
@@ -756,6 +848,11 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   localizedFields?: SubscribableSignalLike<LocalizedField[]>;
 }
 
+/**
+ * Methods to interact with the extension's UI.
+ *
+ * @publicDocs
+ */
 export interface Ui {
   /**
    * Allows the extension to close an overlay programmatically.
@@ -772,6 +869,11 @@ interface Overlay {
   close(overlayId: string): void;
 }
 
+/**
+ * The API for interacting with session tokens.
+ *
+ * @publicDocs
+ */
 export interface SessionToken {
   /**
    * Requests a session token that hasn't expired. You should call this method every
@@ -782,6 +884,11 @@ export interface SessionToken {
   get(): Promise<string>;
 }
 
+/**
+ * The API for interacting with the buyer identity.
+ *
+ * @publicDocs
+ */
 export interface BuyerIdentity {
   /**
    * The buyer's customer account. The value is undefined if the buyer isn’t a
@@ -818,7 +925,11 @@ export interface BuyerIdentity {
 }
 
 /**
+ * The API for interacting with the buyer identity.
+ *
  * The information about a company that the business customer is purchasing on behalf of.
+ *
+ * @publicDocs
  */
 export interface PurchasingCompany {
   /**
@@ -835,6 +946,11 @@ export interface PurchasingCompany {
   location: CompanyLocation;
 }
 
+/**
+ * The API for interacting with the buyer identity.
+ *
+ * @publicDocs
+ */
 export interface Company {
   /**
    * The company ID.
@@ -856,6 +972,11 @@ export interface Company {
   externalId?: string;
 }
 
+/**
+ * The API for interacting with the buyer identity.
+ *
+ * @publicDocs
+ */
 export interface CompanyLocation {
   /**
    * The company location ID.
@@ -877,6 +998,11 @@ export interface CompanyLocation {
   externalId?: string;
 }
 
+/**
+ * The API for interacting with gift cards.
+ *
+ * @publicDocs
+ */
 export interface AppliedGiftCard {
   /**
    * The last four characters of the applied gift card's code.
@@ -894,6 +1020,11 @@ export interface AppliedGiftCard {
   balance: Money;
 }
 
+/**
+ * The API for interacting with shop.
+ *
+ * @publicDocs
+ */
 export interface Shop {
   /**
    * The shop ID.
@@ -917,6 +1048,11 @@ export interface Shop {
   myshopifyDomain: string;
 }
 
+/**
+ * The API for interacting with the cost of a checkout.
+ *
+ * @publicDocs
+ */
 export interface CartCost {
   /**
    * A `Money` value representing the subtotal value of the items in the cart at the current
@@ -946,6 +1082,11 @@ export interface CartCost {
   totalAmount: SubscribableSignalLike<Money>;
 }
 
+/**
+ * The API for interacting with the cart lines.
+ *
+ * @publicDocs
+ */
 export interface CartLine {
   /**
    * These line item IDs are not stable at the moment, they might change after
@@ -992,6 +1133,11 @@ export interface CartLine {
   parentRelationship: CartLineParentRelationship | null;
 }
 
+/**
+ * The API for interacting with the cart lines.
+ *
+ * @publicDocs
+ */
 export interface CartLineParentRelationship {
   /**
    * The parent cart line that a cart line is associated with.
@@ -1010,6 +1156,11 @@ export interface CartLineParentRelationship {
 
 type CartLineComponentType = CartBundleLineComponent;
 
+/**
+ * The API for interacting with the cart lines.
+ *
+ * @publicDocs
+ */
 export interface CartBundleLineComponent {
   type: 'bundle';
 
@@ -1045,6 +1196,11 @@ export interface CartBundleLineComponent {
   attributes: Attribute[];
 }
 
+/**
+ * The API for interacting with the cost of a checkout.
+ *
+ * @publicDocs
+ */
 export interface CartLineCost {
   /**
    * The total amount after reductions the buyer can expect to pay that is directly attributable to a single
@@ -1053,6 +1209,11 @@ export interface CartLineCost {
   totalAmount: Money;
 }
 
+/**
+ * The API for interacting with the cost of a checkout.
+ *
+ * @publicDocs
+ */
 export interface Money {
   /**
    * The price amount.
@@ -1065,8 +1226,18 @@ export interface Money {
   currencyCode: CurrencyCode;
 }
 
+/**
+ * The API for interacting with the cart lines.
+ *
+ * @publicDocs
+ */
 export type Merchandise = ProductVariant;
 
+/**
+ * The API for interacting with the cart lines.
+ *
+ * @publicDocs
+ */
 export interface BaseMerchandise {
   /**
    * The merchandise ID.
@@ -1074,6 +1245,11 @@ export interface BaseMerchandise {
   id: string;
 }
 
+/**
+ * The API for interacting with the cart lines.
+ *
+ * @publicDocs
+ */
 export interface ProductVariant extends BaseMerchandise {
   type: 'variant';
 
@@ -1125,6 +1301,11 @@ export interface ProductVariant extends BaseMerchandise {
   sku?: string;
 }
 
+/**
+ * The API for interacting with the cart lines.
+ *
+ * @publicDocs
+ */
 export interface Product {
   /**
    * A globally-unique identifier.
@@ -1142,6 +1323,11 @@ export interface Product {
   productType: string;
 }
 
+/**
+ * The API for interacting with the cart lines.
+ *
+ * @publicDocs
+ */
 export interface ImageDetails {
   /**
    * The image URL.
@@ -1154,6 +1340,11 @@ export interface ImageDetails {
   altText?: string;
 }
 
+/**
+ * The API for interacting with the cart lines.
+ *
+ * @publicDocs
+ */
 export interface SelectedOption {
   /**
    * The name of the merchandise option.
@@ -1167,7 +1358,11 @@ export interface SelectedOption {
 }
 
 /**
+ * The API for interacting with the payment options.
+ *
  * A payment option presented to the buyer.
+ *
+ * @publicDocs
  */
 export interface PaymentOption {
   /**
@@ -1208,19 +1403,40 @@ export interface PaymentOption {
   handle: string;
 }
 
+/**
+ * The API for interacting with the payment options.
+ *
+ * @publicDocs
+ */
 export type SelectedPaymentOption = PaymentOption;
 
+/**
+ * The API for interacting with discounts.
+ *
+ * @publicDocs
+ */
 export interface CartDiscountCode {
   /**
    * The code for the discount
    */
   code: string;
 }
+
+/**
+ * The API for interacting with discounts.
+ *
+ * @publicDocs
+ */
 export type CartDiscountAllocation =
   | CartCodeDiscountAllocation
   | CartAutomaticDiscountAllocation
   | CartCustomDiscountAllocation;
 
+/**
+ * The API for interacting with discounts.
+ *
+ * @publicDocs
+ */
 export interface CartDiscountAllocationBase {
   /**
    * The money amount that has been discounted from the order
@@ -1228,6 +1444,11 @@ export interface CartDiscountAllocationBase {
   discountedAmount: Money;
 }
 
+/**
+ * The API for interacting with discounts.
+ *
+ * @publicDocs
+ */
 export interface CartCodeDiscountAllocation extends CartDiscountAllocationBase {
   /**
    * The code for the discount
@@ -1240,6 +1461,11 @@ export interface CartCodeDiscountAllocation extends CartDiscountAllocationBase {
   type: 'code';
 }
 
+/**
+ * The API for interacting with discounts.
+ *
+ * @publicDocs
+ */
 export interface CartAutomaticDiscountAllocation
   extends CartDiscountAllocationBase {
   /**
@@ -1253,6 +1479,11 @@ export interface CartAutomaticDiscountAllocation
   type: 'automatic';
 }
 
+/**
+ * The API for interacting with discounts.
+ *
+ * @publicDocs
+ */
 export interface CartCustomDiscountAllocation
   extends CartDiscountAllocationBase {
   /**
@@ -1284,10 +1515,6 @@ interface InterceptorResultBlock {
   behavior: 'block';
 }
 
-export type InterceptorRequest =
-  | InterceptorRequestAllow
-  | InterceptorRequestBlock;
-
 interface InterceptorRequestAllow {
   /**
    * Indicates that the interceptor will allow the buyer's journey to continue.
@@ -1302,6 +1529,16 @@ interface InterceptorRequestAllow {
    */
   perform?(result: InterceptorResult): void | Promise<void>;
 }
+
+/**
+ * The API for interacting with the buyer journey.
+ *
+ * @publicDocs
+ */
+export type InterceptorRequest =
+  | InterceptorRequestAllow
+  | InterceptorRequestBlock;
+
 // The reason is used for tracing and debugging purposes.
 interface InterceptorRequestBlock {
   /**
@@ -1330,6 +1567,11 @@ interface InterceptorRequestBlock {
   perform?(result: InterceptorResult): void | Promise<void>;
 }
 
+/**
+ * The API for interacting with the buyer journey.
+ *
+ * @publicDocs
+ */
 export interface InterceptorProps {
   /**
    * Whether the interceptor has the capability to block a buyer's progress through
@@ -1339,20 +1581,28 @@ export interface InterceptorProps {
 }
 
 /**
+ * The API for interacting with the buyer journey.
+ *
  * A function for intercepting and preventing navigation on checkout. You can block
  * navigation by returning an object with
  * `{behavior: 'block', reason: InvalidResultReason.InvalidExtensionState, errors?: ValidationErrors[]}`.
  * If you do, then you're expected to also update some part of your UI to reflect the reason why navigation
  * was blocked, either by targeting checkout UI fields, passing errors to the page level or rendering the errors in your extension.
+ *
+ * @publicDocs
  */
 export type Interceptor = (
   interceptorProps: InterceptorProps,
 ) => InterceptorRequest | Promise<InterceptorRequest>;
 
 /**
+ * The API for interacting with the buyer identity.
+ *
  * Information about a customer who has previously purchased from this shop.
  *
  * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+ *
+ * @publicDocs
  */
 export interface Customer {
   /**
@@ -1438,7 +1688,11 @@ export interface Customer {
 }
 
 /**
+ * The API for interacting with merchant settings.
+ *
  * Settings describing the behavior of the buyer's checkout.
+ *
+ * @publicDocs
  */
 export interface CheckoutSettings {
   /**
@@ -1456,7 +1710,11 @@ export interface CheckoutSettings {
 }
 
 /**
+ * The API for interacting with merchant settings.
+ *
  * Settings describing the behavior of the shipping address.
+ *
+ * @publicDocs
  */
 export interface ShippingAddressSettings {
   /**
@@ -1466,7 +1724,11 @@ export interface ShippingAddressSettings {
 }
 
 /**
+ * The API for interacting with merchant settings.
+ *
  * Represents the payment terms template object.
+ *
+ * @publicDocs
  */
 export interface PaymentTermsTemplate {
   /**
@@ -1489,7 +1751,11 @@ export interface PaymentTermsTemplate {
 }
 
 /**
+ * The API for interacting with the buyer identity.
+ *
  * Information about a Store Credit Account.
+ *
+ * @publicDocs
  */
 export interface StoreCreditAccount {
   /**
@@ -1504,13 +1770,22 @@ export interface StoreCreditAccount {
 }
 
 /**
+ * The API for interacting with merchant settings.
+ *
  * The merchant-defined setting values for the extension.
+ *
+ * @publicDocs
  */
 export type ExtensionSettings = Record<
   string,
   string | number | boolean | undefined
 >;
 
+/**
+ * The API for interacting with web pixels.
+ *
+ * @publicDocs
+ */
 export interface Analytics {
   /**
    * Publish method to emit analytics events to [Web Pixels](https://shopify.dev/docs/apps/marketing).
@@ -1522,13 +1797,22 @@ export interface Analytics {
    */
   visitor(data: {email?: string; phone?: string}): Promise<VisitorResult>;
 }
+
 /**
+ * The API for interacting with web pixels.
+ *
  * Represents a visitor result.
+ *
+ * @publicDocs
  */
 export type VisitorResult = VisitorSuccess | VisitorError;
 
 /**
+ * The API for interacting with web pixels.
+ *
  * Represents a successful visitor result.
+ *
+ * @publicDocs
  */
 export interface VisitorSuccess {
   /**
@@ -1538,7 +1822,11 @@ export interface VisitorSuccess {
 }
 
 /**
+ * The API for interacting with web pixels.
+ *
  * Represents an unsuccessful visitor result.
+ *
+ * @publicDocs
  */
 export interface VisitorError {
   /**
@@ -1556,8 +1844,12 @@ export interface VisitorError {
 }
 
 /**
+ * The APIs for interacting with delivery and shipping options.
+ *
  * Represents the delivery information and options available for one or
  * more cart lines.
+ *
+ * @publicDocs
  */
 export interface DeliveryGroup {
   /**
@@ -1591,12 +1883,20 @@ export interface DeliveryGroup {
 }
 
 /**
+ * The APIs for interacting with delivery and shipping options.
+ *
  * The possible types of a delivery group.
+ *
+ * @publicDocs
  */
 export type DeliveryGroupType = 'oneTimePurchase' | 'subscription';
 
 /**
+ * The APIs for interacting with delivery and shipping options.
+ *
  * Represents a reference to a cart line.
+ *
+ * @publicDocs
  */
 export interface CartLineReference {
   /**
@@ -1606,7 +1906,11 @@ export interface CartLineReference {
 }
 
 /**
+ * The APIs for interacting with delivery and shipping options.
+ *
  * Represents a reference to a delivery option.
+ *
+ * @publicDocs
  */
 export interface DeliveryOptionReference {
   /**
@@ -1615,13 +1919,22 @@ export interface DeliveryOptionReference {
   handle: string;
 }
 
+/**
+ * The APIs for interacting with delivery and shipping options.
+ *
+ * @publicDocs
+ */
 export type DeliveryOption =
   | ShippingOption
   | PickupPointOption
   | PickupLocationOption;
 
 /**
+ * The APIs for interacting with delivery and shipping options.
+ *
  * Represents a base interface for a single delivery option.
+ *
+ * @publicDocs
  */
 export interface DeliveryOptionBase {
   /**
@@ -1651,7 +1964,11 @@ export interface DeliveryOptionBase {
 }
 
 /**
+ * The APIs for interacting with delivery and shipping options.
+ *
  * Represents a delivery option that is a shipping option.
+ *
+ * @publicDocs
  */
 export interface ShippingOption extends DeliveryOptionBase {
   /**
@@ -1680,6 +1997,11 @@ export interface ShippingOption extends DeliveryOptionBase {
   deliveryEstimate: DeliveryEstimate;
 }
 
+/**
+ * The APIs for interacting with delivery and shipping options.
+ *
+ * @publicDocs
+ */
 export interface DeliveryEstimate {
   /**
    * The estimated time in transit for the delivery in seconds.
@@ -1687,6 +2009,11 @@ export interface DeliveryEstimate {
   timeInTransit?: NumberRange;
 }
 
+/**
+ * The APIs for interacting with delivery and shipping options.
+ *
+ * @publicDocs
+ */
 export interface ShippingOptionCarrier {
   /**
    * The name of the carrier.
@@ -1694,6 +2021,11 @@ export interface ShippingOptionCarrier {
   name?: string;
 }
 
+/**
+ * The APIs for interacting with delivery and shipping options.
+ *
+ * @publicDocs
+ */
 export interface PickupPointOption extends DeliveryOptionBase {
   /**
    * The type of this delivery option.
@@ -1721,6 +2053,11 @@ export interface PickupPointOption extends DeliveryOptionBase {
   location: PickupPointLocation;
 }
 
+/**
+ * The APIs for interacting with delivery and shipping options.
+ *
+ * @publicDocs
+ */
 export interface PickupLocationOption extends DeliveryOptionBase {
   /**
    * The type of this delivery option.
@@ -1774,6 +2111,11 @@ interface PickupPointCarrier {
   name?: string;
 }
 
+/**
+ * The APIs for interacting with delivery and shipping options.
+ *
+ * @publicDocs
+ */
 export interface NumberRange {
   /**
    * The lower bound of the number range.
@@ -1787,7 +2129,11 @@ export interface NumberRange {
 }
 
 /**
+ * The APIs for interacting with delivery and shipping options.
+ *
  * Represents a DeliveryGroup with expanded reference fields and full details.
+ *
+ * @publicDocs
  */
 export interface DeliveryGroupDetails extends DeliveryGroup {
   /**
@@ -1801,6 +2147,11 @@ export interface DeliveryGroupDetails extends DeliveryGroup {
   targetedCartLines: CartLine[];
 }
 
+/**
+ * The API for interacting with a customer's privacy consent.
+ *
+ * @publicDocs
+ */
 export interface AllowedProcessing {
   /**
    * Can collect customer analytics about how the shop was used and interactions made on the shop.
@@ -1820,6 +2171,11 @@ export interface AllowedProcessing {
   saleOfData: boolean;
 }
 
+/**
+ * The API for interacting with a customer's privacy consent.
+ *
+ * @publicDocs
+ */
 export interface VisitorConsent {
   /**
    * Visitor consents to recording data to understand how customers interact with the site.
@@ -1839,6 +2195,11 @@ export interface VisitorConsent {
   saleOfData?: boolean;
 }
 
+/**
+ * The API for interacting with a customer's privacy consent.
+ *
+ * @publicDocs
+ */
 export interface TrackingConsentMetafield {
   /**
    * The name of the metafield. It must be between 3 and 30 characters in
@@ -1853,6 +2214,11 @@ export interface TrackingConsentMetafield {
   value: string;
 }
 
+/**
+ * The API for interacting with a customer's privacy consent.
+ *
+ * @publicDocs
+ */
 export interface TrackingConsentMetafieldChange {
   /**
    * The name of the metafield. It must be between 3 and 30 characters in
@@ -1867,6 +2233,11 @@ export interface TrackingConsentMetafieldChange {
   value: string | null;
 }
 
+/**
+ * The API for interacting with a customer's privacy consent.
+ *
+ * @publicDocs
+ */
 export interface VisitorConsentChange extends VisitorConsent {
   /**
    * Tracking consent metafield data to be saved.
@@ -1879,10 +2250,20 @@ export interface VisitorConsentChange extends VisitorConsent {
   type: 'changeVisitorConsent';
 }
 
+/**
+ * The API for interacting with a customer's privacy consent.
+ *
+ * @publicDocs
+ */
 export type ApplyTrackingConsentChangeType = (
   visitorConsent: VisitorConsentChange,
 ) => Promise<TrackingConsentChangeResult>;
 
+/**
+ * The API for interacting with a customer's privacy consent.
+ *
+ * @publicDocs
+ */
 export interface CustomerPrivacyRegion {
   /**
    * The [ISO 3166 Alpha-2 format](https://www.iso.org/iso-3166-country-codes.html) for the buyer's country.
@@ -1904,6 +2285,11 @@ export interface CustomerPrivacyRegion {
   provinceCode?: string;
 }
 
+/**
+ * The API for interacting with a customer's privacy consent. It is similar to the [Customer Privacy API in storefront](/docs/api/customer-privacy).
+ *
+ * @publicDocs
+ */
 export interface CustomerPrivacy {
   /**
    * An object containing flags for each consent property denoting whether they can be processed based on visitor consent, merchant configuration, and user location.
@@ -1941,12 +2327,21 @@ export interface CustomerPrivacy {
   region?: CustomerPrivacyRegion;
 }
 
+/**
+ * The API for interacting with a customer's privacy consent.
+ *
+ * @publicDocs
+ */
 export type TrackingConsentChangeResult =
   | TrackingConsentChangeResultSuccess
   | TrackingConsentChangeResultError;
 
 /**
+ * The API for interacting with a customer's privacy consent.
+ *
  * The returned result of a successful tracking consent preference update.
+ *
+ * @publicDocs
  */
 export interface TrackingConsentChangeResultSuccess {
   /**
@@ -1956,8 +2351,12 @@ export interface TrackingConsentChangeResultSuccess {
 }
 
 /**
+ * The API for interacting with a customer's privacy consent.
+ *
  * The returned result of an unsuccessful tracking consent preference update
  * with a message detailing the type of error that occurred.
+ *
+ * @publicDocs
  */
 export interface TrackingConsentChangeResultError {
   /**
@@ -1973,6 +2372,11 @@ export interface TrackingConsentChangeResultError {
   message: string;
 }
 
+/**
+ * Instructions used to create the checkout.
+ *
+ * @publicDocs
+ */
 export interface CartInstructions {
   /**
    * Cart instructions related to cart attributes.
@@ -2005,6 +2409,11 @@ export interface CartInstructions {
   notes: NotesCartInstructions;
 }
 
+/**
+ * Instructions used to create the checkout.
+ *
+ * @publicDocs
+ */
 export interface AttributesCartInstructions {
   /**
    * Indicates whether or not cart attributes can be updated.
@@ -2012,6 +2421,11 @@ export interface AttributesCartInstructions {
   canUpdateAttributes: boolean;
 }
 
+/**
+ * Instructions used to create the checkout.
+ *
+ * @publicDocs
+ */
 export interface DeliveryCartInstructions {
   /**
    * Indicates whether a buyer can select a custom address.
@@ -2021,6 +2435,11 @@ export interface DeliveryCartInstructions {
   canSelectCustomAddress: boolean;
 }
 
+/**
+ * Instructions used to create the checkout.
+ *
+ * @publicDocs
+ */
 export interface DiscountsCartInstructions {
   /**
    * Indicates whether or not discount codes can be updated.
@@ -2028,6 +2447,11 @@ export interface DiscountsCartInstructions {
   canUpdateDiscountCodes: boolean;
 }
 
+/**
+ * Instructions used to create the checkout.
+ *
+ * @publicDocs
+ */
 export interface CartLinesCartInstructions {
   /**
    * Indicates whether or not new cart lines can be added.
@@ -2045,6 +2469,11 @@ export interface CartLinesCartInstructions {
   canUpdateCartLine: boolean;
 }
 
+/**
+ * Instructions used to create the checkout.
+ *
+ * @publicDocs
+ */
 export interface MetafieldsCartInstructions {
   /**
    * Indicates whether or not cart metafields can be added or updated.
@@ -2057,6 +2486,11 @@ export interface MetafieldsCartInstructions {
   canDeleteCartMetafield: boolean;
 }
 
+/**
+ * Instructions used to create the checkout.
+ *
+ * @publicDocs
+ */
 export interface NotesCartInstructions {
   /**
    * Indicates whether or not notes can be updated.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,9 +1916,10 @@
     pkg-dir "^5.0.0"
     pluralize "^8.0.0"
 
-"@shopify/generate-docs@https://registry.npmjs.org/@shopify/generate-docs/-/generate-docs-0.19.8.tgz":
-  version "0.19.8"
-  resolved "https://registry.npmjs.org/@shopify/generate-docs/-/generate-docs-0.19.8.tgz#1d0475e08e488abee64171a85a438ab1a2142e40"
+"@shopify/generate-docs@^1.0.0":
+  version "1.0.0"
+  resolved "https://npm.shopify.io/node/@shopify/generate-docs/-/generate-docs-1.0.0.tgz#2aaa894e8e09ff1acea9ac49eb1ab212088f30c8"
+  integrity sha512-DOkWeqGjVg3xxS6slNuyYpegvRLMn1o9VPwZm1fIzsRsJRAHy12TZM3Bq3yMimx5IU3J34y+iD/jPb/S/gFU5g==
   dependencies:
     "@types/react" "^18.0.21"
     globby "^11.1.0"


### PR DESCRIPTION
What I fed the llm to get it to add the `@publicDocs` and the type's description from the relative `.doc.ts` file:

```
we are working on the 2026-01 generate docs types. I want you to add the js doccomment `@publicDocs` tAG to all top level types, these types historically have had their own .doc.ts files so you may find that useful to reference.  Just do the top level types/interfaces, their child types will be automatically included.  Also add the .doc.ts descriptions for these types in the js doc comment like i did in this bogus example @/Users/laurelthorburn/src/github.com/Shopify/ui-extensions/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts:497-506 
```

to run the script:
```
yarn docs:checkout 2026-01
```


For the time being, I would continue to work in the .doc.ts files until checkout has been migrated to .mdx in shopify.dev