### PR TITLE
Move Localization API (Order Status) to Order APIs subcategory

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/localization.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/localization.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   description: 'The API for localizing your extension.',
   isVisualComponent: false,
   category: 'Target APIs',
-  subCategory: 'Platform APIs',
+  subCategory: 'Order APIs',
   type: 'API',
   definitions: [
     {


### PR DESCRIPTION
Changes the subCategory for Localization API (Order Status) from 'Platform APIs' to 'Order APIs' to better reflect its purpose.

Made with [Cursor](https://cursor.com)