### PR TITLE
[Components content]: Bug bash - Fix pattern file Polaris prop issues for 2025-10

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/calloutCard.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/calloutCard.html
@@ -20,6 +20,7 @@
           <s-image
             src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
             alt="Customize checkout illustration"
+            inlineSize="fill"
             aspectRatio="1/0.5"
           ></s-image>
         </s-box>

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/calloutCard.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/calloutCard.jsx
@@ -24,6 +24,7 @@
           <s-image
             src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
             alt="Customize checkout illustration"
+            inlineSize="fill"
             aspectRatio="1/0.5"
            />
         </s-box>

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/details.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/details.html
@@ -77,7 +77,7 @@
               borderStyle="solid"
               overflow="hidden"
             >
-              <s-table border="base" borderRadius="base" borderStyle="solid">
+              <s-table>
                 <s-table-header-row>
                   <s-table-header listSlot="primary">Template</s-table-header>
                   <s-table-header>

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/emptyState.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/emptyState.html
@@ -3,6 +3,7 @@
     <s-box maxInlineSize="200px" maxBlockSize="200px">
       <!-- aspectRatio should match the actual image dimensions (width/height) -->
       <s-image
+        inlineSize="fill"
         aspectRatio="1/0.5"
         src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
         alt="A stylized graphic of four characters, each holding a puzzle piece"

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/emptyState.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/emptyState.jsx
@@ -3,6 +3,7 @@
     <s-box maxInlineSize="200px" maxBlockSize="200px">
       {/* aspectRatio should match the actual image dimensions (width/height) */}
       <s-image
+        inlineSize="fill"
         aspectRatio="1/0.5"
         src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
         alt="A stylized graphic of four characters, each holding a puzzle piece"

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.html
@@ -241,7 +241,7 @@
       <!-- Metrics cards -->
       <!-- Your app homepage should provide merchants with quick statistics or status updates that help them understand how the app is performing for them. -->
       <!-- === -->
-      <s-section padding="small">
+      <s-section padding="none">
           <s-grid
             gridTemplateColumns="@container (inline-size <= 400px) 1fr, 1fr auto 1fr auto 1fr"
             gap="small"
@@ -317,6 +317,7 @@
                 <s-image
                   src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
                   alt="Customize checkout illustration"
+                  inlineSize="fill"
                   aspectRatio="1/0.5"
                 ></s-image>
               </s-box>
@@ -340,6 +341,7 @@
           <s-box border="base" borderRadius="base" overflow="hidden">
             <s-clickable href="/puzzles/4-piece" accessibilityLabel="4-pieces puzzle template">
               <s-image
+                inlineSize="fill"
                 aspectRatio="1/1"
                 objectFit="cover"
                 alt="4-pieces puzzle template"
@@ -364,6 +366,7 @@
           <s-box border="base" borderRadius="base" background="transparent" overflow="hidden">
             <s-clickable href="/puzzles/9-piece" accessibilityLabel="9-pieces puzzle template">
               <s-image
+                inlineSize="fill"
                 aspectRatio="1/1"
                 objectFit="cover"
                 alt="9-pieces puzzle template"
@@ -388,6 +391,7 @@
           <s-box border="base" borderRadius="base" background="transparent" overflow="hidden">
             <s-clickable href="/puzzles/16-piece" accessibilityLabel="16-pieces puzzle template">
               <s-image
+                inlineSize="fill"
                 aspectRatio="1/1"
                 objectFit="cover"
                 alt="16-pieces puzzle template"

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/homepage.jsx
@@ -373,6 +373,7 @@ return (
                   <s-image
                     src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
                     alt="Customize checkout illustration"
+                    inlineSize="fill"
                     aspectRatio="1/0.5"
                    />
                 </s-box>
@@ -405,6 +406,7 @@ return (
               accessibilityLabel="4-pieces puzzle template"
             >
               <s-image
+                inlineSize="fill"
                 aspectRatio="1/1"
                 objectFit="cover"
                 alt="4-pieces puzzle template"
@@ -440,6 +442,7 @@ return (
               accessibilityLabel="9-pieces puzzle template"
             >
               <s-image
+                inlineSize="fill"
                 aspectRatio="1/1"
                 objectFit="cover"
                 alt="9-pieces puzzle template"
@@ -475,6 +478,7 @@ return (
               accessibilityLabel="16-pieces puzzle template"
             >
               <s-image
+                inlineSize="fill"
                 aspectRatio="1/1"
                 objectFit="cover"
                 alt="16-pieces puzzle template"

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/index.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/index.html
@@ -23,8 +23,7 @@
           <s-box maxInlineSize="200px" maxBlockSize="200px">
             <!-- aspectRatio should match the actual image dimensions (width/height) -->
             <s-image
-              maxInlineSize="200px"
-              maxBlockSize="200px"
+              inlineSize="fill"
               aspectRatio="1/0.5"
               src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
               alt="A stylized graphic of four characters, each holding a puzzle piece"

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/index.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/index.jsx
@@ -17,6 +17,7 @@
           <s-box maxInlineSize="200px" maxBlockSize="200px">
             {/* aspectRatio should match the actual image dimensions (width/height) */}
             <s-image
+              inlineSize="fill"
               aspectRatio="1/0.5"
               src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
               alt="A stylized graphic of four characters, each holding a puzzle piece"

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/mediaCard.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/mediaCard.html
@@ -1,6 +1,7 @@
 <s-box border="base" borderRadius="base" overflow="hidden" maxInlineSize="216px">
   <s-clickable href="">
     <s-image
+      inlineSize="fill"
       aspectRatio="1/1"
       objectFit="cover"
       alt="Illustration of characters with a 4-piece puzzle"

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/mediaCard.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/mediaCard.jsx
@@ -6,6 +6,7 @@
 >
   <s-clickable href="">
     <s-image
+      inlineSize="fill"
       aspectRatio="1/1"
       objectFit="cover"
       alt="Illustration of characters with a 4-piece puzzle"

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/metricsCard.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/examples/metricsCard.html
@@ -1,4 +1,4 @@
-<s-section padding="small">
+<s-section padding="none">
     <s-grid
       gridTemplateColumns="@container (inline-size <= 400px) 1fr, 1fr auto 1fr auto 1fr"
       gap="small"


### PR DESCRIPTION
## Summary

Fixes Polaris prop issues in pattern example files on the 2025-10 branch. Every fix is backed by the Polaris component spec.

## What changed

**Invalid props on wrong components:**
- `padding="small"` on `<s-section>` changed to `padding="none"` in homepage.html, metricsCard.html (s-section.md says only `"base"` or `"none"` are valid)
- Removed `maxInlineSize`/`maxBlockSize` from `<s-image>` in index.html (not in s-image.md, these are s-box props; wrapper already has them)
- Removed `border`/`borderRadius`/`borderStyle` from `<s-table>` in details.html (not in s-table.md; wrapper s-box already has them)

**aspectRatio without inlineSize="fill":**
- Added `inlineSize="fill"` to all `<s-image>` elements using `aspectRatio` across 10 pattern files (.html and .jsx)
- Per s-image.md: aspectRatio is ignored when `inlineSize="auto"` (the default)
- Files: calloutCard, emptyState, homepage, index, mediaCard

Made with [Cursor](https://cursor.com)