### PR TITLE
Add bolded lead-ins to best practices for Modal, Page, Popover, and DropZone

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
@@ -11,9 +11,9 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Define file restrictions:** Set clear file type and size restrictions using the \`accept\` property.
-- **Provide meaningful error messages:** Use the \`droprejected\` event to display meaningful error messages when uploads fail validation.
-- **Prevent duplicate uploads:** Consider using \`disabled\` to prevent uploads during processing.`,
+      sectionContent: `- **Define file restrictions**: Set clear file type and size restrictions using the \`accept\` property.
+- **Provide meaningful error messages**: Use the \`droprejected\` event to display meaningful error messages when uploads fail validation.
+- **Prevent duplicate uploads**: Consider using \`disabled\` to prevent uploads during processing.`,
     },
     {
       title: 'Limitations',

--- a/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
@@ -11,9 +11,9 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- Set clear file type and size restrictions using the \`accept\` property.
-- Use the \`droprejected\` event to display meaningful error messages when uploads fail validation.
-- Consider using \`disabled\` to prevent uploads during processing.`,
+      sectionContent: `- **Define file restrictions:** Set clear file type and size restrictions using the \`accept\` property.
+- **Provide meaningful error messages:** Use the \`droprejected\` event to display meaningful error messages when uploads fail validation.
+- **Prevent duplicate uploads:** Consider using \`disabled\` to prevent uploads during processing.`,
     },
     {
       title: 'Limitations',

--- a/packages/ui-extensions/src/surfaces/admin/components/Modal/Modal.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal/Modal.ab.doc.ts
@@ -10,13 +10,11 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- Use for focused, specific tasks that require merchants to make a decision or acknowledge critical information.
-- Include a prominent and clear call to action.
-- Don't nest modals (avoid launching one modal from another).
-- Use specific action verbs: Label buttons with clear verbs like "Delete", "Save", or "Continue" rather than vague terms like "Yes", "OK", or "Submit".
-- For destructive actions, explain the consequences in the modal body.
-- Use thoughtfully and sparingly—don't create unnecessary interruptions.
-- Use as a last resort for important decisions, not for contextual tools or actions that could happen on the page directly.`,
+      sectionContent: `- **Focus on critical decisions:** Use for focused, specific tasks that require merchants to make a decision or acknowledge critical information.
+- **Avoid nesting modals:** Don't nest modals (avoid launching one modal from another).
+- **Use specific action verbs:** Label buttons with clear verbs like "Delete", "Save", or "Continue" rather than vague terms like "Yes", "OK", or "Submit".
+- **Explain destructive consequences:** For destructive actions, explain the consequences in the modal body.
+- **Reserve for important decisions:** Use as a last resort for important decisions, not for contextual tools or actions that could happen on the page directly.`,
     },
     {
       title: 'Limitations',

--- a/packages/ui-extensions/src/surfaces/admin/components/Modal/Modal.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal/Modal.ab.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Focus on critical decisions**: Use for focused, specific tasks that require merchants to make a decision or acknowledge critical information.
 - **Avoid nesting modals**: Don't nest modals (avoid launching one modal from another).
-- **Use specific action verbs**: Label buttons with clear verbs like "Delete," "Save," or "Continue" rather than vague terms like "Yes," "OK," or "Submit."
+- **Use specific action verbs**: Label buttons with clear verbs like "Delete," "Save," or "Continue" rather than vague terms like "Yes" or "OK."
 - **Explain destructive consequences**: For destructive actions, explain the consequences in the modal body.
 - **Reserve for important decisions**: Use as a last resort for important decisions, not for contextual tools or actions that could happen on the page directly.`,
     },

--- a/packages/ui-extensions/src/surfaces/admin/components/Modal/Modal.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal/Modal.ab.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Focus on critical decisions**: Use for focused, specific tasks that require merchants to make a decision or acknowledge critical information.
 - **Avoid nesting modals**: Don't nest modals (avoid launching one modal from another).
