### PR TITLE
[Admin UI extensions 2024-01]: Consistent casing for admin UI extensions term

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/standard/standard.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Standard API',
   description:
-    'The Standard API provides core functionality available to all Admin UI extension types. Use this API to query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, navigate within the admin, and handle intent-based navigation.',
+    'The Standard API provides core functionality available to all admin UI extension types. Use this API to query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, navigate within the admin, and handle intent-based navigation.',
   isVisualComponent: false,
   type: 'API',
   defaultExample: {

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -52,7 +52,7 @@ type OrderRoutingComponents = AnyComponentBuilder<
 >;
 
 /**
- * The full set of UI components available for most Admin UI extension targets. This includes all components except those restricted to specific targets.
+ * The full set of UI components available for most admin UI extension targets. This includes all components except those restricted to specific targets.
  */
 type AllComponents = AnyComponentBuilder<
   Omit<
@@ -218,7 +218,7 @@ export interface ExtensionTargets {
 }
 
 /**
- * A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components.
+ * A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components.
  */
 export type ExtensionTarget = keyof ExtensionTargets;
 


### PR DESCRIPTION
## This PR: 
- Standardizes the casing of "admin UI extensions" / "admin UI extension" to use lowercase "admin" when the term appears mid-sentence across content `.ts` files
- Keeps capitalized "Admin UI extensions" only when it's at the start of a sentence, in a heading, or in a title attribute
- Partially fixes https://github.com/Shopify/shopify-dev/issues/68908