### PR TITLE
Update API names to align with new naming convention (2025-10)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/address.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/address.doc.ts
@@ -12,7 +12,8 @@ const data: ReferenceEntityTemplateSchema = {
   description: 'The API for interacting with addresses.',
   isVisualComponent: false,
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA_LEVEL_2,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/address.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/address.doc.ts
@@ -8,7 +8,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Addresses',
+  name: 'Addresses API',
   description: 'The API for interacting with addresses.',
   isVisualComponent: false,
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA_LEVEL_2,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/analytics.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/analytics.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Analytics',
+  name: 'Analytics API',
   description: 'The API for interacting with web pixels.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/analytics.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/analytics.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Analytics API',
   description: 'The API for interacting with web pixels.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/attributes.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/attributes.doc.ts
@@ -12,7 +12,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Attributes API',
   description: 'The API for interacting with cart and checkout attributes.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/attributes.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/attributes.doc.ts
@@ -9,7 +9,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Attributes',
+  name: 'Attributes API',
   description: 'The API for interacting with cart and checkout attributes.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-identity.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-identity.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Buyer Identity',
+  name: 'Buyer Identity API',
   description: 'The API for interacting with the buyer identity.',
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA_LEVEL_2,
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-identity.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-identity.doc.ts
@@ -11,7 +11,8 @@ const data: ReferenceEntityTemplateSchema = {
   description: 'The API for interacting with the buyer identity.',
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA_LEVEL_2,
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Buyer Journey',
+  name: 'Buyer Journey API',
   description: 'The API for interacting with the buyer journey.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/buyer-journey.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Buyer Journey API',
   description: 'The API for interacting with the buyer journey.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cart-instructions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cart-instructions.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Cart Instructions API',
   description: 'Instructions used to create the checkout.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cart-instructions.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cart-instructions.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Cart Instructions',
+  name: 'Cart Instructions API',
   description: 'Instructions used to create the checkout.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cart-lines.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cart-lines.doc.ts
@@ -8,7 +8,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Cart Lines',
+  name: 'Cart Lines API',
   description: 'The API for interacting with the cart lines.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cart-lines.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cart-lines.doc.ts
@@ -11,7 +11,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Cart Lines API',
   description: 'The API for interacting with the cart lines.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/checkout-token.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/checkout-token.doc.ts
@@ -9,7 +9,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Checkout Token API',
   description: 'The API for interacting with the token of a checkout.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/checkout-token.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/checkout-token.doc.ts
@@ -6,7 +6,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Checkout Token',
+  name: 'Checkout Token API',
   description: 'The API for interacting with the token of a checkout.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cost.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cost.doc.ts
@@ -6,7 +6,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Cost',
+  name: 'Cost API',
   description: 'The API for interacting with the cost of a checkout.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cost.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/cost.doc.ts
@@ -9,7 +9,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Cost API',
   description: 'The API for interacting with the cost of a checkout.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/customer-privacy.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/customer-privacy.doc.ts
@@ -8,7 +8,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Customer Privacy',
+  name: 'Customer Privacy API',
   description:
     "The API for interacting with a customer's privacy consent. It is similar to the [Customer Privacy API in storefront](/docs/api/customer-privacy).",
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/customer-privacy.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/customer-privacy.doc.ts
@@ -13,7 +13,8 @@ const data: ReferenceEntityTemplateSchema = {
     "The API for interacting with a customer's privacy consent. It is similar to the [Customer Privacy API in storefront](/docs/api/customer-privacy).",
   isVisualComponent: false,
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/delivery.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/delivery.doc.ts
@@ -17,7 +17,8 @@ const data: ReferenceEntityTemplateSchema = {
   overviewPreviewDescription:
     'The APIs for interacting with delivery and shipping options.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/delivery.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/delivery.doc.ts
@@ -8,7 +8,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Delivery',
+  name: 'Delivery API',
   description: `
   The APIs for interacting with delivery and shipping options.
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/discounts.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/discounts.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Discounts API',
   description: 'The API for interacting with discounts.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/discounts.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/discounts.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Discounts',
+  name: 'Discounts API',
   description: 'The API for interacting with discounts.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/extension-meta.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/extension-meta.doc.ts
@@ -9,7 +9,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Extension API',
   description: 'The API for interacting with the metadata of an extension.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/extension-meta.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/extension-meta.doc.ts
@@ -6,7 +6,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Extension',
+  name: 'Extension API',
   description: 'The API for interacting with the metadata of an extension.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/gift-cards.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/gift-cards.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Gift Cards API',
   description: 'The API for interacting with gift cards.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/gift-cards.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/gift-cards.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Gift Cards',
+  name: 'Gift Cards API',
   description: 'The API for interacting with gift cards.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/localization.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/localization.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Localization API',
   description: 'The APIs for localizing your extension.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/localization.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/localization.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Localization',
+  name: 'Localization API',
   description: 'The APIs for localizing your extension.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/localized-fields.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/localized-fields.doc.ts
@@ -8,7 +8,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Localized Fields',
+  name: 'Localized Fields API',
   description: 'The API for interacting with localized fields.',
   isVisualComponent: false,
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/localized-fields.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/localized-fields.doc.ts
@@ -12,7 +12,8 @@ const data: ReferenceEntityTemplateSchema = {
   description: 'The API for interacting with localized fields.',
   isVisualComponent: false,
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/metafields.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/metafields.doc.ts
@@ -9,7 +9,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Metafields',
+  name: 'Metafields API',
   description: 'The API for interacting with metafields.',
   isVisualComponent: false,
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/metafields.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/metafields.doc.ts
@@ -13,7 +13,8 @@ const data: ReferenceEntityTemplateSchema = {
   description: 'The API for interacting with metafields.',
   isVisualComponent: false,
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/note.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/note.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Note API',
   description: 'The API for interacting with the note applied to checkout.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/note.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/note.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Note',
+  name: 'Note API',
   description: 'The API for interacting with the note applied to checkout.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/order.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/order.doc.ts
@@ -16,7 +16,7 @@ import {
 interface OrderStatusApiEmpty {}
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Order',
+  name: 'Order API',
   description:
     'The API for interacting with the order confirmation, available on the **Thank You** page.',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/order.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/order.doc.ts
@@ -20,7 +20,8 @@ const data: ReferenceEntityTemplateSchema = {
   description:
     'The API for interacting with the order confirmation, available on the **Thank You** page.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   defaultExample: getExample('order-confirmation/default', ['jsx']),
   definitions: [

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/payment-options.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/payment-options.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Payments API',
   description: 'The API for interacting with the payment options.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Checkout APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/payment-options.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/payment-options.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Payments',
+  name: 'Payments API',
   description: 'The API for interacting with the payment options.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/query.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/query.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Storefront API',
   description: 'Querying the Storefront API.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/session-token.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/session-token.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Session Token',
+  name: 'Session Token API',
   description: 'The API for interacting with session tokens.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/session-token.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/session-token.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Session Token API',
   description: 'The API for interacting with session tokens.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/settings.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/settings.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Settings API',
   description: 'The API for interacting with merchant settings.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/settings.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/settings.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Settings',
+  name: 'Settings API',
   description: 'The API for interacting with merchant settings.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/shop.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/shop.doc.ts
@@ -6,7 +6,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Shop',
+  name: 'Shop API',
   description: 'The API for interacting with shop.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/shop.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/shop.doc.ts
@@ -9,7 +9,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Shop API',
   description: 'The API for interacting with shop.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/storage.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/storage.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Storage',
+  name: 'Storage API',
   description: 'The API for interacting with local storage.',
   isVisualComponent: false,
   category: 'APIs',

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/storage.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/storage.doc.ts
@@ -10,7 +10,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Storage API',
   description: 'The API for interacting with local storage.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {


### PR DESCRIPTION
Fixes https://github.com/Shopify/temp-project-mover-Archetypically-20260313091522/issues/378

### Background

As part of the [Shopify Dev Docs UI Extension Reference Docs Quality & Completeness GSD project](https://vault.shopify.io/gsd/projects/49303-Shopify-Dev-Docs-UI-Extension-Reference-Docs-Quality-Completeness), API names in ui-extensions need to match the naming convention approved for the IA. 

### Solution

Updates the `name` field in 24 `*.doc.ts` files under `packages/ui-extensions/docs/surfaces/checkout/reference/apis/`. 

The IA categorization follows the approved structure from: https://docs.google.com/document/d/1pkVbWRGUl6upl0PgvnwHd6LtS8TgQ_UbWG1p5HdRpII/edit?tab=t.0#heading=h.tv19o950t1oy

### 🎩

- Verify API names display correctly on shopify.dev

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation