### PR TITLE
[POS UI extensions 2025-10]: Use 'web components' terminology

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/generated/pos_ui_extensions/2025-10/generated_docs_data.json
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/generated/pos_ui_extensions/2025-10/generated_docs_data.json
@@ -9056,7 +9056,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "defaultExample": {
       "image": "badge-default.png",
@@ -9168,7 +9168,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "defaultExample": {
       "image": "banner-default.png",
@@ -9195,7 +9195,7 @@
   },
   {
     "name": "Box",
-    "description": "The box component provides a container for layout and visual styling. Use it to apply padding, borders, and background colors, or to nest and group other components.\n\nFor user interaction, use box in combination with interactive components like [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable). For scrollable content, use [scroll box](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/scroll-box).",
+    "description": "The box component provides a container for layout and visual styling. Use it to apply padding, borders, and background colors, or to nest and group other components.\n\nFor user interaction, use box in combination with interactive components like [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable). For scrollable content, use [scroll box](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/layout-and-structure/scroll-box).",
     "thumbnail": "box-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -9390,7 +9390,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "defaultExample": {
       "image": "box-default.png",
@@ -9583,7 +9583,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Actions",
     "defaultExample": {
       "image": "button-default.png",
@@ -9797,7 +9797,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "choicelist-default.png",
@@ -9871,7 +9871,7 @@
   },
   {
     "name": "Clickable",
-    "description": "The clickable component makes any content interactive. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.\n\nUnlike the [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) component, clickable doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
+    "description": "The clickable component makes any content interactive. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.\n\nUnlike the [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) component, clickable doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
     "thumbnail": "clickable-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -9992,7 +9992,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Actions",
     "defaultExample": {
       "image": "clickable-default.png",
@@ -10025,7 +10025,7 @@
   },
   {
     "name": "Date field",
-    "description": "The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) or [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) components.",
+    "description": "The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-picker) or [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-spinner) components.",
     "thumbnail": "date-field-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -10203,7 +10203,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "date-field-default.png",
@@ -10223,7 +10223,7 @@
         "type": "Generic",
         "anchorLink": "best-practices",
         "title": "Best practices",
-        "sectionContent": "\n- **Choose for direct text input:** Use date field when users know the exact date and can type it efficiently. Use [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) for calendar selection or [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) for space-constrained layouts.\n- **Explain date constraints:** Use `details` to clarify requirements like \"Select a date within the next 30 days\" or \"Must be a future date.\"\n- **Write actionable error messages:** Provide clear validation messages for invalid dates that help users correct their input.\n"
+        "sectionContent": "\n- **Choose for direct text input:** Use date field when users know the exact date and can type it efficiently. Use [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-picker) for calendar selection or [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-spinner) for space-constrained layouts.\n- **Explain date constraints:** Use `details` to clarify requirements like \"Select a date within the next 30 days\" or \"Must be a future date.\"\n- **Write actionable error messages:** Provide clear validation messages for invalid dates that help users correct their input.\n"
       }
     ],
     "related": [],
@@ -10247,7 +10247,7 @@
   },
   {
     "name": "Date picker",
-    "description": "The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, consider using [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) instead. For text date entry, use [date field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-field).",
+    "description": "The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, consider using [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-spinner) instead. For text date entry, use [date field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-field).",
     "thumbnail": "date-picker-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -10393,7 +10393,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "date-picker-default.png",
@@ -10413,7 +10413,7 @@
         "type": "Generic",
         "anchorLink": "best-practices",
         "title": "Best practices",
-        "sectionContent": "\n- **Choose for calendar-based selection:** Use date picker when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) for tight spaces or [date field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-field) when users know the exact date.\n- **Provide adequate space:** Ensure sufficient spacing around the picker to avoid interfering with on-screen keyboards or other interactive elements.\n"
+        "sectionContent": "\n- **Choose for calendar-based selection:** Use date picker when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-spinner) for tight spaces or [date field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-field) when users know the exact date.\n- **Provide adequate space:** Ensure sufficient spacing around the picker to avoid interfering with on-screen keyboards or other interactive elements.\n"
       }
     ],
     "related": [],
