### PR TITLE
Fix doc generation for sentence-case component names

### DIFF
--- a/packages/ui-extensions/src/docs/shared/component-definitions.ts
+++ b/packages/ui-extensions/src/docs/shared/component-definitions.ts
@@ -32,6 +32,13 @@ interface ComponentDoc {
   extraExamples?: ReferenceEntityTemplateSchema['examples'];
 }
 
+function toPascalCase(name: string) {
+  return name
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('');
+}
+
 function buildDefinitions({
   name,
   description,
@@ -41,13 +48,15 @@ function buildDefinitions({
   description?: string;
   definitions: DefinitionsConfiguration;
 }) {
+  const typeName = toPascalCase(name);
+
   return [
     ...(description
       ? [
           {
             title: `${name}`,
             description,
-            type: `${name}ElementProps`,
+            type: `${typeName}ElementProps`,
           },
         ]
       : []),
@@ -57,7 +66,7 @@ function buildDefinitions({
           {
             title: 'Properties',
             description: '',
-            type: `${name}ElementProps`,
+            type: `${typeName}ElementProps`,
           },
         ]
       : []),
@@ -67,7 +76,7 @@ function buildDefinitions({
           {
             title: 'Events',
             description: `Learn more about [registering events](${CHECKOUT_PATH}#event-handling).`,
-            type: `${name}ElementEvents`,
+            type: `${typeName}ElementEvents`,
           },
         ]
       : []),
@@ -77,7 +86,7 @@ function buildDefinitions({
           {
             title: 'Slots',
             description: `Learn more about [component slots](${CHECKOUT_PATH}#slots).`,
-            type: `${name}ElementSlots`,
+            type: `${typeName}ElementSlots`,
           },
         ]
       : []),
@@ -87,7 +96,7 @@ function buildDefinitions({
           {
             title: 'Methods',
             description: `Learn more about [component methods](${CHECKOUT_PATH}#methods).`,
-            type: `${name}ElementMethods`,
+            type: `${typeName}ElementMethods`,
           },
         ]
       : []),
@@ -114,6 +123,7 @@ export function createComponentDoc({
   const kebabCasedName = name
     .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
     .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/\s+/g, '-')
     .toLowerCase();
 
   return {


### PR DESCRIPTION
## Summary
- Fixes doc generation error (`Type Choice listElementProps was not found`) caused by #3919 changing component names from PascalCase to sentence case
- Adds `toPascalCase` helper to convert display names back to PascalCase for type lookups (`ChoiceListElementProps` instead of `Choice listElementProps`)
- Handles spaces in kebab-case conversion for asset paths (thumbnails, examples)

## Test plan
- [ ] Run `yarn docs:checkout 2026-01` and verify it completes without errors
- [ ] Verify generated docs for multi-word components (ChoiceList, DropZone, GridItem, etc.) are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)