### PR TITLE
Regenerate checkout docs with sentence-case fixes

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data.json
@@ -200238,7 +200238,7 @@
     "thumbnail": "abbreviation-thumbnail.png",
     "requires": "",
     "type": "",
-    "subCategory": "Titles and text",
+    "subCategory": "Typography and content",
     "definitions": [
       {
         "title": "Properties",
@@ -201259,7 +201259,7 @@
   },
   {
     "name": "Button",
-    "description": "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface.\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button-group).",
+    "description": "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use buttons to let users perform specific tasks or initiate interactions throughout the interface.\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button-group).",
     "category": "Polaris web components",
     "related": [],
     "isVisualComponent": true,
@@ -204368,8 +204368,8 @@
     "subSections": []
   },
   {
-    "name": "DropZone",
-    "description": "Lets users upload files through drag-and-drop functionality into a designated area on a page, or by activating a button.",
+    "name": "Drop zone",
+    "description": "The drop zone component lets users upload files through drag-and-drop or by clicking to browse. Use for file uploads such as images, documents, or CSV imports.\n\nThe component provides visual feedback during drag operations and supports file type validation through the `accept` property. Rejected files trigger the `droprejected` event for custom error handling.",
     "category": "Polaris web components",
     "related": [],
     "isVisualComponent": true,
@@ -207538,7 +207538,7 @@
   },
   {
     "name": "Modal",
-    "description": "Displays content in an overlay. Use to create a distraction-free experience such as a confirmation dialog or a settings panel.",
+    "description": "The modal component displays content in an overlay. Use to create a distraction-free experience such as a confirmation dialog or a settings panel.\n\nA button triggers the modal using the `commandFor` attribute. Content within the modal scrolls if it exceeds available height.",
     "category": "Polaris web components",
     "related": [],
     "isVisualComponent": true,
@@ -209062,7 +209062,7 @@
   },
   {
     "name": "Popover",
-    "description": "Popovers are used to display content in an overlay that can be triggered by a button.",
+    "description": "The popover component displays contextual content in an overlay triggered by a button using the [`commandFor`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#commandfor) attribute. Use for secondary actions, settings, or information that doesn't require a full modal.\n\nFor interactions that need more space or user focus, such as confirmations or complex forms, use [modal](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/overlays/modal) instead.",
     "category": "Polaris web components",
     "related": [],
     "isVisualComponent": true,
@@ -212584,7 +212584,7 @@
     "thumbnail": "time-thumbnail.png",
     "requires": "",
     "type": "",
-    "subCategory": "Titles and text",
+    "subCategory": "Typography and content",
     "definitions": [
       {
         "title": "Properties",


### PR DESCRIPTION
### Background

This pull request updates component documentation in the UI extensions checkout surface to improve clarity and consistency across component descriptions.

### Solution

Updated component documentation with more detailed and consistent descriptions:

- **Button component**: Changed "Use button" to "Use buttons" for better grammar
- **DropZone component**: Renamed to "Drop zone" and expanded description to include drag-and-drop functionality, file type validation, and error handling details
- **Modal component**: Enhanced description to explain the `commandFor` attribute trigger mechanism and scrolling behavior
- **Popover component**: Completely rewrote description to explain the `commandFor` attribute, provide clearer usage guidance, and include a reference to the modal component for comparison
- **Typography components**: Updated subcategory from "Titles and text" to "Typography and content" for abbreviation and time components

These changes provide developers with clearer guidance on when and how to use each component, including technical implementation details and cross-references to related components.

### 🎩

- Enhanced component descriptions with technical implementation details
- Improved grammar and consistency across component documentation
- Added cross-references between related components (popover/modal)
- Updated component categorization for better organization

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation