### PR TITLE
Add GitHub Action that posts an MDX migration notice on new PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
       - id: typescript-cache
         name: Restore TypeScript cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: |
             packages/*/build/ts
@@ -31,7 +31,7 @@ jobs:
 
       - id: jest-cache
         name: Restore jest cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .loom/cache/jest/
           key: ${{ runner.os }}-jest-v1-${{ github.sha }}
@@ -50,7 +50,7 @@ jobs:
 
       - id: eslint-cache
         name: Restore ESLint cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .loom/cache/eslint
           key: ${{ runner.os }}-eslint-v1-${{ github.sha }}

--- a/.github/workflows/mdx-migration-notice.yml
+++ b/.github/workflows/mdx-migration-notice.yml
@@ -1,0 +1,52 @@
+name: MDX migration notice
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  notify:
+    name: MDX migration notice
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '## 🚨🚨🚨 Docs migration in progress 🚨🚨🚨',
+              '',
+              'We are actively migrating UI extension reference docs to MDX in the `areas/platforms/shopify-dev` zone of the monorepo. This impacts docs for the following surfaces:',
+              '',
+              '- [Admin UI extensions](https://shopify.dev/docs/api/admin-extensions)',
+              '- [App Home](https://shopify.dev/docs/api/app-home)',
+              '- [Checkout UI extensions](https://shopify.dev/docs/api/checkout-ui-extensions)',
+              '- [Customer account UI extensions](https://shopify.dev/docs/api/customer-account-ui-extensions)',
+              '- [POS UI extensions](https://shopify.dev/docs/api/pos-ui-extensions)',
+              '',
+              'During this migration, please be aware of the following:',
+              '',
+              '**`.doc.ts` files are being deprecated.** Changes to `.doc.ts` files in this repo will **not** be reflected in the new MDX-based docs. If you need to update docs for a reference that has already been migrated, make your changes directly in the `areas/platforms/shopify-dev` zone of the monorepo instead.',
+              '',
+              '**Doc comments in `.ts` source files** (the comment blocks above types and functions) are also affected. Generating docs from these comments currently requires a newer version of the `@shopify/generate-docs` library that isn\'t yet available. Updates to doc comments may not produce the expected output until the migration is complete.',
+              '',
+              '**Examples** that previously lived in this repo are being moved to the `areas/platforms/shopify-dev` zone of the monorepo and should be authored there going forward.',
+              '',
+              '### What should I do?',
+              '',
+              '- If your PR includes changes to **`.doc.ts` files**, **doc comments**, or **examples**, please reach out to us in [#devtools-proj-templated-refs](https://shopify.enterprise.slack.com/archives/C099RJCHAKE) so we can help ensure your updates are captured correctly.',
+              '- If your PR is limited to **source code changes** (non-docs), you can ignore this notice.',
+              '',
+              'Thanks for your patience while we complete the migration! 🙏',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });


### PR DESCRIPTION
## This PR: 
- Creates a GitHub Actions workflow (`.github/workflows/mdx-migration-notice.yml`) that automatically posts a migration notice as a comment on every new PR opened in the `ui-extensions` repo
- Uses `pull_request_target` and `actions/github-script` to ensure it works for fork PRs and avoids introducing a new third-party action dependency

## Context: 
The notice explains the three authorship impacts of the MDX migration: `.doc.ts` files are being deprecated, doc comments in `.ts` source files won't generate correctly, and examples are moving to the `areas/platforms/shopify-dev` zone of the monorepo. It directs contributors to `#devtools-proj-templated-refs` for help.
