### PR TITLE
[2026-04] Generate changeset for checkout metafield removal

### DIFF
--- a/.changeset/brown-moose-visit.md
+++ b/.changeset/brown-moose-visit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Remove checkout metafields in favour of cart metafields


### PR DESCRIPTION
### Background

Follow-up to https://github.com/Shopify/ui-extensions/pull/3989

Adds a missing changeset for checkout metafield type removal