### PR TITLE
[Admin UI extensions]: Remove duplicate metafields definition 2024 07

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/metafields.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/metafields.ts
@@ -103,9 +103,6 @@ type MetafieldChangeResult =
   | MetafieldChangeSuccess
   | MetafieldChangeResultError;
 
-/**
- * A function that applies metafield changes to validation settings. Call this function with an update or removal operation, then await the Promise to receive a result indicating success or failure. Use the result to provide feedback or handle errors in your settings interface.
- */
 export type ApplyMetafieldChange = (
   change: MetafieldChange,
 ) => Promise<MetafieldChangeResult>;


### PR DESCRIPTION
## This PR: 
- Removes a duplicate metafields definition that doesn't need to render in the docs
- Relates to https://shopify.slack.com/archives/C099RJCHAKE/p1772595567943199?thread_ts=1772565490.979649&cid=C099RJCHAKE