-- **Use specific action verbs**: Label buttons with clear verbs like "Delete", "Save", or "Continue" rather than vague terms like "Yes", "OK", or "Submit".
+- **Use specific action verbs**: Label buttons with clear verbs like "Delete," "Save," or "Continue" rather than vague terms like "Yes," "OK," or "Submit."
 - **Explain destructive consequences**: For destructive actions, explain the consequences in the modal body.
 - **Reserve for important decisions**: Use as a last resort for important decisions, not for contextual tools or actions that could happen on the page directly.`,
     },

--- a/packages/ui-extensions/src/surfaces/admin/components/Modal/Modal.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal/Modal.ab.doc.ts
@@ -10,11 +10,11 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Focus on critical decisions:** Use for focused, specific tasks that require merchants to make a decision or acknowledge critical information.
-- **Avoid nesting modals:** Don't nest modals (avoid launching one modal from another).
-- **Use specific action verbs:** Label buttons with clear verbs like "Delete", "Save", or "Continue" rather than vague terms like "Yes", "OK", or "Submit".
-- **Explain destructive consequences:** For destructive actions, explain the consequences in the modal body.
-- **Reserve for important decisions:** Use as a last resort for important decisions, not for contextual tools or actions that could happen on the page directly.`,
+      sectionContent: `- **Focus on critical decisions**: Use for focused, specific tasks that require merchants to make a decision or acknowledge critical information.
+- **Avoid nesting modals**: Don't nest modals (avoid launching one modal from another).
+- **Use specific action verbs**: Label buttons with clear verbs like "Delete", "Save", or "Continue" rather than vague terms like "Yes", "OK", or "Submit".
+- **Explain destructive consequences**: For destructive actions, explain the consequences in the modal body.
+- **Reserve for important decisions**: Use as a last resort for important decisions, not for contextual tools or actions that could happen on the page directly.`,
     },
     {
       title: 'Limitations',

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
@@ -11,11 +11,10 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- Always provide a title that describes the current page.
-- Include breadcrumbs when the page is part of a flow.
-- Include page actions in the header only if they are relevant to the entire page.
-- Include no more than one primary action and 3 secondary actions per page.
-- Don't include any actions at the bottom of the page.`,
+      sectionContent: `- **Use breadcrumbs for navigation:** Include breadcrumbs when the page is part of a flow.
+- **Scope header actions appropriately:** Include page actions in the header only if they are relevant to the entire page.
+- **Limit action count:** Include no more than one primary action and 3 secondary actions per page.
+- **Avoid bottom actions:** Don't include any actions at the bottom of the page.`,
     },
     {
       title: 'Limitations',

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
@@ -11,10 +11,10 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use breadcrumbs for navigation:** Include breadcrumbs when the page is part of a flow.
-- **Scope header actions appropriately:** Include page actions in the header only if they are relevant to the entire page.
-- **Limit action count:** Include no more than one primary action and 3 secondary actions per page.
-- **Avoid bottom actions:** Don't include any actions at the bottom of the page.`,
+      sectionContent: `- **Use breadcrumbs for navigation**: Include breadcrumbs when the page is part of a flow.
+- **Scope header actions appropriately**: Include page actions in the header only if they are relevant to the entire page.
+- **Limit action count**: Include no more than one primary action and 3 secondary actions per page.
+- **Avoid bottom actions**: Don't include any actions at the bottom of the page.`,
     },
     {
       title: 'Limitations',

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
@@ -13,7 +13,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Use breadcrumbs for navigation**: Include breadcrumbs when the page is part of a flow.
 - **Scope header actions appropriately**: Include page actions in the header only if they are relevant to the entire page.
-- **Limit action count**: Include no more than one primary action and 3 secondary actions per page.
+- **Limit action count**: Include no more than one primary action and three secondary actions per page.
 - **Avoid bottom actions**: Don't include any actions at the bottom of the page.`,
     },
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Popover/Popover.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Popover/Popover.ab.doc.ts
@@ -11,9 +11,9 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- Use for secondary or less important information and actions since they're hidden until triggered.
-- Contain actions that share a relationship to each other.
-- Be triggered by a clearly labeled default or tertiary button.`,
+      sectionContent: `- **Reserve for secondary content:** Use for secondary or less important information and actions since they're hidden until triggered.
+- **Group related actions:** Contain actions that share a relationship to each other.
+- **Use clear trigger labels:** Be triggered by a clearly labeled default or tertiary button.`,
     },
     {
       title: 'Limitations',

--- a/packages/ui-extensions/src/surfaces/admin/components/Popover/Popover.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Popover/Popover.ab.doc.ts
@@ -11,9 +11,9 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Reserve for secondary content:** Use for secondary or less important information and actions since they're hidden until triggered.
-- **Group related actions:** Contain actions that share a relationship to each other.
-- **Use clear trigger labels:** Be triggered by a clearly labeled default or tertiary button.`,
+      sectionContent: `- **Reserve for secondary content**: Use for secondary or less important information and actions since they're hidden until triggered.
+- **Group related actions**: Contain actions that share a relationship to each other.
+- **Use clear trigger labels**: Be triggered by a clearly labeled default or tertiary button.`,
     },
     {
       title: 'Limitations',


### PR DESCRIPTION
## Summary
- Adds bolded lead-in phrases to best practices for Modal, Page, Popover, and DropZone components
- Aligns with existing component documentation style (e.g., Button) where each bullet starts with `**Action phrase:**`
- Removes generic/fluff items that don't provide specific guidance:
  - Modal: removed "Include clear calls to action" and "Use sparingly"
  - Page: removed "Provide descriptive titles"

## Test plan
- [ ] Verify best practices render correctly with bolded lead-ins on shopify.dev
- [ ] Confirm no linter errors


Made with [Cursor](https://cursor.com)