### PR TITLE
feat(pos): add TypeScript types for pos.app.ready.data background target

### DIFF
--- a/packages/ui-extensions-tester/src/index.ts
+++ b/packages/ui-extensions-tester/src/index.ts
@@ -201,10 +201,7 @@ class Extension<T extends AnyExtensionTarget> implements ExtensionHarness<T> {
     (globalThis as any).navigation = this.#navigationImpl;
   }
 
-  #addEventListener = (
-    type: string,
-    listener: (event: any) => void,
-  ): void => {
+  #addEventListener = (type: string, listener: (event: any) => void): void => {
     let set = this.#eventListeners.get(type);
     if (!set) {
       set = new Set();

--- a/packages/ui-extensions-tester/src/index.ts
+++ b/packages/ui-extensions-tester/src/index.ts
@@ -1,7 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import type {AnyExtensionTarget, ApiForTarget} from './targets';
+import type {
+  AnyExtensionTarget,
+  ApiForTarget,
+  EventMapForTarget,
+} from './targets';
 import {isCheckoutTarget} from './targets';
 import {createMockTargetApi} from './mocks/target-apis';
 import {createMockNavigation, type Navigation} from './navigation';
@@ -99,12 +103,26 @@ interface BaseExtensionHarness<T extends AnyExtensionTarget> {
    * are ignored, and thrown errors are caught per-listener so one bad
    * listener doesn't block the others.
    *
+   * The `event` argument must be a real `Event` instance, matching what
+   * the host dispatches at runtime. Construct it with `new Event(type)`
+   * and attach payload fields via `Object.assign`:
+   *
    * ```ts
    * shopify.addEventListener('transactioncomplete', (event) => { ... });
-   * extension.dispatch('transactioncomplete', { transaction: {...} });
+   *
+   * const event = Object.assign(new Event('transactioncomplete'), {
+   *   transactionType: 'Sale',
+   *   orderId: 1,
+   *   grandTotal: { amount: 10, currency: 'USD' },
+   *   // ...
+   * });
+   * extension.dispatch('transactioncomplete', event);
    * ```
    */
-  dispatch(type: string, event?: unknown): void;
+  dispatch<K extends keyof EventMapForTarget<T>>(
+    type: K,
+    event: EventMapForTarget<T>[K],
+  ): void;
 }
 
 /**
@@ -217,8 +235,11 @@ class Extension<T extends AnyExtensionTarget> implements ExtensionHarness<T> {
     this.#eventListeners.get(type)?.delete(listener);
   };
 
-  dispatch(type: string, event?: unknown): void {
-    const listeners = this.#eventListeners.get(type);
+  dispatch<K extends keyof EventMapForTarget<T>>(
+    type: K,
+    event: EventMapForTarget<T>[K],
+  ): void {
+    const listeners = this.#eventListeners.get(type as string);
     if (!listeners) return;
     // Snapshot so listeners that register/unregister during dispatch
     // don't mutate the iteration.

--- a/packages/ui-extensions-tester/src/index.ts
+++ b/packages/ui-extensions-tester/src/index.ts
@@ -90,6 +90,21 @@ interface BaseExtensionHarness<T extends AnyExtensionTarget> {
    * ```
    */
   navigation: Navigation;
+
+  /**
+   * Fires a host event at every listener registered via
+   * `shopify.addEventListener(name, listener)`.
+   *
+   * Matches the `shopify.addEventListener` contract: listener return values
+   * are ignored, and thrown errors are caught per-listener so one bad
+   * listener doesn't block the others.
+   *
+   * ```ts
+   * shopify.addEventListener('transactioncomplete', (event) => { ... });
+   * extension.dispatch('transactioncomplete', { transaction: {...} });
+   * ```
+   */
+  dispatch(type: string, event?: unknown): void;
 }
 
 /**
@@ -138,6 +153,7 @@ class Extension<T extends AnyExtensionTarget> implements ExtensionHarness<T> {
   #previousFetch: typeof globalThis.fetch | undefined;
   #navigationImpl: Navigation = createMockNavigation();
   #previousNavigation: any;
+  #eventListeners = new Map<string, Set<(event: any) => void>>();
 
   constructor(target: T, options?: {configSearchDir?: string}) {
     const configSearchDir =
@@ -174,11 +190,49 @@ class Extension<T extends AnyExtensionTarget> implements ExtensionHarness<T> {
     this.#previousFetch = (globalThis as any).fetch;
     this.#previousNavigation = (globalThis as any).navigation;
     this.#navigationImpl = createMockNavigation();
+    this.#eventListeners.clear();
     (globalThis as any).shopify = deepWritableProxy(
-      createMockTargetApi(this.#target),
+      Object.assign(createMockTargetApi(this.#target), {
+        addEventListener: this.#addEventListener,
+        removeEventListener: this.#removeEventListener,
+      }),
     );
     (globalThis as any).fetch = this.#fetchImpl;
     (globalThis as any).navigation = this.#navigationImpl;
+  }
+
+  #addEventListener = (
+    type: string,
+    listener: (event: any) => void,
+  ): void => {
+    let set = this.#eventListeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.#eventListeners.set(type, set);
+    }
+    set.add(listener);
+  };
+
+  #removeEventListener = (
+    type: string,
+    listener: (event: any) => void,
+  ): void => {
+    this.#eventListeners.get(type)?.delete(listener);
+  };
+
+  dispatch(type: string, event?: unknown): void {
+    const listeners = this.#eventListeners.get(type);
+    if (!listeners) return;
+    // Snapshot so listeners that register/unregister during dispatch
+    // don't mutate the iteration.
+    for (const listener of [...listeners]) {
+      try {
+        listener(event);
+      } catch {
+        // Fire-and-forget: per the shopify.addEventListener contract,
+        // listener errors must not affect other listeners.
+      }
+    }
   }
 
   get shopify(): Mutable<ApiForTarget<T>> {
@@ -233,6 +287,7 @@ class Extension<T extends AnyExtensionTarget> implements ExtensionHarness<T> {
       document.body.innerHTML = '';
     }
     delete (globalThis as any).shopify;
+    this.#eventListeners.clear();
     if (this.#previousFetch === undefined) {
       delete (globalThis as any).fetch;
     } else {

--- a/packages/ui-extensions-tester/src/point-of-sale/factories.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/factories.ts
@@ -447,6 +447,10 @@ function createDataTargetMock<T extends ExtensionTarget>(
 ): DataTargetApi<T> {
   return {
     extensionPoint: target,
+    extension: {
+      apiVersion: '2026-04',
+      target,
+    },
     i18n: createMockI18n(),
     session: {
       currentSession: createSessionCurrentSession(),

--- a/packages/ui-extensions-tester/src/point-of-sale/factories.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/factories.ts
@@ -4,6 +4,7 @@ import type {
   RenderExtensionTarget,
   StandardApi,
   ActionTargetApi,
+  DataTargetApi,
   ActionApi,
   CartApi,
   OrderApi,
@@ -440,6 +441,51 @@ function createActionTargetCashDrawerMock<T extends RenderExtensionTarget>(
   };
 }
 
+// Data target factories
+function createDataTargetMock<T extends ExtensionTarget>(
+  target: T,
+): DataTargetApi<T> {
+  return {
+    extensionPoint: target,
+    i18n: createMockI18n(),
+    session: {
+      currentSession: createSessionCurrentSession(),
+      getSessionToken: async () => 'mock-session-token',
+      deviceId: 1,
+    },
+    storage: createStorage(),
+    locale: {current: createReadonlySignalLike('en-US')},
+    connectivity: {
+      current: createReadonlySignalLike(createConnectivityState()),
+    },
+    device: {
+      name: 'Mock POS Device',
+      registerName: 'Register 1',
+      getDeviceId: async () => 'mock-device-id',
+      isTablet: async () => false,
+    },
+    productSearch: {
+      searchProducts: async () => ({items: [], hasNextPage: false}),
+      fetchProductWithId: async () => undefined,
+      fetchProductsWithIds: async () => ({
+        fetchedResources: [],
+        idsForResourcesNotFound: [],
+      }),
+      fetchProductVariantWithId: async () => undefined,
+      fetchProductVariantsWithIds: async () => ({
+        fetchedResources: [],
+        idsForResourcesNotFound: [],
+      }),
+      fetchProductVariantsWithProductId: async () => [],
+      fetchPaginatedProductVariantsWithProductId: async () => ({
+        items: [],
+        hasNextPage: false,
+      }),
+    },
+    ...createMockCartApi(),
+  };
+}
+
 // Event target factories
 function createTransactionCompleteMock<T extends ExtensionTarget>(
   _target: T,
@@ -558,6 +604,9 @@ const posMockFactories: PosMockFactory = {
 
   // Group Q: ActionTargetApi + CashDrawerApi
   'pos.register-details.action.render': createActionTargetCashDrawerMock,
+
+  // Data targets
+  'pos.app.ready.data': createDataTargetMock,
 
   // Event targets
   'pos.transaction-complete.event.observe': createTransactionCompleteMock,

--- a/packages/ui-extensions-tester/src/targets.ts
+++ b/packages/ui-extensions-tester/src/targets.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   ExtensionTarget as PosExtensionTarget,
   ExtensionTargets as PointOfSaleExtensionTargets,
+  ShopifyEventMap as PosEventMap,
 } from '@shopify/ui-extensions/point-of-sale';
 import type {
   CustomerAccountExtensionTarget,
@@ -41,6 +42,16 @@ export type ApiForTarget<T extends AnyExtensionTarget> =
     : AllExtensionTargets[T] extends (data: infer D) => unknown
     ? D
     : never;
+
+/**
+ * Maps an extension target to the event map available via
+ * `shopify.addEventListener` on that surface.
+ *
+ * - POS targets: the POS `ShopifyEventMap`.
+ * - Other surfaces: no host events, so the map is empty.
+ */
+export type EventMapForTarget<T extends AnyExtensionTarget> =
+  T extends PosExtensionTarget ? PosEventMap : Record<string, never>;
 
 export function isCheckoutTarget(
   target: string,

--- a/packages/ui-extensions-tester/src/tests/shopify-events.test.ts
+++ b/packages/ui-extensions-tester/src/tests/shopify-events.test.ts
@@ -1,0 +1,141 @@
+import {getExtension} from '../index';
+
+import {createTestSandbox, type TestSandbox} from './helpers';
+
+describe('shopify.addEventListener / extension.dispatch', () => {
+  let sandbox: TestSandbox;
+
+  beforeEach(() => {
+    sandbox = createTestSandbox();
+    sandbox.placeToml();
+  });
+
+  afterEach(() => {
+    sandbox.destroy();
+  });
+
+  function setUpExt() {
+    const extension = getExtension('purchase.checkout.block.render', {
+      configSearchDir: sandbox.tempDir,
+    });
+    extension.setUp();
+    return extension;
+  }
+
+  it('exposes addEventListener and removeEventListener on the shopify global', () => {
+    setUpExt();
+    const shopify = (globalThis as any).shopify;
+    expect(typeof shopify.addEventListener).toBe('function');
+    expect(typeof shopify.removeEventListener).toBe('function');
+  });
+
+  it('dispatches a registered listener with the provided event payload', () => {
+    const extension = setUpExt();
+    const shopify = (globalThis as any).shopify;
+    const listener = jest.fn();
+    shopify.addEventListener('transactioncomplete', listener);
+
+    const eventData = {transaction: {id: 1}};
+    extension.dispatch('transactioncomplete', eventData);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(eventData);
+  });
+
+  it('fires every listener registered for the same event', () => {
+    const extension = setUpExt();
+    const shopify = (globalThis as any).shopify;
+    const listenerA = jest.fn();
+    const listenerB = jest.fn();
+    shopify.addEventListener('transactioncomplete', listenerA);
+    shopify.addEventListener('transactioncomplete', listenerB);
+
+    extension.dispatch('transactioncomplete', 42);
+
+    expect(listenerA).toHaveBeenCalledWith(42);
+    expect(listenerB).toHaveBeenCalledWith(42);
+  });
+
+  it('does not fire other events when dispatching one', () => {
+    const extension = setUpExt();
+    const shopify = (globalThis as any).shopify;
+    const target = jest.fn();
+    const other = jest.fn();
+    shopify.addEventListener('transactioncomplete', target);
+    shopify.addEventListener('cashtrackingsessionstart', other);
+
+    extension.dispatch('transactioncomplete', undefined);
+
+    expect(target).toHaveBeenCalledTimes(1);
+    expect(other).not.toHaveBeenCalled();
+  });
+
+  it('stops calling a listener after removeEventListener', () => {
+    const extension = setUpExt();
+    const shopify = (globalThis as any).shopify;
+    const listener = jest.fn();
+    shopify.addEventListener('transactioncomplete', listener);
+    shopify.removeEventListener('transactioncomplete', listener);
+
+    extension.dispatch('transactioncomplete', undefined);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('only fires once when the same listener is added twice', () => {
+    const extension = setUpExt();
+    const shopify = (globalThis as any).shopify;
+    const listener = jest.fn();
+    shopify.addEventListener('transactioncomplete', listener);
+    shopify.addEventListener('transactioncomplete', listener);
+
+    extension.dispatch('transactioncomplete', undefined);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates listener errors so later listeners still run', () => {
+    const extension = setUpExt();
+    const shopify = (globalThis as any).shopify;
+    const throwing = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const follower = jest.fn();
+    shopify.addEventListener('transactioncomplete', throwing);
+    shopify.addEventListener('transactioncomplete', follower);
+
+    expect(() =>
+      extension.dispatch('transactioncomplete', undefined),
+    ).not.toThrow();
+    expect(throwing).toHaveBeenCalledTimes(1);
+    expect(follower).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when dispatching an event with no registered listeners', () => {
+    const extension = setUpExt();
+    expect(() =>
+      extension.dispatch('cashtrackingsessionstart', {}),
+    ).not.toThrow();
+  });
+
+  it('clears listeners on tearDown so they do not leak across tests', () => {
+    const extension = setUpExt();
+    const shopify = (globalThis as any).shopify;
+    const leaked = jest.fn();
+    shopify.addEventListener('transactioncomplete', leaked);
+    extension.tearDown();
+
+    extension.setUp();
+    extension.dispatch('transactioncomplete', undefined);
+
+    expect(leaked).not.toHaveBeenCalled();
+  });
+
+  it('removeEventListener on a non-registered listener is a no-op', () => {
+    setUpExt();
+    const shopify = (globalThis as any).shopify;
+    expect(() =>
+      shopify.removeEventListener('transactioncomplete', () => {}),
+    ).not.toThrow();
+  });
+});

--- a/packages/ui-extensions-tester/src/tests/shopify-events.test.ts
+++ b/packages/ui-extensions-tester/src/tests/shopify-events.test.ts
@@ -1,13 +1,41 @@
+import type {
+  CashTrackingSessionStartEvent,
+  TransactionCompleteEvent,
+} from '@shopify/ui-extensions/point-of-sale';
+
 import {getExtension} from '../index';
 
 import {createTestSandbox, type TestSandbox} from './helpers';
+
+function makeTransactionCompleteEvent(): TransactionCompleteEvent {
+  return Object.assign(new Event('transactioncomplete'), {
+    transactionType: 'Sale' as const,
+    discounts: [],
+    taxTotal: {amount: 0, currency: 'USD'},
+    subtotal: {amount: 0, currency: 'USD'},
+    grandTotal: {amount: 0, currency: 'USD'},
+    paymentMethods: [],
+    balanceDue: {amount: 0, currency: 'USD'},
+    shippingLines: [],
+    taxLines: [],
+    executedAt: '2024-01-01T00:00:00Z',
+    lineItems: [],
+  });
+}
+
+function makeCashTrackingSessionStartEvent(): CashTrackingSessionStartEvent {
+  return Object.assign(new Event('cashtrackingsessionstart'), {
+    id: 1,
+    openingTime: '2024-01-01T00:00:00Z',
+  });
+}
 
 describe('shopify.addEventListener / extension.dispatch', () => {
   let sandbox: TestSandbox;
 
   beforeEach(() => {
     sandbox = createTestSandbox();
-    sandbox.placeToml();
+    sandbox.placeToml({target: 'pos.app.ready.data'});
   });
 
   afterEach(() => {
@@ -15,7 +43,7 @@ describe('shopify.addEventListener / extension.dispatch', () => {
   });
 
   function setUpExt() {
-    const extension = getExtension('purchase.checkout.block.render', {
+    const extension = getExtension('pos.app.ready.data', {
       configSearchDir: sandbox.tempDir,
     });
     extension.setUp();
@@ -35,11 +63,11 @@ describe('shopify.addEventListener / extension.dispatch', () => {
     const listener = jest.fn();
     shopify.addEventListener('transactioncomplete', listener);
 
-    const eventData = {transaction: {id: 1}};
-    extension.dispatch('transactioncomplete', eventData);
+    const event = makeTransactionCompleteEvent();
+    extension.dispatch('transactioncomplete', event);
 
     expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toHaveBeenCalledWith(eventData);
+    expect(listener).toHaveBeenCalledWith(event);
   });
 
   it('fires all listeners registered for the same event', () => {
@@ -50,10 +78,11 @@ describe('shopify.addEventListener / extension.dispatch', () => {
     shopify.addEventListener('transactioncomplete', listenerA);
     shopify.addEventListener('transactioncomplete', listenerB);
 
-    extension.dispatch('transactioncomplete', 42);
+    const event = makeTransactionCompleteEvent();
+    extension.dispatch('transactioncomplete', event);
 
-    expect(listenerA).toHaveBeenCalledWith(42);
-    expect(listenerB).toHaveBeenCalledWith(42);
+    expect(listenerA).toHaveBeenCalledWith(event);
+    expect(listenerB).toHaveBeenCalledWith(event);
   });
 
   it('does not fire other events when dispatching one', () => {
@@ -64,7 +93,7 @@ describe('shopify.addEventListener / extension.dispatch', () => {
     shopify.addEventListener('transactioncomplete', target);
     shopify.addEventListener('cashtrackingsessionstart', other);
 
-    extension.dispatch('transactioncomplete', undefined);
+    extension.dispatch('transactioncomplete', makeTransactionCompleteEvent());
 
     expect(target).toHaveBeenCalledTimes(1);
     expect(other).not.toHaveBeenCalled();
@@ -77,7 +106,7 @@ describe('shopify.addEventListener / extension.dispatch', () => {
     shopify.addEventListener('transactioncomplete', listener);
     shopify.removeEventListener('transactioncomplete', listener);
 
-    extension.dispatch('transactioncomplete', undefined);
+    extension.dispatch('transactioncomplete', makeTransactionCompleteEvent());
 
     expect(listener).not.toHaveBeenCalled();
   });
@@ -89,7 +118,7 @@ describe('shopify.addEventListener / extension.dispatch', () => {
     shopify.addEventListener('transactioncomplete', listener);
     shopify.addEventListener('transactioncomplete', listener);
 
-    extension.dispatch('transactioncomplete', undefined);
+    extension.dispatch('transactioncomplete', makeTransactionCompleteEvent());
 
     expect(listener).toHaveBeenCalledTimes(1);
   });
@@ -105,7 +134,7 @@ describe('shopify.addEventListener / extension.dispatch', () => {
     shopify.addEventListener('transactioncomplete', follower);
 
     expect(() =>
-      extension.dispatch('transactioncomplete', undefined),
+      extension.dispatch('transactioncomplete', makeTransactionCompleteEvent()),
     ).not.toThrow();
     expect(throwing).toHaveBeenCalledTimes(1);
     expect(follower).toHaveBeenCalledTimes(1);
@@ -114,7 +143,10 @@ describe('shopify.addEventListener / extension.dispatch', () => {
   it('is a no-op when dispatching an event with no registered listeners', () => {
     const extension = setUpExt();
     expect(() =>
-      extension.dispatch('cashtrackingsessionstart', {}),
+      extension.dispatch(
+        'cashtrackingsessionstart',
+        makeCashTrackingSessionStartEvent(),
+      ),
     ).not.toThrow();
   });
 
@@ -126,7 +158,7 @@ describe('shopify.addEventListener / extension.dispatch', () => {
     extension.tearDown();
 
     extension.setUp();
-    extension.dispatch('transactioncomplete', undefined);
+    extension.dispatch('transactioncomplete', makeTransactionCompleteEvent());
 
     expect(leaked).not.toHaveBeenCalled();
   });

--- a/packages/ui-extensions-tester/src/tests/shopify-events.test.ts
+++ b/packages/ui-extensions-tester/src/tests/shopify-events.test.ts
@@ -42,7 +42,7 @@ describe('shopify.addEventListener / extension.dispatch', () => {
     expect(listener).toHaveBeenCalledWith(eventData);
   });
 
-  it('fires every listener registered for the same event', () => {
+  it('fires all listeners registered for the same event', () => {
     const extension = setUpExt();
     const shopify = (globalThis as any).shopify;
     const listenerA = jest.fn();

--- a/packages/ui-extensions/buildTargetDts.ts
+++ b/packages/ui-extensions/buildTargetDts.ts
@@ -77,7 +77,11 @@ function createInitialTargetDefinition({
     surface === 'point-of-sale'
       ? `export {POS_EVENT_NAMES} from '../events';
 export type {ShopifyEventMap, TransactionCompleteEvent, CashTrackingSessionStartEvent, CashTrackingSessionCompleteEvent} from '../events';
-${parts.join('.') === 'pos.app.ready.data' ? `export type {BackgroundShopifyGlobal as ShopifyGlobal} from '../globals';\n` : ''}`
+${
+  parts.join('.') === 'pos.app.ready.data'
+    ? `export type {BackgroundShopifyGlobal as ShopifyGlobal} from '../globals';\n`
+    : ''
+}`
       : ''
   }
 type Target = ExtensionTargets[${name}];

--- a/packages/ui-extensions/buildTargetDts.ts
+++ b/packages/ui-extensions/buildTargetDts.ts
@@ -58,10 +58,12 @@ function createInitialTargetDefinition({
   buildPath,
   name,
   surface,
+  isDataTarget,
 }: {
   buildPath: string;
   name: string;
   surface: string;
+  isDataTarget: boolean;
 }) {
   const parts = name.replaceAll("'", '').split('.');
   const fileName = `${parts.join('.')}.d.ts`;
@@ -76,7 +78,7 @@ function createInitialTargetDefinition({
   }${
     surface === 'point-of-sale'
       ? `export * from '../events';\n${
-          parts.join('.') === 'pos.app.ready.data'
+          isDataTarget
             ? `export type {BackgroundShopifyGlobal as ShopifyGlobal} from '../globals';\n`
             : ''
         }`
@@ -141,10 +143,12 @@ function getTargets(sourceFile: SourceFile) {
 // Target definitions
 function extractTargetComponents(
   sourceFile: SourceFile,
-): {name: string; components?: string[]}[] {
+): {name: string; components?: string[]; isDataTarget: boolean}[] {
   const extensionTargetArray = getTargets(sourceFile);
   return extensionTargetArray
     .map((extensionTargets) => {
+      const isDataTarget =
+        extensionTargets.getName() === 'DataExtensionTargets';
       return extensionTargets.getProperties().map((property) => {
         const componentsType = property
           .getType()
@@ -166,6 +170,7 @@ function extractTargetComponents(
         return {
           name: property.getName(),
           components,
+          isDataTarget,
         };
       });
     })
@@ -177,15 +182,20 @@ function createTargetDefinition({
   buildPath,
   project,
   surface,
-  target: {name, components},
+  target: {name, components, isDataTarget},
 }: {
   srcPaths: string[];
   buildPath: string;
   project: Project;
   surface: string;
-  target: {name: string; components?: string[]};
+  target: {name: string; components?: string[]; isDataTarget: boolean};
 }) {
-  const targetPath = createInitialTargetDefinition({name, surface, buildPath});
+  const targetPath = createInitialTargetDefinition({
+    name,
+    surface,
+    buildPath,
+    isDataTarget,
+  });
   const targetFile = project.addSourceFileAtPath(targetPath);
   const names = new Set<string>();
 

--- a/packages/ui-extensions/buildTargetDts.ts
+++ b/packages/ui-extensions/buildTargetDts.ts
@@ -75,13 +75,11 @@ function createInitialTargetDefinition({
       : ''
   }${
     surface === 'point-of-sale'
-      ? `export {POS_EVENT_NAMES} from '../events';
-export type {ShopifyEventMap, TransactionCompleteEvent, CashTrackingSessionStartEvent, CashTrackingSessionCompleteEvent} from '../events';
-${
-  parts.join('.') === 'pos.app.ready.data'
-    ? `export type {BackgroundShopifyGlobal as ShopifyGlobal} from '../globals';\n`
-    : ''
-}`
+      ? `export * from '../events';\n${
+          parts.join('.') === 'pos.app.ready.data'
+            ? `export type {BackgroundShopifyGlobal as ShopifyGlobal} from '../globals';\n`
+            : ''
+        }`
       : ''
   }
 type Target = ExtensionTargets[${name}];

--- a/packages/ui-extensions/buildTargetDts.ts
+++ b/packages/ui-extensions/buildTargetDts.ts
@@ -73,6 +73,12 @@ function createInitialTargetDefinition({
     surface === 'customer-account' || surface === 'point-of-sale'
       ? `import '../globals';\n`
       : ''
+  }${
+    surface === 'point-of-sale'
+      ? `export {POS_EVENT_NAMES} from '../events';
+export type {ShopifyEventMap, TransactionCompleteEvent, CashTrackingSessionStartEvent, CashTrackingSessionCompleteEvent} from '../events';
+${parts.join('.') === 'pos.app.ready.data' ? `export type {BackgroundShopifyGlobal as ShopifyGlobal} from '../globals';\n` : ''}`
+      : ''
   }
 type Target = ExtensionTargets[${name}];
 export type Api = Target['api'];

--- a/packages/ui-extensions/src/surfaces/point-of-sale.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale.ts
@@ -1,4 +1,5 @@
 export * from './point-of-sale/api';
+export * from './point-of-sale/events';
 export * from './point-of-sale/extension-targets';
 export * from './point-of-sale/event/data';
 export * from './point-of-sale/event/output';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -17,6 +17,13 @@ export type {
   ExtensionApiContent,
 } from './api/extension-api/extension-api';
 export type {ActionTargetApi} from './api/action-target-api/action-target-api';
+export type {DataTargetApi} from './api/data-target-api/data-target-api';
+export type {
+  TransactionCompleteEvent,
+  CashTrackingSessionStartEvent,
+  CashTrackingSessionCompleteEvent,
+  ShopifyEventMap,
+} from './events';
 
 export type {
   CameraApi,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/data-target-api/data-target-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/data-target-api/data-target-api.ts
@@ -1,0 +1,23 @@
+import {CartApi} from '../cart-api/cart-api';
+import {ConnectivityApi} from '../connectivity-api/connectivity-api';
+import {DeviceApi} from '../device-api/device-api';
+import {LocaleApi} from '../locale-api/locale-api';
+import {ProductSearchApi} from '../product-search-api/product-search-api';
+import {SessionApi} from '../session-api/session-api';
+import {StorageApi} from '../storage-api/storage-api';
+import type {I18n} from '../../../../api';
+
+/**
+ * API surface for non-rendering data extension targets.
+ * @publicDocs
+ */
+export type DataTargetApi<T> = {
+  extensionPoint: T;
+  i18n: I18n;
+} & SessionApi &
+  StorageApi &
+  LocaleApi &
+  ConnectivityApi &
+  DeviceApi &
+  ProductSearchApi &
+  CartApi;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/data-target-api/data-target-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/data-target-api/data-target-api.ts
@@ -1,6 +1,7 @@
 import {CartApi} from '../cart-api/cart-api';
 import {ConnectivityApi} from '../connectivity-api/connectivity-api';
 import {DeviceApi} from '../device-api/device-api';
+import {ExtensionApi} from '../extension-api/extension-api';
 import {LocaleApi} from '../locale-api/locale-api';
 import {ProductSearchApi} from '../product-search-api/product-search-api';
 import {SessionApi} from '../session-api/session-api';
@@ -12,9 +13,13 @@ import type {I18n} from '../../../../api';
  * @publicDocs
  */
 export type DataTargetApi<T> = {
+  /**
+   * @deprecated Use `extension.target` instead.
+   */
   extensionPoint: T;
   i18n: I18n;
-} & SessionApi &
+} & ExtensionApi<T> &
+  SessionApi &
   StorageApi &
   LocaleApi &
   ConnectivityApi &

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data.ts
@@ -12,5 +12,9 @@ export type {
 
 export type {CartUpdateEventData} from './data/CartUpdateEventData';
 
+export type {SaleTransactionData} from './data/SaleTransactionData';
+export type {ReturnTransactionData} from './data/ReturnTransactionData';
+export type {ExchangeTransactionData} from './data/ExchangeTransactionData';
+
 export type {Device} from '../types/device';
 export type {Money} from '../types/money';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -5,6 +5,18 @@ import type {
 } from './events/cash-tracking-session-events';
 
 /**
+ * Canonical event-name constants for POS host events. Prefer these over string
+ * literals when calling `shopify.addEventListener` / `removeEventListener`.
+ *
+ * @publicDocs
+ */
+export const POS_EVENT_NAMES = {
+  TRANSACTION_COMPLETE: 'transactioncomplete',
+  CASH_TRACKING_SESSION_START: 'cashtrackingsessionstart',
+  CASH_TRACKING_SESSION_COMPLETE: 'cashtrackingsessioncomplete',
+} as const;
+
+/**
  * Maps Shopify POS event names to their corresponding `Event` subclass types.
  *
  * Used as the generic type parameter for `shopify.addEventListener` and
@@ -13,9 +25,9 @@ import type {
  * @publicDocs
  */
 export interface ShopifyEventMap {
-  transactioncomplete: TransactionCompleteEvent;
-  cashtrackingsessionstart: CashTrackingSessionStartEvent;
-  cashtrackingsessioncomplete: CashTrackingSessionCompleteEvent;
+  [POS_EVENT_NAMES.TRANSACTION_COMPLETE]: TransactionCompleteEvent;
+  [POS_EVENT_NAMES.CASH_TRACKING_SESSION_START]: CashTrackingSessionStartEvent;
+  [POS_EVENT_NAMES.CASH_TRACKING_SESSION_COMPLETE]: CashTrackingSessionCompleteEvent;
 }
 
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -1,0 +1,25 @@
+import type {TransactionCompleteEvent} from './events/transaction-complete-event';
+import type {
+  CashTrackingSessionStartEvent,
+  CashTrackingSessionCompleteEvent,
+} from './events/cash-tracking-session-events';
+
+/**
+ * Maps Shopify POS event names to their corresponding `Event` subclass types.
+ *
+ * Used as the generic type parameter for `shopify.addEventListener` and
+ * `shopify.removeEventListener`.
+ *
+ * @publicDocs
+ */
+export interface ShopifyEventMap {
+  transactioncomplete: TransactionCompleteEvent;
+  cashtrackingsessionstart: CashTrackingSessionStartEvent;
+  cashtrackingsessioncomplete: CashTrackingSessionCompleteEvent;
+}
+
+export type {
+  TransactionCompleteEvent,
+  CashTrackingSessionStartEvent,
+  CashTrackingSessionCompleteEvent,
+};

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events/cash-tracking-session-events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events/cash-tracking-session-events.ts
@@ -1,0 +1,24 @@
+/**
+ * Dispatched when a cash tracking session is opened.
+ * @publicDocs
+ */
+export interface CashTrackingSessionStartEvent extends Event {
+  /** The numeric identifier for the cash tracking session. */
+  readonly id: number;
+  /** ISO 8601 timestamp when the session was opened. */
+  readonly openingTime: string;
+}
+
+/**
+ * Dispatched when a cash tracking session is successfully closed via
+ * reconciliation. Abandoned or force-closed sessions do not fire this event.
+ * @publicDocs
+ */
+export interface CashTrackingSessionCompleteEvent extends Event {
+  /** The numeric identifier for the cash tracking session. */
+  readonly id: number;
+  /** ISO 8601 timestamp when the session was opened (carried forward from session start). */
+  readonly openingTime: string;
+  /** ISO 8601 timestamp when the session was closed. */
+  readonly closingTime: string;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events/cash-tracking-session-events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events/cash-tracking-session-events.ts
@@ -1,8 +1,7 @@
 /**
- * Dispatched when a cash tracking session is opened.
- * @publicDocs
+ * Shared fields for every cash tracking session event.
  */
-export interface CashTrackingSessionStartEvent extends Event {
+interface CashTrackingSessionEvent extends Event {
   /** The numeric identifier for the cash tracking session. */
   readonly id: number;
   /** ISO 8601 timestamp when the session was opened. */
@@ -10,15 +9,19 @@ export interface CashTrackingSessionStartEvent extends Event {
 }
 
 /**
- * Dispatched when a cash tracking session is successfully closed via
- * reconciliation. Abandoned or force-closed sessions do not fire this event.
+ * Dispatched when a cash tracking session is opened.
  * @publicDocs
  */
-export interface CashTrackingSessionCompleteEvent extends Event {
-  /** The numeric identifier for the cash tracking session. */
-  readonly id: number;
-  /** ISO 8601 timestamp when the session was opened (carried forward from session start). */
-  readonly openingTime: string;
+export interface CashTrackingSessionStartEvent
+  extends CashTrackingSessionEvent {}
+
+/**
+ * Dispatched when a cash tracking session is successfully closed via
+ * reconciliation.
+ * @publicDocs
+ */
+export interface CashTrackingSessionCompleteEvent
+  extends CashTrackingSessionEvent {
   /** ISO 8601 timestamp when the session was closed. */
   readonly closingTime: string;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events/transaction-complete-event.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events/transaction-complete-event.ts
@@ -1,0 +1,155 @@
+import type {Customer, Discount, LineItem} from '../types/cart';
+import type {Money} from '../types/money';
+import type {Payment} from '../types/payment';
+import type {ShippingLine} from '../types/shipping-line';
+import type {TaxLine} from '../types/tax-line';
+
+/**
+ * Shared fields on every transaction-complete event, available regardless of
+ * `transactionType`.
+ */
+interface BaseTransactionCompleteEvent extends Event {
+  /**
+   * The transaction type identifier indicating which kind of transaction was completed (for example, `'Sale'` for new purchases, `'Return'` for refunds, `'Exchange'` for item swaps). Narrow on this field to access transaction-type-specific properties.
+   */
+  readonly transactionType: 'Sale' | 'Return' | 'Exchange';
+  /**
+   * The unique numeric identifier for the Shopify order created by this transaction. This ID links the POS transaction to the order record in Shopify's system and can be used for order lookups, tracking, and API operations. Returns `undefined` when order creation is pending.
+   */
+  readonly orderId?: number;
+  /**
+   * The customer information if this transaction is associated with a customer account. Contains the customer ID for linking to customer records. Returns `undefined` for guest transactions where no customer was selected or when the transaction doesn't support customer association.
+   */
+  readonly customer?: Customer;
+  /**
+   * An array of all discounts applied to this transaction, including cart-level discounts, automatic discounts, and discount codes. Each discount entry contains the discount amount, type, and description. Empty when no discounts were applied. The sum of discount amounts reduces the final transaction total.
+   */
+  readonly discounts: Discount[];
+  /**
+   * The total tax amount charged on this transaction as a `Money` object. This is the sum of all tax lines and represents the combined tax from all applicable tax jurisdictions and rules. Tax calculations are based on the location, products, customer, and tax settings configured in Shopify.
+   */
+  readonly taxTotal: Money;
+  /**
+   * The subtotal amount before taxes and after discounts are applied, as a `Money` object. This represents the sum of all line item prices (quantity × unit price) minus any discounts, but before tax is added. This is the taxable base amount for most tax calculations.
+   */
+  readonly subtotal: Money;
+  /**
+   * The final total amount the customer pays for this transaction as a `Money` object. This includes all line items, shipping charges, taxes, and accounts for all discounts. This is the amount that must be tendered through payment methods. Calculated as: subtotal + taxTotal + shipping - discounts.
+   */
+  readonly grandTotal: Money;
+  /**
+   * An array of all payment methods used to complete this transaction. Each payment entry specifies the payment type (for example, cash, credit card), amount tendered, and currency. Multiple entries indicate split payments where the customer paid using multiple methods (for example, part cash, part credit card). The sum of all payment amounts should equal or exceed the `grandTotal`.
+   */
+  readonly paymentMethods: Payment[];
+  /**
+   * The remaining balance still owed on this transaction as a `Money` object. Typically zero for fully paid transactions. A positive balance indicates partial payment or layaway scenarios. A negative balance indicates overpayment, where change should be returned to the customer. Calculated as: grandTotal minus sum of all payment amounts.
+   */
+  readonly balanceDue: Money;
+  /**
+   * An array of shipping charges applied to this transaction. Each shipping line represents a shipping method with its price and associated taxes. Multiple entries can exist when different shipping methods apply to different items or when combining shipping with pickup. Empty for transactions with no shipping charges (for example, in-store purchases, digital products).
+   */
+  readonly shippingLines: ShippingLine[];
+  /**
+   * An array of individual tax lines showing the detailed tax breakdown by jurisdiction and tax type. Each tax line represents a specific tax (for example, state tax, federal tax, VAT, GST) with its rate and calculated amount. Multiple tax lines can apply to a single transaction based on location, product taxability, and tax rules. Empty for tax-exempt transactions or when detailed tax breakdown isn't available.
+   */
+  readonly taxLines: TaxLine[];
+  /**
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp when the transaction was executed and completed (for example, `"2024-05-15T14:30:00Z"`). This marks the exact moment the transaction was finalized, payment was processed, and the order was created. Commonly used for transaction history, chronological sorting, reporting, audit trails, and synchronization with external systems.
+   */
+  readonly executedAt: string;
+  /**
+   * The tip amount added to this transaction as a `Money` object. This represents the gratuity the customer chose to add on top of the grand total, typically for service-based businesses or hospitality transactions. Tipping can be enabled through POS settings and may be added as a percentage or fixed amount. Returns `undefined` when no tip was added or when tipping is not enabled for the transaction.
+   */
+  readonly tipAmount?: Money;
+}
+
+/**
+ * Dispatched when a sale transaction completes.
+ * Cancelled, voided, or failed sales do not fire this event.
+ */
+interface SaleCompleteEvent extends BaseTransactionCompleteEvent {
+  readonly transactionType: 'Sale';
+  /**
+   * The UUID of the draft order's checkout. Set when the sale originated from
+   * a draft order; `undefined` otherwise.
+   */
+  readonly draftCheckoutUuid?: string;
+  /**
+   * An array of line items included in the sale transaction.
+   */
+  readonly lineItems: LineItem[];
+}
+
+/**
+ * Dispatched when a return transaction completes.
+ * Cancelled, voided, or failed returns do not fire this event.
+ */
+interface ReturnCompleteEvent extends BaseTransactionCompleteEvent {
+  readonly transactionType: 'Return';
+  /**
+   * The refund ID. `undefined` when the return did not issue a refund
+   * (for example, store-credit-only returns).
+   */
+  readonly refundId?: number;
+  /**
+   * The return ID for the completed return transaction.
+   */
+  readonly returnId?: number;
+  /**
+   * The exchange ID when this return is the gift-card side of an exchange;
+   * `undefined` for standalone returns.
+   */
+  readonly exchangeId?: number;
+  /**
+   * An array of line items included in the return transaction.
+   */
+  readonly lineItems: LineItem[];
+}
+
+/**
+ * Dispatched when an exchange transaction completes.
+ * Cancelled, voided, or failed exchanges do not fire this event.
+ */
+interface ExchangeCompleteEvent extends BaseTransactionCompleteEvent {
+  readonly transactionType: 'Exchange';
+  /**
+   * The exchange ID linking the return and sale sides of the exchange.
+   */
+  readonly exchangeId: number;
+  /**
+   * The return-side ID. `undefined` when the exchange has no return side.
+   */
+  readonly returnId?: number;
+  /**
+   * An array of line items added to the customer in the exchange.
+   */
+  readonly lineItemsAdded: LineItem[];
+  /**
+   * An array of line items removed from the customer in the exchange.
+   */
+  readonly lineItemsRemoved: LineItem[];
+}
+
+/**
+ * Dispatched when a sale, return, or exchange transaction completes.
+ * Cancelled, voided, or failed transactions do not fire this event.
+ *
+ * Narrow on `transactionType` ('Sale' | 'Return' | 'Exchange') to access
+ * per-type fields. Shared fields (`orderId`, `grandTotal`, `customer`, etc.)
+ * are available without narrowing.
+ *
+ * @example
+ * ```ts
+ * shopify.addEventListener('transactioncomplete', (event) => {
+ *   if (event.transactionType === 'Sale') {
+ *     console.log(event.lineItems, event.draftCheckoutUuid);
+ *   }
+ *   console.log(event.orderId, event.grandTotal);
+ * });
+ * ```
+ * @publicDocs
+ */
+export type TransactionCompleteEvent =
+  | SaleCompleteEvent
+  | ReturnCompleteEvent
+  | ExchangeCompleteEvent;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events/transaction-complete-event.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events/transaction-complete-event.ts
@@ -65,7 +65,6 @@ interface BaseTransactionCompleteEvent extends Event {
 
 /**
  * Dispatched when a sale transaction completes.
- * Cancelled, voided, or failed sales do not fire this event.
  */
 interface SaleCompleteEvent extends BaseTransactionCompleteEvent {
   readonly transactionType: 'Sale';
@@ -82,7 +81,6 @@ interface SaleCompleteEvent extends BaseTransactionCompleteEvent {
 
 /**
  * Dispatched when a return transaction completes.
- * Cancelled, voided, or failed returns do not fire this event.
  */
 interface ReturnCompleteEvent extends BaseTransactionCompleteEvent {
   readonly transactionType: 'Return';
@@ -108,7 +106,6 @@ interface ReturnCompleteEvent extends BaseTransactionCompleteEvent {
 
 /**
  * Dispatched when an exchange transaction completes.
- * Cancelled, voided, or failed exchanges do not fire this event.
  */
 interface ExchangeCompleteEvent extends BaseTransactionCompleteEvent {
   readonly transactionType: 'Exchange';
@@ -132,11 +129,8 @@ interface ExchangeCompleteEvent extends BaseTransactionCompleteEvent {
 
 /**
  * Dispatched when a sale, return, or exchange transaction completes.
- * Cancelled, voided, or failed transactions do not fire this event.
  *
- * Narrow on `transactionType` ('Sale' | 'Return' | 'Exchange') to access
- * per-type fields. Shared fields (`orderId`, `grandTotal`, `customer`, etc.)
- * are available without narrowing.
+ * Narrow on `transactionType` to access per-type fields.
  *
  * @example
  * ```ts

--- a/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
@@ -6,7 +6,9 @@ import {
 import {TransactionCompleteData} from './event/data/TransactionCompleteData';
 import {CartUpdateEventData} from './event/data/CartUpdateEventData';
 
-import type {RenderExtension} from '../../extension';
+import type {RenderExtension, RunnableExtension} from '../../extension';
+
+import type {DataTargetApi} from './api/data-target-api/data-target-api';
 
 import type {
   StandardApi,
@@ -44,6 +46,21 @@ export interface EventExtensionTargets {
   'pos.cart-update.event.observe': (
     data: CartUpdateEventData,
   ) => Promise<BaseOutput>;
+}
+
+/**
+ * @publicDocs
+ */
+export interface DataExtensionTargets {
+  /**
+   * A persistent background extension that starts when POS loads and runs for
+   * the session's lifetime. Use this target to observe POS events without
+   * rendering UI.
+   */
+  'pos.app.ready.data': RunnableExtension<
+    DataTargetApi<'pos.app.ready.data'>,
+    undefined
+  >;
 }
 
 /**
@@ -371,7 +388,8 @@ export interface RenderExtensionTargets {
  */
 export interface ExtensionTargets
   extends RenderExtensionTargets,
-    EventExtensionTargets {}
+    EventExtensionTargets,
+    DataExtensionTargets {}
 
 /**
  * @publicDocs
@@ -381,6 +399,10 @@ export type RenderExtensionTarget = keyof RenderExtensionTargets;
  * @publicDocs
  */
 export type EventExtensionTarget = keyof EventExtensionTargets;
+/**
+ * @publicDocs
+ */
+export type DataExtensionTarget = keyof DataExtensionTargets;
 /**
  * @publicDocs
  */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
@@ -1,6 +1,39 @@
-import {Navigation} from './api/navigation-api/navigation-api';
+import type {Navigation} from './api/navigation-api/navigation-api';
+import type {ShopifyEventMap} from './events';
+
+/**
+ * The `shopify` global provides APIs that are available to all POS extensions
+ * without needing to access them through the target's `api` argument.
+ *
+ * @publicDocs
+ */
+export interface ShopifyGlobal {
+  /**
+   * Register a listener for a POS host event. Listeners are fire-and-forget:
+   * their return values are ignored, and their errors are caught without
+   * affecting the host or other listeners.
+   */
+  addEventListener<K extends keyof ShopifyEventMap>(
+    type: K,
+    listener: (event: ShopifyEventMap[K]) => void,
+  ): void;
+
+  /**
+   * Remove a listener previously registered with `addEventListener`. The
+   * `listener` reference must match the one used to register.
+   */
+  removeEventListener<K extends keyof ShopifyEventMap>(
+    type: K,
+    listener: (event: ShopifyEventMap[K]) => void,
+  ): void;
+}
 
 declare global {
   // @ts-expect-error - Intentionally overriding navigation type for POS context
   const navigation: Navigation;
+
+  // conflicts with build/ts/globals.d.ts
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const shopify: ShopifyGlobal;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
@@ -7,7 +7,17 @@ import type {ShopifyEventMap} from './events';
  *
  * @publicDocs
  */
-export interface ShopifyGlobal {
+export interface ShopifyGlobal {}
+
+/**
+ * Background-only extension of `ShopifyGlobal`. Adds host-event listener APIs
+ * that are only valid from the session-lifetime background target
+ * (`pos.app.ready.data`). Non-background targets see the narrower
+ * `ShopifyGlobal` and cannot type-check calls to these methods.
+ *
+ * @publicDocs
+ */
+export interface BackgroundShopifyGlobal extends ShopifyGlobal {
   /**
    * Register a listener for a POS host event. Listeners are fire-and-forget:
    * their return values are ignored, and their errors are caught without
@@ -32,7 +42,9 @@ declare global {
   // @ts-expect-error - Intentionally overriding navigation type for POS context
   const navigation: Navigation;
 
-  // conflicts with build/ts/globals.d.ts
+  // Collides with checkout/globals.ts during this package's own typecheck: both
+  // declare `const shopify` with surface-specific shapes. Consumers import only
+  // one surface, so the collision is internal to this package's build.
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   const shopify: ShopifyGlobal;


### PR DESCRIPTION
## What

Add TypeScript types for the `pos.app.ready.data` persistent background extension target.

### New types

- **`DataTargetApi<T>`** — API surface for non-rendering data targets. Includes non-UI APIs (cart, storage, session, locale, connectivity, device, product search); excludes UI-presenting APIs.
- **`ShopifyEventMap`** — Maps event names to their typed `Event` subclasses (`transactioncomplete`, `cashtrackingsessionstart`, `cashtrackingsessioncomplete`).
- **`DataExtensionTargets`** — New target interface with `pos.app.ready.data` as a `RunnableExtension<DataTargetApi, undefined>`.
- **`DataExtensionTarget`** — Type alias for data target keys.
- **`ShopifyGlobal`** — POS `shopify` global type, augmented with `addEventListener` / `removeEventListener` keyed on `ShopifyEventMap`. Follows the same `declare global` pattern Checkout uses.

### Event types

- **`TransactionCompleteEvent`** — Discriminated union of three module-local variant interfaces (`SaleCompleteEvent | ReturnCompleteEvent | ExchangeCompleteEvent`), each extending `BaseTransactionCompleteEvent`. All fields are `readonly`. Narrow on `event.transactionType` (`'Sale'` | `'Return'` | `'Exchange'`) to access per-type fields (`lineItems`, `refundId`, `lineItemsAdded`, etc.). Shared fields (`orderId`, `grandTotal`, `customer`, `paymentMethods`, …) are available without narrowing. The three variants are internal scaffolding — only `TransactionCompleteEvent` is part of the public surface.
- **`BaseTransactionCompleteEvent`** — Internal shared base extending `Event`. Contains the 12 fields common to Sale/Return/Exchange (orderId, customer, grandTotal, taxTotal, paymentMethods, shippingLines, etc.).
- **`CashTrackingSessionStartEvent`** — `Event` subclass with `id: number` and `openingTime: string` (ISO 8601).
- **`CashTrackingSessionCompleteEvent`** — Adds `closingTime: string`.

### Folder structure

Event types live at the surface-level `point-of-sale/events/` (sibling to `api/` and `globals.ts`), not nested inside `api/data-target-api/`. Host events are dispatched on the global `shopify` object and consumable by any target, so they aren't scoped to a specific API. The layout mirrors the existing `api.ts` + `api/` pattern:

```
point-of-sale/
├── api.ts     + api/       (APIs)
├── events.ts  + events/    (host events)
└── globals.ts
```

### `shopify` global augmentation

POS host events are received via `shopify.addEventListener()` on the global `shopify` object, consistent with TAG proposal Shopify/ui-api-design#1418.

```ts
shopify.addEventListener('transactioncomplete', (event) => {
  if (event.transactionType === 'Sale') {
    console.log(event.lineItems, event.grandTotal);
  }
});
```

## Why

POS apps need a persistent background extension that starts when POS loads and runs for the session lifetime. This replaces the existing fire-and-forget `.event.observe` targets with a single long-lived target that receives events via `shopify.addEventListener`, aligning with the shape TAG approved in Shopify/ui-api-design#1418.

## Related PRs

- **ui-api-design (TAG proposal):** Shopify/ui-api-design#1418
- **extensibility host (`eventListenerPlugin` + `eventDispatchFactory`):** Shopify/extensibility#1064
- **pos-mobile wiring:** shop/world#508117, shop/world#508119
- **Observe target deprecation:** Shopify/ui-extensions#4146

## Status

Draft until TAG approves Shopify/ui-api-design#1418. Types will publish with the 2026-07 quarterly release train.