### PR TITLE
Fix typo in Button component description

### DIFF
--- a/packages/ui-extensions/src/docs/shared/components/Button.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Button.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
-    'The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface.' +
+    'The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use buttons to let users perform specific tasks or initiate interactions throughout the interface.' +
     '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button-group).',
   category: 'Polaris web components',
   subCategory: 'Actions',


### PR DESCRIPTION
## Summary
- Fix typo in `Button.ts` description: "Use button" → "Use buttons"

## Test plan
- Verify the description reads correctly in generated docs

Made with [Cursor](https://cursor.com)