### PR TITLE
[Components content]: Bug bash - Fix component example code and descriptions for 2025-10

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar/examples/in-customer-list-context.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar/examples/in-customer-list-context.html
@@ -1,7 +1,7 @@
 <s-stack gap="base">
   <s-stack direction="inline" gap="small">
     <s-avatar
-      src="/customers/merchant-alice.jpg"
+      src="https://example.com/customers/merchant-alice.jpg"
       initials="AJ"
       alt="Alice's jewelry store"
       size="small"
@@ -14,7 +14,7 @@
   </s-stack>
   <s-stack direction="inline" gap="small">
     <s-avatar
-      src="/customers/charlie-cafe.jpg"
+      src="https://example.com/customers/charlie-cafe.jpg"
       initials="CC"
       alt="Charlie's coffee corner"
       size="small"

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar/examples/with-image-source-and-fallback.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar/examples/with-image-source-and-fallback.html
@@ -1,5 +1,5 @@
 <s-avatar
-  src="/customers/profile-123.jpg"
+  src="https://example.com/customers/profile-123.jpg"
   initials="MR"
   alt="Maria Rodriguez"
   size="base"

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar/examples/with-section-component.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar/examples/with-section-component.html
@@ -2,7 +2,7 @@
   <s-stack gap="base">
     <s-stack direction="inline" gap="small">
       <s-avatar
