### PR TITLE
Remove Polaris branding from Customer Account UI Extensions docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.footer.render-after.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.footer.render-after.doc.ts
@@ -9,7 +9,7 @@ the footer on all customer account pages (**Order index**, **Order status**, **P
   
 > Tip:
 > To prevent layout shifting, avoid dynamic data fetching & rendering in this target. If you need to render dynamic content, consider reserving space for your content while it is loading.
-> See: [Spinner](/docs/api/checkout-ui-extensions/polaris-web-components/feedback/spinner), [SkeletonParagraph](/docs/api/checkout-ui-extensions/polaris-web-components/feedback/skeletonparagraph), or [Stack](/docs/api/checkout-ui-extensions/polaris-web-components/structure/stack).
+> See: [Spinner](/docs/api/checkout-ui-extensions/web-components/feedback/spinner), [SkeletonParagraph](/docs/api/checkout-ui-extensions/web-components/feedback/skeletonparagraph), or [Stack](/docs/api/checkout-ui-extensions/web-components/structure/stack).
 `,
   category: 'Targets',
   isVisualComponent: false,

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.action.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.action.render.doc.ts
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
   description: `
     A [static extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#static-extension-targets) that renders inside a modal, as a result of the customer clicking an order action button.
     This target only renders if you’ve also implemented an order action button via the [customer-account.order.action.menu-item.render extension target](/docs/api/customer-account-ui-extensions/targets/order-action-menu/customer-account-order-action-menu-item-render), without the \`to\` and \`onPress\` props.
-    The root of the \`customer-account.order.action.render\` extension must be a [CustomerAccountAction](/docs/api/customer-account-ui-extensions/polaris-web-components/actions/customeraccountaction).
+    The root of the \`customer-account.order.action.render\` extension must be a [CustomerAccountAction](/docs/api/customer-account-ui-extensions/web-components/actions/customeraccountaction).
   `,
   overviewPreviewDescription:
     'A [static extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#static-extension-targets) that renders inside a modal, as a result of the customer clicking the button rendered via the `customer-account.order.action.menu-item.render` extension target.',

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/overview.doc.ts
@@ -164,14 +164,14 @@ APIs with a \`value\` property are [Preact Signals](https://preactjs.com/guide/v
       image: 'ui-components.gif',
       altText:
         "An animation of a card that contains an image, heading, description, and button, shifting and transforming into highly customized versions of the same UI to reflect each merchant's unique branding.",
-      sectionContent: `Customer account UI extensions declare their interface using [Polaris web components](/docs/api/customer-account-ui-extensions/using-polaris-components). Shopify renders the UI natively, so it’s performant, accessible, and works in all of customer account’s supported browsers.
+      sectionContent: `Customer account UI extensions declare their interface using [web components](/docs/api/customer-account-ui-extensions/using-web-components). Shopify renders the UI natively, so it’s performant, accessible, and works in all of customer account’s supported browsers.
 
 Customer account components are designed to be flexible, enabling you to layer and mix them to create highly-customized app extensions that feel seamless within the customer account experience. All components inherit a merchant’s brand settings and the CSS cannot be altered or overridden.`,
       sectionCard: [
         {
           name: 'Component library',
           subtitle: 'API Reference',
-          url: '/api/customer-account-ui-extensions/polaris-web-components',
+          url: '/api/customer-account-ui-extensions/web-components',
           type: 'blocks',
         },
         {

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/upgrading-to-2025-10.doc.ts
@@ -5,7 +5,7 @@ import type {LandingTemplateSchema} from '@shopify/generate-docs';
 
 const data: LandingTemplateSchema = {
   title: 'Upgrading to 2025-10',
-  description: `This guide describes how to upgrade your customer account UI extension to API version \`2025-10\` and adopt [Polaris](/beta/next-gen-dev-platform/polaris) web components.`,
+  description: `This guide describes how to upgrade your customer account UI extension to API version \`2025-10\` and adopt web components.`,
   // The id for the page that is used for routing. If this documentation is for a primary landing page, confirm the id matches the reference name.
   id: 'upgrading-to-2025-10',
   sections: [
@@ -14,7 +14,7 @@ const data: LandingTemplateSchema = {
       anchorLink: 'update-api-version',
       title: 'Update API version',
       sectionContent:
-        'Set the API version to `2025-10` in `shopify.extension.toml` to use Polaris web components.',
+        'Set the API version to `2025-10` in `shopify.extension.toml` to use web components.',
       codeblock: {
         title: 'shopify.extension.toml',
         tabs: [
@@ -223,10 +223,10 @@ If your app is using ESLint, update your configuration to include the new global
     },
     {
       type: 'GenericAccordion',
-      anchorLink: 'migrate-to-polaris-web-components',
-      title: 'Migrate to Polaris web components',
+      anchorLink: 'migrate-to-web-components',
+      title: 'Migrate to web components',
       sectionContent:
-        'Polaris web components are exposed as custom HTML elements. Update your React or JavaScript components to custom elements.',
+        'Web components are exposed as custom HTML elements. Update your React or JavaScript components to custom elements.',
       accordionContent: [
         {
           title: 'New components in Preact',
@@ -274,19 +274,19 @@ If your app is using ESLint, update your configuration to include the new global
     },
     {
       type: 'Markdown',
-      anchorLink: 'mapping-legacy-components-to-polaris-web',
-      title: 'Mapping Legacy components to Polaris web',
+      anchorLink: 'mapping-legacy-components-to-web',
+      title: 'Mapping legacy components to web components',
       sectionContent: `
-|   **Legacy Component**   |   **Polaris Web Component**   |   **Migration Notes**   |
+|   **Legacy Component**   |   **Web Component**   |   **Migration Notes**   |
 | :----------------------: | :-------------------------------: | :---------------------: |
-|   \`Avatar\`                |   [Avatar](/api/customer-account-ui-extensions/polaris-web-components/media/avatar)   |   Available today   |
-|                             |  [ButtonGroup](/api/customer-account-ui-extensions/polaris-web-components/actions/buttongroup)   |   Available today   |
-|   \`Card\`                  |  [Section](/api/customer-account-ui-extensions/polaris-web-components/structure/section)   |   Available today   |
-|   \`CustomerAccountAction\`  |  [CustomerAccountAction](/api/customer-account-ui-extensions/polaris-web-components/actions/customeraccountaction)   |   Available today       |
-|   \`ImageGroup\`            |  [ImageGroup](/api/customer-account-ui-extensions/polaris-web-components/media/imagegroup)                         |   Available today       |
-|   \`Menu\`                  |  [Menu](/api/customer-account-ui-extensions/polaris-web-components/actions/menu)    |   Available today   |
-|   \`Page\`                  |  [Page](/api/customer-account-ui-extensions/polaris-web-components/structure/page)    |   Available today |
-|   \`ResourceItem\`          |                                |   Removed. Use [Section](/api/customer-account-ui-extensions/polaris-web-components/structure/section)   |
+|   \`Avatar\`                |   [Avatar](/api/customer-account-ui-extensions/web-components/media/avatar)   |   Available today   |
+|                             |  [ButtonGroup](/api/customer-account-ui-extensions/web-components/actions/buttongroup)   |   Available today   |
+|   \`Card\`                  |  [Section](/api/customer-account-ui-extensions/web-components/structure/section)   |   Available today   |
+|   \`CustomerAccountAction\`  |  [CustomerAccountAction](/api/customer-account-ui-extensions/web-components/actions/customeraccountaction)   |   Available today       |
+|   \`ImageGroup\`            |  [ImageGroup](/api/customer-account-ui-extensions/web-components/media/imagegroup)                         |   Available today       |
+|   \`Menu\`                  |  [Menu](/api/customer-account-ui-extensions/web-components/actions/menu)    |   Available today   |
+|   \`Page\`                  |  [Page](/api/customer-account-ui-extensions/web-components/structure/page)    |   Available today |
+|   \`ResourceItem\`          |                                |   Removed. Use [Section](/api/customer-account-ui-extensions/web-components/structure/section)   |
 `,
     },
     {
@@ -294,13 +294,13 @@ If your app is using ESLint, update your configuration to include the new global
       anchorLink: 'additional-components',
       title: 'Additional components',
       sectionContent:
-        'In addition to the components above, you can also use Polaris web components in the Checkout library to build customer account UI extensions.',
+        'In addition to the components above, you can also use web components in the Checkout library to build customer account UI extensions.',
       sectionCard: [
         {
           type: 'blocks',
           name: 'Checkout components',
-          subtitle: 'More Polaris web components',
-          url: '/docs/api/checkout-ui-extensions/polaris-web-components',
+          subtitle: 'More web components',
+          url: '/docs/api/checkout-ui-extensions/web-components',
         },
       ],
     },

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/using-web-components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/using-web-components.doc.ts
@@ -343,7 +343,8 @@ Use methods when you need to trigger actions that can't be achieved through prop
       type: 'GenericAccordion',
       anchorLink: 'troubleshooting',
       title: 'Troubleshooting',
-      sectionContent: 'Common issues and debugging tips for using web components.',
+      sectionContent:
+        'Common issues and debugging tips for using web components.',
       accordionContent: [
         {
           title: 'Common issues',

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/using-web-components.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/using-web-components.doc.ts
@@ -1,17 +1,17 @@
 import type {LandingTemplateSchema} from '@shopify/generate-docs';
 
 const data: LandingTemplateSchema = {
-  title: 'Using Polaris web components',
+  title: 'Using web components',
   description:
-    "Polaris web components are Shopify's UI toolkit for building interfaces that match the Shopify Checkout design system. This toolkit provides a set of custom HTML elements (web components) that you can use to create consistent, accessible, and performant user interfaces for Customer Account UI Extensions.",
-  id: 'using-polaris-components',
+    "Web components are Shopify's UI toolkit for building interfaces that match the Shopify Checkout design system. This toolkit provides a set of custom HTML elements (web components) that you can use to create consistent, accessible, and performant user interfaces for Customer Account UI Extensions.",
+  id: 'using-web-components',
   sections: [
     {
       type: 'Generic',
       anchorLink: 'styling',
       title: 'Styling',
       sectionContent:
-        "Polaris web components come with built-in styling that follows Shopify's design system. The components will automatically apply the correct styling based on the properties you set and the context in which they are used. For example, headings automatically display at progressively less prominent sizes based on how many levels deep they are nested inside of sections. All components inherit a merchant's brand settings and the CSS cannot be altered or overridden.",
+        "Web components come with built-in styling that follows Shopify's design system. The components will automatically apply the correct styling based on the properties you set and the context in which they are used. For example, headings automatically display at progressively less prominent sizes based on how many levels deep they are nested inside of sections. All components inherit a merchant's brand settings and the CSS cannot be altered or overridden.",
       codeblock: {
         title: 'Example',
         tabs: [
@@ -179,7 +179,7 @@ By default, the responsive value will query against the closest parent; to look 
       anchorLink: 'using-with-preact',
       title: 'Using with Preact',
       sectionContent:
-        'For UI Extensions, Shopify provides Preact as the framework of choice. Using Polaris web components with Preact is very similar to using them with React.  ',
+        'For UI Extensions, Shopify provides Preact as the framework of choice. Using web components with Preact is very similar to using them with React.  ',
       codeblock: {
         title: 'Example',
         tabs: [
@@ -195,12 +195,12 @@ By default, the responsive value will query against the closest parent; to look 
       anchorLink: 'properties-vs-attributes',
       title: 'Properties vs attributes',
       sectionContent:
-        'Polaris web components follow the same property and attribute patterns as standard HTML elements. Understanding this distinction is important for using the components effectively.',
+        'Web components follow the same property and attribute patterns as standard HTML elements. Understanding this distinction is important for using the components effectively.',
       accordionContent: [
         {
           title: 'Key concepts',
           description:
-            "1. **Attributes** are HTML attributes that appear in the HTML markup.\n2. **Properties** are JavaScript object properties accessed directly on the DOM element.\n3. Most attributes in Polaris web components are reflected as properties, with a few exceptions like `value` and `checked` which follow HTML's standard behavior.",
+            "1. **Attributes** are HTML attributes that appear in the HTML markup.\n2. **Properties** are JavaScript object properties accessed directly on the DOM element.\n3. Most attributes in web components are reflected as properties, with a few exceptions like `value` and `checked` which follow HTML's standard behavior.",
           codeblock: {
             tabs: [],
             title: '',
@@ -211,7 +211,7 @@ By default, the responsive value will query against the closest parent; to look 
         {
           title: 'How JSX properties are applied',
           description:
-            "When using Polaris web components in JSX, the framework determines how to apply your props based on whether the element has a matching property name.\n\nIf the element has a property with the exact same name as your prop, the value is set as a property. Otherwise, it's applied as an attribute. Here's how this works in pseudocode:",
+            "When using web components in JSX, the framework determines how to apply your props based on whether the element has a matching property name.\n\nIf the element has a property with the exact same name as your prop, the value is set as a property. Otherwise, it's applied as an attribute. Here's how this works in pseudocode:",
           codeblock: {
             tabs: [
               {
@@ -228,7 +228,7 @@ By default, the responsive value will query against the closest parent; to look 
         {
           title: 'Examples',
           description:
-            'For Polaris web components, you can generally just use the property names as documented, and everything will work as expected.',
+            'For web components, you can generally just use the property names as documented, and everything will work as expected.',
           codeblock: {
             tabs: [
               {
@@ -265,7 +265,7 @@ By default, the responsive value will query against the closest parent; to look 
       anchorLink: 'slots',
       title: 'Slots',
       sectionContent:
-        'Slots allow you to insert custom content into specific areas of Polaris web components. Use the `slot` attribute to specify where your content should appear within a component.\n\nKey points:\n- Named slots (e.g., `slot="title"`) place content in designated areas\n- Multiple elements can share the same slot name\n- Elements without a slot attribute go into the default (unnamed) slot',
+        'Slots allow you to insert custom content into specific areas of web components. Use the `slot` attribute to specify where your content should appear within a component.\n\nKey points:\n- Named slots (e.g., `slot="title"`) place content in designated areas\n- Multiple elements can share the same slot name\n- Elements without a slot attribute go into the default (unnamed) slot',
       codeblock: {
         title: 'Examples',
         tabs: [
@@ -282,7 +282,7 @@ By default, the responsive value will query against the closest parent; to look 
       title: 'Methods',
       sectionContent: `Methods are functions available on components for programmatic control. Components like \`Modal\`, \`Sheet\`, and \`Announcement\` provide methods such as \`hideOverlay()\` or \`dismiss()\` to control their behavior imperatively when needed.
 
-Use methods when you need to trigger actions that can’t be achieved through property changes alone, such as closing an overlay after an async operation or resetting component state.`,
+Use methods when you need to trigger actions that can't be achieved through property changes alone, such as closing an overlay after an async operation or resetting component state.`,
       codeblock: {
         title: 'Example',
         tabs: [
@@ -302,7 +302,7 @@ Use methods when you need to trigger actions that can’t be achieved through pr
     {
       type: 'Generic',
       title: 'Using Forms',
-      sectionContent: `The [Form](https://shopify.dev/docs/api/checkout-ui-extensions/polaris-web-components/forms/form) component provides a way to manage form state and submit data to your app's backend or directly to Shopify using Direct API access.\n\nWhen the form is submitted or reset the relevant callback in the form component will get triggered.\n\nUsing this, you can control what defines a component to be dirty by utilizing the input's defaultValue property.\n\nRules:\n\n- When the defaultValue is set, the component will be considered dirty if the value of the input is different from the defaultValue. You may update the defaultValue when the form is submitted to reset the dirty state of the form.\n\n- When the defaultValue is not set, the component will be considered dirty if the value of the input is different from the initial value or from the last dynamic update to the input's value that wasn't triggered by user input.
+      sectionContent: `The [Form](/docs/api/customer-account-ui-extensions/web-components/forms/form) component provides a way to manage form state and submit data to your app's backend or directly to Shopify using Direct API access.\n\nWhen the form is submitted or reset the relevant callback in the form component will get triggered.\n\nUsing this, you can control what defines a component to be dirty by utilizing the input's defaultValue property.\n\nRules:\n\n- When the defaultValue is set, the component will be considered dirty if the value of the input is different from the defaultValue. You may update the defaultValue when the form is submitted to reset the dirty state of the form.\n\n- When the defaultValue is not set, the component will be considered dirty if the value of the input is different from the initial value or from the last dynamic update to the input's value that wasn't triggered by user input.
 
         Note: In order to trigger the dirty state, each input must have a name attribute.
         `,
@@ -328,7 +328,7 @@ Use methods when you need to trigger actions that can’t be achieved through pr
       anchorLink: 'accessibility',
       title: 'Accessibility',
       sectionContent:
-        'Polaris web components are built with accessibility in mind. They:\n\n- Use semantic HTML under the hood\n- Support keyboard navigation\n- Include proper ARIA attributes\n- Manage focus appropriately\n- Provide appropriate color contrast\n- Log warnings when component properties are missing and required for accessibility\n\nTo ensure your application remains accessible, follow these best practices:\n\n1. Always use the `label` and `error` properties for form elements\n2. Use appropriate heading levels with `s-heading` or the `heading` property\n3. Ensure sufficient color contrast\n4. Test keyboard navigation\n5. Use `labelAccessibilityVisibility` to hide labels and keep them visible to assistive technologies\n6. Use `accessibilityRole` to specify the `aria-role` of the component',
+        'Web components are built with accessibility in mind. They:\n\n- Use semantic HTML under the hood\n- Support keyboard navigation\n- Include proper ARIA attributes\n- Manage focus appropriately\n- Provide appropriate color contrast\n- Log warnings when component properties are missing and required for accessibility\n\nTo ensure your application remains accessible, follow these best practices:\n\n1. Always use the `label` and `error` properties for form elements\n2. Use appropriate heading levels with `s-heading` or the `heading` property\n3. Ensure sufficient color contrast\n4. Test keyboard navigation\n5. Use `labelAccessibilityVisibility` to hide labels and keep them visible to assistive technologies\n6. Use `accessibilityRole` to specify the `aria-role` of the component',
       codeblock: {
         title: 'Example',
         tabs: [
@@ -343,8 +343,7 @@ Use methods when you need to trigger actions that can’t be achieved through pr
       type: 'GenericAccordion',
       anchorLink: 'troubleshooting',
       title: 'Troubleshooting',
-      sectionContent:
-        'Common issues and debugging tips for using Polaris web components.',
+      sectionContent: 'Common issues and debugging tips for using web components.',
       accordionContent: [
         {
           title: 'Common issues',

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -120,7 +120,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * - Use noun + past tense verb format. For example, \`Changes saved\`.
    *
-   * For errors, or information that needs to persist on the page, use a [banner](/docs/api/checkout-ui-extensions/polaris-web-components/feedback/banner) component.
+   * For errors, or information that needs to persist on the page, use a [banner](/docs/api/checkout-ui-extensions/web-components/feedback/banner) component.
    */
   toast: ToastApi;
 

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
@@ -17,11 +17,11 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'Learn more about [registering events](/docs/api/app-home/using-polaris-components#event-handling).',
+        'Learn more about [registering events](/docs/api/customer-account-ui-extensions/using-web-components#handling-events).',
       type: 'AvatarEventsDocs',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   defaultExample: {
     image: 'avatar-default.png',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup.d.ts
@@ -9,11 +9,11 @@ export interface ButtonGroupProps extends IdProps {
 
 export interface ButtonGroupElementSlots {
   /**
-   * The primary action for the group. Accepts a single [Button](/docs/api/checkout-ui-extensions/polaris-web-components/actions/button) element.
+   * The primary action for the group. Accepts a single [Button](/docs/api/checkout-ui-extensions/web-components/actions/button) element.
    */
   'primary-action'?: HTMLElement;
   /**
-   * The secondary actions for the group. Accepts multiple [Button](/docs/api/checkout-ui-extensions/polaris-web-components/actions/button) elements.
+   * The secondary actions for the group. Accepts multiple [Button](/docs/api/checkout-ui-extensions/web-components/actions/button) elements.
    */
   'secondary-actions'?: HTMLElement;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup/ButtonGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup/ButtonGroup.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Button group',
   description: `The button group component is used to display multiple buttons in a layout that is contextual based on the screen width or parent component. When there is more than one secondary action, they get collapsed.
     
-When used within a [Section](/docs/api/customer-account-ui-extensions/polaris-web-components/structure/section) component, the buttons will fill the width of the section.
+When used within a [Section](/docs/api/customer-account-ui-extensions/web-components/structure/section) component, the buttons will fill the width of the section.
 `,
   thumbnail: 'buttongroup-thumbnail.png',
   requires: '',
@@ -22,7 +22,7 @@ When used within a [Section](/docs/api/customer-account-ui-extensions/polaris-we
       type: 'ButtonGroupElementSlotsDocs',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   defaultExample: {
     image: 'buttongroup-default.png',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
@@ -26,7 +26,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Docs_CustomerAccountAction_SlotButton',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   defaultExample: {
     image: 'customeraccountaction-default.png',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.doc.ts
@@ -3,7 +3,7 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image group',
   description:
-    'Display up to 4 images in a grid or stacked layout. The images are displayed as a grid when used within a [Section](/docs/api/customer-account-ui-extensions/polaris-web-components/structure/section) component. For example, images of products in a wishlist or subscription. When there are more than 4 images, the component indicates how many more images are not displayed.',
+    'Display up to 4 images in a grid or stacked layout. The images are displayed as a grid when used within a [Section](/docs/api/customer-account-ui-extensions/web-components/structure/section) component. For example, images of products in a wishlist or subscription. When there are more than 4 images, the component indicates how many more images are not displayed.',
   thumbnail: 'imagegroup-thumbnail.png',
   requires: '',
   isVisualComponent: true,
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'ImageGroupPropsDocs',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   defaultExample: {
     image: 'imagegroup-default.png',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Menu/Menu.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Menu/Menu.doc.ts
@@ -21,7 +21,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Docs_Menu_Button_Action',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   defaultExample: {
     image: 'menu-default.png',
@@ -71,7 +71,7 @@ Use short labels (ideally two words) that start with a verb, use sentence case, 
     {
       name: 'Popover',
       subtitle: 'Component',
-      url: '/docs/api/customer-account-ui-extensions/polaris-web-components/overlays/popover',
+      url: '/docs/api/customer-account-ui-extensions/web-components/overlays/popover',
       type: 'Component',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.doc.ts
@@ -38,7 +38,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'Docs_Page_Button_SecondaryAction',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   defaultExample: {
     image: 'page-default.png',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/QueryContainer/QueryContainer.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/QueryContainer/QueryContainer.doc.ts
@@ -10,7 +10,7 @@ const data: ReferenceEntityTemplateSchema = createComponentDoc({
     {
       name: 'Responsive values',
       subtitle: 'Utility',
-      url: '/docs/api/customer-account-ui-extensions/latest/using-polaris-components#responsive-values',
+      url: '/docs/api/customer-account-ui-extensions/latest/using-web-components#responsive-values',
       type: 'utility',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Section.d.ts
@@ -18,11 +18,11 @@ export interface SectionProps extends IdProps {
 
 export interface SectionElementSlots {
   /**
-   * The primary action for the section. Accepts a single [Button](/docs/api/checkout-ui-extensions/polaris-web-components/actions/button) element.
+   * The primary action for the section. Accepts a single [Button](/docs/api/checkout-ui-extensions/web-components/actions/button) element.
    */
   'primary-action'?: HTMLElement;
   /**
-   * The secondary actions for the section. Accepts multiple [Button](/docs/api/checkout-ui-extensions/polaris-web-components/actions/button) elements.
+   * The secondary actions for the section. Accepts multiple [Button](/docs/api/checkout-ui-extensions/web-components/actions/button) elements.
    */
   'secondary-actions'?: HTMLElement;
 }


### PR DESCRIPTION
## Summary
- Rename `using-polaris-web-components.doc.ts` to `using-web-components.doc.ts` and update all content
- Change component category from "Polaris web components" to "Web components" for customer-account specific components (Avatar, ButtonGroup, CustomerAccountAction, ImageGroup, Menu, Page)
- Update all `/polaris-web-components/` URLs to `/web-components/` throughout customer-account docs
- Update `overview.doc.ts` and `upgrading-to-2025-10.doc.ts` to remove Polaris references

## Scope
All 15 changed files are within the customer-account surface only:
- `docs/surfaces/customer-account/` (5 files)
- `src/surfaces/customer-account/` (10 files)

Cross-references to checkout-ui-extensions URLs have been updated to `/web-components/` in anticipation of checkout also making this change.

## Test plan
- [ ] Regenerate docs for 2025-10, 2026-01, 2026-04-rc
- [ ] Verify generated static pages have no "Polaris web components" references
- [ ] Verify component category shows "Web components" for customer-account specific components
- [ ] Copy generated files to world and verify pages render correctly


Made with [Cursor](https://cursor.com)