### PR TITLE
Customer account UI extension: Update API names and categories v2026-04-rc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/analytics.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/analytics.doc.ts
@@ -3,10 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Analytics',
+  name: 'Analytics API',
   description: 'The API for interacting with web pixels.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/authenticated-account.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/authenticated-account.doc.ts
@@ -3,11 +3,12 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Authenticated Account',
+  name: 'Authenticated Account API',
   description:
     'The API for interacting with an account in which the customer is fully authenticated.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Account APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/customer-account-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/customer-account-api.doc.ts
@@ -9,7 +9,8 @@ const data: ReferenceEntityTemplateSchema = {
   The \`API_VERSION\` specified in the URL determines which version of the Customer Account API is used.
   `,
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Account APIs',
   type: 'API',
   defaultExample: {
     codeblock: {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/customer-privacy.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/customer-privacy.doc.ts
@@ -5,12 +5,13 @@ import {
 } from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Customer Privacy',
+  name: 'Customer Privacy API',
   description:
     "The API for interacting with a customer's privacy consent. It is similar to the [Customer Privacy API in storefront](/docs/api/customer-privacy).",
   isVisualComponent: false,
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Account APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/extension.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/extension.doc.ts
@@ -3,10 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Extension',
+  name: 'Extension API',
   description: 'The API for interacting with the metadata of an extension.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/intents.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/intents.doc.ts
@@ -1,12 +1,13 @@
 import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Intents',
+  name: 'Intents API',
   overviewPreviewDescription:
     'The API for invoking Shopify intents to request workflows.',
   description: `The Intents API provides a way to invoke existing customer account workflows for managing buyer information.`,
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   defaultExample: {
     description: '',

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/localization.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/localization.doc.ts
@@ -3,10 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Localization',
+  name: 'Localization API',
   description: 'The API for localizing your extension.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/navigation.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/navigation.doc.ts
@@ -1,12 +1,13 @@
 import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Navigation',
+  name: 'Navigation API',
   overviewPreviewDescription:
     'The API provided to extensions to navigate to extensions or host page.',
   description: `The API provided to extensions to navigate to extensions or host page.`,
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/address.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/address.doc.ts
@@ -6,13 +6,13 @@ import {
 } from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Addresses',
+  name: 'Addresses API',
   description: 'The API for interacting with addresses.',
   isVisualComponent: false,
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA_LEVEL_2,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Order APIs',
   type: 'API',
-  subCategory: 'Order Status API',
   definitions: [
     {
       title: ORDER_STATUS_API_DEFINITION.title,

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/attributes.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/attributes.doc.ts
@@ -3,11 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Attributes',
+  name: 'Attributes API',
   description: 'The API for interacting with cart and checkout attributes.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Order APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/authentication-state.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/authentication-state.doc.ts
@@ -3,11 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Authentication State',
+  name: 'Authentication State API',
   description: 'The API for interacting with authentication state.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Account APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/buyer-identity.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/buyer-identity.doc.ts
@@ -6,13 +6,13 @@ import {
 } from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Buyer Identity',
+  name: 'Buyer Identity API',
   description: 'The API for interacting with the buyer identity.',
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA_LEVEL_2,
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Account APIs',
   type: 'API',
-  subCategory: 'Order Status API',
   definitions: [
     {
       title: ORDER_STATUS_API_DEFINITION.title,

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/cart-lines.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/cart-lines.doc.ts
@@ -6,11 +6,11 @@ import {
 } from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Cart Lines',
+  name: 'Cart Lines API',
   description: 'The APIs for interacting with the cart lines.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Order APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/checkout-settings.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/checkout-settings.doc.ts
@@ -3,11 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Checkout Settings',
+  name: 'Checkout Settings API',
   description: 'The API for interacting with the checkout settings.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Account APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/cost.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/cost.doc.ts
@@ -3,11 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Cost',
+  name: 'Cost API',
   description: 'The API for interacting with the cost of a checkout.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Order APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/discounts.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/discounts.doc.ts
@@ -3,11 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Discounts',
+  name: 'Discounts API',
   description: 'The API for interacting with discounts.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Order APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/gift-cards.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/gift-cards.doc.ts
@@ -3,11 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Gift Cards',
+  name: 'Gift Cards API',
   description: 'The API for interacting with gift cards.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Order APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/localization.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/localization.doc.ts
@@ -3,11 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Localization (Order Status API)',
+  name: 'Localization API (Order Status)',
   description: 'The API for localizing your extension.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/metafields.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/metafields.doc.ts
@@ -6,12 +6,12 @@ import {
 } from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Metafields',
+  name: 'Metafields API',
   description: 'The API for interacting with metafields.',
   isVisualComponent: false,
   requires: REQUIRES_PROTECTED_CUSTOMER_DATA,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Order APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/note.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/note.doc.ts
@@ -3,11 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Note',
+  name: 'Note API',
   description: 'The API for interacting with the note applied to checkout.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Order APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/order.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/order.doc.ts
@@ -3,12 +3,12 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Order',
+  name: 'Order API',
   description:
     'The API for interacting with the order, available on the Order Status Page.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Order APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/require-login.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/require-login.doc.ts
@@ -3,11 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Require Login',
+  name: 'Require Login API',
   description: 'The API for interacting with the authentication.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Account APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/shop.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/shop.doc.ts
@@ -3,11 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Shop',
+  name: 'Shop API',
   description: 'The API for interacting with shop.',
   isVisualComponent: false,
-  category: 'APIs',
-  subCategory: 'Order Status API',
+  category: 'Target APIs',
+  subCategory: 'Order APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/query.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/query.doc.ts
@@ -6,7 +6,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Storefront API',
   description: 'Querying the Storefront API.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/session-token.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/session-token.doc.ts
@@ -3,10 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Session Token',
+  name: 'Session Token API',
   description: 'The API for interacting with session tokens.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/settings.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/settings.doc.ts
@@ -3,10 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Settings',
+  name: 'Settings API',
   description: 'The API for interacting with merchant settings.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/storage.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/storage.doc.ts
@@ -3,10 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Storage',
+  name: 'Storage API',
   description: 'The API for interacting with local storage.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/toast.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/toast.doc.ts
@@ -3,10 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Toast',
+  name: 'Toast API',
   description: 'The API for interacting with toast.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/version.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/version.doc.ts
@@ -3,10 +3,11 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Version',
+  name: 'Version API',
   description: 'The API for interacting with version.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {


### PR DESCRIPTION
- Add "API" suffix to all API names for consistency
- Change category from "APIs" to "Target APIs"
- Add subcategories:
  - Account APIs: authentication, buyer identity, customer privacy, etc.
  - Order APIs: addresses, cart lines, cost, discounts, order, etc.
  - Platform APIs: analytics, extension, intents, localization, etc.

Relates to: https://github.com/Shopify/temp-project-mover-Archetypically-20260313091522/issues/423



### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
