### PR TITLE
Add doc validation skills for ui-extensions

### DIFF
--- a/.claude/skills/apis.md
+++ b/.claude/skills/apis.md
@@ -1,0 +1,122 @@
+---
+name: ui-extensions-validate-apis
+description: Use when validating API documentation updates in the ui-extensions repo. Covers API descriptions, .doc.ts file structure, properties, methods, helper docs, and missing assets. Run after ui-extensions:universal.
+---
+
+# APIs Validation
+
+Run after `ui-extensions:universal`. Also run `ui-extensions:type-definitions`.
+
+**How to use:** Evaluate each item against the files provided. Skip items that clearly don't apply. Flag anything you can't definitively verify rather than guessing. Works for all surfaces (admin, checkout, customer account).
+
+## API Descriptions
+
+- [ ] Starts with "The [API Name] API lets you..."
+- [ ] Description includes a tutorial link (flag if missing; don't validate the URL)
+- [ ] Explains purpose and use cases (not just "provides access to...")
+
+**Good:**
+> "The Action Extension API lets you build action extensions that merchants access from the More actions menu on details and index pages. Use this API to create workflows for processing resources, configuring settings, or integrating with external systems."
+
+**Avoid:**
+> "The Action Extension API provides access to action extension functionality."
+
+## URL Placeholders
+
+### Surface-specific `.doc.ts` files
+
+- [ ] Use `{API_VERSION}` placeholder (surface name is hardcoded)
+- [ ] Format: `/docs/api/admin-extensions/{API_VERSION}/...`
+
+### Shared component files (`src/docs/shared/components/*.ts`)
+
+- [ ] Use both `{API_NAME}` and `{API_VERSION}` placeholders
+- [ ] Format: `/docs/api/{API_NAME}/{API_VERSION}/...`
+
+## API `.doc.ts` File Structure
+
+### `requires` field
+
+- [ ] Links to required component: `'the [component name](/docs/api/admin-extensions/{API_VERSION}/...) component.'`
+
+### `defaultExample`
+
+- [ ] `description`: Explains what the example does AND why (not "This example shows...")
+- [ ] `codeblock.title`: Action-oriented verb phrase (e.g., "Process selected products")
+- [ ] Links to related APIs/components in the description
+
+### Additional Examples (`examples` object)
+
+- [ ] `examples.description`: Brief intro to the examples section
+- [ ] Each example has a distinct use case with detailed description
+- [ ] Example titles are action-oriented verbs
+
+### `subSections` (Best Practices & Limitations)
+
+- [ ] **Best Practices**: Each item starts with `**Bold verb phrase:**` (colon outside bold)
+- [ ] **Limitations**: Uses contractions (can't, don't); explains what AND why it matters
+- [ ] Links to workarounds or alternatives where applicable
+
+### `metadata`
+
+- [ ] `category`: Set appropriately (e.g., `'Target APIs'`)
+- [ ] `subCategory`: Set appropriately (e.g., `'Core APIs'`, `'Utility APIs'`)
+
+### `definitions` section
+
+- [ ] `title`: Usually "Properties"
+- [ ] `description`: Explains what the API object provides and how to access it
+- [ ] `type`: Matches TypeScript interface name
+
+## API Properties
+
+- [ ] Each property has a JSDoc description
+- [ ] Signal-based properties (`SubscribableSignalLike`) explain reactive behavior
+- [ ] Required vs optional clearly indicated
+
+## API Methods
+
+- [ ] Method descriptions explain when/how to call
+- [ ] Return types documented
+- [ ] Parameters described
+
+## Helper Docs (`helper.docs.ts`)
+
+- [ ] Reusable API definitions are kept in helper files
+- [ ] Constants like `CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION` are up to date
+
+## Missing Assets
+
+- [ ] Every target has a corresponding example directory
+- [ ] Every component has at least one example file
+- [ ] Screenshots exist for visual components (if applicable)
+
+## Shared Component Descriptions (`src/docs/shared/components/*.ts`)
+
+- [ ] 2-paragraph description minimum:
+  - Paragraph 1: What the component does and when to use it
+  - Paragraph 2: How it works, key behaviors, interactions
+- [ ] Include practical guidance (e.g., "A button triggers the modal using the `commandFor` attribute")
+- [ ] Use `{API_NAME}` and `{API_VERSION}` placeholders in all links
+- [ ] `category`: Usually `'Polaris web components'`
+- [ ] `subCategory`: Set appropriately (e.g., `'Overlays'`, `'Forms'`, `'Layout and structure'`)
+
+---
+
+## Output Format
+
+```markdown
+## Validation Report
+
+### What's good
+- [passing items]
+
+### Needs attention
+- [items that may need work]
+
+### Must fix
+- [items that must be fixed before merging]
+
+### Recommendation
+[Ready to merge / Needs changes / Major revision needed]
+```

--- a/.claude/skills/build-verification.md
+++ b/.claude/skills/build-verification.md
@@ -1,0 +1,47 @@
+---
+name: ui-extensions-build-verification
+description: Use when verifying that documentation changes generate correctly in the ui-extensions repo. Covers running docs generation commands, verifying generated JSON output, and previewing locally.
+---
+
+# Build & Preview Verification
+
+**How to use:** Run the relevant command and report what you observe. Flag anything unexpected rather than guessing at the cause.
+
+## Documentation Generation
+
+Run the appropriate command for the surface you updated:
+
+```bash
+yarn docs:checkout
+yarn docs:customer-account
+```
+
+- [ ] Command runs without errors
+- [ ] Generated JSON (`generated_docs_data.json`) reflects your changes
+- [ ] Preview locally to confirm rendering
+
+## Generated Files
+
+- [ ] Do **not** manually edit files in `generated/` directories
+- [ ] Source `.d.ts` and `.doc.ts` files are the source of truth
+- [ ] CI regenerates these files — verify your source changes produce expected output
+
+---
+
+## Output Format
+
+```
+## Verification Report
+
+### What's good
+- [passing items]
+
+### Needs attention
+- [items that may need work]
+
+### Must fix
+- [items that must be fixed before merging]
+
+### Recommendation
+[Ready to merge / Needs changes / Major revision needed]
+```

--- a/.claude/skills/components.md
+++ b/.claude/skills/components.md
@@ -1,0 +1,68 @@
+---
+name: ui-extensions-validate-components
+description: Use when validating component documentation updates in the ui-extensions repo. Covers example file format, component descriptions, best practices, limitations, and sections to remove. Run after ui-extensions:universal.
+---
+
+# Components Validation
+
+Run after `ui-extensions:universal`. Also run `ui-extensions:type-definitions` and `ui-extensions:cross-surface`.
+
+**How to use:** Evaluate each item against the files provided. Skip items that clearly don't apply. Flag anything you can't definitively verify rather than guessing. Works for all surfaces (admin, checkout, customer account).
+
+## Example Files (HTML Only)
+
+- [ ] Remove all `.jsx` example files from the `examples/` folder
+- [ ] Remove all JSX/React tab references from `.doc.ts` files
+- [ ] Set tab `language: 'html'` (lowercase)
+
+## Component Descriptions
+
+- [ ] Starts with "The [Component Name] component [action verb]..."
+- [ ] Description includes a resource link where applicable (flag if missing; don't validate the URL)
+- [ ] Explains purpose and use cases (not just "provides access to...")
+- [ ] Uses friendly term for component names, not code syntax ("button", not `Button` or `s-button`)
+
+**Good:**
+> "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface."
+
+**Avoid:**
+> "The button component provides access to action extension functionality."
+
+## subSections
+
+### Best Practices
+- [ ] Each bullet starts with `**Action verb phrase**:` (bold, colon outside)
+- [ ] Each bullet ends with a period
+- [ ] Flag any best practice that appears generic or not specific to this component — the author should confirm traceability to Built for Shopify requirements, Polaris guidelines, or documented UX research
+- [ ] No generic advice — each item addresses scenarios specific to this component, or remove it
+
+### Limitations
+- [ ] Each limitation describes a real technical or UX constraint, not obvious behavior
+- [ ] No filler — if a limitation isn't a real constraint, remove it
+
+## Sections to Remove
+
+- [ ] Flag if the `.doc.ts` file sets `usefulFor` — this section should be removed from the component's doc config
+- [ ] Remove "Content guidelines" section
+- [ ] Remove "Related to" section/links
+- [ ] Only keep Best Practices and Limitations where applicable
+
+---
+
+## Output Format
+
+```
+## Validation Report
+
+### What's good
+- [passing items]
+
+### Needs attention
+- [items that may need work]
+
+### Must fix
+- [items that must be fixed before merging]
+
+### Recommendation
+[Ready to merge / Needs changes / Major revision needed]
+```

--- a/.claude/skills/cross-surface.md
+++ b/.claude/skills/cross-surface.md
@@ -1,0 +1,47 @@
+---
+name: ui-extensions-validate-cross-surface
+description: Use when validating consistency of component or API documentation across multiple surfaces (Admin, Checkout, POS) in the ui-extensions repo. Covers description parity, terminology, and shared component consistency.
+---
+
+# Cross-Surface Consistency Validation
+
+Use when a component or shared description appears on multiple surfaces.
+
+**How to use:** Evaluate each item against the files provided. Skip items that clearly don't apply. Flag anything you can't definitively verify rather than guessing.
+
+## Description Consistency
+
+- [ ] Compare descriptions with the same component on other surfaces (Admin, Checkout, POS)
+- [ ] Descriptions should be aligned in scope and quality — not necessarily identical, but consistent in what they cover
+- [ ] Surface-specific nuances should be explicitly noted where applicable
+
+## Terminology
+
+- [ ] Terminology is consistent across surfaces (same words for the same concepts)
+- [ ] Extension type names use the correct domain prefix, lowercased: admin UI extension, checkout UI extension, POS UI extension
+
+## Shared Components
+
+- [ ] Shared components (via `src/docs/shared/components/*.ts`) have consistent descriptions across the surfaces that use them
+- [ ] If a shared component description was updated, verify the change reads correctly in all surfaces it appears on
+- [ ] Placeholder usage: `{API_NAME}` and `{API_VERSION}` are used (not hardcoded surface/version values)
+
+---
+
+## Output Format
+
+```
+## Validation Report
+
+### What's good
+- [passing items]
+
+### Needs attention
+- [items that may need work]
+
+### Must fix
+- [items that must be fixed before merging]
+
+### Recommendation
+[Ready to merge / Needs changes / Major revision needed]
+```

--- a/.claude/skills/examples.md
+++ b/.claude/skills/examples.md
@@ -1,0 +1,82 @@
+---
+name: ui-extensions-examples
+description: Use when a PR touches example files in the ui-extensions repo. Covers example description quality, title conventions, accessibility attributes, uniqueness, and real-world usefulness. Only invoke when example files are changed — skip for type definition or API-only changes.
+---
+
+# Example Validation
+
+**How to use:** Apply judgment, not mechanical scanning. The automated example validation script in this repo already checks syntax and rendering — don't duplicate that. This skill covers what the script can't: whether examples are *useful*, *unique*, and *well-described*.
+
+**When to invoke:** Only when the PR includes changes to `examples/` files. Skip this skill for PRs that only change `.d.ts`, `.doc.ts` metadata fields, or non-example assets.
+
+## Example Descriptions (2-Sentence Pattern)
+
+Each example's `description` field must follow this pattern:
+
+- **Sentence 1**: What it does / user benefit. Use an action-oriented verb. Don't start with "This example".
+- **Sentence 2**: What this specific example demonstrates. Start with "This example [verb]...".
+
+**Good:**
+> "Focus merchant attention on a critical decision before proceeding. This example presents a delete confirmation with cancel and confirm buttons."
+
+**Avoid:**
+> "This example shows a modal." — single sentence, starts with "This example shows", no user benefit
+
+## Example Titles
+
+- [ ] Action-oriented verbs: "Confirm a merchant action", "Navigate to App Store"
+- [ ] Avoid: "Default", "Basic", or just the page name
+- [ ] Remove lead-ins like "Basic:"
+
+## Example Files (Accessibility)
+
+The script checks syntax. These must be checked manually:
+
+- [ ] Form fields include a `details` attribute with an accessible description
+- [ ] Interactive elements include `accessibilityLabel`
+
+## Example Quality
+
+**What to check (judgment required):**
+
+### Uniqueness
+- [ ] No two examples demonstrate the same functionality
+- [ ] If examples look similar, each has a clear differentiating purpose explained in the description
+- [ ] If an example only changes one prop value from another, consider whether they should be consolidated
+
+### Usefulness
+- [ ] Each example shows a real-world scenario, not just a minimal property demo
+- [ ] Examples are complex enough to be copy-paste useful — not just `<s-button>Click</s-button>`
+- [ ] Examples show what the component is actually for, not edge-case configurations
+
+### Content
+- [ ] No placeholder text (Lorem ipsum, TODO, sample text, etc.)
+
+## What the Script Already Checks (Don't Repeat)
+
+The repo's automated validation script covers:
+- Syntax errors
+- Import resolution
+- Required fields presence
+
+Don't flag these in your validation report — the script will catch them on build.
+
+---
+
+## Output Format
+
+```
+## Validation Report
+
+### What's good
+- [passing items]
+
+### Needs attention
+- [items that may need work]
+
+### Must fix
+- [items that must be fixed before merging]
+
+### Recommendation
+[Ready to merge / Needs changes / Major revision needed]
+```

--- a/.claude/skills/link-validation.md
+++ b/.claude/skills/link-validation.md
@@ -1,0 +1,48 @@
+---
+name: ui-extensions-validate-links
+description: Use when validating that documentation links in the ui-extensions repo point to real pages on shopify.dev. Run separately from other validation skills due to MCP tool overhead.
+---
+
+# Link Validation
+
+Validates that documentation links point to real shopify.dev pages. This skill uses MCP tools and adds time to validation — run it separately from content validation skills.
+
+**How to use:** For each link found in the files provided, use `mcp__shopify-dev-mcp__search_docs_chunks` to verify the path exists and is correct for the surface being documented (admin, checkout, customer account). Report broken or suspicious links.
+
+## What to Check
+
+- [ ] Tutorial links in API descriptions (e.g., links after "The [API Name] API lets you...")
+- [ ] Resource links in component descriptions
+- [ ] Links in `requires` fields of `.doc.ts` files
+- [ ] Links to related APIs/components in example descriptions
+- [ ] Links in `subSections` (best practices, limitations) pointing to workarounds or alternatives
+- [ ] Links to child component docs in slot descriptions
+
+## What NOT to Check
+
+- `{API_VERSION}` and `{API_NAME}` placeholders — these are resolved at build time, don't try to expand them
+- Relative anchors within the same page
+- MDN links — flag these for human review instead of verifying
+
+## Common Issues
+
+- Admin-specific paths used on checkout or customer account pages
+- Hardcoded version numbers instead of `{API_VERSION}` placeholder
+- Links to pages that were moved or renamed
+
+---
+
+## Output Format
+
+```markdown
+## Link Validation Report
+
+### Valid links
+- [list of verified links]
+
+### Broken or suspicious
+- [link] — [reason: not found / wrong surface / hardcoded version]
+
+### Flagged for human review
+- [link] — [reason: MDN link / can't verify / ambiguous]
+```

--- a/.claude/skills/link-validation.md
+++ b/.claude/skills/link-validation.md
@@ -7,12 +7,7 @@ description: Use when validating that documentation links in the ui-extensions r
 
 Validates that documentation links point to real shopify.dev pages. This skill uses MCP tools and adds time to validation — run it separately from content validation skills.
 
-**How to use:** For each link found in the files provided, verify the path exists and is correct for the surface being documented (admin, checkout, customer account).
-
-- Use `mcp__shopify-dev-mcp__search_docs_chunks` to find a page when you're not sure of the exact path.
-- Use `mcp__shopify-dev-mcp__fetch_full_docs` when you have a candidate path and need to confirm the page exists and that the linked section or content is actually there.
-
-Use both tools together: search to locate, fetch to confirm.
+**How to use:** For each link found in the files provided, use `mcp__shopify-dev-mcp__search_docs_chunks` to locate the page, then `mcp__shopify-dev-mcp__fetch_full_docs` to confirm the path exists and that the linked content is actually there. Verify the path is correct for the surface being documented (admin, checkout, customer account).
 
 ## What to Check
 

--- a/.claude/skills/link-validation.md
+++ b/.claude/skills/link-validation.md
@@ -7,7 +7,12 @@ description: Use when validating that documentation links in the ui-extensions r
 
 Validates that documentation links point to real shopify.dev pages. This skill uses MCP tools and adds time to validation — run it separately from content validation skills.
 
-**How to use:** For each link found in the files provided, use `mcp__shopify-dev-mcp__search_docs_chunks` to verify the path exists and is correct for the surface being documented (admin, checkout, customer account). Report broken or suspicious links.
+**How to use:** For each link found in the files provided, verify the path exists and is correct for the surface being documented (admin, checkout, customer account).
+
+- Use `mcp__shopify-dev-mcp__search_docs_chunks` to find a page when you're not sure of the exact path.
+- Use `mcp__shopify-dev-mcp__fetch_full_docs` when you have a candidate path and need to confirm the page exists and that the linked section or content is actually there.
+
+Use both tools together: search to locate, fetch to confirm.
 
 ## What to Check
 

--- a/.claude/skills/router.md
+++ b/.claude/skills/router.md
@@ -1,0 +1,43 @@
+---
+name: ui-extensions-router
+description: Use when validating documentation updates in the ui-extensions repo and unsure which validation skills to invoke. Routes to the correct skill based on the page type being updated.
+---
+
+# UI Extensions Validation Router
+
+Determines which validation skills to use based on page type.
+
+## Quick Navigation
+
+| Updating...                       | Invoke these skills (in order)                                                                                                                              |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Any page**                      | `ui-extensions:style-lint`                                                                                                                                  |
+| **Any page with example changes** | `ui-extensions:style-lint` → `ui-extensions:examples`                                                                                                      |
+| **Component**                     | `ui-extensions:style-lint` → `ui-extensions:examples` → `ui-extensions:components` → `ui-extensions:type-definitions` → `ui-extensions:cross-surface`      |
+| **API**                           | `ui-extensions:style-lint` → `ui-extensions:examples` → `ui-extensions:apis` → `ui-extensions:type-definitions`                                            |
+| **Links**                         | `ui-extensions:link-validation` (run separately — uses MCP tools, adds time)                                                                               |
+| **Build output**                  | `ui-extensions:build-verification`                                                                                                                          |
+
+## How to Identify Page Type
+
+- **Component**: `.doc.ts` files under `docs/surfaces/*/reference/components/`
+- **API**: `.doc.ts` files under `docs/surfaces/*/reference/apis/` or `src/surfaces/*/api/`
+- **Type definitions**: `.d.ts` files
+
+## Output Format (all validation skills)
+
+```
+## Validation Report
+
+### What's good
+- [passing items]
+
+### Needs attention
+- [items that may need work]
+
+### Must fix
+- [items that must be fixed before merging]
+
+### Recommendation
+[Ready to merge / Needs changes / Major revision needed]
+```

--- a/.claude/skills/style-lint.md
+++ b/.claude/skills/style-lint.md
@@ -1,0 +1,63 @@
+---
+name: ui-extensions-style-lint
+description: Use when validating any documentation update in the ui-extensions repo. Covers mechanical text checks: contractions, punctuation, bolding, backtick usage, capitalization, file references, and orphaned files. Always run first on any PR, regardless of page type.
+---
+
+# Style Lint (All Page Types)
+
+**How to use:** Scan the changed files mechanically against each rule below. These are objective pass/fail checks — no judgment needed. Skip items that clearly don't apply to this file type. Flag anything you can't verify rather than guessing.
+
+## Contractions
+
+- [ ] Use contractions throughout: don't, isn't, won't, they're, it's, you'll, we've
+
+## Punctuation
+
+- [ ] All bullet points end with a period
+- [ ] Straight quotes `"` not curly quotes `"` or `"`
+
+## Formatting
+
+- [ ] **Bolding**: Colon goes outside the bold span → `**word**:` not `**word:**`
+- [ ] **Code, paths, filenames, values, props, endpoints**: All wrapped in backticks → `` `propName` ``, `` `src/index.ts` ``, `` `true` ``
+
+## Capitalization
+
+- [ ] Extension types include the domain, lowercased: *admin UI extension*, *checkout UI extension*, *customer account UI extension*, *POS UI extension*
+- [ ] "Shopify CLI", not "the CLI"
+- [ ] **"checkout" and "customer account" are lowercase in prose.** The only valid exceptions are:
+  - First word of a sentence in rendered text (e.g., "Checkout UI extensions let you...")
+  - First word of a heading or document title
+  - **Not** valid exceptions: string values, property values, alt text, code comments, or any context where it begins a string but isn't genuinely the start of rendered prose
+
+  > **Example:** `altText="Checkout image"` is wrong even though "Checkout" starts the string. Use `altText="checkout image"` or rephrase to avoid capitalizing it.
+
+## File References
+
+- [ ] All files referenced in `codeblock.tabs` exist in the `examples/` folder
+- [ ] No orphaned example files (files exist in `examples/` but aren't referenced anywhere)
+
+## Final Checks
+
+- [ ] Run `yarn lint` and fix any errors introduced
+- [ ] No unintended changes from other branches are present
+
+---
+
+## Output Format
+
+```
+## Validation Report
+
+### What's good
+- [passing items]
+
+### Needs attention
+- [items that may need work]
+
+### Must fix
+- [items that must be fixed before merging]
+
+### Recommendation
+[Ready to merge / Needs changes / Major revision needed]
+```

--- a/.claude/skills/type-definitions.md
+++ b/.claude/skills/type-definitions.md
@@ -1,0 +1,78 @@
+---
+name: ui-extensions-validate-type-definitions
+description: Use when validating .d.ts type definition files in the ui-extensions repo. Covers JSDoc quality, slot descriptions, event descriptions, source of truth verification, and architecture patterns. Run after ui-extensions:universal.
+---
+
+# Type Definitions Validation (`.d.ts` files)
+
+Run after `ui-extensions:universal`.
+
+**How to use:** Evaluate each item against the files provided. Skip items that clearly don't apply. Flag anything you can't definitively verify rather than guessing. Works for all surfaces (admin, checkout, customer account).
+
+## Property Descriptions (JSDoc)
+
+### Quality Standards
+- [ ] Every property has a JSDoc description (not just a type)
+- [ ] Descriptions explain **what it does**, not just **what it is**
+  - ❌ "The heading"
+  - ✅ "The main title displayed at the top of the modal, rendered in the header alongside the close button."
+- [ ] Include `@default` tags for properties with default values
+- [ ] Include `@see` links to MDN for web platform concepts
+
+### Content Guidelines
+- [ ] Describe **when/why** to use, not just **what**
+- [ ] Include practical examples in prose (e.g., "such as 'Order #1001'")
+- [ ] Mention related properties when relevant
+- [ ] For enum values, explain each option's use case
+
+### Common Patterns
+- [ ] **Size props**: List available values and when to use each
+- [ ] **Boolean props**: Explain both true/false behaviors
+- [ ] **Callback props**: Describe when fired, what event contains, typical use cases
+- [ ] **Accessibility props**: Explain relationship to visible labels
+
+## Slot Descriptions
+
+- [ ] Every slot has a description explaining its purpose
+- [ ] Slot descriptions mention accepted child components
+- [ ] Link to child component docs (e.g., "Accepts a [Button](/docs/api/...)")
+- [ ] Note any restrictions on children (e.g., "single Button element with restricted properties")
+
+## Event Descriptions
+
+- [ ] Every event/callback has a JSDoc description
+- [ ] Describes **when** the event fires (e.g., "before animation begins", "after fully closed")
+- [ ] Describes **how** to access event data (e.g., `event.currentTarget.files`)
+- [ ] Suggests typical use cases (e.g., "Use to perform cleanup or reset form state")
+- [ ] For related events (onShow/onAfterShow), explains the difference
+
+## Source of Truth Verification
+
+- [ ] Check if types or descriptions originate from a different source such as `ui-api-design`
+- [ ] If so, **flag before updating** — descriptions must go there first, not directly in this repo
+
+## Architecture Awareness
+
+- [ ] Identify if types use `extends Pick<BaseType, ...>` pattern
+- [ ] If expanding an interface to add JSDoc, document the workaround in comments
+- [ ] Check VERSION headers match the expected version
+
+---
+
+## Output Format
+
+```
+## Validation Report
+
+### What's good
+- [passing items]
+
+### Needs attention
+- [items that may need work]
+
+### Must fix
+- [items that must be fixed before merging]
+
+### Recommendation
+[Ready to merge / Needs changes / Major revision needed]
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# UI Extensions Documentation Skills
+
+Skills for validating documentation updates in this repo. Used by the docs team. All skills are **invoked manually** — they do not auto-trigger.
+
+## Quick Navigation
+
+| Updating...       | Invoke these skills (in order)                                                                                                                              |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Any page**      | `ui-extensions:style-lint`                                                                                                                                  |
+| **Any page with example changes** | `ui-extensions:style-lint` → `ui-extensions:examples`                                                                                    |
+| **Component**     | `ui-extensions:style-lint` → `ui-extensions:examples` → `ui-extensions:components` → `ui-extensions:type-definitions` → `ui-extensions:cross-surface`      |
+| **API**           | `ui-extensions:style-lint` → `ui-extensions:examples` → `ui-extensions:apis` → `ui-extensions:type-definitions`                                            |
+| **Links**         | `ui-extensions:link-validation` (run separately — uses MCP tools, adds time)                                                                               |
+| **Build output**  | `ui-extensions:build-verification`                                                                                                                          |
+
+Not sure which to use? Invoke `ui-extensions:router`.
+
+## Available Skills
+
+- **`ui-extensions:router`** — Entry point. Routes to the correct skills based on page type.
+- **`ui-extensions:style-lint`** — Mechanical text checks: contractions, punctuation, bolding, backticks, capitalization, file references. Always run first.
+- **`ui-extensions:examples`** — Example description quality, titles, accessibility, uniqueness, usefulness. Only when example files are changed.
+- **`ui-extensions:components`** — Component descriptions, example file format, best practices/limitations.
+- **`ui-extensions:apis`** — API descriptions, `.doc.ts` structure, properties, methods, helper docs.
+- **`ui-extensions:type-definitions`** — JSDoc quality, slots, events, source of truth, architecture patterns.
+- **`ui-extensions:cross-surface`** — Description and terminology consistency across Admin, Checkout, POS.
+- **`ui-extensions:link-validation`** — Verifies documentation links via MCP tools. Run separately due to overhead.
+- **`ui-extensions:build-verification`** — Docs generation (`yarn docs:checkout`, `yarn docs:customer-account`), generated JSON verification, local preview.
+
+## How to Invoke
+
+Name the skill in your prompt:
+
+> "Use ui-extensions:universal to validate this component page."
+> "Use ui-extensions:router to figure out which skills I need."


### PR DESCRIPTION
Closed in favour of https://github.com/Shopify/ui-extensions/pull/4085

Adds Claude Code skills for validating documentation updates in this repo. Used by the docs team.

Closes https://github.com/Shopify/temp-project-mover-Archetypically-20260313091522/issues/343

## Skills added

- `ui-extensions:router` — entry point, routes to correct skills by page type
- `ui-extensions:style-lint` — mechanical text checks (contractions, punctuation, formatting, capitalization, file references)
- `ui-extensions:examples` — example quality checks covering only what the automated script can't (uniqueness, description pattern, usefulness)
- `ui-extensions:components` — component description format, best practices, limitations
- `ui-extensions:apis` — API `.doc.ts` structure, properties, methods, helper docs
- `ui-extensions:type-definitions` — JSDoc quality, slots, events, source of truth
- `ui-extensions:cross-surface` — consistency across admin, checkout, POS
- `ui-extensions:link-validation` — link verification via MCP tools (run separately)
- `ui-extensions:build-verification` — docs generation and JSON verification

## Design

- All skills invoked manually, not auto-triggered
- Output format: Validation Report (what's good / needs attention / must fix / recommendation)
- Style-lint and examples are split so Claude doesn't context-switch between mechanical scanning and subjective judgment
- Example validation explicitly defers to the existing automated script for syntax/rendering checks