### PR TITLE
Add missing example directories for Customer Account targets

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order.page.render/default.example.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order.page.render/default.example.jsx
@@ -1,0 +1,14 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  return (
+    <s-page heading="Order Page Extension">
+      <s-text>This is an order-specific full page extension.</s-text>
+    </s-page>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.page.render/default.example.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.page.render/default.example.jsx
@@ -1,0 +1,14 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  return (
+    <s-page heading="Full Page Extension">
+      <s-text>This is a full page extension.</s-text>
+    </s-page>
+  );
+}


### PR DESCRIPTION
## Summary
- Creates placeholder example directories for two Customer Account targets that were missing them
- Enables example content to be added in follow-up PRs

**Targets:**
- `[customer-account.order.page.render](https://shopify.dev/docs/api/customer-account-ui-extensions/latest/targets/full-page/customer-account-order-page-render)` (order-specific full page extension)
- `[customer-account.page.render](https://shopify.dev/docs/api/customer-account-ui-extensions/latest/targets/full-page/customer-account-page-render)` (general full page extension)

Closes: https://github.com/Shopify/shopify-dev/issues/68753

## Test plan
- [ ] Verify directories are created in correct location
- [ ] Confirm placeholder examples follow existing patterns


Made with [Cursor](https://cursor.com)