### PR TITLE
Add category/subCategory to Announcement and UI API doc.ts files

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/announcement.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/announcement.doc.ts
@@ -6,7 +6,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Announcement API',
   description: 'The API for interacting with the announcement bar.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/ui.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/ui.doc.ts
@@ -11,7 +11,8 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'UI API',
   description: 'The API for interacting with the extension’s UI.',
   isVisualComponent: false,
-  category: 'APIs',
+  category: 'Target APIs',
+  subCategory: 'Platform APIs',
   type: 'API',
   definitions: [
     {


### PR DESCRIPTION
Fixes https://github.com/Shopify/temp-project-mover-Archetypically-20260313091522/issues/378

Adds `category: 'Target APIs'` and `subCategory: 'Platform APIs'` to `announcement.doc.ts` and `ui.doc.ts` on the 2025-07 branch, consistent with the other 25 checkout API files.