### PR TITLE
Fix doc generation for sentence-case component names

### DIFF
--- a/packages/ui-extensions/src/docs/shared/component-definitions.ts
+++ b/packages/ui-extensions/src/docs/shared/component-definitions.ts
@@ -32,6 +32,13 @@ interface ComponentDoc {
   extraExamples?: ReferenceEntityTemplateSchema['examples'];
 }
 
+function toPascalCase(name: string) {
+  return name
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('');
+}
+
 function buildDefinitions({
   name,
   description,
@@ -41,13 +48,15 @@ function buildDefinitions({
   description?: string;
   definitions: DefinitionsConfiguration;
 }) {
+  const typeName = toPascalCase(name);
+
   return [
     ...(description
       ? [
           {
             title: `${name}`,
             description,
-            type: `${name}ElementProps`,
+            type: `${typeName}ElementProps`,
           },
         ]
       : []),
@@ -57,7 +66,7 @@ function buildDefinitions({
           {
             title: 'Properties',
             description: '',
-            type: `${name}ElementProps`,
+            type: `${typeName}ElementProps`,
           },
         ]
       : []),
@@ -67,7 +76,7 @@ function buildDefinitions({
           {
             title: 'Events',
             description: `Learn more about [registering events](${CHECKOUT_PATH}#event-handling).`,
-            type: `${name}ElementEvents`,
+            type: `${typeName}ElementEvents`,
           },
         ]
       : []),
@@ -77,7 +86,7 @@ function buildDefinitions({
           {
             title: 'Slots',
             description: `Learn more about [component slots](${CHECKOUT_PATH}#slots).`,
-            type: `${name}ElementSlots`,
+            type: `${typeName}ElementSlots`,
           },
         ]
       : []),
@@ -87,7 +96,7 @@ function buildDefinitions({
           {
             title: 'Methods',
             description: `Learn more about [component methods](${CHECKOUT_PATH}#methods).`,
-            type: `${name}ElementMethods`,
+            type: `${typeName}ElementMethods`,
           },
         ]
       : []),
@@ -114,6 +123,7 @@ export function createComponentDoc({
   const kebabCasedName = name
     .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
     .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/\s+/g, '-')
     .toLowerCase();
 
   return {


### PR DESCRIPTION
### Background

This pull request addresses an issue with component documentation generation where component names containing spaces were not being properly converted to valid TypeScript type names, causing type reference errors in the generated documentation.

### Solution

Added a `toPascalCase` utility function that converts component names with spaces into proper PascalCase format for TypeScript type names. The function splits the name by spaces, capitalizes the first letter of each word, and joins them together. Additionally, updated the `kebabCasedName` conversion to handle spaces by replacing them with hyphens.

This approach ensures that component names like "My Component" are converted to "MyComponentElementProps" for type references while maintaining "my-component" for kebab-case usage. The alternative would have been to restrict component names to not contain spaces, but this solution maintains flexibility in naming while ensuring valid TypeScript types.

### 🎩

- Component documentation now generates valid TypeScript type references for components with spaces in their names
- Kebab-case conversion properly handles spaces by converting them to hyphens

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation