### PR TITLE
2026-04: Fix doc generation to resolve shopify-dev from World

### DIFF
--- a/packages/ui-extensions/docs/surfaces/build-doc-shared.mjs
+++ b/packages/ui-extensions/docs/surfaces/build-doc-shared.mjs
@@ -3,33 +3,22 @@ import childProcess from 'child_process';
 import fs from 'fs/promises';
 import {existsSync} from 'fs';
 import path from 'path';
-import readline from 'readline/promises';
-import process, {stdin as input, stdout as output} from 'process';
+import process from 'process';
 
-export const resolveShopifyDevPath = async (rootPath) => {
-  const defaultPath = path.resolve(rootPath, '../../../shopify-dev');
-  if (existsSync(defaultPath)) return defaultPath;
+export const resolveShopifyDevPath = async () => {
+  const worldPath = path.join(
+    process.env.HOME,
+    'world/trees/root/src/areas/platforms/shopify-dev',
+  );
 
-  const rl = readline.createInterface({input, output});
-  const answer = (
-    await rl.question(
-      `\n\x1b[33m⚠️  Shopify dev directory not found at:\x1b[0m \x1b[1m${defaultPath}\x1b[0m\n\x1b[32mPlease provide the absolute path to your "shopify-dev" repo:\x1b[0m `,
-    )
-  ).trim();
-  rl.close();
-
-  const shopifyDevPath = answer ? path.resolve(answer) : '';
-  if (!shopifyDevPath || !existsSync(shopifyDevPath)) {
+  if (!existsSync(worldPath)) {
     throw new Error(
-      `\x1b[31m❌ Error: ${
-        shopifyDevPath
-          ? `shopify-dev directory not found at ${shopifyDevPath}.`
-          : 'Path cannot be empty.'
-      } Check the path and try again!\x1b[0m`,
+      `\x1b[31m❌ Error: shopify-dev not found at ${worldPath}.\n` +
+        `Run: tec checkout add //areas/platforms/shopify-dev\x1b[0m`,
     );
   }
 
-  return shopifyDevPath;
+  return worldPath;
 };
 
 export const replaceFileContent = async ({

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/build-docs.mjs
@@ -31,7 +31,7 @@ const srcRelativePath = 'src/surfaces/point-of-sale';
 const docsPath = path.join(rootPath, docsRelativePath);
 const srcPath = path.join(rootPath, srcRelativePath);
 const generatedDocsPath = path.join(docsPath, 'generated');
-const shopifyDevPath = await resolveShopifyDevPath(rootPath);
+const shopifyDevPath = await resolveShopifyDevPath();
 const shopifyDevDBPath = path.join(
   shopifyDevPath,
   'areas/platforms/shopify-dev/db/data/docs/templated_apis',


### PR DESCRIPTION
Related to https://github.com/shop/issues-retail/issues/26023

### TL;DR

Update doc generation path to resolve `shopify-dev` from the World monorepo instead of the deprecated standalone repo.

### What changed?

- `resolveShopifyDevPath` now resolves to `~/world/trees/root/src/areas/platforms/shopify-dev`
- Removed legacy fallback to `../../../shopify-dev` (standalone repo)
- Removed interactive prompt and unused `readline` import
- Updated `build-docs.mjs` caller to match new signature (no args)

### Why?

`shopify-dev` has moved into World at `//areas/platforms/shopify-dev`. The standalone repo is deprecated. Running `yarn docs:point-of-sale` should copy generated output directly to the World zone.

### Note

This PR targets `2026-04-rc`. The same change needs to be applied to other active version branches (e.g. `2025-10`, `2026-01`) since `build-doc-shared.mjs` and `build-docs.mjs` are shared across all versions. Cherry-pick or open matching PRs for other branches as needed.

### How to test?

Requires `//areas/platforms/shopify-dev` in your sparse checkout:

```bash
tec checkout add //areas/platforms/shopify-dev
```

Then run `yarn docs:point-of-sale 2026-04-rc` — generated JSON should appear in `~/world/trees/root/src/areas/platforms/shopify-dev/db/data/docs/templated_apis/pos_ui_extensions/2026-04-rc/`.