### PR TITLE
[Backport 2026-01-rc] Added imports for preact bindings in POS docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Modal.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/mdxExamples/subscription-example/Modal.jsx
@@ -1,5 +1,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
+// Allows the use of `shopify.cart.current.value` as a stateful subscription.
+import '@shopify/ui-extensions/preact';
 import {fetchSellingPlans} from './FetchSellingPlans';
 
 export default function extension() {

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/check-cart-editable.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/check-cart-editable.jsx
@@ -1,5 +1,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
+// Allows the use of `shopify.cart.current.value` as a stateful subscription.
+import '@shopify/ui-extensions/preact';
 
 export default async () => {
   render(<Extension />, document.body);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/subscribe.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/cart-api/subscribe.jsx
@@ -1,5 +1,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
+// Allows the use of `shopify.cart.current.value` as a stateful subscription.
+import '@shopify/ui-extensions/preact';
 
 export default async () => {
   render(<Extension />, document.body);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/connectivity-api/subscribe.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/connectivity-api/subscribe.jsx
@@ -1,5 +1,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
+// Allows the use of `shopify.connectivity.current.value` as a stateful subscription.
+import '@shopify/ui-extensions/preact';
 
 export default async () => {
   render(<Extension />, document.body);

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/locale-api/subscribe.jsx
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/examples/locale-api/subscribe.jsx
@@ -1,5 +1,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
+// Allows the use of `shopify.locale.current.value` as a stateful subscription.
+import '@shopify/ui-extensions/preact';
 
 export default async () => {
   render(<Extension />, document.body);


### PR DESCRIPTION
### Background

Backport of #3931 to the `2026-01-rc` branch.

The original PR was merged directly into `2026-04-rc`, which means when `2026-01` docs are synchronized in shopify-dev, these import statements are missing, causing the documentation examples to be incorrect (the `import '@shopify/ui-extensions/preact'` lines get deleted).

### Solution

Cherry-pick of the same changes: adds the `import '@shopify/ui-extensions/preact';` statement along with explanatory comments to POS example files that use stateful subscriptions.

Files changed:
- Subscription example Modal component
- Cart API examples (check-cart-editable and subscribe)
- Connectivity API subscribe example
- Locale API subscribe example

### Original PR
https://github.com/Shopify/ui-extensions/pull/3931