@@ -10449,7 +10449,7 @@
   },
   {
     "name": "Date spinner",
-    "description": "The date spinner component enables merchants to select dates using a spinner interface with scrollable columns for month, day, and year. Use it for compact date selection in space-constrained layouts or when selecting dates close to the current date.\n\nFor visual calendar context, consider using [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) instead. For text date entry, use [date field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-field).",
+    "description": "The date spinner component enables merchants to select dates using a spinner interface with scrollable columns for month, day, and year. Use it for compact date selection in space-constrained layouts or when selecting dates close to the current date.\n\nFor visual calendar context, consider using [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-picker) instead. For text date entry, use [date field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-field).",
     "thumbnail": "date-spinner-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -10595,7 +10595,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "date-spinner-default.png",
@@ -10615,7 +10615,7 @@
         "type": "Generic",
         "anchorLink": "best-practices",
         "title": "Best practices",
-        "sectionContent": "\n- **Use for space-constrained layouts:** Choose date spinner for narrow layouts or split-screen interfaces where a calendar view would be impractical.\n- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) provides faster navigation.\n- **Provide interaction cues:** Consider labels or instructions to help first-time users understand the scrollable column interface.\n"
+        "sectionContent": "\n- **Use for space-constrained layouts:** Choose date spinner for narrow layouts or split-screen interfaces where a calendar view would be impractical.\n- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-picker) provides faster navigation.\n- **Provide interaction cues:** Consider labels or instructions to help first-time users understand the scrollable column interface.\n"
       }
     ],
     "related": [],
@@ -10689,7 +10689,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "defaultExample": {
       "image": "divider-default.png",
@@ -10943,7 +10943,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "email-field-default.png",
@@ -10969,7 +10969,7 @@
         "type": "Generic",
         "anchorLink": "limitations",
         "title": "Limitations",
-        "sectionContent": "\nThe `accessory` slot supports only [`button`](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [`clickable`](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components—other component types can't be used in the accessory slot.\n"
+        "sectionContent": "\nThe `accessory` slot supports only [`button`](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [`clickable`](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components—other component types can't be used in the accessory slot.\n"
       }
     ],
     "related": [],