-        src="/merchants/premium-store.jpg"
+        src="https://example.com/merchants/premium-store.jpg"
         initials="PS"
         alt="Premium store"
         size="base"

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/examples/dismissible-success-banner.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/examples/dismissible-success-banner.html
@@ -1,3 +1,3 @@
-<s-banner heading="Products imported" tone="success" dismissible="true">
+<s-banner heading="Products imported" tone="success" dismissible>
   Successfully imported 50 products to your store.
 </s-banner>

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorField/ColorField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorField/ColorField.doc.ts
@@ -152,7 +152,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Provide immediate feedback on color format validity. This example demonstrates real-time validation that checks hex format as the user types.',
+              'Display a validation error for an invalid color value. This example shows a color field with a static error message for a malformed hex code.',
             codeblock: {
               title: 'Validate in real time',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorField/examples/form-integration.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorField/examples/form-integration.html
@@ -6,7 +6,6 @@
         label="Primary brand color"
         name="primaryColor"
         value="#1a73e8"
-        defaultValue="#1a73e8"
         details="This color will be used for buttons, links, and brand elements"
         required
       ></s-color-field>

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
@@ -166,7 +166,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Validate a date field in real time and update the error message as the merchant interacts. This example shows a required date field that clears its error once a valid date is selected.',
+              'Display a validation error on a required date field. This example shows a date field with a static error message and the `required` attribute.',
             codeblock: {
               title: 'Validate a date field dynamically',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/form-integration.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/form-integration.html
@@ -16,7 +16,7 @@
     <s-date-field
       label="Requested delivery date"
       name="deliveryDate"
-      disallowDays="[0, 6]"
+      disallowDays="sunday, saturday"
       details="Weekdays only"
     ></s-date-field>
 

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/with-date-restrictions.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/with-date-restrictions.html
@@ -1,6 +1,6 @@
 <s-date-field
   label="Delivery date"
   name="deliveryDate"
-  disallowDays="[0, 6]"
+  disallowDays="sunday, saturday"
   details="Delivery available Monday through Friday only"
 ></s-date-field>

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/with-specific-allowed-dates.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/examples/with-specific-allowed-dates.html
@@ -1,6 +1,6 @@
 <s-date-field
   label="Available appointment dates"
   name="appointmentDate"
-  allow='["2024-03-20", "2024-03-22", "2024-03-25", "2024-03-27"]'
+  allow="2024-03-20, 2024-03-22, 2024-03-25, 2024-03-27"
   details="Select from available time slots"
 ></s-date-field>

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
@@ -84,7 +84,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Capture the selected date when the merchant makes a change so you can update your app state. This example shows a range picker inside a form with an `onChange` handler that stores the selected value.',
+              'Combine a date picker with other form elements. This example shows a range picker inside a form with a text field and submit button.',
             codeblock: {
               title: 'Capture date selections with onChange',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
@@ -74,7 +74,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Preview uploaded images before submission. This example generates thumbnails after file selection.',
+              'Accept image files for upload. This example restricts file types to images using the `accept` property.',
             codeblock: {
               title: 'Upload images',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/examples/default.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/examples/default.html
@@ -2,5 +2,5 @@
   src="https://cdn.shopify.com/static/images/polaris/image-wc_src.png"
   alt="Four pixelated characters ready to build amazing Shopify apps"
   aspectRatio="59/161"
-  inlineSize="auto"
+  inlineSize="fill"
 ></s-image>

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/examples/responsive-images-with-srcset.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/examples/responsive-images-with-srcset.html
@@ -4,6 +4,7 @@
           https://cdn.shopify.com/static/sample-product/House-Plant1.png 800w"
   sizes="(max-width: 600px) 100vw, (max-width: 1200px) 50vw, 400px"
   alt="Product detail"
+  inlineSize="fill"
   aspectRatio="16/9"
   objectFit="cover"
 ></s-image>

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/examples/responsive-layout-with-aspect-ratio.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/examples/responsive-layout-with-aspect-ratio.html
@@ -1,6 +1,7 @@
 <s-image
   src="https://cdn.shopify.com/static/sample-product/House-Plant1.png"
   alt="Featured product"
+  inlineSize="fill"
   aspectRatio="16/9"
   objectFit="cover"
   loading="lazy"

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/examples/with-border-styling.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/examples/with-border-styling.html
@@ -6,6 +6,7 @@
     borderStyle="solid"
     borderColor="strong"
     borderRadius="large"
+    inlineSize="fill"
     objectFit="cover"
     aspectRatio="1/1"
   ></s-image>

--- a/packages/ui-extensions/src/surfaces/admin/components/Popover/examples/table-display-options.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/Popover/examples/table-display-options.html
@@ -1,4 +1,4 @@
-<s-button commandFor="table-settings-popover" disclosure="true" icon="settings">
+<s-button commandFor="table-settings-popover" icon="settings">
   Columns
 </s-button>
 

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/disabled-state.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/disabled-state.html
@@ -1,5 +1,5 @@
 <s-url-field
   label="Store URL"
-  value="https://your-store.myshopify.com"
+  value="https://your-store.example.com"
   disabled
 ></s-url-field>

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/with-default-value.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/examples/with-default-value.html
@@ -1,5 +1,5 @@
 <s-url-field
   label="Profile URL"
-  value="https://shop.myshopify.com"
+  value="https://shop.example.com"
   readOnly
 ></s-url-field>


### PR DESCRIPTION
## Summary

Fixes 19 verified issues across component example code and descriptions on the 2025-10 branch. Every fix is backed by the Polaris component spec.

## What changed

**Description-code mismatches (4 doc.ts files):**
- DropZone: description claimed "generates thumbnails" but code is a single `<s-drop-zone>` tag
- DatePicker: description claimed "onChange handler" but code has no onChange
- ColorField: description claimed "real-time validation" but code is static HTML
- DateField: description claimed "validate in real time" but code is a static error

**Code bugs (14 HTML files):**
- DateField `disallowDays="[0, 6]"` changed to `"sunday, saturday"` per Polaris spec (2 files)
- DateField `allow` changed from JSON array to comma-separated dates per Polaris spec
- Image: added `inlineSize="fill"` to 4 files using `aspectRatio` (spec says aspectRatio is ignored without it)
- ColorField: removed redundant `defaultValue` when `value` is already set
- Banner: changed `dismissible="true"` to bare `dismissible` boolean attribute
- Avatar: fixed broken relative `src` paths to absolute `example.com` URLs (3 files)
- URLField: changed `myshopify.com` URLs to `example.com` per style guide (2 files)
- Popover: removed invalid `disclosure` prop from `<s-button>` (not in Polaris spec)

Made with [Cursor](https://cursor.com)