### PR TITLE
ui-extensions-tester: support explicit resource management

### DIFF
--- a/.changeset/explicit-resource-management.md
+++ b/.changeset/explicit-resource-management.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions-tester': minor
+---
+
+Add `setUpExtension()` for Explicit Resource Management (`using` keyword) support.

--- a/examples/testing/admin-testing-example/package-lock.json
+++ b/examples/testing/admin-testing-example/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../../packages/ui-extensions": {
       "name": "@shopify/ui-extensions",
-      "version": "2026.4.0-rc.1",
+      "version": "2026.4.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "ts-morph": "^25.0.1"
@@ -49,11 +49,11 @@
     },
     "../../../packages/ui-extensions-tester": {
       "name": "@shopify/ui-extensions-tester",
-      "version": "2026.4.0-rc.1",
+      "version": "2026.4.0-rc.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shopify/ui-extensions": "2026.4.0-rc.1"
+        "@shopify/ui-extensions": "2026.4.0-rc.2"
       },
       "devDependencies": {
         "typescript": "^4.9.0"

--- a/examples/testing/checkout-basic-testing-example/package-lock.json
+++ b/examples/testing/checkout-basic-testing-example/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../../packages/ui-extensions": {
       "name": "@shopify/ui-extensions",
-      "version": "2026.4.0-rc.1",
+      "version": "2026.4.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "ts-morph": "^25.0.1"
@@ -49,11 +49,11 @@
     },
     "../../../packages/ui-extensions-tester": {
       "name": "@shopify/ui-extensions-tester",
-      "version": "2026.4.0-rc.1",
+      "version": "2026.4.0-rc.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shopify/ui-extensions": "2026.4.0-rc.1"
+        "@shopify/ui-extensions": "2026.4.0-rc.2"
       },
       "devDependencies": {
         "typescript": "^4.9.0"

--- a/examples/testing/customer-account-testing-example/package-lock.json
+++ b/examples/testing/customer-account-testing-example/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../../packages/ui-extensions": {
       "name": "@shopify/ui-extensions",
-      "version": "2026.4.0-rc.1",
+      "version": "2026.4.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "ts-morph": "^25.0.1"
@@ -49,11 +49,11 @@
     },
     "../../../packages/ui-extensions-tester": {
       "name": "@shopify/ui-extensions-tester",
-      "version": "2026.4.0-rc.1",
+      "version": "2026.4.0-rc.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shopify/ui-extensions": "2026.4.0-rc.1"
+        "@shopify/ui-extensions": "2026.4.0-rc.2"
       },
       "devDependencies": {
         "typescript": "^4.9.0"

--- a/examples/testing/point-of-sale-testing-example/package-lock.json
+++ b/examples/testing/point-of-sale-testing-example/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../../packages/ui-extensions": {
       "name": "@shopify/ui-extensions",
-      "version": "2026.4.0-rc.1",
+      "version": "2026.4.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "ts-morph": "^25.0.1"
@@ -49,11 +49,11 @@
     },
     "../../../packages/ui-extensions-tester": {
       "name": "@shopify/ui-extensions-tester",
-      "version": "2026.4.0-rc.1",
+      "version": "2026.4.0-rc.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shopify/ui-extensions": "2026.4.0-rc.1"
+        "@shopify/ui-extensions": "2026.4.0-rc.2"
       },
       "devDependencies": {
         "typescript": "^4.9.0"

--- a/packages/ui-extensions-tester/README.md
+++ b/packages/ui-extensions-tester/README.md
@@ -14,6 +14,7 @@ This testing library provides strongly typed mocks of the extension API--like th
 ## 📋 Recommendations
 
 - **TypeScript** — we recommend TypeScript to enforce API compliance against mock objects
+- **Node.js ≥ 22.0.0** and **TypeScript ≥ 5.2** — to use ([Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management))
 - **@testing-library/preact** — if your extension uses [Preact](https://preactjs.com/), we recommend installing [`@testing-library/preact`](https://preactjs.com/guide/v10/preact-testing-library/) for its `fireEvent` and `waitFor` helpers
 
 ## 📦 Installation
@@ -72,7 +73,7 @@ Your extension's own `package.json` (inside `extensions/my-extension/`) already 
   "devDependencies": {
     "@shopify/ui-extensions-tester": "latest",
     "@testing-library/preact": "^3.2.0",
-    "typescript": "^5.0.0",
+    "typescript": "^5.2.0",
     "vitest": "^3.0.0"
   }
 }
@@ -144,7 +145,34 @@ The path must match the target you pass to `getExtension()`.
 
 ## 🏊‍♀️ Getting started
 
-Every test file follows the same pattern: create an extension harness, call `extension.setUp()` before each test, call `extension.tearDown()` after.
+Every test file follows the same pattern:
+create an extension harness, set it up before
+each test, and tear it down after.
+
+### Quick start with `using` (Node ≥ 22.0.0)
+
+If your runtime supports
+[Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management),
+use `setUpExtension` for zero-boilerplate
+setup and automatic teardown:
+
+```ts
+import {setUpExtension} from '@shopify/ui-extensions-tester';
+
+test('rendering the extension', async () => {
+  using extension = setUpExtension(
+    'purchase.checkout.block.render',
+  );
+  await extension.render();
+  // tearDown() is called automatically at the end of the block
+});
+```
+
+### Classic setup
+
+Alternatively, create the harness once and
+manage the lifecycle with `beforeEach` /
+`afterEach`:
 
 ```ts
 import {getExtension} from '@shopify/ui-extensions-tester';
@@ -339,25 +367,31 @@ Each surface exports some helpers:
 
 Exports from `@shopify/ui-extensions-tester`:
 
-### `getExtension(target, options?)`
+### `setUpExtension(target, options?)`
 
-Returns an extension test harness for the given target. It reads `shopify.extension.toml`, finds the module for the given target, and provides helpers to mock the environment and render the extension. It locates `shopify.extension.toml` by walking up from the calling test file's directory, and falls back to searching `extensions/` under the current working directory.
+Sets up an extension for testing and returns a
+disposable object that supports automatic
+teardown with the `using` keyword:
+
+```ts
+test('example', async () => {
+  using extension = setUpExtension(
+    'purchase.checkout.block.render',
+  );
+  await extension.render();
+  // tearDown() called automatically
+});
+```
+
+It reads `shopify.extension.toml`, finds the module for the given target, and provides helpers to mock the environment and render the extension. It locates `shopify.extension.toml` by walking up from the calling test file's directory, and falls back to searching `extensions/` under the current working directory. Results are cached: calling `getExtension` twice with the same target and the same resolved TOML returns the same instance.
 
 | Option            | Type     | Default                       | Description                                                |
 | ----------------- | -------- | ----------------------------- | ---------------------------------------------------------- |
 | `configSearchDir` | `string` | calling test file's directory | Directory to start searching for `shopify.extension.toml`. |
 
-By default `getExtension` walks up from the test file's directory to find `shopify.extension.toml`.
+By default, it walks up from the test file's directory to find `shopify.extension.toml`.
 
-**Returns** an `Extension<T>` object with the following members:
-
-#### `extension.setUp()`
-
-Sets up an extension environment for testing. Creates a mock `shopify` global with some defaults.
-
-#### `extension.tearDown()`
-
-Tears down the extension environment. Resets the `shopify` global and clears `document.body`.
+**Returns** an `Extension` object with the following members:
 
 #### `extension.render()`
 
@@ -401,6 +435,22 @@ extension.navigation.currentEntry =
 ```
 
 Assigning to `extension.navigation` also updates `globalThis.navigation`, so extension code that calls `navigation.navigate()` directly will use the mock.
+
+### `getExtension(target, options?)`
+
+> ⚠️ Prefer [`setUpExtension`](#setupextensiontarget-options) on Node ≥ 22.0.0. Use `getExtension` only if your runtime does not support [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management).
+
+Accepts the same arguments as `setUpExtension`. You must call `extension.setUp()` and `extension.tearDown()` explicitly.
+
+**Returns** an `Extension` object with the following additional members:
+
+#### `extension.setUp()`
+
+Sets up an extension environment for testing. Creates a mock `shopify` global with some defaults.
+
+#### `extension.tearDown()`
+
+Tears down the extension environment. Resets the `shopify` global and clears `document.body`.
 
 ### `createNavigationHistoryEntry(options?)`
 

--- a/packages/ui-extensions-tester/loom.config.ts
+++ b/packages/ui-extensions-tester/loom.config.ts
@@ -1,5 +1,5 @@
 import {createPackage} from '@shopify/loom';
-import {readFileSync} from 'fs';
+import {copyFileSync, readFileSync, writeFileSync} from 'fs';
 import {resolve} from 'path';
 
 import {rollupPlugins} from '@shopify/loom-plugin-build-library';
@@ -30,6 +30,47 @@ export default createPackage((pkg) => {
         },
         preventAssignment: true,
       }),
+      {
+        // TypeScript 4.9 cannot emit `typeof Symbol.dispose` or
+        // `[Symbol.dispose]` in declaration files because it predates
+        // the Explicit Resource Management proposal (TS >= 5.2).
+        //
+        // This plugin patches the emitted .d.ts after the build so
+        // consumers on TS >= 5.2 can use the `using` keyword:
+        //
+        //   using extension = setUpExtension('purchase.checkout.block.render');
+        //
+        // Remove this plugin once the repo upgrades to TS >= 5.2.
+        name: 'patch-disposable-types',
+        closeBundle: async () => {
+          const pkgDir = resolve(
+            process.cwd(),
+            'packages/ui-extensions-tester',
+          );
+          const buildDir = resolve(pkgDir, 'build/ts');
+          const indexDts = resolve(buildDir, 'index.d.ts');
+
+          // Copy ambient Disposable type declarations (tsc doesn't emit .d.ts inputs)
+          copyFileSync(
+            resolve(pkgDir, 'src/disposable.d.ts'),
+            resolve(buildDir, 'disposable.d.ts'),
+          );
+
+          // Patch index.d.ts so the emitted types use Symbol.dispose
+          let content = readFileSync(indexDts, 'utf-8');
+          // We need to add this in a post-build script so the path doesn't get mangled.
+          const ref = '/// <reference path="./disposable.d.ts" />';
+          if (!content.startsWith(ref)) {
+            content = `${ref}\n${content}`;
+          }
+          content = content.replace(
+            'declare const SymbolDispose: unique symbol',
+            'declare const SymbolDispose: typeof Symbol.dispose',
+          );
+          content = content.replace(/\[SymbolDispose\]/g, '[Symbol.dispose]');
+          writeFileSync(indexDts, content);
+        },
+      },
     ]),
   );
 });

