### PR TITLE
[Admin UI extensions 2026-04-rc]: Fix issues with examples

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/custom-product-labels.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/custom-product-labels.jsx
@@ -1,5 +1,5 @@
 import {render} from 'preact';
-import {useState} from 'preact/hooks';
+import {useState, useCallback} from 'preact/hooks';
 
 export default async () => {
   render(<Extension />, document.body);
@@ -7,38 +7,41 @@ export default async () => {
 
 function Extension() {
   const {data} = shopify;
-  const [additionalCount, setAdditionalCount] = useState(0);
+  const [additionalProducts, setAdditionalProducts] = useState([]);
+  const [printUrl, setPrintUrl] = useState(null);
 
   const handleSelectMore = async () => {
-    const additionalProducts = await shopify.resourcePicker({
+    const picked = await shopify.resourcePicker({
       type: 'product',
       multiple: 10,
       action: 'add',
     });
 
-    if (additionalProducts) {
-      setAdditionalCount(additionalProducts.length);
+    if (picked) {
+      setAdditionalProducts((prev) => [...prev, ...picked]);
     }
   };
 
-  const handleGenerate = async () => {
-    const productIds = data.selected.map((item) => item.id);
-    
+  const handleGenerate = useCallback(async () => {
+    const selectedIds = data.selected.map((item) => item.id);
+    const additionalIds = additionalProducts.map((item) => item.id);
+    const productIds = [...selectedIds, ...additionalIds];
+
     const response = await fetch('/api/generate-labels', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({productIds}),
     });
 
-    const {printUrl} = await response.json();
-    return printUrl;
-  };
+    const {printUrl: url} = await response.json();
+    setPrintUrl(url);
+  }, [data, additionalProducts]);
 
   return (
-    <s-admin-print-action onPrint={handleGenerate}>
-      <s-text>{data.selected.length} products selected</s-text>
+    <s-admin-print-action src={printUrl}>
+      <s-text>{data.selected.length + additionalProducts.length} products selected</s-text>
       <s-button onClick={handleSelectMore}>Add More Products</s-button>
-      {additionalCount > 0 && <s-text>+{additionalCount} additional</s-text>}
+      <s-button onClick={handleGenerate}>Generate Labels</s-button>
     </s-admin-print-action>
   );
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/generate-packing-slip.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/generate-packing-slip.jsx
@@ -1,4 +1,5 @@
 import {render} from 'preact';
+import {useState, useEffect} from 'preact/hooks';
 
 export default async () => {
   render(<Extension />, document.body);
@@ -6,23 +7,28 @@ export default async () => {
 
 function Extension() {
   const {data} = shopify;
+  const [printUrl, setPrintUrl] = useState(null);
 
-  const handleGenerate = async () => {
-    const orderIds = data.selected.map((item) => item.id);
+  useEffect(() => {
+    const generateSlip = async () => {
+      const orderIds = data.selected.map((item) => item.id);
 
-    const response = await fetch('/api/generate-packing-slip', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({orderIds}),
-    });
+      const response = await fetch('/api/generate-packing-slip', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({orderIds}),
+      });
 
-    const {printUrl} = await response.json();
-    return printUrl;
-  };
+      const {printUrl: url} = await response.json();
+      setPrintUrl(url);
+    };
+
+    generateSlip();
+  }, [data]);
 
   return (
-    <s-admin-print-action onPrint={handleGenerate}>
-      <s-text>Generating packing slip for {data.selected.length} orders</s-text>
+    <s-admin-print-action src={printUrl}>
+      <s-text>Packing slip for {data.selected.length} orders</s-text>
     </s-admin-print-action>
   );
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/shipping-manifest.jsx
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/examples/shipping-manifest.jsx
@@ -8,6 +8,7 @@ export default async () => {
 function Extension() {
   const {data} = shopify;
   const [orders, setOrders] = useState([]);
+  const [printUrl, setPrintUrl] = useState(null);
 
   useEffect(() => {
     const fetchOrders = async () => {
@@ -31,24 +32,22 @@ function Extension() {
       );
 
       setOrders(ordersData.nodes);
+
+      const response = await fetch('/api/generate-shipping-manifest', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({orders: ordersData.nodes}),
+      });
+
+      const {printUrl: url} = await response.json();
+      setPrintUrl(url);
     };
 
     fetchOrders();
   }, [data]);
 
-  const handleGenerate = async () => {
-    const response = await fetch('/api/generate-shipping-manifest', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({orders}),
-    });
-
-    const {printUrl} = await response.json();
-    return printUrl;
-  };
-
   return (
-    <s-admin-print-action onPrint={handleGenerate}>
+    <s-admin-print-action src={printUrl}>
       <s-text>Shipping manifest for {orders.length} orders</s-text>
       {orders.map((order) => (
         <s-text key={order.id}>{order.name}</s-text>

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -10,7 +10,7 @@ const data: ReferenceEntityTemplateSchema = {
     'the [admin print action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-print-action) component.',
   defaultExample: {
     description:
-      "Generate a packing slip PDF for selected orders by calling your app's backend service. This example shows extracting order IDs from the selected resources, making an API call to your backend to generate the PDF, and returning the printable URL to display the document.",
+      "Generate a packing slip PDF for selected orders by calling your app's backend service. This example shows extracting order IDs from the selected resources, making an API call to your backend to generate the PDF, and setting the printable URL as the `src` prop to display the document.",
     codeblock: {
       title: 'Generate packing slip',
       tabs: [
@@ -81,7 +81,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent:
-        "- Print action extensions must return a URL string. You can't render the print UI directly within the extension or control the print preview appearance.\n" +
+        "- Print action extensions must provide a URL string through the `src` prop. You can't render the print UI directly within the extension or control the print preview appearance.\n" +
         '- URLs must be publicly accessible with CORS headers allowing the Shopify admin origin. Authentication tokens in URLs can expire while merchants have the preview open.\n' +
         "- Extensions don't have access to printer settings. You can't configure print options like page orientation, margins, or paper size. Merchants control these through browser print dialogs.",
     },

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/examples/with-form-content.html
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/examples/with-form-content.html
@@ -1,7 +1,7 @@
 <s-admin-action heading="Edit shipping settings">
   <s-stack direction="block" gap="base">
     <s-text-field label="Shipping rate name" value="Standard shipping"></s-text-field>
-    <s-number-field label="Flat rate amount" min="0" step="0.01" prefix="$" value="5.99"></s-number-field>
+    <s-number-field label="Flat rate amount" prefix="$" value="5.99"></s-number-field>
   </s-stack>
   <s-button slot="primary-action" variant="primary">Save changes</s-button>
   <s-button slot="secondary-actions">Discard</s-button>


### PR DESCRIPTION
## This PR: 
- Fixes examples with validation errors, based on Laurel's findings in https://github.com/Shopify/shopify-dev/pull/68942.
- Partially fixes https://github.com/Shopify/temp-project-mover-Archetypically-20260313091522/issues/1