### PR TITLE
fix(docs): Rename to Order Status Localization API for correct sorting

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/localization-order-status.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/localization-order-status.doc.ts
@@ -3,7 +3,7 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Localization (Order Status) API',
+  name: 'Order Status Localization API',
   description: 'The API for localizing your extension.',
   isVisualComponent: false,
   category: 'Target APIs',


### PR DESCRIPTION
## Summary
Renames "Localization (Order Status) API" to "Order Status Localization API" to fix alphabetical sorting in the docs navigation.

## Problem
The parentheses in "Localization (Order Status) API" caused the API to sort incorrectly - it appeared after "Shop API" instead of in its correct alphabetical position.

## Solution
Rename to "Order Status Localization API" which:
- Generates clean slug: `order-status-localization-api`
- Sorts correctly under "O" (after Note API, before Shop API)
- Removes problematic parentheses from the name

## Test plan
- [ ] Verify docs generate without errors
- [ ] Confirm API appears in correct alphabetical order in navigation

Made with [Cursor](https://cursor.com)