### PR TITLE
Add missing example directories for Customer Account targets

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order.page.render/default.example.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.order.page.render/default.example.jsx
@@ -1,0 +1,14 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  return (
+    <s-page heading="Order Page Extension">
+      <s-text>This is an order-specific full page extension.</s-text>
+    </s-page>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.page.render/default.example.jsx
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/examples/targets/customer-account.page.render/default.example.jsx
@@ -1,0 +1,14 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<Extension />, document.body);
+};
+
+function Extension() {
+  return (
+    <s-page heading="Full Page Extension">
+      <s-text>This is a full page extension.</s-text>
+    </s-page>
+  );
+}


### PR DESCRIPTION
## Summary
Cherry-pick of #4064 for 2025-10 branch.

Creates placeholder example directories for two Customer Account targets:
- `customer-account.order.page.render`
- `customer-account.page.render`


Made with [Cursor](https://cursor.com)