--- a/packages/ui-extensions-tester/src/disposable.d.ts
+++ b/packages/ui-extensions-tester/src/disposable.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Polyfill type declarations for the Explicit Resource Management proposal
+ * (https://github.com/tc39/proposal-explicit-resource-management).
+ *
+ * TypeScript >= 5.2 ships these in `lib.esnext.disposable.d.ts`.
+ * For older versions we declare them here so that consumers can write
+ * `using extension = setUpExtension(...)` with full type safety.
+ *
+ * These declarations are additive — if `Symbol.dispose` already exists
+ * in the type system (TS >= 5.2 with `lib: ["esnext"]`), the interfaces
+ * merge harmlessly.
+ */
+
+interface SymbolConstructor {
+  readonly dispose: unique symbol;
+}
+
+interface Disposable {
+  [Symbol.dispose](): void;
+}

--- a/packages/ui-extensions-tester/src/index.ts
+++ b/packages/ui-extensions-tester/src/index.ts
@@ -32,21 +32,19 @@ type Mutable<T> = T extends (...args: any[]) => any
   ? {-readonly [K in keyof T]: Mutable<T[K]>}
   : T;
 
-interface Extension<T extends AnyExtensionTarget> {
-  /**
-   * Sets up an extension environment for testing.
-   *
-   * For example, it creates a mock `shopify` global with some defaults.
-   */
-  setUp(): void;
+/**
+ * `Symbol.dispose` for runtimes that support it, with a polyfill
+ * fallback so the library works on older Node versions too.
+ */
+export const SymbolDispose: typeof Symbol.dispose = ((Symbol as any).dispose ??
+  Symbol.for('Symbol.dispose')) as typeof Symbol.dispose;
 
-  /**
-   * Tears down the extension environment.
-   *
-   * For example, it resets the `shopify` global and clears `document.body`.
-   */
-  tearDown(): void;
-
+/**
+ * Members shared by both {@link ExtensionHarness} (returned by
+ * `getExtension`) and {@link DisposableExtensionHarness} (returned
+ * by `setUpExtension`).
+ */
+interface BaseExtensionHarness<T extends AnyExtensionTarget> {
   /**
    * Imports and executes the extension module's default export,
    * rendering the extension into `document.body`.
@@ -95,6 +93,163 @@ interface Extension<T extends AnyExtensionTarget> {
 }
 
 /**
+ * Returned by `getExtension`.  The caller is responsible for calling
+ * `setUp()` before each test and `tearDown()` after.
+ */
+interface ExtensionHarness<T extends AnyExtensionTarget>
+  extends BaseExtensionHarness<T> {
+  /**
+   * Sets up an extension environment for testing.
+   *
+   * For example, it creates a mock `shopify` global with some defaults.
+   */
+  setUp(): void;
+
+  /**
+   * Tears down the extension environment.
+   *
+   * For example, it resets the `shopify` global and clears `document.body`.
+   */
+  tearDown(): void;
+}
+
+/**
+ * Returned by `setUpExtension`.  Already set up — tears down
+ * automatically via `Symbol.dispose` (the `using` keyword):
+ *
+ * ```ts
+ * using extension = setUpExtension('purchase.checkout.block.render');
+ * ```
+ */
+interface DisposableExtensionHarness<T extends AnyExtensionTarget>
+  extends BaseExtensionHarness<T> {
+  [SymbolDispose](): void;
+}
+
+class Extension<T extends AnyExtensionTarget> implements ExtensionHarness<T> {
+  #target: T;
+  #resolvedModule: string;
+  #modulePath: string;
+  #checkout: boolean;
+  #networkAccess: boolean;
+  #apiAccess: boolean;
+
+  #fetchImpl!: typeof globalThis.fetch;
+  #previousFetch: typeof globalThis.fetch | undefined;
+  #navigationImpl: Navigation = createMockNavigation();
+  #previousNavigation: any;
+
+  constructor(target: T, options?: {configSearchDir?: string}) {
+    const configSearchDir =
+      options?.configSearchDir ?? path.dirname(getCallerFile());
+    const tomlPath = findToml(configSearchDir);
+    const tomlDir = path.dirname(tomlPath);
+    const tomlContent = fs.readFileSync(tomlPath, 'utf-8');
+    validateApiVersion(tomlContent);
+    const modulePath = parseTargetModule(tomlContent, target);
+
+    this.#target = target;
+    this.#modulePath = modulePath;
+    this.#resolvedModule = path.resolve(tomlDir, modulePath);
+    this.#checkout = isCheckoutTarget(target);
+    this.#networkAccess = this.#checkout && parseNetworkAccess(tomlContent);
+    this.#apiAccess = this.#checkout && parseApiAccess(tomlContent);
+  }
+
+  setUp(): void {
+    installFetchPolyfills();
+
+    this.#fetchImpl =
+      this.#checkout && !this.#networkAccess && !this.#apiAccess
+        ? async () => {
+            // Checkout is the only surface that currently enforces
+            // fetch capabilities.
+            throw new Error(
+              'fetch() is not available. Add network_access = true or ' +
+                'api_access = true to [extensions.capabilities] in shopify.extension.toml.',
+            );
+          }
+        : async () => new Response();
+
+    this.#previousFetch = (globalThis as any).fetch;
+    this.#previousNavigation = (globalThis as any).navigation;
+    this.#navigationImpl = createMockNavigation();
+    (globalThis as any).shopify = deepWritableProxy(
+      createMockTargetApi(this.#target),
+    );
+    (globalThis as any).fetch = this.#fetchImpl;
+    (globalThis as any).navigation = this.#navigationImpl;
+  }
+
+  get shopify(): Mutable<ApiForTarget<T>> {
+    if (!(globalThis as any).shopify) {
+      throw new Error(
+        'You must call extension.setUp() before accessing extension.shopify.',
+      );
+    }
+    return (globalThis as any).shopify;
+  }
+
+  get fetch(): typeof globalThis.fetch {
+    return this.#fetchImpl;
+  }
+
+  set fetch(fn: typeof globalThis.fetch) {
+    this.#fetchImpl = fn;
+    (globalThis as any).fetch = fn;
+  }
+
+  get navigation() {
+    return this.#navigationImpl;
+  }
+
+  set navigation(obj: any) {
+    this.#navigationImpl = obj;
+    (globalThis as any).navigation = obj;
+  }
+
+  async render(): Promise<void> {
+    const mod = await import(this.#resolvedModule);
+    const renderFn = mod.default;
+    if (typeof renderFn !== 'function') {
+      throw new Error(
+        `Expected default export of ${
+          this.#modulePath
+        } to be a function, got ${typeof renderFn}`,
+      );
+    }
+    await renderFn();
+  }
+
+  tearDown(): void {
+    // Dynamically import preact to unmount cleanly without requiring
+    // the test file to depend on preact directly.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const {render} = require('preact');
+      render(null, document.body);
+    } catch {
+      // Fallback if preact isn't available
+      document.body.innerHTML = '';
+    }
+    delete (globalThis as any).shopify;
+    if (this.#previousFetch === undefined) {
+      delete (globalThis as any).fetch;
+    } else {
+      (globalThis as any).fetch = this.#previousFetch;
+    }
+    if (this.#previousNavigation === undefined) {
+      delete (globalThis as any).navigation;
+    } else {
+      (globalThis as any).navigation = this.#previousNavigation;
+    }
+    uninstallFetchPolyfills();
+  }
+}
+
+const extensionCache = new Map<string, Extension<any>>();
+
+/**
  * Returns an extension test harness for the given target.
  *
  * It reads `shopify.extension.toml`, finds the module for the given target,
@@ -112,114 +267,52 @@ interface Extension<T extends AnyExtensionTarget> {
 export function getExtension<T extends AnyExtensionTarget>(
   target: T,
   options?: {configSearchDir?: string},
-): Extension<T> {
-  const configSearchDir =
+): ExtensionHarness<T> {
+  const resolvedConfigSearchDir =
     options?.configSearchDir ?? path.dirname(getCallerFile());
-  const tomlPath = findToml(configSearchDir);
-  const tomlDir = path.dirname(tomlPath);
-  const tomlContent = fs.readFileSync(tomlPath, 'utf-8');
-  validateApiVersion(tomlContent);
-  const modulePath = parseTargetModule(tomlContent, target);
-  const resolvedModule = path.resolve(tomlDir, modulePath);
-  const checkout = isCheckoutTarget(target);
-  const networkAccess = checkout && parseNetworkAccess(tomlContent);
-  const apiAccess = checkout && parseApiAccess(tomlContent);
+  const tomlPath = findToml(resolvedConfigSearchDir);
+  const tomlMtimeMs = fs.statSync(tomlPath).mtimeMs;
+  const cacheKey = JSON.stringify([target, tomlPath, tomlMtimeMs]);
 
-  let fetchImpl: typeof globalThis.fetch;
-  let previousFetch: typeof globalThis.fetch | undefined;
-  let navigationImpl = createMockNavigation();
-  let previousNavigation: any;
+  const cached = extensionCache.get(cacheKey);
+  if (cached) {
+    return cached as Extension<T>;
+  }
 
-  const ext = {
-    setUp(): void {
-      installFetchPolyfills();
+  const ext = new Extension<T>(target, {
+    configSearchDir: resolvedConfigSearchDir,
+  });
+  extensionCache.set(cacheKey, ext);
+  return ext;
+}
 
-      fetchImpl =
-        checkout && !networkAccess && !apiAccess
-          ? async () => {
-              // Checkout is the only surface that currently enforces
-              // fetch capabilities.
-              throw new Error(
-                'fetch() is not available. Add network_access = true or ' +
-                  'api_access = true to [extensions.capabilities] in shopify.extension.toml.',
-              );
-            }
-          : async () => new Response();
+/**
+ * Sets up an extension for testing and returns a disposable object
+ * that supports automatic teardown with the `using` keyword:
+ *
+ * ```ts
+ * test('rendering the extension', async () => {
+ *   using extension = setUpExtension(
+ *     'purchase.checkout.block.render',
+ *   );
+ *   await extension.render();
+ *   // tearDown() is called automatically at the end of the block
+ * });
+ * ```
+ *
+ * @param target - The extension target to mock.
+ * @param options - Optional configuration (same as {@link getExtension}).
+ */
+export function setUpExtension<T extends AnyExtensionTarget>(
+  target: T,
+  options?: {configSearchDir?: string},
+): DisposableExtensionHarness<T> {
+  const extension = getExtension(target, options);
+  extension.setUp();
 
-      previousFetch = (globalThis as any).fetch;
-      previousNavigation = (globalThis as any).navigation;
-      (globalThis as any).shopify = deepWritableProxy(
-        createMockTargetApi(target),
-      );
-      (globalThis as any).fetch = fetchImpl;
-      (globalThis as any).navigation = navigationImpl;
-    },
-
-    get shopify(): any {
-      if (!(globalThis as any).shopify) {
-        throw new Error(
-          'You must call extension.setUp() before accessing extension.shopify.',
-        );
-      }
-      return (globalThis as any).shopify;
-    },
-
-    get fetch(): typeof globalThis.fetch {
-      return fetchImpl;
-    },
-
-    set fetch(fn: typeof globalThis.fetch) {
-      fetchImpl = fn;
-      (globalThis as any).fetch = fn;
-    },
-
-    get navigation() {
-      return navigationImpl;
-    },
-
-    set navigation(obj: any) {
-      navigationImpl = obj;
-      (globalThis as any).navigation = obj;
-    },
-
-    async render(): Promise<void> {
-      const mod = await import(resolvedModule);
-      const renderFn = mod.default;
-      if (typeof renderFn !== 'function') {
-        throw new Error(
-          `Expected default export of ${modulePath} to be a function, got ${typeof renderFn}`,
-        );
-      }
-      await renderFn();
-    },
-
-    tearDown(): void {
-      // Dynamically import preact to unmount cleanly without requiring
-      // the test file to depend on preact directly.
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const {render} = require('preact');
-        render(null, document.body);
-      } catch {
-        // Fallback if preact isn't available
-        document.body.innerHTML = '';
-      }
-      delete (globalThis as any).shopify;
-      if (previousFetch === undefined) {
-        delete (globalThis as any).fetch;
-      } else {
-        (globalThis as any).fetch = previousFetch;
-      }
-      if (previousNavigation === undefined) {
-        delete (globalThis as any).navigation;
-      } else {
-        (globalThis as any).navigation = previousNavigation;
-      }
-      uninstallFetchPolyfills();
-    },
-  };
-
-  return ext as Extension<T>;
+  return Object.assign(extension, {
+    [SymbolDispose]: () => extension.tearDown(),
+  }) as DisposableExtensionHarness<T>;
 }
 
 function validateApiVersion(toml: string): void {
@@ -301,8 +394,10 @@ function getCallerFile(): string {
     let callerFile = '';
 
     Error.prepareStackTrace = (_err, stack) => {
-      // stack[0] is getCallerFile, stack[1] is getExtension, stack[2] is the caller
-      for (let i = 2; i < stack.length; i++) {
+      // Walk the stack, skipping all frames that originate from this
+      // package file.  This works regardless of whether the caller is
+      // getExtension() or setUpExtension() → getExtension().
+      for (let i = 1; i < stack.length; i++) {
         const fileName = stack[i]!.getFileName();
         if (fileName && fileName !== thisPackageFilePath) {
           callerFile = fileName;

--- a/packages/ui-extensions-tester/src/tests/getExtension.test.ts
+++ b/packages/ui-extensions-tester/src/tests/getExtension.test.ts
@@ -1,7 +1,10 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 import {getExtension} from '../index';
 
 import {API_VERSION} from '../api-version';
-import {createTestSandbox, type TestSandbox} from './helpers';
+import {createTestSandbox, makeToml, type TestSandbox} from './helpers';
 
 describe('getExtension', () => {
   let sandbox: TestSandbox;
@@ -162,6 +165,95 @@ describe('getExtension', () => {
         // eslint-disable-next-line @babel/no-unused-expressions
         extension.shopify.appMetafields.bogus;
       }).toThrow(/bogus.*does not exist/);
+    });
+  });
+
+  describe('caching', () => {
+    it('returns the same instance for the same target and configSearchDir', () => {
+      sandbox.placeToml();
+      const ext1 = getExtension('purchase.checkout.block.render', {
+        configSearchDir: sandbox.tempDir,
+      });
+      const ext2 = getExtension('purchase.checkout.block.render', {
+        configSearchDir: sandbox.tempDir,
+      });
+      expect(ext1).toBe(ext2);
+    });
+
+    it('returns different instances for the same target but different configSearchDir', () => {
+      sandbox.placeToml({inDir: 'root'});
+      sandbox.placeToml({inDir: 'subDir'});
+      const ext1 = getExtension('purchase.checkout.block.render', {
+        configSearchDir: sandbox.tempDir,
+      });
+      const ext2 = getExtension('purchase.checkout.block.render', {
+        configSearchDir: sandbox.tomlDirs.subDir,
+      });
+      expect(ext1).not.toBe(ext2);
+    });
+
+    it('returns the same instance when configSearchDir resolves to the same path', () => {
+      sandbox.placeToml();
+      const ext1 = getExtension('purchase.checkout.block.render', {
+        configSearchDir: sandbox.tempDir,
+      });
+      // Use a path with a redundant segment that resolves to the same directory
+      const ext2 = getExtension('purchase.checkout.block.render', {
+        configSearchDir: `${sandbox.tempDir}/sub/..`,
+      });
+      expect(ext1).toBe(ext2);
+    });
+
+    it('returns the same instance when configSearchDir is omitted and then explicitly set to the resolved default', () => {
+      sandbox.placeToml();
+      // When configSearchDir is omitted, it defaults to path.dirname(getCallerFile()).
+      // If we then call with that same directory explicitly, we should get the same instance.
+      const callerDir = path.dirname(__filename);
+
+      // Place a toml in the caller's directory tree so both calls find it
+      const tomlPath = path.join(callerDir, 'shopify.extension.toml');
+      fs.writeFileSync(tomlPath, makeToml());
+
+      try {
+        const ext1 = getExtension('purchase.checkout.block.render');
+        const ext2 = getExtension('purchase.checkout.block.render', {
+          configSearchDir: callerDir,
+        });
+        expect(ext1).toBe(ext2);
+      } finally {
+        fs.unlinkSync(tomlPath);
+      }
+    });
+
+    it('returns different instances for different targets', () => {
+      sandbox.placeToml({
+        target: 'purchase.checkout.block.render',
+      });
+      const ext1 = getExtension('purchase.checkout.block.render', {
+        configSearchDir: sandbox.tempDir,
+      });
+
+      sandbox.placeToml({target: 'pos.home.tile.render'});
+      const ext2 = getExtension('pos.home.tile.render', {
+        configSearchDir: sandbox.tempDir,
+      });
+
+      expect(ext1).not.toBe(ext2);
+    });
+
+    it('returns a new instance when the config file changes on disk', () => {
+      sandbox.placeToml();
+      const ext1 = getExtension('purchase.checkout.block.render', {
+        configSearchDir: sandbox.tempDir,
+      });
+
+      // Rewrite the toml — the resolved config file has changed
+      sandbox.placeToml();
+      const ext2 = getExtension('purchase.checkout.block.render', {
+        configSearchDir: sandbox.tempDir,
+      });
+
+      expect(ext1).not.toBe(ext2);
     });
   });
 });

--- a/packages/ui-extensions-tester/src/tests/setUpExtension.test.ts
+++ b/packages/ui-extensions-tester/src/tests/setUpExtension.test.ts
@@ -1,0 +1,52 @@
+import {setUpExtension, SymbolDispose} from '../index';
+
+import {createTestSandbox, type TestSandbox} from './helpers';
+
+describe('setUpExtension', () => {
+  let sandbox: TestSandbox;
+
+  beforeEach(() => {
+    sandbox = createTestSandbox();
+    sandbox.placeToml();
+  });
+
+  afterEach(() => {
+    sandbox.destroy();
+  });
+
+  it('calls setUp and returns a ready extension', () => {
+    const extension = setUpExtension('purchase.checkout.block.render', {
+      configSearchDir: sandbox.tempDir,
+    });
+    // shopify global should be available without calling setUp manually
+    expect(extension.shopify).toBeDefined();
+    expect(extension.shopify.extension.apiVersion).toBeDefined();
+  });
+
+  it('tears down when Symbol.dispose is called', () => {
+    const extension = setUpExtension('purchase.checkout.block.render', {
+      configSearchDir: sandbox.tempDir,
+    });
+    expect((globalThis as any).shopify).toBeDefined();
+    extension[SymbolDispose]();
+    expect((globalThis as any).shopify).toBeUndefined();
+  });
+
+  it('supports repeated setUp/tearDown cycles via setUpExtension', () => {
+    // First cycle
+    const ext1 = setUpExtension('purchase.checkout.block.render', {
+      configSearchDir: sandbox.tempDir,
+    });
+    expect((globalThis as any).shopify).toBeDefined();
+    ext1[SymbolDispose]();
+    expect((globalThis as any).shopify).toBeUndefined();
+
+    // Second cycle (reuses cached Extension)
+    const ext2 = setUpExtension('purchase.checkout.block.render', {
+      configSearchDir: sandbox.tempDir,
+    });
+    expect((globalThis as any).shopify).toBeDefined();
+    ext2[SymbolDispose]();
+    expect((globalThis as any).shopify).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Support [explicit resource management](https://github.com/tc39/proposal-explicit-resource-management) (`using` keyword) and prefer this as the library interface.

### Notes

- **New** **`setUpExtension`** **function** as the entry point
- **Caching**: allow `setUpExtension()` to be called repeatedly
- **Backward compatibility**: The existing `getExtension` function remains unchanged for runtimes that don't support Explicit Resource Management

# 🎩

📄 [Preview the README](https://github.com/Shopify/ui-extensions/blob/03-16-ui-extensions-tester_support_explicit_resource_management_using_keyword_/packages/ui-extensions-tester/README.md)

Using the snapshot packages (below), I verified I could create a test suite via `using`. This required some build fixes 👍 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation