### PR TITLE
Fix snapit by exiting 'pre' mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
           NPM_TOKEN: ''
           NPM_CONFIG_PROVENANCE: true
         with:
+          post_install_script: yarn changeset:exit-pre-mode
           build_script: yarn build
           comment_command: /snapit
 


### PR DESCRIPTION
`/snapit` is failing on branches based on `2026-04-rc` because it's in `pre` mode. I think we just lost this change in a merge: https://github.com/Shopify/ui-extensions/pull/2904/