@@ -10977,7 +10977,7 @@
       "description": "Learn how to add accessory buttons and handle email input events.",
       "examples": [
         {
-          "description": "Add action buttons to the email field using the accessory slot for quick actions like clearing input or verifying email addresses. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the email input context.",
+          "description": "Add action buttons to the email field using the accessory slot for quick actions like clearing input or verifying email addresses. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components in the accessory slot, providing inline functionality within the email input context.",
           "codeblock": {
             "title": "Add accessory buttons",
             "tabs": [
@@ -11005,7 +11005,7 @@
   },
   {
     "name": "Heading",
-    "description": "The heading component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces.\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.",
+    "description": "The heading component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces.\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/layout-and-structure/section) components, ensuring a meaningful page outline.",
     "thumbnail": "heading-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -11034,7 +11034,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "defaultExample": {
       "image": "heading-default.png",
@@ -11061,7 +11061,7 @@
   },
   {
     "name": "Icon",
-    "description": "The icon component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories. Use icons to enhance navigation or provide visual context alongside text.\n\nFor interactive icons, wrap them in [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components.",
+    "description": "The icon component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories. Use icons to enhance navigation or provide visual context alongside text.\n\nFor interactive icons, wrap them in [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components.",
     "thumbnail": "icon-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -11154,7 +11154,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "defaultExample": {
       "image": "icon-default.png",
@@ -11181,7 +11181,7 @@
   },
   {
     "name": "Image",
-    "description": "The image component displays visual content. Use images to showcase products, illustrate concepts, or provide visual context in POS workflows.\n\nImages are display-only components. For interactive functionality, wrap them in [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components.",
+    "description": "The image component displays visual content. Use images to showcase products, illustrate concepts, or provide visual context in POS workflows.\n\nImages are display-only components. For interactive functionality, wrap them in [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components.",
     "thumbnail": "image-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -11236,7 +11236,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "defaultExample": {
       "image": "image-default.png",
@@ -11269,7 +11269,7 @@
   },
   {
     "name": "Modal",
-    "description": "The modal component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.\n\nModals block interaction with the underlying interface until the merchant resolves the modal content.\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through [events](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/modal#events).",
+    "description": "The modal component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.\n\nModals block interaction with the underlying interface until the merchant resolves the modal content.\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through [events](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/modal#events).",
     "thumbnail": "modal-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -11429,7 +11429,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "defaultExample": {
       "image": "modal-default.png",
@@ -11716,7 +11716,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "number-field-default.png",
@@ -11849,7 +11849,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "defaultExample": {
       "image": "page-default.png",
@@ -11973,7 +11973,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "defaultExample": {
       "image": "pos-block-default.png",
@@ -12195,7 +12195,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "defaultExample": {
       "image": "scrollbox-default.png",
@@ -12384,7 +12384,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "search-field-default.png",
@@ -12488,7 +12488,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "defaultExample": {
       "image": "section-default.png",
@@ -12827,7 +12827,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "defaultExample": {
       "image": "stack-default.png",
@@ -12917,7 +12917,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "defaultExample": {
       "image": "text-default.png",
@@ -12950,7 +12950,7 @@
   },
   {
     "name": "Text area",
-    "description": "The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/text-field).",
+    "description": "The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/text-field).",
     "thumbnail": "text-area-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -13186,7 +13186,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "text-area-default.png",
@@ -13212,7 +13212,7 @@
         "type": "Generic",
         "anchorLink": "limitations",
         "title": "Limitations",
-        "sectionContent": "\nThe `accessory` slot supports only [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components. Other component types can't be used for field accessories.\n"
+        "sectionContent": "\nThe `accessory` slot supports only [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components. Other component types can't be used for field accessories.\n"
       }
     ],
     "related": [],
@@ -13220,7 +13220,7 @@
       "description": "Learn how to add accessory buttons, configure visible rows, and handle events.",
       "examples": [
         {
-          "description": "Add action buttons to the text area using the accessory slot for quick actions like clearing text or formatting content. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the multi-line input context.",
+          "description": "Add action buttons to the text area using the accessory slot for quick actions like clearing text or formatting content. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components in the accessory slot, providing inline functionality within the multi-line input context.",
           "codeblock": {
             "title": "Add accessory buttons",
             "tabs": [
@@ -13260,7 +13260,7 @@
   },
   {
     "name": "Text field",
-    "description": "The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [text area](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/text-area) component.",
+    "description": "The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [text area](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/text-area) component.",
     "thumbnail": "text-field-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -13487,7 +13487,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "text-field-default.png",
@@ -13507,13 +13507,13 @@
         "type": "Generic",
         "anchorLink": "best-practices",
         "title": "Best practices",
-        "sectionContent": "\n- **Use for single-line text input:** Choose text field for short values like names, titles, or identifiers. For multi-line content, use [text area](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/text-area).\n- **Show character limit feedback:** When approaching `maxLength`, display remaining characters in the `details` text.\n- **Write descriptive labels:** Use specific labels like \"Product Name\" or \"Reference Code\" rather than generic terms.\n"
+        "sectionContent": "\n- **Use for single-line text input:** Choose text field for short values like names, titles, or identifiers. For multi-line content, use [text area](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/text-area).\n- **Show character limit feedback:** When approaching `maxLength`, display remaining characters in the `details` text.\n- **Write descriptive labels:** Use specific labels like \"Product Name\" or \"Reference Code\" rather than generic terms.\n"
       },
       {
         "type": "Generic",
         "anchorLink": "limitations",
         "title": "Limitations",
-        "sectionContent": "\nThe `accessory` slot supports only [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.\n"
+        "sectionContent": "\nThe `accessory` slot supports only [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.\n"
       }
     ],
     "related": [],
@@ -13521,7 +13521,7 @@
       "description": "Learn how to add accessory buttons, configure validation properties, and handle events.",
       "examples": [
         {
-          "description": "Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components with text content in the accessory slot, enabling inline actions without leaving the input context.",
+          "description": "Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components with text content in the accessory slot, enabling inline actions without leaving the input context.",
           "codeblock": {
             "title": "Add accessory buttons",
             "tabs": [
@@ -13718,7 +13718,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Actions",
     "defaultExample": {
       "image": "tile-default.png",
@@ -13751,7 +13751,7 @@
   },
   {
     "name": "Time field",
-    "description": "The time field component captures time input through direct text entry. Use it when merchants know the exact time they want to enter or for quick time data entry.\n\nFor visual time selection with clock or spinner interfaces, use [time picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/time-picker).",
+    "description": "The time field component captures time input through direct text entry. Use it when merchants know the exact time they want to enter or for quick time data entry.\n\nFor visual time selection with clock or spinner interfaces, use [time picker](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/time-picker).",
     "thumbnail": "time-field-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -13929,7 +13929,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "time-field-default.png",
@@ -13973,7 +13973,7 @@
   },
   {
     "name": "Time picker",
-    "description": "The time picker component allows merchants to select times using an interactive picker interface. Use it when merchants benefit from visual time selection rather than typing exact times.\n\nFor direct text entry when merchants know the exact time, use [time field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/time-field).",
+    "description": "The time picker component allows merchants to select times using an interactive picker interface. Use it when merchants benefit from visual time selection rather than typing exact times.\n\nFor direct text entry when merchants know the exact time, use [time field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/time-field).",
     "thumbnail": "time-spinner-thumbnail.png",
     "isVisualComponent": true,
     "type": "",
@@ -14119,7 +14119,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "defaultExample": {
       "image": "time-spinner-default.png",
@@ -14139,7 +14139,7 @@
         "type": "Generic",
         "anchorLink": "best-practices",
         "title": "Best practices",
-        "sectionContent": "\n- **Choose for visual time selection:** Use time picker when users benefit from a visual picker interface. Use [time field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/time-field) when users know the exact time.\n- **Use correct format:** Always use `HH:mm:ss` format with leading zeros. The internal format is always 24-hour regardless of UI presentation.\n- **Validate before setting values:** Invalid values reset to empty string. Implement validation to show appropriate error messages.\n"
+        "sectionContent": "\n- **Choose for visual time selection:** Use time picker when users benefit from a visual picker interface. Use [time field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/time-field) when users know the exact time.\n- **Use correct format:** Always use `HH:mm:ss` format with leading zeros. The internal format is always 24-hour regardless of UI presentation.\n- **Validate before setting values:** Invalid values reset to empty string. Implement validation to show appropriate error messages.\n"
       }
     ],
     "related": [],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pos-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/pos-overview.doc.ts
@@ -40,7 +40,7 @@ You can track new releases and update your extensions by referencing the [develo
         {
           subtitle: 'Components',
           name: 'See all available components',
-          url: '/docs/api/pos-ui-extensions/polaris-web-components',
+          url: '/docs/api/pos-ui-extensions/web-components',
           type: 'blocks',
         },
       ],

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/using-polaris-web-components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/staticPages/using-polaris-web-components.doc.ts
@@ -1,9 +1,9 @@
 import type {LandingTemplateSchema} from '@shopify/generate-docs';
 
 const data: LandingTemplateSchema = {
-  title: 'Using Polaris web components',
+  title: 'Using web components',
   description:
-    "Polaris web components are Shopify's UI toolkit for building interfaces that match the Shopify Point of Sale design system. This toolkit provides a set of custom HTML elements (web components) that you can use to create consistent, accessible, and performant user interfaces for the POS UI Extensions.",
+    "Web components are Shopify's UI toolkit for building interfaces that match the Shopify Point of Sale design system. This toolkit provides a set of custom HTML elements (web components) that you can use to create consistent, accessible, and performant user interfaces for the POS UI Extensions.",
   id: 'using-polaris-components',
   sections: [
     {
@@ -11,7 +11,7 @@ const data: LandingTemplateSchema = {
       anchorLink: 'styling',
       title: 'Styling',
       sectionContent:
-        "Polaris web components come with built-in styling that follows Shopify's design system. The components will automatically apply the correct styling based on the properties you set and the context in which they are used. For example, headings automatically display at progressively less prominent sizes based on how many levels deep they are nested inside of sections. All components inherit a merchant's brand settings and the CSS cannot be altered or overridden.",
+        "Web components come with built-in styling that follows Shopify's design system. The components will automatically apply the correct styling based on the properties you set and the context in which they are used. For example, headings automatically display at progressively less prominent sizes based on how many levels deep they are nested inside of sections. All components inherit a merchant's brand settings and the CSS cannot be altered or overridden.",
       codeblock: {
         title: 'Example',
         tabs: [
@@ -69,7 +69,7 @@ const data: LandingTemplateSchema = {
       anchorLink: 'using-with-preact',
       title: 'Using with Preact',
       sectionContent:
-        'For UI Extensions, Shopify provides Preact as the framework of choice. Using Polaris web components with Preact is very similar to using them with React.  ',
+        'For UI Extensions, Shopify provides Preact as the framework of choice. Using web components with Preact is very similar to using them with React.  ',
       codeblock: {
         title: 'Example',
         tabs: [
@@ -86,12 +86,12 @@ const data: LandingTemplateSchema = {
       anchorLink: 'properties-vs-attributes',
       title: 'Properties vs attributes',
       sectionContent:
-        'Polaris web components follow the same property and attribute patterns as standard HTML elements. Understanding this distinction is important for using the components effectively.',
+        'Web components follow the same property and attribute patterns as standard HTML elements. Understanding this distinction is important for using the components effectively.',
       accordionContent: [
         {
           title: 'Key concepts',
           description:
-            "1. **Attributes** are HTML attributes that appear in the HTML markup.\n2. **Properties** are JavaScript object properties accessed directly on the DOM element.\n3. Most attributes in Polaris web components are reflected as properties, with a few exceptions like `value` and `checked` which follow HTML's standard behavior.",
+            "1. **Attributes** are HTML attributes that appear in the HTML markup.\n2. **Properties** are JavaScript object properties accessed directly on the DOM element.\n3. Most attributes in web components are reflected as properties, with a few exceptions like `value` and `checked` which follow HTML's standard behavior.",
           codeblock: {
             tabs: [],
             title: '',
@@ -102,7 +102,7 @@ const data: LandingTemplateSchema = {
         {
           title: 'How JSX properties are applied',
           description:
-            "When using Polaris web components in JSX, the framework determines how to apply your props based on whether the element has a matching property name.\n\nIf the element has a property with the exact same name as your prop, the value is set as a property. Otherwise, it's applied as an attribute. Here's how this works in pseudocode:",
+            "When using web components in JSX, the framework determines how to apply your props based on whether the element has a matching property name.\n\nIf the element has a property with the exact same name as your prop, the value is set as a property. Otherwise, it's applied as an attribute. Here's how this works in pseudocode:",
           codeblock: {
             tabs: [
               {
@@ -119,7 +119,7 @@ const data: LandingTemplateSchema = {
         {
           title: 'Examples',
           description:
-            'For Polaris web components, you can generally just use the property names as documented, and everything will work as expected.',
+            'For web components, you can generally just use the property names as documented, and everything will work as expected.',
           codeblock: {
             tabs: [
               {
@@ -157,7 +157,7 @@ const data: LandingTemplateSchema = {
       anchorLink: 'slots',
       title: 'Slots',
       sectionContent:
-        'Slots allow you to insert custom content into specific areas of Polaris web components. Use the `slot` attribute to specify where your content should appear within a component.\n\nKey points:\n- Named slots (e.g., `slot="title"`) place content in designated areas\n- Multiple elements can share the same slot name\n- Elements without a slot attribute go into the default (unnamed) slot',
+        'Slots allow you to insert custom content into specific areas of web components. Use the `slot` attribute to specify where your content should appear within a component.\n\nKey points:\n- Named slots (e.g., `slot="title"`) place content in designated areas\n- Multiple elements can share the same slot name\n- Elements without a slot attribute go into the default (unnamed) slot',
       codeblock: {
         title: 'Examples',
         tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Badge/Badge.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Badge',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   defaultExample: {
     image: 'badge-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Banner/Banner.doc.ts
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'BannerSlots',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   defaultExample: {
     image: 'banner-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Box/Box.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
     'The box component provides a container for layout and visual styling. Use it to apply padding, borders, and background colors, or to nest and group other components.' +
-    '\n\nFor user interaction, use box in combination with interactive components like [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable). For scrollable content, use [scroll box](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/scroll-box).',
+    '\n\nFor user interaction, use box in combination with interactive components like [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable). For scrollable content, use [scroll box](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/layout-and-structure/scroll-box).',
   thumbnail: 'box-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Box',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'box-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Button/Button.doc.ts
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ButtonEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   defaultExample: {
     image: 'button-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ChoiceList/ChoiceList.doc.ts
@@ -28,7 +28,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Choice',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'choicelist-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Clickable/Clickable.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
     'The clickable component makes any content interactive. Use it to add click interactions to non-interactive elements while maintaining full control over their visual presentation.' +
-    "\n\nUnlike the [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) component, clickable doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
+    "\n\nUnlike the [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) component, clickable doesn't impose visual styling, allowing you to create custom interactive elements. You must implement focus indicators and other visual cues yourself.",
   thumbnail: 'clickable-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ClickableEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   defaultExample: {
     image: 'clickable-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateField/DateField.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Date field',
   description:
     'The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
-    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) or [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) components.',
+    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-picker) or [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-spinner) components.',
   thumbnail: 'date-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'DateFieldEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'date-field-default.png',
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for direct text input:** Use date field when users know the exact date and can type it efficiently. Use [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) for calendar selection or [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) for space-constrained layouts.
+- **Choose for direct text input:** Use date field when users know the exact date and can type it efficiently. Use [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-picker) for calendar selection or [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-spinner) for space-constrained layouts.
 - **Explain date constraints:** Use \`details\` to clarify requirements like "Select a date within the next 30 days" or "Must be a future date."
 - **Write actionable error messages:** Provide clear validation messages for invalid dates that help users correct their input.
 `,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DatePicker/DatePicker.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Date picker',
   description:
     'The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
-    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, consider using [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) instead. For text date entry, use [date field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-field).',
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For tight spaces, consider using [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-spinner) instead. For text date entry, use [date field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-field).',
   thumbnail: 'date-picker-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'DatePickerEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'date-picker-default.png',
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for calendar-based selection:** Use date picker when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-spinner) for tight spaces or [date field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-field) when users know the exact date.
+- **Choose for calendar-based selection:** Use date picker when users benefit from seeing a calendar view, like selecting dates relative to today or needing weekday context. Use [date spinner](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-spinner) for tight spaces or [date field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-field) when users know the exact date.
 - **Provide adequate space:** Ensure sufficient spacing around the picker to avoid interfering with on-screen keyboards or other interactive elements.
 `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/DateSpinner/DateSpinner.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Date spinner',
   description:
     'The date spinner component enables merchants to select dates using a spinner interface with scrollable columns for month, day, and year. Use it for compact date selection in space-constrained layouts or when selecting dates close to the current date.' +
-    '\n\nFor visual calendar context, consider using [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) instead. For text date entry, use [date field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-field).',
+    '\n\nFor visual calendar context, consider using [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-picker) instead. For text date entry, use [date field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-field).',
   thumbnail: 'date-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'DateSpinnerEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'date-spinner-default.png',
@@ -45,7 +45,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent: `
 - **Use for space-constrained layouts:** Choose date spinner for narrow layouts or split-screen interfaces where a calendar view would be impractical.
-- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/date-picker) provides faster navigation.
+- **Best for nearby dates:** Use when selecting dates close to the current date. For distant dates, [date picker](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/date-picker) provides faster navigation.
 - **Provide interaction cues:** Consider labels or instructions to help first-time users understand the scrollable column interface.
 `,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Divider/Divider.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Divider',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'divider-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/EmailField/EmailField.doc.ts
@@ -28,7 +28,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'EmailFieldEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'email-field-default.png',
@@ -60,7 +60,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-The \`accessory\` slot supports only [\`button\`](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [\`clickable\`](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components—other component types can't be used in the accessory slot.
+The \`accessory\` slot supports only [\`button\`](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [\`clickable\`](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components—other component types can't be used in the accessory slot.
 `,
     },
   ],
@@ -71,7 +71,7 @@ The \`accessory\` slot supports only [\`button\`](/docs/api/pos-ui-extensions/{A
     examples: [
       {
         description:
-          'Add action buttons to the email field using the accessory slot for quick actions like clearing input or verifying email addresses. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the email input context.',
+          'Add action buttons to the email field using the accessory slot for quick actions like clearing input or verifying email addresses. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components in the accessory slot, providing inline functionality within the email input context.',
         codeblock: {
           title: 'Add accessory buttons',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Heading/Heading.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
     'The heading component renders hierarchical titles to communicate the structure and organization of page content and help users navigate complex interfaces.' +
-    '\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring a meaningful page outline.',
+    '\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/layout-and-structure/section) components, ensuring a meaningful page outline.',
   thumbnail: 'heading-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -16,7 +16,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Heading',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'heading-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Icon/Icon.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
     'The icon component displays standardized visual symbols from the POS catalog to represent actions, statuses, or categories. Use icons to enhance navigation or provide visual context alongside text.' +
-    '\n\nFor interactive icons, wrap them in [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components.',
+    '\n\nFor interactive icons, wrap them in [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components.',
   thumbnail: 'icon-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Icon',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   defaultExample: {
     image: 'icon-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image/Image.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
     'The image component displays visual content. Use images to showcase products, illustrate concepts, or provide visual context in POS workflows.' +
-    '\n\nImages are display-only components. For interactive functionality, wrap them in [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components.',
+    '\n\nImages are display-only components. For interactive functionality, wrap them in [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components.',
   thumbnail: 'image-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Image',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   defaultExample: {
     image: 'image-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Modal/Modal.doc.ts
@@ -5,7 +5,7 @@ const data: ReferenceEntityTemplateSchema = {
   description:
     'The modal component displays content in an overlay that requires merchant attention. Use modals to present critical information, confirmations, or focused tasks while maintaining page context.' +
     '\n\nModals block interaction with the underlying interface until the merchant resolves the modal content.' +
-    "\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through [events](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/modal#events).",
+    "\n\nModals don't automatically handle state management or persistence, so manage visibility and lifecycle programmatically through [events](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/modal#events).",
   thumbnail: 'modal-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -28,7 +28,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ModalEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   defaultExample: {
     image: 'modal-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/NumberField/NumberField.doc.ts
@@ -28,7 +28,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'NumberFieldEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'number-field-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Page/Page.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'PageSlots',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'page-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/PosBlock/PosBlock.doc.ts
@@ -28,7 +28,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'PosBlockSlots',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'pos-block-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/ScrollBox/ScrollBox.doc.ts
@@ -16,7 +16,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ScrollBox',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'scrollbox-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/SearchField/SearchField.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'SearchFieldEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'search-field-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Section/Section.doc.ts
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'SectionSlots',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'section-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Stack/Stack.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Stack',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'stack-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Text/Text.doc.ts
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Text',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'text-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextArea/TextArea.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Text area',
   description:
     'The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
-    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/text-field).',
+    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/text-field).',
   thumbnail: 'text-area-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -28,7 +28,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'TextAreaEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'text-area-default.png',
@@ -60,7 +60,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-The \`accessory\` slot supports only [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components. Other component types can't be used for field accessories.
+The \`accessory\` slot supports only [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components. Other component types can't be used for field accessories.
 `,
     },
   ],
@@ -71,7 +71,7 @@ The \`accessory\` slot supports only [button](/docs/api/pos-ui-extensions/{API_V
     examples: [
       {
         description:
-          'Add action buttons to the text area using the accessory slot for quick actions like clearing text or formatting content. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components in the accessory slot, providing inline functionality within the multi-line input context.',
+          'Add action buttons to the text area using the accessory slot for quick actions like clearing text or formatting content. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components in the accessory slot, providing inline functionality within the multi-line input context.',
         codeblock: {
           title: 'Add accessory buttons',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TextField/TextField.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Text field',
   description:
     'The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
-    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [text area](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/text-area) component.',
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use the [text area](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/text-area) component.',
   thumbnail: 'text-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -28,7 +28,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'TextFieldEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'text-field-default.png',
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Use for single-line text input:** Choose text field for short values like names, titles, or identifiers. For multi-line content, use [text area](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/text-area).
+- **Use for single-line text input:** Choose text field for short values like names, titles, or identifiers. For multi-line content, use [text area](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/text-area).
 - **Show character limit feedback:** When approaching \`maxLength\`, display remaining characters in the \`details\` text.
 - **Write descriptive labels:** Use specific labels like "Product Name" or "Reference Code" rather than generic terms.
 `,
@@ -60,7 +60,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'limitations',
       title: 'Limitations',
       sectionContent: `
-The \`accessory\` slot supports only [button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.
+The \`accessory\` slot supports only [button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components with text content only—other component types or complex layouts can't be used for field accessories.
 `,
     },
   ],
@@ -71,7 +71,7 @@ The \`accessory\` slot supports only [button](/docs/api/pos-ui-extensions/{API_V
     examples: [
       {
         description:
-          'Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/actions/clickable) components with text content in the accessory slot, enabling inline actions without leaving the input context.',
+          'Add action buttons to the text field using the accessory slot for quick actions like clearing text or submitting input. This example shows how to use [s-button](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/button) and [s-clickable](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/actions/clickable) components with text content in the accessory slot, enabling inline actions without leaving the input context.',
         codeblock: {
           title: 'Add accessory buttons',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Tile/Tile.doc.ts
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'TileEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   defaultExample: {
     image: 'tile-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimeField/TimeField.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Time field',
   description:
     'The time field component captures time input through direct text entry. Use it when merchants know the exact time they want to enter or for quick time data entry.' +
-    '\n\nFor visual time selection with clock or spinner interfaces, use [time picker](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/time-picker).',
+    '\n\nFor visual time selection with clock or spinner interfaces, use [time picker](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/time-picker).',
   thumbnail: 'time-field-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'TimeFieldEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'time-field-default.png',

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/TimePicker/TimePicker.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Time picker',
   description:
     'The time picker component allows merchants to select times using an interactive picker interface. Use it when merchants benefit from visual time selection rather than typing exact times.' +
-    '\n\nFor direct text entry when merchants know the exact time, use [time field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/time-field).',
+    '\n\nFor direct text entry when merchants know the exact time, use [time field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/time-field).',
   thumbnail: 'time-spinner-thumbnail.png',
   isVisualComponent: true,
   type: '',
@@ -22,7 +22,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'TimePickerEvents',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   defaultExample: {
     image: 'time-spinner-default.png',
@@ -44,7 +44,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       title: 'Best practices',
       sectionContent: `
-- **Choose for visual time selection:** Use time picker when users benefit from a visual picker interface. Use [time field](/docs/api/pos-ui-extensions/{API_VERSION}/polaris-web-components/forms/time-field) when users know the exact time.
+- **Choose for visual time selection:** Use time picker when users benefit from a visual picker interface. Use [time field](/docs/api/pos-ui-extensions/{API_VERSION}/web-components/forms/time-field) when users know the exact time.
 - **Use correct format:** Always use \`HH:mm:ss\` format with leading zeros. The internal format is always 24-hour regardless of UI presentation.
 - **Validate before setting values:** Invalid values reset to empty string. Implement validation to show appropriate error messages.
 `,


### PR DESCRIPTION
## This PR: 
- Revises the terminology from "Polaris web components" to "Web components", in response to Eytan's release feedback
- Relates to https://github.com/shop/world/pull/499821