### PR TITLE
fix(docs): Rename to Order Status Localization API for correct sorting (2024-07)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/localization-order-status.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/apis/order-status-api/localization-order-status.doc.ts
@@ -3,7 +3,7 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 import {ORDER_STATUS_API_DEFINITION} from '../../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
-  name: 'Localization (Order Status) API',
+  name: 'Order Status Localization API',
   description: 'The API for localizing your extension.',
   isVisualComponent: false,
   category: 'APIs',


### PR DESCRIPTION
Renames 'Localization (Order Status) API' to 'Order Status Localization API' to fix alphabetical sorting in docs navigation.

Made with [Cursor](https://cursor.com)