### PR TITLE
Fix POS component types to express how they are DOM compatible

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-badge';
 export interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
@@ -65,7 +65,7 @@ export interface BadgeJSXProps extends Pick<BadgeProps, 'id'> {
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: BadgeJSXProps;
+    [tagName]: BadgeJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner.d.ts
@@ -43,7 +43,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-banner';
 export interface BannerJSXProps extends Pick<BannerProps, 'heading' | 'id'> {
@@ -80,7 +80,7 @@ export interface BannerJSXProps extends Pick<BannerProps, 'heading' | 'id'> {
 export type ElementProps = Omit<BannerJSXProps, 'primaryAction'>;
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ElementProps;
+    [tagName]: ElementProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box.d.ts
@@ -47,7 +47,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-box';
 /**
@@ -157,7 +157,7 @@ export interface BoxJSXProps {
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: BoxJSXProps;
+    [tagName]: BoxJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -127,7 +127,7 @@ export interface ButtonJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ButtonJSXProps;
+    [tagName]: ButtonJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Choice.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Choice.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-choice';
 export interface ChoiceJSXProps
@@ -47,7 +47,7 @@ export interface ChoiceJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ChoiceJSXProps;
+    [tagName]: ChoiceJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -91,7 +91,7 @@ export interface ChoiceListJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ChoiceListJSXProps;
+    [tagName]: ChoiceListJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -87,7 +87,7 @@ export interface ClickableJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ClickableJSXProps;
+    [tagName]: ClickableJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -99,7 +99,7 @@ export interface DateFieldJSXProps
 export type ElementProps = Omit<DateFieldJSXProps, 'accessory'>;
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ElementProps;
+    [tagName]: ElementProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -95,7 +95,7 @@ export interface DatePickerJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: DatePickerJSXProps;
+    [tagName]: DatePickerJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -95,7 +95,7 @@ export interface DateSpinnerJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: DateSpinnerJSXProps;
+    [tagName]: DateSpinnerJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider.d.ts
@@ -38,14 +38,14 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-divider';
 export interface DividerJSXProps
   extends Pick<DividerProps, 'id' | 'direction'> {}
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: DividerJSXProps;
+    [tagName]: DividerJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-heading';
 export interface HeadingJSXProps extends Pick<HeadingProps, 'id'> {
@@ -49,7 +49,7 @@ export interface HeadingJSXProps extends Pick<HeadingProps, 'id'> {
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: HeadingJSXProps;
+    [tagName]: HeadingJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-icon';
 /**
@@ -183,7 +183,7 @@ export interface IconJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: IconJSXProps;
+    [tagName]: IconJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-image';
 export interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit'> {
@@ -58,7 +58,7 @@ export interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit'> {
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ImageJSXProps;
+    [tagName]: ImageJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal.d.ts
@@ -43,7 +43,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -107,7 +107,7 @@ export type ElementProps = Omit<
 >;
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ElementProps;
+    [tagName]: ElementProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField.d.ts
@@ -43,7 +43,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -159,7 +159,7 @@ export interface NumberFieldJSXProps
 export type ElementProps = Omit<NumberFieldJSXProps, 'accessory'>;
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ElementProps;
+    [tagName]: ElementProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page.d.ts
@@ -43,7 +43,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-page';
 export interface PageJSXProps extends Pick<PageProps, 'id'> {
@@ -73,7 +73,7 @@ export interface PageJSXProps extends Pick<PageProps, 'id'> {
 export type ElementProps = Omit<PageJSXProps, 'secondaryActions' | 'aside'>;
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ElementProps;
+    [tagName]: ElementProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock.d.ts
@@ -43,7 +43,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-pos-block';
 export interface PosBlockJSXProps
@@ -60,7 +60,7 @@ export interface PosBlockJSXProps
 export type ElementProps = Omit<PosBlockJSXProps, 'secondaryActions'>;
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ElementProps;
+    [tagName]: ElementProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/QrCode.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/QrCode.d.ts
@@ -38,13 +38,13 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-qr-code';
 export interface QrCodeJSXProps extends Pick<QRCodeProps, 'id' | 'content'> {}
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: QrCodeJSXProps;
+    [tagName]: QrCodeJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox.d.ts
@@ -48,7 +48,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 /**
  * Defines the available padding size options using a semantic scale. Provides consistent spacing values that align with the POS design system.
@@ -154,7 +154,7 @@ export interface ScrollBoxJSXProps extends Pick<ScrollBoxProps, 'id'> {
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ScrollBoxJSXProps;
+    [tagName]: ScrollBoxJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -95,7 +95,7 @@ export interface SearchFieldJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: SearchFieldJSXProps;
+    [tagName]: SearchFieldJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section.d.ts
@@ -43,7 +43,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-section';
 export interface SectionJSXProps extends Pick<SectionProps, 'id'> {
@@ -63,7 +63,7 @@ export interface SectionJSXProps extends Pick<SectionProps, 'id'> {
 export type ElementProps = Omit<SectionJSXProps, 'secondaryActions'>;
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ElementProps;
+    [tagName]: ElementProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack.d.ts
@@ -52,7 +52,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-stack';
 /**
@@ -221,7 +221,7 @@ export interface StackJSXProps extends PickedProps {
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: StackJSXProps;
+    [tagName]: StackJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-text';
 export interface TextJSXProps extends Pick<TextProps, 'id'> {
@@ -82,7 +82,7 @@ export interface TextJSXProps extends Pick<TextProps, 'id'> {
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: TextJSXProps;
+    [tagName]: TextJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField.d.ts
@@ -43,7 +43,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -116,7 +116,7 @@ export interface TextFieldJSXProps
 export type ElementProps = Omit<TextFieldJSXProps, 'accessory'>;
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: ElementProps;
+    [tagName]: ElementProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents an event triggered by user interaction with the tile. Provides information about the event and access to the tile element that triggered it.
  */
@@ -92,7 +92,7 @@ export interface TileJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: TileJSXProps;
+    [tagName]: TileJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -98,7 +98,7 @@ export interface TimeFieldJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: TimeFieldJSXProps;
+    [tagName]: TimeFieldJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
    */
   children?: ComponentChildren;
 }
-export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T>;
+export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 /**
  * Represents the event object passed to callback functions when interactive events occur. Contains metadata about the event, including the target element, event phase, and propagation behavior.
  */
@@ -95,7 +95,7 @@ export interface TimePickerJSXProps
 }
 declare global {
   interface HTMLElementTagNameMap {
-    [tagName]: TimePickerJSXProps;
+    [tagName]: TimePickerJSXProps & HTMLElement;
   }
 }
 declare module 'preact' {


### PR DESCRIPTION
Fixes https://github.com/shop/issues-retail/issues/25351
                                                                                                                                                                                                                                                     
 POS component .d.ts files register custom elements in HTMLElementTagNameMap as just the JSX props type, so document.body.querySelector('s-tile') resolves to TileJSXProps — missing standard DOM properties like textContent, getAttribute(), etc.  
                                                                                                                                                                                                                                                     
 Admin and checkout don't have this issue because their HTMLElementTagNameMap entries use classes/interfaces that already extend HTMLElement:                                                                                                        
                                                                                                                                                                                                                                                     
 ```ts                                                                                                                                                                                                                                               
   // admin — class inherits from HTMLElement                                                                                                                                                                                                        
   declare class Badge extends PreactCustomElement { ... }                                                                                                                                                                                           
   // PreactCustomElement extends typeof globalThis.HTMLElement                                                                                                                                                                                      
                                                                                                                                                                                                                                                     
   // checkout — interface extends HTMLElement                                                                                                                                                                                                       
   export interface BadgeElement extends BadgeElementProps, Omit<HTMLElement, 'id'> {}                                                                                                                                                               
 ```                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                     
 POS uses plain JSX props interfaces with no HTMLElement in the type hierarchy. This was already fixed in 11 components (Spinner, Switch, Tabs, etc.), committed more recently, but not the remaining 28 (this PR fixes those).                                                                      
                                                                                                                                                                                                                                                     
 ### Changes                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                     
 Two fixes per component .d.ts file:                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                     
 1. HTMLElementTagNameMap — intersect with HTMLElement so querySelector returns the correct type:                                                                                                                                                    
   ```ts
     [tagName]: TileJSXProps & HTMLElement;                                                                                                                                                                                                     
   ```                                                                                                                                                                                                                                               
 2. IntrinsicElementProps — pass T & HTMLElement to BaseElementPropsWithChildren so Preact ref callbacks receive the correct type:                                                                                                                   
   ```ts
     export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;                                                                                                                                                      
   ``` 