### PR TITLE
Update generated checkout docs data

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data.json
@@ -200174,7 +200174,7 @@
     "name": "Abbreviation",
     "description": "Displays abbreviated text or acronyms, revealing their full meaning or additional context through a tooltip on hover or focus. Use to clarify shortened terms, initialisms, or technical language without interrupting the reading flow.",
     "category": "Polaris web components",
-    "subCategory": "Titles and text",
+    "subCategory": "Typography and content",
     "related": [],
     "isVisualComponent": true,
     "thumbnail": "abbreviation-thumbnail.png",
@@ -204081,8 +204081,8 @@
     "subSections": []
   },
   {
-    "name": "DropZone",
-    "description": "Lets users upload files through drag-and-drop functionality into a designated area on a page, or by activating a button.",
+    "name": "Drop zone",
+    "description": "The drop zone component lets users upload files through drag-and-drop or by clicking to browse. Use for file uploads such as images, documents, or CSV imports.\n\nThe component provides visual feedback during drag operations and supports file type validation through the `accept` property. Rejected files trigger the `droprejected` event for custom error handling.",
     "category": "Polaris web components",
     "subCategory": "Forms",
     "related": [],
@@ -211077,7 +211077,7 @@
     "name": "Time",
     "description": "Represents a specific point or duration in time. Use to display dates, times, or durations clearly and consistently. May include a machine-readable `datetime` attribute for improved accessibility and functionality.",
     "category": "Polaris web components",
-    "subCategory": "Titles and text",
+    "subCategory": "Typography and content",
     "related": [],
     "isVisualComponent": true,
     "thumbnail": "time-thumbnail.png",


### PR DESCRIPTION
## Summary
- Update subcategory for Abbreviation and Time components from "Titles and text" to "Typography and content"
- Update DropZone component name to "Drop zone" and improve its description

## Test plan
- [ ] Verify generated docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)