### PR TITLE
add discount index targets

### DIFF
--- a/.changeset/grumpy-lamps-switch.md
+++ b/.changeset/grumpy-lamps-switch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Adds discount-index.selection-action extension point

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -320,6 +320,14 @@ export interface ExtensionTargets {
   >;
 
   /**
+   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.
+   */
+  'admin.discount-index.selection-action.render': RenderExtension<
+    ActionExtensionApi<'admin.discount-index.selection-action.render'>,
+    ActionExtensionComponents
+  >;
+
+  /**
    * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.
    */
   'admin.draft-order-index.selection-action.render': RenderExtension<
@@ -595,6 +603,14 @@ export interface ExtensionTargets {
    */
   'admin.customer-index.selection-action.should-render': RunnableExtension<
     ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,
+    ShouldRenderOutput
+  >;
+
+  /**
+   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.
+   */
+  'admin.discount-index.selection-action.should-render': RunnableExtension<
+    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,
     ShouldRenderOutput
   >;
 


### PR DESCRIPTION
### Background

Adds discount index bulk action targets that are already added in [Core](https://github.com/shop/world/pull/460701) and about to be shipped in Admin under a beta.

Do I need to add to other versions? Link and UI Extensions for actions aren't versioned the same way

### Solution

Allows to use `discount-index.selection-action.should-render` and `discount-index.selection-action.render` extension points. 

