### PR TITLE
[Admin UI extensions 2025-07]: Consistent casing for admin UI extensions term

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/picker/picker.doc.ts
@@ -112,7 +112,7 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Utility APIs',
   thumbnail: 'picker.png',
   requires:
-    'an Admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.',
+    'an admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.',
   defaultExample: {
     description:
       'Build a custom picker for email templates with multiple columns and status badges. This example shows defining column headers, populating items with searchable data fields, adding visual status indicators, and handling the selection promise. Use this pattern for app-specific resources like templates, product reviews, or subscription options where you need custom data structures beyond standard Shopify resources.',

--- a/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/resource-picker/resource-picker.doc.ts
@@ -171,7 +171,7 @@ const data: ReferenceEntityTemplateSchema = {
   subCategory: 'Utility APIs',
   thumbnail: 'resource-picker.png',
   requires:
-    'an Admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.',
+    'an admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.',
   defaultExample: {
     description:
       'Open the product resource picker to select items from the store catalog. This example invokes `shopify.resourcePicker` with `type: "product"`, handles the async selection, and displays the count of selected products. When merchants confirm their selection, the resource picker returns an array of product objects with GIDs, titles, and handles for use in your extension.',

--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Standard API',
   description:
-    'The Standard API provides core functionality available to all Admin UI extension types. Use this API to authenticate with your app backend, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, and handle intent-based navigation.',
+    'The Standard API provides core functionality available to all admin UI extension types. Use this API to authenticate with your app backend, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, and handle intent-based navigation.',
   isVisualComponent: false,
   type: 'API',
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -43,7 +43,7 @@ type OrderRoutingComponents = AnyComponentBuilder<
 >;
 
 /**
- * The set of UI components available for all Admin UI extension targets. This includes all standard Polaris components except for specialized components used in specific contexts. Use this type to define which components can be rendered in your extension.
+ * The set of UI components available for all admin UI extension targets. This includes all standard Polaris components except for specialized components used in specific contexts. Use this type to define which components can be rendered in your extension.
  */
 type AllComponents = AnyComponentBuilder<
   Omit<
@@ -677,7 +677,7 @@ export interface ExtensionTargets {
 }
 
 /**
- * A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components.
+ * A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components.
  */
 export type ExtensionTarget = keyof ExtensionTargets;
 


### PR DESCRIPTION
## This PR: 
- Standardizes the casing of "admin UI extensions" / "admin UI extension" to use lowercase "admin" when the term appears mid-sentence across content `.ts` files
- Keeps capitalized "Admin UI extensions" only when it's at the start of a sentence, in a heading, or in a title attribute
- Partially fixes https://github.com/Shopify/shopify-dev/issues/68908